### PR TITLE
[codex] Allow removing customer-managed nodes

### DIFF
--- a/cli/internal/workflow/app.go
+++ b/cli/internal/workflow/app.go
@@ -1621,7 +1621,12 @@ func (a *App) NodeDelete(ctx context.Context, opts NodeDeleteOptions) error {
 	if a.Printer.JSON {
 		return a.Printer.PrintJSON(result)
 	}
-	a.Printer.Println("Delete requested for managed node #" + strconv.Itoa(intFromMap(result, "id")) + "; server scheduled for delete.")
+	if managed, _ := result["managed"].(bool); managed {
+		a.Printer.Println("Delete requested for managed node #" + strconv.Itoa(intFromMap(result, "id")) + "; server scheduled for delete.")
+		return nil
+	}
+	a.Printer.Println("Removed node #" + strconv.Itoa(intFromMap(result, "id")) + ".")
+	a.Printer.Println("If the agent is still installed, run `devopsellence-agent uninstall --purge-runtime` on the machine to clean it up.")
 	return nil
 }
 

--- a/cli/internal/workflow/management_test.go
+++ b/cli/internal/workflow/management_test.go
@@ -685,7 +685,7 @@ func TestNodeDeleteDeletesUnassignedManagedNode(t *testing.T) {
 	app := newTestApp(t, root, roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		switch {
 		case r.Method == http.MethodDelete && r.URL.Path == "/api/v1/cli/nodes/55":
-			return jsonResponse(t, map[string]any{"id": 55, "revoked_at": "2026-04-08T12:00:00Z"}), nil
+			return jsonResponse(t, map[string]any{"id": 55, "managed": true, "revoked_at": "2026-04-08T12:00:00Z"}), nil
 		default:
 			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
 			return nil, nil
@@ -696,6 +696,32 @@ func TestNodeDeleteDeletesUnassignedManagedNode(t *testing.T) {
 		t.Fatalf("NodeDelete() error = %v", err)
 	}
 	if !strings.Contains(stdout.String(), "Delete requested for managed node #55; server scheduled for delete.") {
+		t.Fatalf("NodeDelete() output = %q", stdout.String())
+	}
+}
+
+func TestNodeDeleteDeletesUnassignedCustomerManagedNode(t *testing.T) {
+	t.Parallel()
+
+	root := makeRailsRoot(t, "ShopApp")
+	var stdout bytes.Buffer
+	app := newTestApp(t, root, roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		switch {
+		case r.Method == http.MethodDelete && r.URL.Path == "/api/v1/cli/nodes/55":
+			return jsonResponse(t, map[string]any{"id": 55, "managed": false, "revoked_at": "2026-04-08T12:00:00Z"}), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+			return nil, nil
+		}
+	}))
+	app.Printer.Out = &stdout
+	if err := app.NodeDelete(context.Background(), NodeDeleteOptions{NodeID: 55}); err != nil {
+		t.Fatalf("NodeDelete() error = %v", err)
+	}
+	if !strings.Contains(stdout.String(), "Removed node #55.") {
+		t.Fatalf("NodeDelete() output = %q", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "devopsellence-agent uninstall --purge-runtime") {
 		t.Fatalf("NodeDelete() output = %q", stdout.String())
 	}
 }

--- a/control-plane/app/controllers/api/v1/cli/nodes_controller.rb
+++ b/control-plane/app/controllers/api/v1/cli/nodes_controller.rb
@@ -54,29 +54,29 @@ module Api
             .find_by(id: params[:id])
           return render_error("forbidden", "owner role required", status: :forbidden) unless node
           return render_error("forbidden", "manual node management is unavailable for trial organizations", status: :forbidden) if node.organization&.trial?
-          unless node.managed?
-            return render_error(
-              "invalid_request",
-              "node remove is unsupported for customer-managed nodes; use node detach, then run devopsellence-agent uninstall --purge-runtime on the machine",
-              status: :unprocessable_entity
-            )
-          end
+          organization_id = node.organization_id
+          managed = node.managed?
           if node.environment_id.present?
             return render_error(
               "invalid_request",
-              "node remove requires an unassigned managed node; use node detach first",
+              "node remove requires an unassigned node; use node detach first",
               status: :unprocessable_entity
             )
           end
 
-          result = Nodes::Cleanup.new(node: node).call
+          result = if managed
+            Nodes::Cleanup.new(node: node).call
+          else
+            Nodes::Retire.new(node: node).call
+          end
 
           render json: {
             id: node.id,
-            organization_id: node.organization_id,
-            environment_id: result.environment&.id,
-            desired_state_uri: result.desired_state&.uri,
-            revoked_at: node.revoked_at&.utc&.iso8601
+            organization_id: organization_id,
+            environment_id: result.respond_to?(:environment) ? result.environment&.id : nil,
+            desired_state_uri: result.respond_to?(:desired_state) ? result.desired_state&.uri : nil,
+            revoked_at: (result.respond_to?(:revoked_at) ? result.revoked_at : node.revoked_at)&.utc&.iso8601,
+            managed: managed
           }
         end
 

--- a/control-plane/app/services/nodes/retire.rb
+++ b/control-plane/app/services/nodes/retire.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Nodes
+  class Retire
+    Result = Struct.new(:node, :revoked_at, keyword_init: true)
+
+    def initialize(node:, revoked_at: Time.current, broker: nil, logger: Rails.logger)
+      @node = node
+      @revoked_at = revoked_at
+      @broker = broker
+      @logger = logger
+    end
+
+    def call
+      node_bundle = nil
+
+      Node.transaction do
+        node.lock!
+        node_bundle = node.node_bundle
+        node.update!(
+          environment: nil,
+          organization: nil,
+          node_bundle: nil,
+          desired_state_bucket: "",
+          desired_state_object_path: "",
+          lease_expires_at: nil,
+          revoked_at: revoked_at,
+          access_expires_at: revoked_at,
+          refresh_expires_at: revoked_at
+        )
+      end
+
+      revoke_bundle_impersonation!(node_bundle) if node_bundle
+      node_bundle&.destroy!
+      node.destroy!
+      Runtime::EnsureBundles.enqueue if node_bundle
+
+      Result.new(node:, revoked_at:)
+    end
+
+    private
+
+    attr_reader :node, :revoked_at, :logger
+
+    def broker
+      @broker ||= Runtime::Broker.current
+    end
+
+    def revoke_bundle_impersonation!(bundle)
+      broker.revoke_node_bundle_impersonation!(bundle:)
+    rescue StandardError => error
+      logger.warn("[nodes/retire] bundle impersonation revocation failed: #{error.message}")
+    end
+  end
+end

--- a/control-plane/test/integration/api_cli_mvp_test.rb
+++ b/control-plane/test/integration/api_cli_mvp_test.rb
@@ -981,7 +981,7 @@ class ApiCliMvpTest < ActionDispatch::IntegrationTest
     assert_equal %w[web worker], node.reload.labels
   end
 
-  test "legacy node delete rejects customer-managed nodes through the cli api" do
+  test "node delete rejects assigned customer-managed nodes through the cli api" do
     user = User.create!(email: "owner-#{SecureRandom.hex(4)}@example.com", confirmed_at: Time.current)
     organization = Organization.create!(name: "acme")
     OrganizationMembership.create!(organization: organization, user: user, role: OrganizationMembership::ROLE_OWNER)
@@ -1013,7 +1013,7 @@ class ApiCliMvpTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :unprocessable_entity
-    assert_equal "node remove is unsupported for customer-managed nodes; use node detach, then run devopsellence-agent uninstall --purge-runtime on the machine", json_body.fetch("error_description")
+    assert_equal "node remove requires an unassigned node; use node detach first", json_body.fetch("error_description")
     assert_equal environment.id, node.reload.environment_id
     assert_nil node.revoked_at
   end
@@ -1048,9 +1048,33 @@ class ApiCliMvpTest < ActionDispatch::IntegrationTest
       as: :json
 
     assert_response :unprocessable_entity
-    assert_equal "node remove requires an unassigned managed node; use node detach first", json_body.fetch("error_description")
+    assert_equal "node remove requires an unassigned node; use node detach first", json_body.fetch("error_description")
     assert_equal environment.id, node.reload.environment_id
     assert_nil node.revoked_at
+  end
+
+  test "node delete retires an unassigned customer-managed node through the cli api" do
+    user = User.create!(email: "owner-#{SecureRandom.hex(4)}@example.com", confirmed_at: Time.current)
+    organization = Organization.create!(name: "acme")
+    OrganizationMembership.create!(organization: organization, user: user, role: OrganizationMembership::ROLE_OWNER)
+    ensure_test_organization_runtime!(organization)
+    node, = issue_test_node!(organization: organization, name: "dev-laptop")
+    fake_broker = mock("broker")
+    fake_broker.stubs(:revoke_node_bundle_impersonation!).returns(
+      Runtime::Broker::LocalClient::Result.new(status: :ready, message: nil)
+    )
+    Runtime::Broker.stubs(:current).returns(fake_broker)
+
+    delete "/api/v1/cli/nodes/#{node.id}",
+      headers: auth_headers_for(user),
+      as: :json
+
+    assert_response :success
+    assert_equal node.id, json_body.fetch("id")
+    assert_equal false, json_body.fetch("managed")
+    assert_nil json_body["environment_id"]
+    assert_not_nil json_body.fetch("revoked_at")
+    assert_not Node.exists?(node.id)
   end
 
   test "node delete retires an unassigned managed node through the cli api" do
@@ -1081,6 +1105,7 @@ class ApiCliMvpTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_equal node.id, json_body.fetch("id")
+    assert_equal true, json_body.fetch("managed")
     assert_nil json_body["environment_id"]
     assert_not_nil json_body.fetch("revoked_at")
     assert_not_nil node.reload.revoked_at

--- a/control-plane/test/services/nodes/retire_test.rb
+++ b/control-plane/test/services/nodes/retire_test.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class NodesRetireTest < ActiveSupport::TestCase
+  test "retires customer-managed node and destroys claimed node bundle" do
+    organization = Organization.create!(name: "org-#{SecureRandom.hex(3)}")
+    ensure_test_organization_runtime!(organization)
+    project = organization.projects.create!(name: "Project A")
+    environment = project.environments.create!(
+      name: "production",
+      gcp_project_id: organization.gcp_project_id,
+      gcp_project_number: organization.gcp_project_number,
+      workload_identity_pool: organization.workload_identity_pool,
+      workload_identity_provider: organization.workload_identity_provider,
+      service_account_email: "env@#{organization.gcp_project_id}.iam.gserviceaccount.com"
+    )
+    environment_bundle = ensure_test_environment_bundle!(environment)
+    node_bundle = NodeBundle.create!(
+      runtime_project: environment_bundle.runtime_project,
+      organization_bundle: environment_bundle.organization_bundle,
+      environment_bundle: environment_bundle,
+      node: nil,
+      status: NodeBundle::STATUS_CLAIMED
+    )
+    node, = issue_test_node!(organization: organization, name: "node-a")
+    node.update!(
+      node_bundle: node_bundle,
+      desired_state_bucket: node_bundle.desired_state_bucket,
+      desired_state_object_path: node_bundle.desired_state_object_path
+    )
+    node_bundle.update!(node: node)
+    revoked_at = Time.utc(2026, 4, 9, 12, 0, 0)
+
+    result = Nodes::Retire.new(node: node, revoked_at: revoked_at, broker: fake_broker).call
+
+    assert_equal revoked_at, result.revoked_at
+    assert_not Node.exists?(node.id)
+    assert_not NodeBundle.exists?(node_bundle.id)
+  end
+
+  test "retires customer-managed node without resolving broker when no bundle is claimed" do
+    organization = Organization.create!(name: "org-#{SecureRandom.hex(3)}")
+    node, = issue_test_node!(organization: organization, name: "node-a")
+    Runtime::Broker.expects(:current).never
+
+    Nodes::Retire.new(node: node).call
+
+    assert_not Node.exists?(node.id)
+  end
+
+  private
+
+  def fake_broker
+    mock("broker").tap do |broker|
+      broker.stubs(:revoke_node_bundle_impersonation!).returns(
+        Runtime::Broker::LocalClient::Result.new(status: :ready, message: nil)
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Allow `devopsellence node remove` to retire unassigned customer-managed nodes instead of rejecting them.
- Add `Nodes::Retire` to revoke node credentials, detach any claimed bundle, revoke bundle impersonation, destroy the bundle, and remove the node record.
- Preserve managed-node behavior by continuing to schedule managed server deletion, and return a `managed` flag so the CLI can print the right cleanup guidance.

## Why

Customer-managed nodes could be detached but not removed through the CLI API. That left stale unassigned node records after users removed the local agent runtime themselves.

## Validation

- `mise run test -- ./internal/workflow` from `cli/`
- `mise run test -- test/services/nodes/retire_test.rb test/integration/api_cli_mvp_test.rb` from `control-plane/`
- `git diff --check -- . ':(exclude)AGENTS.md' ':(exclude)**/AGENTS.md'`