### PR TITLE
[codex] fix project deletion bundles

### DIFF
--- a/control-plane/app/controllers/api/v1/cli/projects_controller.rb
+++ b/control-plane/app/controllers/api/v1/cli/projects_controller.rb
@@ -39,6 +39,10 @@ module Api
           project = owner_project(params[:id])
           return render_error("forbidden", "owner role required", status: :forbidden) unless project
 
+          project.environments.find_each do |environment|
+            Environments::Delete.new(environment:).call
+          end
+
           unless project.destroy
             return render_error("invalid_request", project.errors.full_messages.to_sentence, status: :unprocessable_entity)
           end

--- a/control-plane/test/integration/api_cli_mvp_test.rb
+++ b/control-plane/test/integration/api_cli_mvp_test.rb
@@ -105,9 +105,10 @@ class ApiCliMvpTest < ActionDispatch::IntegrationTest
     organization = Organization.create!(name: "alpha")
     OrganizationMembership.create!(organization: organization, user: user, role: OrganizationMembership::ROLE_OWNER)
     project = organization.projects.create!(name: "ShopApp")
-    project.environments.create!(name: "production")
+    environment = project.environments.create!(name: "production")
+    environment_bundle = ensure_test_environment_bundle!(environment)
 
-    assert_difference("Project.count", -1) do
+    assert_difference(["Project.count", "Environment.count", "EnvironmentBundle.count"], -1) do
       delete "/api/v1/cli/projects/#{project.id}",
         headers: auth_headers_for(user),
         as: :json
@@ -116,6 +117,7 @@ class ApiCliMvpTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_equal true, json_body.fetch("deleted")
     assert_equal "ShopApp", json_body.fetch("name")
+    assert_not EnvironmentBundle.exists?(environment_bundle.id)
   end
 
   test "owner can create a project through the cli api" do


### PR DESCRIPTION
## Summary

Project deletion now tears down each environment through the existing `Environments::Delete` flow before destroying the project. That clears and destroys claimed environment bundles, avoiding the foreign key violation from `environment_bundles.claimed_by_environment_id`.

The CLI integration regression now deletes a project with a claimed environment bundle and asserts the project, environment, and bundle are removed.

## Impact

`devopsellence context project delete` can remove projects that have managed runtime environments without leaving bundle references behind or returning a 500.

## Validation

- `mise run test -- test/integration/api_cli_mvp_test.rb -n '/owner can delete a project through the cli api/'`
- `mise run test -- test/integration/api_cli_mvp_test.rb`