### PR TITLE
[codex] Tolerate unmergeable Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -93,7 +93,11 @@ jobs:
               fi
             fi
 
-            gh pr merge "$pr_number" --repo "$REPO" --squash --delete-branch --match-head-commit "$head_sha"
+            echo "Merging Dependabot PR #${pr_number}"
+            if ! gh pr merge "$pr_number" --repo "$REPO" --squash --delete-branch --match-head-commit "$head_sha"; then
+              echo "::warning::Dependabot PR #${pr_number} passed CI but is not mergeable. It may need a rebase or conflict resolution."
+              return 0
+            fi
           }
 
           if [[ "$EVENT_NAME" == "workflow_run" ]]; then


### PR DESCRIPTION
## Summary
- log the Dependabot PR number before merge attempts
- treat a passed-but-unmergeable Dependabot PR as a warning instead of failing the whole sweep

## Why
The first manual sweep merged five green Dependabot PRs, then failed on PR #1 because it became conflicted after another CLI dependency PR landed. Future sweeps should keep working and leave conflicted PRs for Dependabot rebase or manual resolution.

## Validation
- ruby YAML parse for dependabot-auto-merge.yml
- bash -n on embedded workflow script
- git diff --check