### PR TITLE
[codex] Fix Dependabot auto merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -10,53 +10,97 @@ on:
       - e2e-solo
     types:
       - completed
+  schedule:
+    - cron: "17 * * * *"
+  workflow_dispatch:
 
 permissions:
   actions: read
+  checks: read
   contents: write
   pull-requests: write
 
 jobs:
   merge:
-    if: github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Merge passing Dependabot PR
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.DEPENDABOT_AUTOMERGE_TOKEN || github.token }}
           REPO: ${{ github.repository }}
-          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          EVENT_NAME: ${{ github.event_name }}
+          WORKFLOW_RUN_EVENT: ${{ github.event.workflow_run.event }}
+          WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          WORKFLOW_RUN_PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
         run: |
           set -euo pipefail
 
-          if [[ -z "${PR_NUMBER:-}" || "${PR_NUMBER}" == "null" ]]; then
-            echo "No associated pull request for workflow run"
+          if [[ "$EVENT_NAME" == "workflow_run" && "$WORKFLOW_RUN_EVENT" != "pull_request" ]]; then
+            echo "Workflow run was not for a pull request"
             exit 0
           fi
 
-          pr_state="$(gh pr view "$PR_NUMBER" --repo "$REPO" --json author,state,isDraft --jq '.author.login + ":" + .state + ":" + (.isDraft | tostring)')"
-          if [[ "${pr_state}" != "app/dependabot:OPEN:false" ]]; then
-            echo "PR #${PR_NUMBER} is not an open Dependabot PR"
-            exit 0
+          merge_pr() {
+            local pr_number="$1"
+            local expected_head_sha="${2:-}"
+
+            if [[ -z "$pr_number" || "$pr_number" == "null" ]]; then
+              echo "No associated pull request"
+              return 0
+            fi
+
+            pr_json="$(gh pr view "$pr_number" --repo "$REPO" --json author,headRefOid,isDraft,reviewDecision,state)"
+            pr_state="$(echo "$pr_json" | jq -r '.author.login + ":" + .state + ":" + (.isDraft | tostring)')"
+            if [[ "$pr_state" != "app/dependabot:OPEN:false" ]]; then
+              echo "PR #${pr_number} is not an open Dependabot PR"
+              return 0
+            fi
+
+            head_sha="$(echo "$pr_json" | jq -r '.headRefOid')"
+            if [[ -n "$expected_head_sha" && "$expected_head_sha" != "null" && "$expected_head_sha" != "$head_sha" ]]; then
+              echo "PR #${pr_number} head changed; skipping stale workflow run"
+              return 0
+            fi
+
+            set +e
+            checks_json="$(gh pr checks "$pr_number" --repo "$REPO" --json bucket,link,name,workflow)"
+            checks_status="$?"
+            set -e
+            if [[ -z "$checks_json" ]]; then
+              return "$checks_status"
+            fi
+
+            ci_checks="$(echo "$checks_json" | jq '[.[] | select(.workflow != "Dependabot Auto Merge")]')"
+            ci_count="$(echo "$ci_checks" | jq 'length')"
+
+            if [[ "$ci_count" -eq 0 ]]; then
+              echo "No CI checks found for Dependabot PR #${pr_number}"
+              return 0
+            fi
+
+            blocking_checks="$(echo "$ci_checks" | jq -r '.[] | select(.bucket == "pending" or .bucket == "fail" or .bucket == "cancel") | "\(.workflow) / \(.name): \(.bucket): \(.link)"')"
+            if [[ -n "${blocking_checks}" ]]; then
+              echo "CI not ready for PR #${pr_number}:"
+              echo "${blocking_checks}"
+              return 0
+            fi
+
+            review_decision="$(echo "$pr_json" | jq -r '.reviewDecision')"
+            if [[ "$review_decision" != "APPROVED" ]]; then
+              if ! gh pr review "$pr_number" --repo "$REPO" --approve --body "Approving Dependabot PR after successful CI."; then
+                echo "::error::Could not approve Dependabot PR. Enable GitHub Actions PR approvals, or set DEPENDABOT_AUTOMERGE_TOKEN to a bot/user token with pull request write access."
+                return 1
+              fi
+            fi
+
+            gh pr merge "$pr_number" --repo "$REPO" --squash --delete-branch --match-head-commit "$head_sha"
+          }
+
+          if [[ "$EVENT_NAME" == "workflow_run" ]]; then
+            merge_pr "$WORKFLOW_RUN_PR_NUMBER" "$WORKFLOW_RUN_HEAD_SHA"
+          else
+            gh pr list --repo "$REPO" --state open --app dependabot --json headRefOid,number --jq '.[] | "\(.number) \(.headRefOid)"' |
+              while read -r pr_number head_sha; do
+                merge_pr "$pr_number" "$head_sha"
+              done
           fi
-
-          runs_json="$(gh run list --repo "$REPO" --commit "$HEAD_SHA" --limit 50 --json workflowName,event,status,conclusion,url)"
-          latest_runs="$(echo "$runs_json" | jq 'reduce [.[] | select(.event == "pull_request")][] as $run ({}; if has($run.workflowName) then . else . + {($run.workflowName): $run} end)')"
-          relevant_runs="$(echo "$latest_runs" | jq 'to_entries | map(select(.key as $name | ["Agent CI", "CLI CI", "Control Plane CI", "e2e-shared", "e2e-solo"] | index($name)))')"
-          relevant_count="$(echo "$relevant_runs" | jq 'length')"
-
-          if [[ "$relevant_count" -eq 0 ]]; then
-            echo "No relevant CI workflows found for ${HEAD_SHA}"
-            exit 0
-          fi
-
-          blocking_runs="$(echo "$relevant_runs" | jq -r '.[] | select(.value.status != "completed" or .value.conclusion != "success") | "\(.key):\(.value.status):\(.value.conclusion // "pending"):\(.value.url)"')"
-          if [[ -n "${blocking_runs}" ]]; then
-            echo "CI not ready for merge:"
-            echo "${blocking_runs}"
-            exit 0
-          fi
-
-          gh pr review "$PR_NUMBER" --repo "$REPO" --approve --body "Approving Dependabot PR after successful CI." || true
-          gh pr merge "$PR_NUMBER" --repo "$REPO" --squash --delete-branch


### PR DESCRIPTION
## Summary
- wait on pull request checks instead of workflow-run lookup
- add hourly/manual sweep for already-green Dependabot PRs
- use DEPENDABOT_AUTOMERGE_TOKEN when configured, with a clear failure if approvals are blocked
- guard merges with the current head SHA

## Root cause
The workflow tried to approve Dependabot PRs with GITHUB_TOKEN, but org settings currently block GitHub Actions from creating PR approvals while master requires one approving review.

## Validation
- ruby YAML parse for dependabot-auto-merge.yml
- bash -n on embedded workflow script
- git diff --check

## Follow-up
To make auto-merge complete after this lands, either enable Actions PR approvals at the org level or set DEPENDABOT_AUTOMERGE_TOKEN to a bot/user token with pull request write access.