### PR TITLE
Redirect binary downloads to GitHub Releases

### DIFF
--- a/control-plane/app/controllers/agent_checksums_controller.rb
+++ b/control-plane/app/controllers/agent_checksums_controller.rb
@@ -11,17 +11,10 @@ class AgentChecksumsController < ActionController::Base
       artifact = AgentReleases::Fetcher.build.fetch_checksums(version: version)
 
       response.headers["Cache-Control"] = "public, max-age=31536000, immutable"
-      send_data artifact.body,
-        filename: artifact.filename,
-        type: "text/plain",
-        disposition: "attachment"
+      redirect_to artifact.url, allow_other_host: true
     end
   rescue AgentReleases::Fetcher::NotConfiguredError => error
     render plain: "agent checksums unavailable: #{error.message}", status: :service_unavailable
-  rescue AgentReleases::Fetcher::NotFoundError => error
-    render plain: error.message, status: :not_found
-  rescue AgentReleases::Fetcher::Error => error
-    render plain: "agent checksum download failed: #{error.message}", status: :bad_gateway
   end
 
   private

--- a/control-plane/app/controllers/agent_downloads_controller.rb
+++ b/control-plane/app/controllers/agent_downloads_controller.rb
@@ -15,19 +15,12 @@ class AgentDownloadsController < ActionController::Base
       )
 
       response.headers["Cache-Control"] = "public, max-age=31536000, immutable"
-      send_data artifact.body,
-        filename: artifact.filename,
-        type: "application/octet-stream",
-        disposition: "attachment"
+      redirect_to artifact.url, allow_other_host: true
     end
   rescue AgentReleases::Fetcher::NotConfiguredError => error
     render plain: "agent binary unavailable: #{error.message}", status: :service_unavailable
   rescue AgentReleases::Fetcher::UnsupportedTargetError => error
     render plain: error.message, status: :unprocessable_entity
-  rescue AgentReleases::Fetcher::NotFoundError => error
-    render plain: error.message, status: :not_found
-  rescue AgentReleases::Fetcher::Error => error
-    render plain: "agent binary download failed: #{error.message}", status: :bad_gateway
   end
 
   private

--- a/control-plane/app/controllers/cli_checksums_controller.rb
+++ b/control-plane/app/controllers/cli_checksums_controller.rb
@@ -11,17 +11,10 @@ class CliChecksumsController < ActionController::Base
       artifact = CliReleases::Fetcher.build.fetch_checksums(version: version)
 
       response.headers["Cache-Control"] = "public, max-age=31536000, immutable"
-      send_data artifact.body,
-        filename: artifact.filename,
-        type: "text/plain",
-        disposition: "attachment"
+      redirect_to artifact.url, allow_other_host: true
     end
   rescue CliReleases::Fetcher::NotConfiguredError => error
     render plain: "cli checksums unavailable: #{error.message}", status: :service_unavailable
-  rescue CliReleases::Fetcher::NotFoundError => error
-    render plain: error.message, status: :not_found
-  rescue CliReleases::Fetcher::Error => error
-    render plain: "cli checksum download failed: #{error.message}", status: :bad_gateway
   end
 
   private

--- a/control-plane/app/controllers/cli_downloads_controller.rb
+++ b/control-plane/app/controllers/cli_downloads_controller.rb
@@ -15,19 +15,12 @@ class CliDownloadsController < ActionController::Base
       )
 
       response.headers["Cache-Control"] = "public, max-age=31536000, immutable"
-      send_data artifact.body,
-        filename: artifact.filename,
-        type: "application/octet-stream",
-        disposition: "attachment"
+      redirect_to artifact.url, allow_other_host: true
     end
   rescue CliReleases::Fetcher::NotConfiguredError => error
     render plain: "cli binary unavailable: #{error.message}", status: :service_unavailable
   rescue CliReleases::Fetcher::UnsupportedTargetError => error
     render plain: error.message, status: :unprocessable_entity
-  rescue CliReleases::Fetcher::NotFoundError => error
-    render plain: error.message, status: :not_found
-  rescue CliReleases::Fetcher::Error => error
-    render plain: "cli binary download failed: #{error.message}", status: :bad_gateway
   end
 
   private

--- a/control-plane/app/services/agent_releases/fetcher.rb
+++ b/control-plane/app/services/agent_releases/fetcher.rb
@@ -1,70 +1,50 @@
 # frozen_string_literal: true
 
 require "erb"
-require "json"
-require "uri"
 
 module AgentReleases
   class Fetcher
     Error = Class.new(StandardError)
     NotConfiguredError = Class.new(Error)
-    NotFoundError = Class.new(Error)
     UnsupportedTargetError = Class.new(Error)
-    Artifact = Struct.new(:body, :filename, :source_name, keyword_init: true)
+    Artifact = Struct.new(:url, :filename, :source_name, keyword_init: true)
 
+    DEFAULT_BASE_DOWNLOAD_URL = "https://github.com/devopsellence/devopsellence/releases/download"
+    DEFAULT_TAG_PREFIX = "agent-"
     SUPPORTED_OSES = %w[linux darwin].freeze
     SUPPORTED_ARCHES = %w[amd64 arm64].freeze
 
     def self.build
-      runtime = Devopsellence::RuntimeConfig.current
-      new(
-        project_id: runtime.agent_release_project_id,
-        location: runtime.agent_release_region,
-        repository: runtime.agent_release_repository,
-        package_name: runtime.agent_release_package,
-        client: Gcp::RestClient.new
-      )
+      new
     end
 
-    def initialize(project_id:, location:, repository:, package_name: nil, client:)
-      @project_id = project_id.to_s.strip
-      @location = location.to_s.strip
-      @repository = repository.to_s.strip
-      @package_name = package_name.to_s.strip.presence || "devopsellence-agent"
-      @client = client
+    def initialize(base_download_url: DEFAULT_BASE_DOWNLOAD_URL, tag_prefix: DEFAULT_TAG_PREFIX)
+      @base_download_url = base_download_url.to_s.delete_suffix("/")
+      @tag_prefix = tag_prefix.to_s
     end
 
     def fetch(version:, os:, arch:)
-      ensure_configured!
       validate_target!(os:, arch:)
 
-      artifact_name = artifact_name(version:, os:, arch:)
-      source_name = resolve_source_name(version:, artifact_name:)
-      response = client.get(download_uri(source_name))
-      raise Error, "artifact download failed (#{response.code})" unless response.code.to_i.between?(200, 299)
-
-      Artifact.new(body: response.body, filename: "devopsellence-agent", source_name: source_name)
+      source_name = artifact_name(os:, arch:)
+      Artifact.new(
+        url: download_url(version:, source_name:),
+        filename: "devopsellence-agent",
+        source_name:
+      )
     end
 
     def fetch_checksums(version:)
-      ensure_configured!
-
-      source_name = resolve_source_name(version:, artifact_name: "SHA256SUMS")
-      response = client.get(download_uri(source_name))
-      raise Error, "artifact download failed (#{response.code})" unless response.code.to_i.between?(200, 299)
-
-      Artifact.new(body: response.body, filename: "SHA256SUMS", source_name: source_name)
+      Artifact.new(
+        url: download_url(version:, source_name: "SHA256SUMS"),
+        filename: "SHA256SUMS",
+        source_name: "SHA256SUMS"
+      )
     end
 
     private
 
-    attr_reader :project_id, :location, :repository, :package_name, :client
-
-    def ensure_configured!
-      return if [ project_id, location, repository ].all?(&:present?)
-
-      raise NotConfiguredError, "configure DEVOPSELLENCE_AGENT_RELEASE_PROJECT_ID, DEVOPSELLENCE_AGENT_RELEASE_REGION, and DEVOPSELLENCE_AGENT_RELEASE_REPOSITORY"
-    end
+    attr_reader :base_download_url, :tag_prefix
 
     def validate_target!(os:, arch:)
       return if SUPPORTED_OSES.include?(os) && SUPPORTED_ARCHES.include?(arch)
@@ -72,35 +52,14 @@ module AgentReleases
       raise UnsupportedTargetError, "unsupported target #{os}/#{arch}"
     end
 
-    def artifact_name(version:, os:, arch:)
+    def artifact_name(os:, arch:)
       "#{os}-#{arch}"
     end
 
-    def resolve_source_name(version:, artifact_name:)
-      response = client.get(files_uri(version:))
-      raise Error, "artifact list failed (#{response.code})" unless response.code.to_i.between?(200, 299)
-
-      files = JSON.parse(response.body).fetch("files", [])
-      match = files.find do |entry|
-        file_name = entry["name"].to_s.split("/files/", 2).last
-        file_name.end_with?(":#{artifact_name}") || file_name == artifact_name
-      end
-      return match.fetch("name").split("/files/", 2).last if match
-
-      raise NotFoundError, "artifact not found for #{version}"
-    end
-
-    def files_uri(version:)
-      parent = "projects/#{project_id}/locations/#{location}/repositories/#{repository}"
-      owner = "#{parent}/packages/#{package_name}/versions/#{version}"
-      uri = URI.parse("#{Gcp::Endpoints.artifact_registry_base}/#{parent}/files")
-      uri.query = URI.encode_www_form(filter: %(owner="#{owner}"))
-      uri.to_s
-    end
-
-    def download_uri(source_name)
-      encoded_name = ERB::Util.url_encode(source_name)
-      "#{Gcp::Endpoints.artifact_registry_download_base}/projects/#{project_id}/locations/#{location}/repositories/#{repository}/files/#{encoded_name}:download?alt=media"
+    def download_url(version:, source_name:)
+      encoded_tag = ERB::Util.url_encode("#{tag_prefix}#{version}")
+      encoded_source_name = ERB::Util.url_encode(source_name)
+      "#{base_download_url}/#{encoded_tag}/#{encoded_source_name}"
     end
   end
 end

--- a/control-plane/app/services/cli_releases/fetcher.rb
+++ b/control-plane/app/services/cli_releases/fetcher.rb
@@ -1,70 +1,50 @@
 # frozen_string_literal: true
 
 require "erb"
-require "json"
-require "uri"
 
 module CliReleases
   class Fetcher
     Error = Class.new(StandardError)
     NotConfiguredError = Class.new(Error)
-    NotFoundError = Class.new(Error)
     UnsupportedTargetError = Class.new(Error)
-    Artifact = Struct.new(:body, :filename, :source_name, keyword_init: true)
+    Artifact = Struct.new(:url, :filename, :source_name, keyword_init: true)
 
+    DEFAULT_BASE_DOWNLOAD_URL = "https://github.com/devopsellence/devopsellence/releases/download"
+    DEFAULT_TAG_PREFIX = "cli-"
     SUPPORTED_OSES = %w[linux darwin].freeze
     SUPPORTED_ARCHES = %w[amd64 arm64].freeze
 
     def self.build
-      runtime = Devopsellence::RuntimeConfig.current
-      new(
-        project_id: runtime.cli_release_project_id,
-        location: runtime.cli_release_region,
-        repository: runtime.cli_release_repository,
-        package_name: runtime.cli_release_package,
-        client: Gcp::RestClient.new
-      )
+      new
     end
 
-    def initialize(project_id:, location:, repository:, package_name: nil, client:)
-      @project_id = project_id.to_s.strip
-      @location = location.to_s.strip
-      @repository = repository.to_s.strip
-      @package_name = package_name.to_s.strip.presence || "devopsellence-cli"
-      @client = client
+    def initialize(base_download_url: DEFAULT_BASE_DOWNLOAD_URL, tag_prefix: DEFAULT_TAG_PREFIX)
+      @base_download_url = base_download_url.to_s.delete_suffix("/")
+      @tag_prefix = tag_prefix.to_s
     end
 
     def fetch(version:, os:, arch:)
-      ensure_configured!
       validate_target!(os:, arch:)
 
-      artifact_name = artifact_name(version:, os:, arch:)
-      source_name = resolve_source_name(version:, artifact_name:)
-      response = client.get(download_uri(source_name))
-      raise Error, "artifact download failed (#{response.code})" unless response.code.to_i.between?(200, 299)
-
-      Artifact.new(body: response.body, filename: "devopsellence", source_name: source_name)
+      source_name = artifact_name(os:, arch:)
+      Artifact.new(
+        url: download_url(version:, source_name:),
+        filename: "devopsellence",
+        source_name:
+      )
     end
 
     def fetch_checksums(version:)
-      ensure_configured!
-
-      source_name = resolve_source_name(version:, artifact_name: "SHA256SUMS")
-      response = client.get(download_uri(source_name))
-      raise Error, "artifact download failed (#{response.code})" unless response.code.to_i.between?(200, 299)
-
-      Artifact.new(body: response.body, filename: "SHA256SUMS", source_name: source_name)
+      Artifact.new(
+        url: download_url(version:, source_name: "SHA256SUMS"),
+        filename: "SHA256SUMS",
+        source_name: "SHA256SUMS"
+      )
     end
 
     private
 
-    attr_reader :project_id, :location, :repository, :package_name, :client
-
-    def ensure_configured!
-      return if [project_id, location, repository].all?(&:present?)
-
-      raise NotConfiguredError, "configure DEVOPSELLENCE_CLI_RELEASE_PROJECT_ID, DEVOPSELLENCE_CLI_RELEASE_REGION, and DEVOPSELLENCE_CLI_RELEASE_REPOSITORY"
-    end
+    attr_reader :base_download_url, :tag_prefix
 
     def validate_target!(os:, arch:)
       return if SUPPORTED_OSES.include?(os) && SUPPORTED_ARCHES.include?(arch)
@@ -72,35 +52,14 @@ module CliReleases
       raise UnsupportedTargetError, "unsupported target #{os}/#{arch}"
     end
 
-    def artifact_name(version:, os:, arch:)
+    def artifact_name(os:, arch:)
       "#{os}-#{arch}"
     end
 
-    def resolve_source_name(version:, artifact_name:)
-      response = client.get(files_uri(version:))
-      raise Error, "artifact list failed (#{response.code})" unless response.code.to_i.between?(200, 299)
-
-      files = JSON.parse(response.body).fetch("files", [])
-      match = files.find do |entry|
-        file_name = entry["name"].to_s.split("/files/", 2).last
-        file_name.end_with?(":#{artifact_name}") || file_name == artifact_name
-      end
-      return match.fetch("name").split("/files/", 2).last if match
-
-      raise NotFoundError, "artifact not found for #{version}"
-    end
-
-    def files_uri(version:)
-      parent = "projects/#{project_id}/locations/#{location}/repositories/#{repository}"
-      owner = "#{parent}/packages/#{package_name}/versions/#{version}"
-      uri = URI.parse("#{Gcp::Endpoints.artifact_registry_base}/#{parent}/files")
-      uri.query = URI.encode_www_form(filter: %(owner="#{owner}"))
-      uri.to_s
-    end
-
-    def download_uri(source_name)
-      encoded_name = ERB::Util.url_encode(source_name)
-      "#{Gcp::Endpoints.artifact_registry_download_base}/projects/#{project_id}/locations/#{location}/repositories/#{repository}/files/#{encoded_name}:download?alt=media"
+    def download_url(version:, source_name:)
+      encoded_tag = ERB::Util.url_encode("#{tag_prefix}#{version}")
+      encoded_source_name = ERB::Util.url_encode(source_name)
+      "#{base_download_url}/#{encoded_tag}/#{encoded_source_name}"
     end
   end
 end

--- a/control-plane/lib/devopsellence/runtime_config.rb
+++ b/control-plane/lib/devopsellence/runtime_config.rb
@@ -19,8 +19,6 @@ module Devopsellence
     DEFAULT_ACME_CONTACT_EMAIL = "admin@devopsellence.com"
     DEFAULT_ACME_DIRECTORY_URL = "https://acme-v02.api.letsencrypt.org/directory"
     DEFAULT_ACME_STAGING_DIRECTORY_URL = "https://acme-staging-v02.api.letsencrypt.org/directory"
-    DEFAULT_AGENT_RELEASE_PACKAGE = "devopsellence-agent"
-    DEFAULT_CLI_RELEASE_PACKAGE = "devopsellence-cli"
     DEFAULT_MANAGED_PROVIDER = "hetzner"
     DEFAULT_MANAGED_REGION = "ash"
     DEFAULT_MANAGED_SIZE = "cpx11"
@@ -80,12 +78,6 @@ module Devopsellence
       acme_directory_url: ["DEVOPSELLENCE_ACME_DIRECTORY_URL", DEFAULT_ACME_DIRECTORY_URL],
       agent_stable_version: ["DEVOPSELLENCE_AGENT_STABLE_VERSION", ""],
       cli_stable_version: ["DEVOPSELLENCE_CLI_STABLE_VERSION", ""],
-      agent_release_project_id: ["DEVOPSELLENCE_AGENT_RELEASE_PROJECT_ID", ""],
-      agent_release_region: ["DEVOPSELLENCE_AGENT_RELEASE_REGION", ""],
-      agent_release_repository: ["DEVOPSELLENCE_AGENT_RELEASE_REPOSITORY", ""],
-      cli_release_project_id: ["DEVOPSELLENCE_CLI_RELEASE_PROJECT_ID", ""],
-      cli_release_region: ["DEVOPSELLENCE_CLI_RELEASE_REGION", ""],
-      cli_release_repository: ["DEVOPSELLENCE_CLI_RELEASE_REPOSITORY", ""],
       agent_container_image: ["DEVOPSELLENCE_AGENT_CONTAINER_IMAGE", ""],
       agent_container_repository: ["DEVOPSELLENCE_AGENT_CONTAINER_REPOSITORY", ""],
       managed_default_provider: ["DEVOPSELLENCE_MANAGED_DEFAULT_PROVIDER", DEFAULT_MANAGED_PROVIDER],
@@ -130,8 +122,6 @@ module Devopsellence
         OPTIONAL_DEFAULTS.each do |name, (key, fallback)|
           config[name] = env.fetch(key, fallback).to_s.strip
         end
-        config.agent_release_package = DEFAULT_AGENT_RELEASE_PACKAGE
-        config.cli_release_package = DEFAULT_CLI_RELEASE_PACKAGE
         config.managed_pool_candidates = build_managed_pool_candidates(config)
         validate_runtime_backend!(config)
         validate_workload_identity_resource_names!(config)

--- a/control-plane/test/integration/abuse_controls_test.rb
+++ b/control-plane/test/integration/abuse_controls_test.rb
@@ -3,7 +3,7 @@
 require "test_helper"
 
 class AbuseControlsTest < ActionDispatch::IntegrationTest
-  FakeArtifact = Struct.new(:body, :filename, keyword_init: true)
+  FakeArtifact = Struct.new(:url, :filename, keyword_init: true)
 
   class DownloadFetcher
     def initialize(result:)
@@ -236,14 +236,14 @@ class AbuseControlsTest < ActionDispatch::IntegrationTest
 
   test "rate limits public artifact downloads per ip across binaries and checksums" do
     remote_addr = { "REMOTE_ADDR" => "203.0.113.10" }
-    cli_fetcher = DownloadFetcher.new(result: FakeArtifact.new(body: "binary", filename: "devopsellence"))
-    checksum_fetcher = ChecksumFetcher.new(result: FakeArtifact.new(body: "checksums", filename: "SHA256SUMS"))
+    cli_fetcher = DownloadFetcher.new(result: FakeArtifact.new(url: "https://example.test/devopsellence", filename: "devopsellence"))
+    checksum_fetcher = ChecksumFetcher.new(result: FakeArtifact.new(url: "https://example.test/SHA256SUMS", filename: "SHA256SUMS"))
 
     with_cli_release_fetcher(cli_fetcher) do
       with_agent_release_fetcher(checksum_fetcher) do
         60.times do
           get cli_download_path, params: { version: "v0.1.0", os: "linux", arch: "amd64" }, headers: remote_addr
-          assert_response :success
+          assert_response :redirect
         end
 
         get agent_checksums_path, params: { version: "v0.1.0" }, headers: remote_addr

--- a/control-plane/test/integration/agent_downloads_test.rb
+++ b/control-plane/test/integration/agent_downloads_test.rb
@@ -3,7 +3,7 @@
 require "test_helper"
 
 class AgentDownloadsTest < ActionDispatch::IntegrationTest
-  FakeArtifact = Struct.new(:body, :filename, keyword_init: true)
+  FakeArtifact = Struct.new(:url, :filename, keyword_init: true)
 
   class FakeFetcher
     attr_reader :calls
@@ -22,13 +22,8 @@ class AgentDownloadsTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "returns service unavailable when no version or release config is configured" do
-    with_env(
-      "DEVOPSELLENCE_AGENT_STABLE_VERSION" => nil,
-      "DEVOPSELLENCE_AGENT_RELEASE_PROJECT_ID" => nil,
-      "DEVOPSELLENCE_AGENT_RELEASE_REGION" => nil,
-      "DEVOPSELLENCE_AGENT_RELEASE_REPOSITORY" => nil
-    ) do
+  test "returns service unavailable when no version is requested and no stable version is configured" do
+    with_env("DEVOPSELLENCE_AGENT_STABLE_VERSION" => nil) do
       get agent_download_path
     end
 
@@ -36,25 +31,23 @@ class AgentDownloadsTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "agent binary unavailable"
   end
 
-  test "downloads explicit version from the configured fetcher" do
-    fetcher = FakeFetcher.new(result: FakeArtifact.new(body: "binary", filename: "devopsellence-agent"))
+  test "redirects explicit version to the configured release asset url" do
+    fetcher = FakeFetcher.new(result: FakeArtifact.new(url: "https://github.com/devopsellence/devopsellence/releases/download/agent-v0.1.0/linux-arm64", filename: "devopsellence-agent"))
 
     with_agent_release_fetcher(fetcher) do
       get agent_download_path, params: { version: "v0.1.0", os: "linux", arch: "arm64" }
     end
 
-    assert_response :success
-    assert_equal "binary", response.body
+    assert_response :redirect
+    assert_equal "https://github.com/devopsellence/devopsellence/releases/download/agent-v0.1.0/linux-arm64", response.location
     assert_equal [{ version: "v0.1.0", os: "linux", arch: "arm64" }], fetcher.calls
-    assert_equal "application/octet-stream", response.media_type
-    assert_match(/attachment/, response.headers["Content-Disposition"])
     assert_includes response.headers["Cache-Control"], "public"
     assert_includes response.headers["Cache-Control"], "max-age=31536000"
     assert_includes response.headers["Cache-Control"], "immutable"
   end
 
   test "redirects unversioned requests to the stable version without downloading" do
-    fetcher = FakeFetcher.new(result: FakeArtifact.new(body: "binary", filename: "devopsellence-agent"))
+    fetcher = FakeFetcher.new(result: FakeArtifact.new(url: "https://example.test/unused", filename: "devopsellence-agent"))
 
     with_env("DEVOPSELLENCE_AGENT_STABLE_VERSION" => "v1.2.3") do
       with_agent_release_fetcher(fetcher) do

--- a/control-plane/test/integration/cli_downloads_test.rb
+++ b/control-plane/test/integration/cli_downloads_test.rb
@@ -3,7 +3,7 @@
 require "test_helper"
 
 class CliDownloadsTest < ActionDispatch::IntegrationTest
-  FakeArtifact = Struct.new(:body, :filename, keyword_init: true)
+  FakeArtifact = Struct.new(:url, :filename, keyword_init: true)
 
   class FakeFetcher
     attr_reader :calls
@@ -22,13 +22,8 @@ class CliDownloadsTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "returns service unavailable when no version or release config is configured" do
-    with_env(
-      "DEVOPSELLENCE_CLI_STABLE_VERSION" => nil,
-      "DEVOPSELLENCE_CLI_RELEASE_PROJECT_ID" => nil,
-      "DEVOPSELLENCE_CLI_RELEASE_REGION" => nil,
-      "DEVOPSELLENCE_CLI_RELEASE_REPOSITORY" => nil
-    ) do
+  test "returns service unavailable when no version is requested and no stable version is configured" do
+    with_env("DEVOPSELLENCE_CLI_STABLE_VERSION" => nil) do
       get cli_download_path
     end
 
@@ -36,25 +31,23 @@ class CliDownloadsTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "cli binary unavailable"
   end
 
-  test "downloads explicit version from the configured fetcher" do
-    fetcher = FakeFetcher.new(result: FakeArtifact.new(body: "binary", filename: "devopsellence"))
+  test "redirects explicit version to the configured release asset url" do
+    fetcher = FakeFetcher.new(result: FakeArtifact.new(url: "https://github.com/devopsellence/devopsellence/releases/download/cli-v0.1.0/darwin-arm64", filename: "devopsellence"))
 
     with_cli_release_fetcher(fetcher) do
       get cli_download_path, params: { version: "v0.1.0", os: "darwin", arch: "arm64" }
     end
 
-    assert_response :success
-    assert_equal "binary", response.body
+    assert_response :redirect
+    assert_equal "https://github.com/devopsellence/devopsellence/releases/download/cli-v0.1.0/darwin-arm64", response.location
     assert_equal [{ version: "v0.1.0", os: "darwin", arch: "arm64" }], fetcher.calls
-    assert_equal "application/octet-stream", response.media_type
-    assert_match(/attachment/, response.headers["Content-Disposition"])
     assert_includes response.headers["Cache-Control"], "public"
     assert_includes response.headers["Cache-Control"], "max-age=31536000"
     assert_includes response.headers["Cache-Control"], "immutable"
   end
 
   test "redirects unversioned requests to the stable version without downloading" do
-    fetcher = FakeFetcher.new(result: FakeArtifact.new(body: "binary", filename: "devopsellence"))
+    fetcher = FakeFetcher.new(result: FakeArtifact.new(url: "https://example.test/unused", filename: "devopsellence"))
 
     with_env("DEVOPSELLENCE_CLI_STABLE_VERSION" => "v1.2.3") do
       with_cli_release_fetcher(fetcher) do

--- a/control-plane/test/integration/release_checksums_test.rb
+++ b/control-plane/test/integration/release_checksums_test.rb
@@ -3,7 +3,7 @@
 require "test_helper"
 
 class ReleaseChecksumsTest < ActionDispatch::IntegrationTest
-  FakeArtifact = Struct.new(:body, :filename, keyword_init: true)
+  FakeArtifact = Struct.new(:url, :filename, keyword_init: true)
 
   class FakeFetcher
     attr_reader :calls
@@ -20,7 +20,7 @@ class ReleaseChecksumsTest < ActionDispatch::IntegrationTest
   end
 
   test "cli checksums redirect unversioned requests to the stable version" do
-    fetcher = FakeFetcher.new(result: FakeArtifact.new(body: "checksums", filename: "SHA256SUMS"))
+    fetcher = FakeFetcher.new(result: FakeArtifact.new(url: "https://example.test/unused", filename: "SHA256SUMS"))
 
     with_env("DEVOPSELLENCE_CLI_STABLE_VERSION" => "v1.2.3") do
       with_cli_release_fetcher(fetcher) do
@@ -33,24 +33,23 @@ class ReleaseChecksumsTest < ActionDispatch::IntegrationTest
     assert_empty fetcher.calls
   end
 
-  test "cli checksums cache explicit version responses" do
-    fetcher = FakeFetcher.new(result: FakeArtifact.new(body: "checksums", filename: "SHA256SUMS"))
+  test "cli checksums redirect explicit version requests to the release asset url" do
+    fetcher = FakeFetcher.new(result: FakeArtifact.new(url: "https://github.com/devopsellence/devopsellence/releases/download/cli-v0.1.0/SHA256SUMS", filename: "SHA256SUMS"))
 
     with_cli_release_fetcher(fetcher) do
       get cli_checksums_path, params: { version: "v0.1.0" }
     end
 
-    assert_response :success
-    assert_equal "checksums", response.body
+    assert_response :redirect
+    assert_equal "https://github.com/devopsellence/devopsellence/releases/download/cli-v0.1.0/SHA256SUMS", response.location
     assert_equal [{ version: "v0.1.0" }], fetcher.calls
-    assert_equal "text/plain", response.media_type
     assert_includes response.headers["Cache-Control"], "public"
     assert_includes response.headers["Cache-Control"], "max-age=31536000"
     assert_includes response.headers["Cache-Control"], "immutable"
   end
 
   test "agent checksums redirect unversioned requests to the stable version" do
-    fetcher = FakeFetcher.new(result: FakeArtifact.new(body: "checksums", filename: "SHA256SUMS"))
+    fetcher = FakeFetcher.new(result: FakeArtifact.new(url: "https://example.test/unused", filename: "SHA256SUMS"))
 
     with_env("DEVOPSELLENCE_AGENT_STABLE_VERSION" => "v2.3.4") do
       with_agent_release_fetcher(fetcher) do
@@ -63,17 +62,16 @@ class ReleaseChecksumsTest < ActionDispatch::IntegrationTest
     assert_empty fetcher.calls
   end
 
-  test "agent checksums cache explicit version responses" do
-    fetcher = FakeFetcher.new(result: FakeArtifact.new(body: "checksums", filename: "SHA256SUMS"))
+  test "agent checksums redirect explicit version requests to the release asset url" do
+    fetcher = FakeFetcher.new(result: FakeArtifact.new(url: "https://github.com/devopsellence/devopsellence/releases/download/agent-v0.1.0/SHA256SUMS", filename: "SHA256SUMS"))
 
     with_agent_release_fetcher(fetcher) do
       get agent_checksums_path, params: { version: "v0.1.0" }
     end
 
-    assert_response :success
-    assert_equal "checksums", response.body
+    assert_response :redirect
+    assert_equal "https://github.com/devopsellence/devopsellence/releases/download/agent-v0.1.0/SHA256SUMS", response.location
     assert_equal [{ version: "v0.1.0" }], fetcher.calls
-    assert_equal "text/plain", response.media_type
     assert_includes response.headers["Cache-Control"], "public"
     assert_includes response.headers["Cache-Control"], "max-age=31536000"
     assert_includes response.headers["Cache-Control"], "immutable"

--- a/control-plane/test/lib/devopsellence/runtime_config_test.rb
+++ b/control-plane/test/lib/devopsellence/runtime_config_test.rb
@@ -37,8 +37,6 @@ module Devopsellence
         assert_equal "", config.cloudflare_zone_id
         assert_equal "devopsellence.io", config.cloudflare_zone_name
         assert_equal "http://devopsellence-envoy:8000", config.cloudflare_envoy_origin
-        assert_equal "devopsellence-agent", config.agent_release_package
-        assert_equal "devopsellence-cli", config.cli_release_package
         assert_equal "noreply@example.com", config.mail_from_address
         assert_equal "", config.activity_notification_to
       end

--- a/control-plane/test/services/cli_releases/fetcher_test.rb
+++ b/control-plane/test/services/cli_releases/fetcher_test.rb
@@ -2,20 +2,20 @@
 
 require "test_helper"
 
-module AgentReleases
+module CliReleases
   class FetcherTest < ActiveSupport::TestCase
     test "fetch builds a github release asset url" do
-      artifact = Fetcher.new.fetch(version: "v0.1.0", os: "linux", arch: "amd64")
+      artifact = Fetcher.new.fetch(version: "v0.1.0", os: "darwin", arch: "arm64")
 
-      assert_equal "https://github.com/devopsellence/devopsellence/releases/download/agent-v0.1.0/linux-amd64", artifact.url
-      assert_equal "devopsellence-agent", artifact.filename
-      assert_equal "linux-amd64", artifact.source_name
+      assert_equal "https://github.com/devopsellence/devopsellence/releases/download/cli-v0.1.0/darwin-arm64", artifact.url
+      assert_equal "devopsellence", artifact.filename
+      assert_equal "darwin-arm64", artifact.source_name
     end
 
     test "fetch_checksums builds a github release asset url" do
       artifact = Fetcher.new.fetch_checksums(version: "v0.1.0")
 
-      assert_equal "https://github.com/devopsellence/devopsellence/releases/download/agent-v0.1.0/SHA256SUMS", artifact.url
+      assert_equal "https://github.com/devopsellence/devopsellence/releases/download/cli-v0.1.0/SHA256SUMS", artifact.url
       assert_equal "SHA256SUMS", artifact.filename
     end
 

--- a/test/e2e/e2e.rb
+++ b/test/e2e/e2e.rb
@@ -1,7 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require "base64"
 require "digest"
 require "fileutils"
 require "json"
@@ -38,10 +37,7 @@ class E2E
   DEFAULT_ENVOY_IMAGE = "docker.io/envoyproxy/envoy@sha256:d9b4a70739d92b3e28cd407f106b0e90d55df453d7d87773efd22b4429777fe8"
   DEFAULT_RUNTIME_BACKEND = "standalone"
   RUNNER_IMAGE_FINGERPRINT_LABEL = "devopsellence.e2e.runner_fingerprint"
-  CLI_RELEASE_PROJECT = "devopsellence-e2e-cli"
-  AGENT_RELEASE_PROJECT = "devopsellence-e2e-agent"
   RELEASE_REGION = "local"
-  RELEASE_REPOSITORY = "devopsellence-releases"
   CONTROL_PLANE_PROJECT = "devopsellence-e2e-control-plane"
   RUNTIME_PROJECT = "devopsellence-e2e-runtime"
   RUNTIME_PROJECT_NUMBER = "123456789012"
@@ -141,7 +137,6 @@ class E2E
     step("postgres") { start_postgres! }
     step("registry") { start_registry! }
     step("gcp-mock") { start_gcp_mock! }
-    step("seed releases") { seed_release_artifacts! }
     step("control plane") { start_control_plane! }
     step("download endpoints") { assert_release_downloads! }
     step("auth token") { create_user_token! }
@@ -351,29 +346,6 @@ class E2E
       http_post_json("#{@host_gcp_mock_base_url}/__admin/reset", {})
     end
 
-    def seed_release_artifacts!
-      entries = []
-      seed_release_package!(entries, project_id: CLI_RELEASE_PROJECT, package: "devopsellence-cli", root: @cli_root)
-      seed_release_package!(entries, project_id: AGENT_RELEASE_PROJECT, package: "devopsellence-agent", root: @agent_root)
-      http_post_json("#{@host_gcp_mock_base_url}/__admin/seed/releases", { entries: entries })
-    end
-
-    def seed_release_package!(entries, project_id:, package:, root:)
-      dist_dir = root.join("dist", @release_version)
-      %w[linux-amd64 linux-arm64 darwin-amd64 darwin-arm64 SHA256SUMS].each do |name|
-        path = dist_dir.join(name)
-        entries << {
-          project_id: project_id,
-          location: RELEASE_REGION,
-          repository: RELEASE_REPOSITORY,
-          package: package,
-          version: @release_version,
-          source_name: name,
-          content_b64: Base64.strict_encode64(path.binread)
-        }
-      end
-    end
-
     def start_control_plane!
       run_runner!("bin/rails db:prepare", timeout: 300)
       start_runner_service(
@@ -408,10 +380,22 @@ class E2E
     end
 
     def assert_release_downloads!
-      assert_artifact_download!("/cli/download?version=#{@release_version}&os=linux&arch=amd64", @cli_root.join("dist", @release_version, "linux-amd64"))
-      assert_artifact_download!("/agent/download?version=#{@release_version}&os=linux&arch=amd64", @agent_root.join("dist", @release_version, "linux-amd64"))
-      assert_artifact_download!("/cli/checksums?version=#{@release_version}", @cli_root.join("dist", @release_version, "SHA256SUMS"))
-      assert_artifact_download!("/agent/checksums?version=#{@release_version}", @agent_root.join("dist", @release_version, "SHA256SUMS"))
+      assert_artifact_redirect!(
+        "/cli/download?version=#{@release_version}&os=linux&arch=amd64",
+        "https://github.com/devopsellence/devopsellence/releases/download/cli-#{@release_version}/linux-amd64"
+      )
+      assert_artifact_redirect!(
+        "/agent/download?version=#{@release_version}&os=linux&arch=amd64",
+        "https://github.com/devopsellence/devopsellence/releases/download/agent-#{@release_version}/linux-amd64"
+      )
+      assert_artifact_redirect!(
+        "/cli/checksums?version=#{@release_version}",
+        "https://github.com/devopsellence/devopsellence/releases/download/cli-#{@release_version}/SHA256SUMS"
+      )
+      assert_artifact_redirect!(
+        "/agent/checksums?version=#{@release_version}",
+        "https://github.com/devopsellence/devopsellence/releases/download/agent-#{@release_version}/SHA256SUMS"
+      )
     end
 
     def create_user_token!
@@ -629,8 +613,6 @@ class E2E
         raise "expected gcp-mock desired state write" unless events.any? { |entry| entry["type"] == "object_written" }
         http_post_json("#{@host_gcp_mock_base_url}/__admin/assert", { event_type: "access_token_generated", min_count: 1 })
       end
-
-      http_post_json("#{@host_gcp_mock_base_url}/__admin/assert", { event_type: "release_downloaded", min_count: 2 })
 
       assert_direct_dns_feature!
     end
@@ -925,13 +907,7 @@ class E2E
     def release_env
       {
         "DEVOPSELLENCE_AGENT_STABLE_VERSION" => @release_version,
-        "DEVOPSELLENCE_CLI_STABLE_VERSION" => @release_version,
-        "DEVOPSELLENCE_AGENT_RELEASE_PROJECT_ID" => AGENT_RELEASE_PROJECT,
-        "DEVOPSELLENCE_AGENT_RELEASE_REGION" => RELEASE_REGION,
-        "DEVOPSELLENCE_AGENT_RELEASE_REPOSITORY" => RELEASE_REPOSITORY,
-        "DEVOPSELLENCE_CLI_RELEASE_PROJECT_ID" => CLI_RELEASE_PROJECT,
-        "DEVOPSELLENCE_CLI_RELEASE_REGION" => RELEASE_REGION,
-        "DEVOPSELLENCE_CLI_RELEASE_REPOSITORY" => RELEASE_REPOSITORY
+        "DEVOPSELLENCE_CLI_STABLE_VERSION" => @release_version
       }
     end
 
@@ -997,11 +973,10 @@ class E2E
       @agent_root.join("dist", @release_version, "linux-amd64")
     end
 
-    def assert_artifact_download!(path, expected_path)
-      body = http_get("#{@host_control_plane_base_url}#{path}").fetch(:body)
-      actual_sha = Digest::SHA256.hexdigest(body)
-      expected_sha = Digest::SHA256.file(expected_path).hexdigest
-      raise "artifact digest mismatch for #{path}" unless actual_sha == expected_sha
+    def assert_artifact_redirect!(path, expected_location)
+      response = http_get("#{@host_control_plane_base_url}#{path}")
+      raise "expected redirect for #{path}, got #{response.fetch(:status)}" unless response.fetch(:status).between?(300, 399)
+      raise "redirect location mismatch for #{path}" unless response.fetch(:location) == expected_location
     end
 
     def public_probe_url(base_url)
@@ -1141,7 +1116,7 @@ class E2E
       uri = URI(url)
       request = Net::HTTP::Get.new(uri)
       response = http_request(uri, request)
-      { status: response.code.to_i, body: response.body.to_s }
+      { status: response.code.to_i, body: response.body.to_s, location: response["Location"].to_s }
     end
 
     def http_request(uri, request)


### PR DESCRIPTION
## Summary
- redirect agent/CLI binary and checksum endpoints to GitHub Release assets instead of streaming bytes from Rails
- remove obsolete GCP release-source runtime config
- update integration and hermetic e2e checks for redirect behavior

## Tests
- mise run test -- test/services/agent_releases/fetcher_test.rb test/services/cli_releases/fetcher_test.rb test/integration/agent_downloads_test.rb test/integration/cli_downloads_test.rb test/integration/release_checksums_test.rb test/integration/abuse_controls_test.rb test/lib/devopsellence/runtime_config_test.rb
- ruby -c test/e2e/e2e.rb