### PR TITLE
[codex] Add Hetzner solo node provisioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,17 @@ Choose the workspace mode once:
 devopsellence mode use solo
 ```
 
-Prepare the app, connect a server, and install the agent:
+Prepare the app, connect a node, and install the agent:
 
 ```bash
+devopsellence provider login hetzner
 devopsellence setup
+```
+
+Or create a Hetzner-backed solo node directly:
+
+```bash
+devopsellence node create prod-1 --provider hetzner
 ```
 
 Deploy over SSH:

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ devopsellence provider login hetzner
 devopsellence setup
 ```
 
-Or create a Hetzner-backed solo node directly:
+Or create a Hetzner-backed node directly:
 
 ```bash
 devopsellence node create prod-1 --provider hetzner
@@ -68,12 +68,15 @@ When you want sign-in, teams, org/project/env context, hosted deploy APIs, or ma
 ```bash
 devopsellence mode use shared
 devopsellence setup
+devopsellence provider login hetzner
+devopsellence node create prod-1 --provider hetzner
 devopsellence deploy
 devopsellence status
 devopsellence open
 ```
 
 The root verbs stay the same. The selected workspace mode decides how they behave.
+In shared mode, `node create` provisions the server and runs the registration install command.
 
 ### Example config
 

--- a/cli/internal/agentsmd/agentsmd.go
+++ b/cli/internal/agentsmd/agentsmd.go
@@ -77,12 +77,13 @@ Shared mode secrets:
 - `+"`printf '%%s' \"$VALUE\" | devopsellence secret set NAME --service web --stdin`"+`
 - `+"`devopsellence secret delete NAME --service web`"+`
 
-Solo mode:
-- `+"`devopsellence mode use solo`"+`
-- `+"`devopsellence secret set NAME --value ...`"+`
-- `+"`devopsellence node list`"+`
-- `+"`devopsellence node logs NODE --follow`"+`
-- `+"`devopsellence server create prod-1 --install`"+`
+	Solo mode:
+	- `+"`devopsellence mode use solo`"+`
+	- `+"`devopsellence provider login hetzner`"+`
+	- `+"`devopsellence secret set NAME --value ...`"+`
+	- `+"`devopsellence node list`"+`
+	- `+"`devopsellence node logs NODE --follow`"+`
+	- `+"`devopsellence node create prod-1`"+`
 
 Shared mode:
 - `+"`devopsellence mode use shared`"+`

--- a/cli/internal/agentsmd/agentsmd.go
+++ b/cli/internal/agentsmd/agentsmd.go
@@ -87,6 +87,8 @@ Shared mode secrets:
 
 Shared mode:
 - `+"`devopsellence mode use shared`"+`
+- `+"`devopsellence provider login hetzner`"+`
+- `+"`devopsellence node create prod-1`"+`
 - `+"`devopsellence deploy --image registry.example.com/app@sha256:...`"+`
 - `+"`devopsellence node register`"+`
 - `+"`devopsellence node list`"+`

--- a/cli/internal/direct/providers/hetzner.go
+++ b/cli/internal/direct/providers/hetzner.go
@@ -12,8 +12,10 @@ import (
 )
 
 const (
-	hetznerAPIBaseURL   = "https://api.hetzner.cloud/v1"
-	defaultHetznerImage = "ubuntu-24.04"
+	hetznerAPIBaseURL       = "https://api.hetzner.cloud/v1"
+	defaultHetznerImage     = "ubuntu-24.04"
+	defaultHetznerFirewall  = "devopsellence-solo"
+	devopsellenceManagedKey = "devopsellence_managed"
 )
 
 type Hetzner struct {
@@ -23,11 +25,32 @@ type Hetzner struct {
 }
 
 func NewHetznerFromEnv() *Hetzner {
+	return NewHetzner("")
+}
+
+func NewHetzner(token string) *Hetzner {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		token = firstEnv("DEVOPSELLENCE_HETZNER_API_TOKEN", "HCLOUD_TOKEN")
+	}
 	return &Hetzner{
 		baseURL: hetznerAPIBaseURL,
-		token:   firstEnv("DEVOPSELLENCE_HETZNER_API_TOKEN", "HCLOUD_TOKEN"),
+		token:   token,
 		client:  http.DefaultClient,
 	}
+}
+
+func (h *Hetzner) Validate(ctx context.Context) error {
+	if err := h.ensureConfigured(); err != nil {
+		return err
+	}
+	var body struct {
+		Locations []map[string]any `json:"locations"`
+	}
+	if err := h.doJSON(ctx, http.MethodGet, "/locations", nil, &body); err != nil {
+		return fmt.Errorf("validate hetzner token: %w", err)
+	}
+	return nil
 }
 
 func (h *Hetzner) CreateServer(ctx context.Context, input CreateServerInput) (Server, error) {
@@ -42,15 +65,29 @@ func (h *Hetzner) CreateServer(ctx context.Context, input CreateServerInput) (Se
 			return Server{}, err
 		}
 	}
+	firewallID, err := h.ensureFirewall(ctx)
+	if err != nil {
+		return Server{}, err
+	}
 	image := strings.TrimSpace(input.Image)
 	if image == "" {
 		image = defaultHetznerImage
+	}
+	labels := map[string]string{
+		devopsellenceManagedKey: "true",
+		"devopsellence_node":    input.Name,
+	}
+	for key, value := range input.Labels {
+		if strings.TrimSpace(key) != "" && strings.TrimSpace(value) != "" {
+			labels[key] = value
+		}
 	}
 	payload := map[string]any{
 		"name":        input.Name,
 		"server_type": input.Size,
 		"location":    input.Region,
 		"image":       image,
+		"labels":      labels,
 		"public_net": map[string]bool{
 			"ipv4_enabled": true,
 			"ipv6_enabled": true,
@@ -58,6 +95,9 @@ func (h *Hetzner) CreateServer(ctx context.Context, input CreateServerInput) (Se
 	}
 	if sshKeyName != "" {
 		payload["ssh_keys"] = []string{sshKeyName}
+	}
+	if firewallID != nil {
+		payload["firewalls"] = []map[string]any{{"firewall": firewallID}}
 	}
 	var body struct {
 		Server map[string]any `json:"server"`
@@ -94,7 +134,7 @@ func (h *Hetzner) Ready(server Server) bool {
 
 func (h *Hetzner) ensureConfigured() error {
 	if strings.TrimSpace(h.token) == "" {
-		return fmt.Errorf("configure DEVOPSELLENCE_HETZNER_API_TOKEN or HCLOUD_TOKEN for direct Hetzner servers")
+		return fmt.Errorf("run `devopsellence provider login hetzner` or configure DEVOPSELLENCE_HETZNER_API_TOKEN/HCLOUD_TOKEN for Hetzner servers")
 	}
 	return nil
 }
@@ -122,6 +162,47 @@ func (h *Hetzner) ensureSSHKey(ctx context.Context, nodeName, publicKey string) 
 		return "", err
 	}
 	return fmt.Sprint(created.SSHKey["name"]), nil
+}
+
+func (h *Hetzner) ensureFirewall(ctx context.Context) (any, error) {
+	var list struct {
+		Firewalls []map[string]any `json:"firewalls"`
+	}
+	if err := h.doJSON(ctx, http.MethodGet, "/firewalls?name="+defaultHetznerFirewall, nil, &list); err != nil {
+		return "", err
+	}
+	for _, firewall := range list.Firewalls {
+		if fmt.Sprint(firewall["name"]) == defaultHetznerFirewall {
+			return firewall["id"], nil
+		}
+	}
+	var created struct {
+		Firewall map[string]any `json:"firewall"`
+	}
+	payload := map[string]any{
+		"name": defaultHetznerFirewall,
+		"labels": map[string]string{
+			devopsellenceManagedKey: "true",
+		},
+		"rules": []map[string]any{
+			hetznerFirewallRule("22"),
+			hetznerFirewallRule("80"),
+			hetznerFirewallRule("443"),
+		},
+	}
+	if err := h.doJSON(ctx, http.MethodPost, "/firewalls", payload, &created); err != nil {
+		return "", err
+	}
+	return created.Firewall["id"], nil
+}
+
+func hetznerFirewallRule(port string) map[string]any {
+	return map[string]any{
+		"direction":  "in",
+		"protocol":   "tcp",
+		"port":       port,
+		"source_ips": []string{"0.0.0.0/0", "::/0"},
+	}
 }
 
 func (h *Hetzner) doJSON(ctx context.Context, method, path string, payload any, out any) error {

--- a/cli/internal/direct/providers/hetzner.go
+++ b/cli/internal/direct/providers/hetzner.go
@@ -3,6 +3,8 @@ package providers
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -60,7 +62,7 @@ func (h *Hetzner) CreateServer(ctx context.Context, input CreateServerInput) (Se
 	sshKeyName := ""
 	if strings.TrimSpace(input.SSHPublicKey) != "" {
 		var err error
-		sshKeyName, err = h.ensureSSHKey(ctx, input.Name, input.SSHPublicKey)
+		sshKeyName, err = h.ensureSSHKey(ctx, input.SSHPublicKey)
 		if err != nil {
 			return Server{}, err
 		}
@@ -139,8 +141,9 @@ func (h *Hetzner) ensureConfigured() error {
 	return nil
 }
 
-func (h *Hetzner) ensureSSHKey(ctx context.Context, nodeName, publicKey string) (string, error) {
-	name := "devopsellence-" + nodeName
+func (h *Hetzner) ensureSSHKey(ctx context.Context, publicKey string) (string, error) {
+	name := contentAddressedSSHKeyName(publicKey)
+	normalizedPublicKey := canonicalSSHPublicKey(publicKey)
 	var list struct {
 		SSHKeys []map[string]any `json:"ssh_keys"`
 	}
@@ -149,6 +152,9 @@ func (h *Hetzner) ensureSSHKey(ctx context.Context, nodeName, publicKey string) 
 	}
 	for _, key := range list.SSHKeys {
 		if fmt.Sprint(key["name"]) == name {
+			if canonicalSSHPublicKey(fmt.Sprint(key["public_key"])) != normalizedPublicKey {
+				return "", fmt.Errorf("Hetzner SSH key %q exists with different public key content", name)
+			}
 			return name, nil
 		}
 	}
@@ -157,11 +163,24 @@ func (h *Hetzner) ensureSSHKey(ctx context.Context, nodeName, publicKey string) 
 	}
 	if err := h.doJSON(ctx, http.MethodPost, "/ssh_keys", map[string]any{
 		"name":       name,
-		"public_key": publicKey,
+		"public_key": normalizedPublicKey,
 	}, &created); err != nil {
 		return "", err
 	}
 	return fmt.Sprint(created.SSHKey["name"]), nil
+}
+
+func contentAddressedSSHKeyName(publicKey string) string {
+	sum := sha256.Sum256([]byte(canonicalSSHPublicKey(publicKey)))
+	return "devopsellence-ssh-" + hex.EncodeToString(sum[:])[:16]
+}
+
+func canonicalSSHPublicKey(publicKey string) string {
+	fields := strings.Fields(publicKey)
+	if len(fields) >= 2 {
+		return fields[0] + " " + fields[1]
+	}
+	return strings.TrimSpace(publicKey)
 }
 
 func (h *Hetzner) ensureFirewall(ctx context.Context) (any, error) {

--- a/cli/internal/direct/providers/hetzner_test.go
+++ b/cli/internal/direct/providers/hetzner_test.go
@@ -12,12 +12,17 @@ import (
 func TestHetznerCreateServer(t *testing.T) {
 	var createPayload map[string]any
 	var firewallPayload map[string]any
+	var sshKeyPayload map[string]any
+	sshKeyName := contentAddressedSSHKeyName("ssh-ed25519 abc")
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/ssh_keys":
 			_ = json.NewEncoder(w).Encode(map[string]any{"ssh_keys": []map[string]any{}})
 		case r.Method == http.MethodPost && r.URL.Path == "/ssh_keys":
-			_ = json.NewEncoder(w).Encode(map[string]any{"ssh_key": map[string]any{"name": "devopsellence-prod-1"}})
+			if err := json.NewDecoder(r.Body).Decode(&sshKeyPayload); err != nil {
+				t.Fatal(err)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"ssh_key": map[string]any{"name": sshKeyName}})
 		case r.Method == http.MethodGet && r.URL.Path == "/firewalls":
 			if r.URL.Query().Get("name") != defaultHetznerFirewall {
 				t.Fatalf("firewall name query = %q", r.URL.RawQuery)
@@ -79,8 +84,71 @@ func TestHetznerCreateServer(t *testing.T) {
 		t.Fatalf("labels = %#v", labels)
 	}
 	keys := createPayload["ssh_keys"].([]any)
-	if len(keys) != 1 || keys[0] != "devopsellence-prod-1" {
+	if len(keys) != 1 || keys[0] != sshKeyName {
 		t.Fatalf("ssh_keys = %#v", keys)
+	}
+	if sshKeyPayload["name"] != sshKeyName || sshKeyPayload["public_key"] != "ssh-ed25519 abc" {
+		t.Fatalf("ssh key payload = %#v", sshKeyPayload)
+	}
+}
+
+func TestHetznerSSHKeyNameIgnoresComment(t *testing.T) {
+	withComment := contentAddressedSSHKeyName("ssh-ed25519 abc alice@example")
+	withoutComment := contentAddressedSSHKeyName("ssh-ed25519 abc")
+	if withComment != withoutComment {
+		t.Fatalf("key name with comment = %q, without = %q", withComment, withoutComment)
+	}
+}
+
+func TestHetznerReusesContentAddressedSSHKey(t *testing.T) {
+	sshKeyName := contentAddressedSSHKeyName("ssh-ed25519 abc")
+	posted := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/ssh_keys":
+			_ = json.NewEncoder(w).Encode(map[string]any{"ssh_keys": []map[string]any{{
+				"name":       sshKeyName,
+				"public_key": "ssh-ed25519 abc existing-comment",
+			}}})
+		case r.Method == http.MethodGet && r.URL.Path == "/firewalls":
+			_ = json.NewEncoder(w).Encode(map[string]any{"firewalls": []map[string]any{{"id": 99, "name": defaultHetznerFirewall}}})
+		case r.Method == http.MethodPost && r.URL.Path == "/ssh_keys":
+			posted = true
+			w.WriteHeader(http.StatusCreated)
+		case r.Method == http.MethodPost && r.URL.Path == "/servers":
+			var payload map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				t.Fatal(err)
+			}
+			keys := payload["ssh_keys"].([]any)
+			if len(keys) != 1 || keys[0] != sshKeyName {
+				t.Fatalf("ssh_keys = %#v", keys)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"server": map[string]any{
+				"id":     42,
+				"name":   "prod-1",
+				"status": "running",
+				"public_net": map[string]any{
+					"ipv4": map[string]any{"ip": "203.0.113.10"},
+				},
+			}})
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	provider := &Hetzner{baseURL: server.URL, token: "test-token", client: server.Client()}
+	if _, err := provider.CreateServer(context.Background(), CreateServerInput{
+		Name:         "prod-1",
+		Region:       "ash",
+		Size:         "cx22",
+		SSHPublicKey: "ssh-ed25519 abc current-comment",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if posted {
+		t.Fatal("posted duplicate ssh key")
 	}
 }
 

--- a/cli/internal/direct/providers/hetzner_test.go
+++ b/cli/internal/direct/providers/hetzner_test.go
@@ -11,12 +11,23 @@ import (
 
 func TestHetznerCreateServer(t *testing.T) {
 	var createPayload map[string]any
+	var firewallPayload map[string]any
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/ssh_keys":
 			_ = json.NewEncoder(w).Encode(map[string]any{"ssh_keys": []map[string]any{}})
 		case r.Method == http.MethodPost && r.URL.Path == "/ssh_keys":
 			_ = json.NewEncoder(w).Encode(map[string]any{"ssh_key": map[string]any{"name": "devopsellence-prod-1"}})
+		case r.Method == http.MethodGet && r.URL.Path == "/firewalls":
+			if r.URL.Query().Get("name") != defaultHetznerFirewall {
+				t.Fatalf("firewall name query = %q", r.URL.RawQuery)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"firewalls": []map[string]any{}})
+		case r.Method == http.MethodPost && r.URL.Path == "/firewalls":
+			if err := json.NewDecoder(r.Body).Decode(&firewallPayload); err != nil {
+				t.Fatal(err)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"firewall": map[string]any{"id": 99, "name": defaultHetznerFirewall}})
 		case r.Method == http.MethodPost && r.URL.Path == "/servers":
 			if auth := r.Header.Get("Authorization"); auth != "Bearer test-token" {
 				t.Fatalf("Authorization = %q", auth)
@@ -44,6 +55,7 @@ func TestHetznerCreateServer(t *testing.T) {
 		Region:       "ash",
 		Size:         "cx22",
 		SSHPublicKey: "ssh-ed25519 abc",
+		Labels:       map[string]string{"devopsellence_project": "shop"},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -54,9 +66,39 @@ func TestHetznerCreateServer(t *testing.T) {
 	if createPayload["image"] != defaultHetznerImage {
 		t.Fatalf("image = %v, want default", createPayload["image"])
 	}
+	if firewallPayload["name"] != defaultHetznerFirewall {
+		t.Fatalf("firewall name = %v, want default", firewallPayload["name"])
+	}
+	firewalls := createPayload["firewalls"].([]any)
+	firewall := firewalls[0].(map[string]any)
+	if firewall["firewall"] != float64(99) {
+		t.Fatalf("firewalls = %#v, want id 99", firewalls)
+	}
+	labels := createPayload["labels"].(map[string]any)
+	if labels["devopsellence_managed"] != "true" || labels["devopsellence_node"] != "prod-1" || labels["devopsellence_project"] != "shop" {
+		t.Fatalf("labels = %#v", labels)
+	}
 	keys := createPayload["ssh_keys"].([]any)
 	if len(keys) != 1 || keys[0] != "devopsellence-prod-1" {
 		t.Fatalf("ssh_keys = %#v", keys)
+	}
+}
+
+func TestHetznerValidateToken(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/locations" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		if auth := r.Header.Get("Authorization"); auth != "Bearer test-token" {
+			t.Fatalf("Authorization = %q", auth)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"locations": []map[string]any{{"name": "ash"}}})
+	}))
+	defer server.Close()
+
+	provider := &Hetzner{baseURL: server.URL, token: "test-token", client: server.Client()}
+	if err := provider.Validate(context.Background()); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/cli/internal/direct/providers/provider.go
+++ b/cli/internal/direct/providers/provider.go
@@ -16,9 +16,11 @@ type CreateServerInput struct {
 	Size         string
 	Image        string
 	SSHPublicKey string
+	Labels       map[string]string
 }
 
 type Provider interface {
+	Validate(context.Context) error
 	CreateServer(context.Context, CreateServerInput) (Server, error)
 	DeleteServer(context.Context, string) error
 	GetServer(context.Context, string) (Server, error)

--- a/cli/internal/direct/providers/resolver.go
+++ b/cli/internal/direct/providers/resolver.go
@@ -3,9 +3,13 @@ package providers
 import "fmt"
 
 func Resolve(slug string) (Provider, error) {
+	return ResolveWithToken(slug, "")
+}
+
+func ResolveWithToken(slug, token string) (Provider, error) {
 	switch slug {
 	case "hetzner":
-		return NewHetznerFromEnv(), nil
+		return NewHetzner(token), nil
 	default:
 		return nil, fmt.Errorf("unsupported direct server provider %q", slug)
 	}

--- a/cli/internal/workflow/app.go
+++ b/cli/internal/workflow/app.go
@@ -232,6 +232,13 @@ type NodeBootstrapOptions struct {
 	Unassigned   bool
 }
 
+type nodeBootstrapToken struct {
+	Organization api.Organization
+	Workspace    Workspace
+	Initialized  *initializedWorkspace
+	Result       map[string]any
+}
+
 type NodeListOptions struct {
 	Organization string
 }
@@ -1358,41 +1365,12 @@ func (a *App) NodeBootstrap(ctx context.Context, opts NodeBootstrapOptions) erro
 		return err
 	}
 
-	var workspace Workspace
-	var initialized *initializedWorkspace
-	var organization api.Organization
-	var result map[string]any
+	var bootstrap nodeBootstrapToken
 	run := func(ctx context.Context, update, _ func(string)) error {
 		var err error
-		if opts.Unassigned {
-			update("Resolving organization…")
-			organization, err = a.resolveNodeBootstrapOrganization(ctx, tokens.AccessToken, opts.Organization)
-			if err != nil {
-				return err
-			}
-		} else {
-			workspace, initialized, err = a.ensureNodeBootstrapWorkspace(ctx, &tokens.AccessToken, opts, update)
-			if err != nil {
-				return err
-			}
-			organization = workspace.Organization
-		}
-		if strings.TrimSpace(organization.PlanTier) == "trial" {
-			return ExitError{Code: 1, Err: errors.New("manual node management is unavailable for trial organizations; `devopsellence node register` is only available in paid organizations")}
-		}
-
-		update("Generating bootstrap token…")
-		environmentID := 0
-		if !opts.Unassigned {
-			environmentID = workspace.Environment.ID
-		}
-		err = a.callWithAuthRetry(ctx, &tokens.AccessToken, a.Printer.Interactive, update, func(accessToken string) error {
-			var callErr error
-			result, callErr = a.API.CreateNodeBootstrapToken(ctx, accessToken, organization.ID, environmentID)
-			return callErr
-		})
+		bootstrap, err = a.createNodeBootstrapToken(ctx, &tokens, opts, update)
 		if err != nil {
-			return wrapError(err)
+			return err
 		}
 		return nil
 	}
@@ -1407,6 +1385,9 @@ func (a *App) NodeBootstrap(ctx context.Context, opts NodeBootstrapOptions) erro
 		}
 	}
 
+	result := bootstrap.Result
+	organization := bootstrap.Organization
+	workspace := bootstrap.Workspace
 	result["schema_version"] = outputSchemaVersion
 	result["organization_id"] = organization.ID
 	result["organization_name"] = organization.Name
@@ -1425,7 +1406,7 @@ func (a *App) NodeBootstrap(ctx context.Context, opts NodeBootstrapOptions) erro
 	if !opts.Unassigned && workspace.Discovery.AppType == config.AppTypeRails && workspace.Discovery.FallbackUsed {
 		a.Printer.Errorln("Could not infer Rails module name; using directory name", fmt.Sprintf("%q.", workspace.Discovery.ProjectName))
 	}
-	if initialized != nil {
+	if bootstrap.Initialized != nil {
 		a.Printer.Println(ui.DefaultRenderer().Muted("Initialized workspace config for this app automatically."))
 	}
 
@@ -1465,6 +1446,52 @@ func (a *App) NodeBootstrap(ctx context.Context, opts NodeBootstrapOptions) erro
 	a.Printer.Println(r.Muted("· Requires: Linux x86_64 or arm64, sudo access"))
 	a.Printer.Println("")
 	return nil
+}
+
+func (a *App) createNodeBootstrapToken(ctx context.Context, tokens *auth.Tokens, opts NodeBootstrapOptions, update func(string)) (nodeBootstrapToken, error) {
+	var (
+		workspace    Workspace
+		initialized  *initializedWorkspace
+		organization api.Organization
+		err          error
+	)
+	if opts.Unassigned {
+		update("Resolving organization...")
+		organization, err = a.resolveNodeBootstrapOrganization(ctx, tokens.AccessToken, opts.Organization)
+		if err != nil {
+			return nodeBootstrapToken{}, err
+		}
+	} else {
+		workspace, initialized, err = a.ensureNodeBootstrapWorkspace(ctx, &tokens.AccessToken, opts, update)
+		if err != nil {
+			return nodeBootstrapToken{}, err
+		}
+		organization = workspace.Organization
+	}
+	if strings.TrimSpace(organization.PlanTier) == "trial" {
+		return nodeBootstrapToken{}, ExitError{Code: 1, Err: errors.New("manual node management is unavailable for trial organizations; `devopsellence node register` is only available in paid organizations")}
+	}
+
+	update("Generating bootstrap token...")
+	environmentID := 0
+	if !opts.Unassigned {
+		environmentID = workspace.Environment.ID
+	}
+	var result map[string]any
+	err = a.callWithAuthRetry(ctx, &tokens.AccessToken, a.Printer.Interactive, update, func(accessToken string) error {
+		var callErr error
+		result, callErr = a.API.CreateNodeBootstrapToken(ctx, accessToken, organization.ID, environmentID)
+		return callErr
+	})
+	if err != nil {
+		return nodeBootstrapToken{}, wrapError(err)
+	}
+	return nodeBootstrapToken{
+		Organization: organization,
+		Workspace:    workspace,
+		Initialized:  initialized,
+		Result:       result,
+	}, nil
 }
 
 func (a *App) NodeList(ctx context.Context, opts NodeListOptions) error {

--- a/cli/internal/workflow/app.go
+++ b/cli/internal/workflow/app.go
@@ -68,6 +68,7 @@ type App struct {
 	API                *api.Client
 	State              *state.Store
 	WorkspaceState     *state.Store
+	ProviderState      *state.Store
 	ConfigStore        config.Store
 	Docker             DockerClient
 	Git                git.Client
@@ -329,6 +330,7 @@ func NewApp(in io.Reader, out, err io.Writer, jsonMode bool, cwd string) *App {
 	loginBase := apiBase
 	store := state.New(state.DefaultPath(filepath.Join("devopsellence", "auth.json")))
 	workspaceStore := state.New(state.DefaultPath(filepath.Join("devopsellence", "workspace.json")))
+	providerStore := state.New(state.DefaultPath(filepath.Join("devopsellence", "providers.json")))
 	return &App{
 		In:                 in,
 		Printer:            output.New(out, err, jsonMode),
@@ -336,6 +338,7 @@ func NewApp(in io.Reader, out, err io.Writer, jsonMode bool, cwd string) *App {
 		API:                api.New(apiBase),
 		State:              store,
 		WorkspaceState:     workspaceStore,
+		ProviderState:      providerStore,
 		ConfigStore:        config.NewStore(),
 		Docker:             docker.Runner{},
 		Git:                git.Client{},

--- a/cli/internal/workflow/direct.go
+++ b/cli/internal/workflow/direct.go
@@ -63,7 +63,7 @@ type DirectDoctorOptions struct {
 	Nodes []string
 }
 
-type DirectServerCreateOptions struct {
+type DirectNodeCreateOptions struct {
 	Name         string
 	Provider     string
 	Region       string
@@ -71,11 +71,11 @@ type DirectServerCreateOptions struct {
 	Image        string
 	Labels       string
 	SSHPublicKey string
-	Install      bool
+	NoInstall    bool
 	Deploy       bool
 }
 
-type DirectServerDeleteOptions struct {
+type DirectNodeRemoveOptions struct {
 	Name string
 	Yes  bool
 }
@@ -622,16 +622,16 @@ func (a *App) SoloDoctor(ctx context.Context) error {
 	return nil
 }
 
-func (a *App) DirectServerCreate(ctx context.Context, opts DirectServerCreateOptions) error {
+func (a *App) DirectNodeCreate(ctx context.Context, opts DirectNodeCreateOptions) error {
 	cfg, workspaceRoot, err := a.loadProjectConfigForDirectUpdate()
 	if err != nil {
 		return err
 	}
 	if opts.Name == "" {
-		return fmt.Errorf("server name is required")
+		return fmt.Errorf("node name is required")
 	}
 	if opts.Deploy && a.Printer.JSON {
-		return fmt.Errorf("direct server create --deploy is not supported with --json")
+		return fmt.Errorf("node create --deploy is not supported with --json")
 	}
 	if cfg.Direct != nil {
 		if _, ok := cfg.Direct.Nodes[opts.Name]; ok {
@@ -649,7 +649,7 @@ func (a *App) DirectServerCreate(ctx context.Context, opts DirectServerCreateOpt
 	if opts.Size == "" {
 		opts.Size = "cx22"
 	}
-	provider, err := providers.Resolve(providerSlug)
+	provider, err := a.resolveDirectProvider(providerSlug)
 	if err != nil {
 		return err
 	}
@@ -666,6 +666,9 @@ func (a *App) DirectServerCreate(ctx context.Context, opts DirectServerCreateOpt
 		Size:         opts.Size,
 		Image:        opts.Image,
 		SSHPublicKey: sshPublicKey,
+		Labels: map[string]string{
+			"devopsellence_project": discovery.Slugify(cfg.Project),
+		},
 	})
 	if err != nil {
 		return err
@@ -698,7 +701,7 @@ func (a *App) DirectServerCreate(ctx context.Context, opts DirectServerCreateOpt
 	if err := a.writeDirectNode(workspaceRoot, cfg, opts.Name, node); err != nil {
 		return err
 	}
-	if opts.Install || opts.Deploy {
+	if !opts.NoInstall || opts.Deploy {
 		if !a.Printer.JSON {
 			a.Printer.Println("Waiting for SSH on " + opts.Name + "...")
 		}
@@ -724,13 +727,13 @@ func (a *App) DirectServerCreate(ctx context.Context, opts DirectServerCreateOpt
 			"config_path":        a.ConfigStore.PathFor(workspaceRoot),
 		})
 	}
-	a.Printer.Println("Created direct node " + opts.Name + " at " + node.Host)
+	a.Printer.Println("Created solo node " + opts.Name + " at " + node.Host)
 	return nil
 }
 
-func (a *App) DirectServerDelete(ctx context.Context, opts DirectServerDeleteOptions) error {
+func (a *App) DirectNodeRemove(ctx context.Context, opts DirectNodeRemoveOptions) error {
 	if !opts.Yes {
-		return fmt.Errorf("direct server delete requires --yes")
+		return fmt.Errorf("node remove requires --yes")
 	}
 	cfg, workspaceRoot, err := a.loadDirectConfig()
 	if err != nil {
@@ -743,7 +746,7 @@ func (a *App) DirectServerDelete(ctx context.Context, opts DirectServerDeleteOpt
 	if node.Provider == "" || node.ProviderServerID == "" {
 		return fmt.Errorf("node %q does not have provider metadata; refusing provider delete", opts.Name)
 	}
-	provider, err := providers.Resolve(node.Provider)
+	provider, err := a.resolveDirectProvider(node.Provider)
 	if err != nil {
 		return err
 	}
@@ -757,15 +760,15 @@ func (a *App) DirectServerDelete(ctx context.Context, opts DirectServerDeleteOpt
 	if a.Printer.JSON {
 		return a.Printer.PrintJSON(map[string]any{"node": opts.Name, "action": "deleted"})
 	}
-	a.Printer.Println("Deleted direct server " + opts.Name)
+	a.Printer.Println("Removed solo node " + opts.Name)
 	return nil
 }
 
 func (a *App) DirectSetup(ctx context.Context, _ DirectSetupOptions) error {
 	if !a.Printer.Interactive {
-		return fmt.Errorf("direct setup requires an interactive terminal; use direct server create or edit devopsellence.yml")
+		return fmt.Errorf("direct setup requires an interactive terminal; use node create or edit devopsellence.yml")
 	}
-	mode, err := a.promptLine("Server source (existing/hetzner)", "existing")
+	mode, err := a.promptLine("Node source (existing/hetzner)", "existing")
 	if err != nil {
 		return err
 	}
@@ -790,14 +793,13 @@ func (a *App) DirectSetup(ctx context.Context, _ DirectSetupOptions) error {
 		if err != nil {
 			return err
 		}
-		if err := a.DirectServerCreate(ctx, DirectServerCreateOptions{
+		if err := a.DirectNodeCreate(ctx, DirectNodeCreateOptions{
 			Name:         name,
 			Provider:     "hetzner",
 			Region:       region,
 			Size:         size,
 			Labels:       labels,
 			SSHPublicKey: sshPublicKey,
-			Install:      true,
 		}); err != nil {
 			return err
 		}

--- a/cli/internal/workflow/direct.go
+++ b/cli/internal/workflow/direct.go
@@ -19,6 +19,7 @@ import (
 	"github.com/devopsellence/cli/internal/direct"
 	"github.com/devopsellence/cli/internal/direct/providers"
 	"github.com/devopsellence/cli/internal/discovery"
+	"github.com/devopsellence/cli/internal/ui"
 )
 
 type DirectDeployOptions struct {
@@ -80,7 +81,93 @@ type DirectNodeRemoveOptions struct {
 	Yes  bool
 }
 
+type SharedNodeCreateOptions struct {
+	DirectNodeCreateOptions
+	NodeBootstrapOptions
+}
+
+type providerNodeCreateResult struct {
+	Node         config.DirectNode
+	Server       providers.Server
+	Labels       []string
+	ProviderSlug string
+}
+
 type DirectSetupOptions struct{}
+
+func (a *App) createProviderNode(ctx context.Context, opts DirectNodeCreateOptions, projectName string) (providerNodeCreateResult, error) {
+	if opts.Name == "" {
+		return providerNodeCreateResult{}, fmt.Errorf("node name is required")
+	}
+	labels, err := parseDirectLabels(firstNonEmpty(opts.Labels, strings.Join(config.DirectDefaultLabels, ",")))
+	if err != nil {
+		return providerNodeCreateResult{}, err
+	}
+	providerSlug := firstNonEmpty(opts.Provider, "hetzner")
+	if opts.Region == "" {
+		opts.Region = "ash"
+	}
+	if opts.Size == "" {
+		opts.Size = "cx22"
+	}
+	provider, err := a.resolveDirectProvider(providerSlug)
+	if err != nil {
+		return providerNodeCreateResult{}, err
+	}
+	sshPublicKey, sshPublicKeyPath, err := readDirectSSHPublicKey(opts.SSHPublicKey)
+	if err != nil {
+		return providerNodeCreateResult{}, err
+	}
+	if !a.Printer.JSON {
+		a.Printer.Println("Creating " + providerSlug + " server " + opts.Name + "...")
+	}
+	providerLabels := map[string]string{}
+	if strings.TrimSpace(projectName) != "" {
+		providerLabels["devopsellence_project"] = discovery.Slugify(projectName)
+	}
+	server, err := provider.CreateServer(ctx, providers.CreateServerInput{
+		Name:         opts.Name,
+		Region:       opts.Region,
+		Size:         opts.Size,
+		Image:        opts.Image,
+		SSHPublicKey: sshPublicKey,
+		Labels:       providerLabels,
+	})
+	if err != nil {
+		return providerNodeCreateResult{}, err
+	}
+	server, err = waitForDirectProviderServer(ctx, provider, server)
+	if err != nil {
+		return providerNodeCreateResult{}, err
+	}
+	if server.PublicIP == "" {
+		return providerNodeCreateResult{}, fmt.Errorf("created server %s but provider did not return a public IPv4 address", server.ID)
+	}
+	node := config.DirectNode{
+		Host:             server.PublicIP,
+		User:             "root",
+		Port:             22,
+		AgentStateDir:    "/var/lib/devopsellence",
+		Labels:           labels,
+		Provider:         providerSlug,
+		ProviderServerID: server.ID,
+		ProviderRegion:   opts.Region,
+		ProviderSize:     opts.Size,
+		ProviderImage:    opts.Image,
+	}
+	if strings.TrimSpace(sshPublicKeyPath) != "" {
+		node.SSHKey = strings.TrimSuffix(sshPublicKeyPath, ".pub")
+		if _, err := os.Stat(node.SSHKey); err != nil {
+			node.SSHKey = ""
+		}
+	}
+	return providerNodeCreateResult{
+		Node:         node,
+		Server:       server,
+		Labels:       labels,
+		ProviderSlug: providerSlug,
+	}, nil
+}
 
 func (a *App) DirectDeploy(ctx context.Context, opts DirectDeployOptions) error {
 	cfg, workspaceRoot, err := a.loadDirectConfig()
@@ -638,77 +725,21 @@ func (a *App) DirectNodeCreate(ctx context.Context, opts DirectNodeCreateOptions
 			return fmt.Errorf("direct node %q already exists", opts.Name)
 		}
 	}
-	labels, err := parseDirectLabels(firstNonEmpty(opts.Labels, strings.Join(config.DirectDefaultLabels, ",")))
+	created, err := a.createProviderNode(ctx, opts, cfg.Project)
 	if err != nil {
 		return err
 	}
-	providerSlug := firstNonEmpty(opts.Provider, "hetzner")
-	if opts.Region == "" {
-		opts.Region = "ash"
-	}
-	if opts.Size == "" {
-		opts.Size = "cx22"
-	}
-	provider, err := a.resolveDirectProvider(providerSlug)
-	if err != nil {
-		return err
-	}
-	sshPublicKey, sshPublicKeyPath, err := readDirectSSHPublicKey(opts.SSHPublicKey)
-	if err != nil {
-		return err
-	}
-	if !a.Printer.JSON {
-		a.Printer.Println("Creating " + providerSlug + " server " + opts.Name + "...")
-	}
-	server, err := provider.CreateServer(ctx, providers.CreateServerInput{
-		Name:         opts.Name,
-		Region:       opts.Region,
-		Size:         opts.Size,
-		Image:        opts.Image,
-		SSHPublicKey: sshPublicKey,
-		Labels: map[string]string{
-			"devopsellence_project": discovery.Slugify(cfg.Project),
-		},
-	})
-	if err != nil {
-		return err
-	}
-	server, err = waitForDirectProviderServer(ctx, provider, server)
-	if err != nil {
-		return err
-	}
-	if server.PublicIP == "" {
-		return fmt.Errorf("created server %s but provider did not return a public IPv4 address", server.ID)
-	}
-	node := config.DirectNode{
-		Host:             server.PublicIP,
-		User:             "root",
-		Port:             22,
-		AgentStateDir:    "/var/lib/devopsellence",
-		Labels:           labels,
-		Provider:         providerSlug,
-		ProviderServerID: server.ID,
-		ProviderRegion:   opts.Region,
-		ProviderSize:     opts.Size,
-		ProviderImage:    opts.Image,
-	}
-	if strings.TrimSpace(sshPublicKeyPath) != "" {
-		node.SSHKey = strings.TrimSuffix(sshPublicKeyPath, ".pub")
-		if _, err := os.Stat(node.SSHKey); err != nil {
-			node.SSHKey = ""
-		}
-	}
-	if err := a.writeDirectNode(workspaceRoot, cfg, opts.Name, node); err != nil {
+	if err := a.writeDirectNode(workspaceRoot, cfg, opts.Name, created.Node); err != nil {
 		return err
 	}
 	if !opts.NoInstall || opts.Deploy {
 		if !a.Printer.JSON {
 			a.Printer.Println("Waiting for SSH on " + opts.Name + "...")
 		}
-		if err := waitForDirectSSH(ctx, node, 3*time.Minute); err != nil {
+		if err := waitForDirectSSH(ctx, created.Node, 3*time.Minute); err != nil {
 			return err
 		}
-		if err := installDirectAgent(ctx, node, DirectAgentInstallOptions{}, a.directProgress(opts.Name)); err != nil {
+		if err := installDirectAgent(ctx, created.Node, DirectAgentInstallOptions{}, a.directProgress(opts.Name)); err != nil {
 			return err
 		}
 	}
@@ -720,14 +751,115 @@ func (a *App) DirectNodeCreate(ctx context.Context, opts DirectNodeCreateOptions
 	if a.Printer.JSON {
 		return a.Printer.PrintJSON(map[string]any{
 			"node":               opts.Name,
-			"host":               node.Host,
-			"labels":             labels,
-			"provider":           providerSlug,
-			"provider_server_id": server.ID,
+			"host":               created.Node.Host,
+			"labels":             created.Labels,
+			"provider":           created.ProviderSlug,
+			"provider_server_id": created.Server.ID,
 			"config_path":        a.ConfigStore.PathFor(workspaceRoot),
 		})
 	}
-	a.Printer.Println("Created solo node " + opts.Name + " at " + node.Host)
+	a.Printer.Println("Created solo node " + opts.Name + " at " + created.Node.Host)
+	return nil
+}
+
+func (a *App) SharedNodeCreate(ctx context.Context, opts SharedNodeCreateOptions) error {
+	if opts.Name == "" {
+		return fmt.Errorf("node name is required")
+	}
+	if opts.Deploy {
+		return fmt.Errorf("node create --deploy is only available in solo mode")
+	}
+
+	var bootstrap nodeBootstrapToken
+	if !opts.NoInstall {
+		tokens, err := a.ensureAuth(ctx, a.Printer.Interactive, false)
+		if err != nil {
+			return err
+		}
+		run := func(ctx context.Context, update, _ func(string)) error {
+			var err error
+			bootstrap, err = a.createNodeBootstrapToken(ctx, &tokens, opts.NodeBootstrapOptions, update)
+			return err
+		}
+		if !a.Printer.JSON && a.Printer.Interactive {
+			if err := ui.RunTask(ctx, a.Printer.Out, "Node Bootstrap", run); err != nil {
+				return err
+			}
+		} else {
+			if err := run(ctx, func(string) {}, func(string) {}); err != nil {
+				return err
+			}
+		}
+	}
+
+	projectName := opts.Project
+	if !opts.Unassigned && bootstrap.Workspace.Project.Name != "" {
+		projectName = bootstrap.Workspace.Project.Name
+	}
+	created, err := a.createProviderNode(ctx, opts.DirectNodeCreateOptions, projectName)
+	if err != nil {
+		return err
+	}
+	if opts.NoInstall {
+		if a.Printer.JSON {
+			return a.Printer.PrintJSON(map[string]any{
+				"schema_version":     outputSchemaVersion,
+				"node":               opts.Name,
+				"host":               created.Node.Host,
+				"labels":             created.Labels,
+				"provider":           created.ProviderSlug,
+				"provider_server_id": created.Server.ID,
+				"registered":         false,
+			})
+		}
+		a.Printer.Println("Created shared node " + opts.Name + " at " + created.Node.Host + " without installing the agent")
+		return nil
+	}
+
+	installCommand := strings.TrimSpace(stringFromMap(bootstrap.Result, "install_command"))
+	if installCommand == "" {
+		return fmt.Errorf("node bootstrap response did not include install_command")
+	}
+	if !a.Printer.JSON {
+		a.Printer.Println("Waiting for SSH on " + opts.Name + "...")
+	}
+	if err := waitForDirectSSH(ctx, created.Node, 3*time.Minute); err != nil {
+		return err
+	}
+	if !a.Printer.JSON {
+		a.Printer.Println("Installing and registering devopsellence agent on " + opts.Name + "...")
+	}
+	stdout, stderr := a.Printer.Out, a.Printer.Err
+	if a.Printer.JSON {
+		stdout, stderr = io.Discard, io.Discard
+	}
+	if err := direct.RunSSHInteractive(ctx, created.Node, installCommand, stdout, stderr); err != nil {
+		return err
+	}
+
+	if a.Printer.JSON {
+		result := map[string]any{
+			"schema_version":     outputSchemaVersion,
+			"node":               opts.Name,
+			"host":               created.Node.Host,
+			"labels":             created.Labels,
+			"provider":           created.ProviderSlug,
+			"provider_server_id": created.Server.ID,
+			"organization_id":    bootstrap.Organization.ID,
+			"organization_name":  bootstrap.Organization.Name,
+			"registered":         true,
+		}
+		if opts.Unassigned {
+			result["assignment_mode"] = "unassigned"
+		} else {
+			result["assignment_mode"] = firstNonEmpty(stringFromMap(bootstrap.Result, "assignment_mode"), "environment")
+			result["project_name"] = bootstrap.Workspace.Project.Name
+			result["environment_id"] = bootstrap.Workspace.Environment.ID
+			result["environment_name"] = bootstrap.Workspace.Environment.Name
+		}
+		return a.Printer.PrintJSON(result)
+	}
+	a.Printer.Println("Created shared node " + opts.Name + " at " + created.Node.Host)
 	return nil
 }
 

--- a/cli/internal/workflow/provider.go
+++ b/cli/internal/workflow/provider.go
@@ -1,0 +1,250 @@
+package workflow
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/devopsellence/cli/internal/direct/providers"
+	"github.com/devopsellence/cli/internal/state"
+)
+
+const providerHetzner = "hetzner"
+
+type ProviderLoginOptions struct {
+	Provider   string
+	Token      string
+	TokenStdin bool
+}
+
+type ProviderStatusOptions struct {
+	Provider string
+}
+
+type ProviderLogoutOptions struct {
+	Provider string
+}
+
+func (a *App) ProviderLogin(ctx context.Context, opts ProviderLoginOptions) error {
+	providerSlug, err := normalizeProvider(opts.Provider)
+	if err != nil {
+		return ExitError{Code: 2, Err: err}
+	}
+	token, err := a.providerLoginToken(opts)
+	if err != nil {
+		return err
+	}
+	provider, err := providers.ResolveWithToken(providerSlug, token)
+	if err != nil {
+		return err
+	}
+	if !a.Printer.JSON {
+		a.Printer.Println("Validating " + providerSlug + " token...")
+	}
+	if err := provider.Validate(ctx); err != nil {
+		return err
+	}
+	if err := saveProviderToken(a.ProviderState, providerSlug, token); err != nil {
+		return err
+	}
+	if a.Printer.JSON {
+		return a.Printer.PrintJSON(map[string]any{
+			"schema_version": outputSchemaVersion,
+			"provider":       providerSlug,
+			"configured":     true,
+			"source":         "state",
+		})
+	}
+	a.Printer.Println("Saved " + providerSlug + " provider token.")
+	return nil
+}
+
+func (a *App) ProviderStatus(ctx context.Context, opts ProviderStatusOptions) error {
+	providerSlug, err := normalizeProvider(opts.Provider)
+	if err != nil {
+		return ExitError{Code: 2, Err: err}
+	}
+	token, source, err := providerToken(a.ProviderState, providerSlug)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(token) == "" {
+		if a.Printer.JSON {
+			return a.Printer.PrintJSON(map[string]any{
+				"schema_version": outputSchemaVersion,
+				"provider":       providerSlug,
+				"configured":     false,
+			})
+		}
+		a.Printer.Println(providerSlug + " provider is not configured.")
+		return nil
+	}
+	provider, err := providers.ResolveWithToken(providerSlug, token)
+	if err != nil {
+		return err
+	}
+	if err := provider.Validate(ctx); err != nil {
+		return err
+	}
+	if a.Printer.JSON {
+		return a.Printer.PrintJSON(map[string]any{
+			"schema_version": outputSchemaVersion,
+			"provider":       providerSlug,
+			"configured":     true,
+			"source":         source,
+		})
+	}
+	a.Printer.Println(providerSlug + " provider is configured (" + source + ").")
+	return nil
+}
+
+func (a *App) ProviderLogout(_ context.Context, opts ProviderLogoutOptions) error {
+	providerSlug, err := normalizeProvider(opts.Provider)
+	if err != nil {
+		return ExitError{Code: 2, Err: err}
+	}
+	deleted, err := deleteProviderToken(a.ProviderState, providerSlug)
+	if err != nil {
+		return err
+	}
+	if a.Printer.JSON {
+		return a.Printer.PrintJSON(map[string]any{
+			"schema_version": outputSchemaVersion,
+			"provider":       providerSlug,
+			"deleted":        deleted,
+		})
+	}
+	if deleted {
+		a.Printer.Println("Removed " + providerSlug + " provider token.")
+	} else {
+		a.Printer.Println(providerSlug + " provider token was not stored.")
+	}
+	return nil
+}
+
+func (a *App) resolveDirectProvider(providerSlug string) (providers.Provider, error) {
+	token, _, err := providerToken(a.ProviderState, providerSlug)
+	if err != nil {
+		return nil, err
+	}
+	return providers.ResolveWithToken(providerSlug, token)
+}
+
+func (a *App) providerLoginToken(opts ProviderLoginOptions) (string, error) {
+	if opts.TokenStdin {
+		data, err := io.ReadAll(a.In)
+		if err != nil {
+			return "", ExitError{Code: 1, Err: err}
+		}
+		token := strings.TrimRight(string(data), "\r\n")
+		if strings.TrimSpace(token) == "" {
+			return "", ExitError{Code: 2, Err: errors.New("provider token is required")}
+		}
+		return token, nil
+	}
+	if strings.TrimSpace(opts.Token) != "" {
+		return opts.Token, nil
+	}
+	if !a.Printer.Interactive {
+		return "", ExitError{Code: 2, Err: errors.New("missing required option: --token or --stdin")}
+	}
+	return a.promptSecretValue("Hetzner API token")
+}
+
+func normalizeProvider(provider string) (string, error) {
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	if provider == "" {
+		provider = providerHetzner
+	}
+	switch provider {
+	case providerHetzner:
+		return provider, nil
+	default:
+		return "", fmt.Errorf("unsupported provider %q", provider)
+	}
+}
+
+func providerToken(store *state.Store, provider string) (string, string, error) {
+	if token, err := readProviderToken(store, provider); err != nil {
+		return "", "", err
+	} else if token != "" {
+		return token, "state", nil
+	}
+	for _, name := range []string{"DEVOPSELLENCE_HETZNER_API_TOKEN", "HCLOUD_TOKEN"} {
+		if value := strings.TrimSpace(os.Getenv(name)); value != "" {
+			return value, name, nil
+		}
+	}
+	return "", "", nil
+}
+
+func readProviderToken(store *state.Store, provider string) (string, error) {
+	value, err := providerRecord(store, provider)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(stringFromAny(value["token"])), nil
+}
+
+func saveProviderToken(store *state.Store, provider, token string) error {
+	if store == nil {
+		return errors.New("provider state store is required")
+	}
+	return store.Update(func(current map[string]any) (map[string]any, error) {
+		providersMap := mapFromAny(current["providers"])
+		providersMap[provider] = map[string]any{
+			"token":      token,
+			"updated_at": time.Now().UTC().Format(time.RFC3339),
+		}
+		current["providers"] = providersMap
+		return current, nil
+	})
+}
+
+func deleteProviderToken(store *state.Store, provider string) (bool, error) {
+	if store == nil {
+		return false, nil
+	}
+	deleted := false
+	err := store.Update(func(current map[string]any) (map[string]any, error) {
+		providersMap := mapFromAny(current["providers"])
+		if _, ok := providersMap[provider]; ok {
+			delete(providersMap, provider)
+			deleted = true
+		}
+		current["providers"] = providersMap
+		return current, nil
+	})
+	return deleted, err
+}
+
+func providerRecord(store *state.Store, provider string) (map[string]any, error) {
+	if store == nil {
+		return map[string]any{}, nil
+	}
+	current, err := store.Read()
+	if err != nil {
+		return nil, err
+	}
+	providersMap := mapFromAny(current["providers"])
+	return mapFromAny(providersMap[provider]), nil
+}
+
+func mapFromAny(value any) map[string]any {
+	result := map[string]any{}
+	if value == nil {
+		return result
+	}
+	source, ok := value.(map[string]any)
+	if !ok {
+		return result
+	}
+	for key, entry := range source {
+		result[key] = entry
+	}
+	return result
+}

--- a/cli/internal/workflow/provider_test.go
+++ b/cli/internal/workflow/provider_test.go
@@ -1,0 +1,50 @@
+package workflow
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/devopsellence/cli/internal/state"
+)
+
+func TestProviderTokenStoreReadDelete(t *testing.T) {
+	t.Parallel()
+
+	store := state.New(filepath.Join(t.TempDir(), "providers.json"))
+	if err := saveProviderToken(store, providerHetzner, "test-token"); err != nil {
+		t.Fatal(err)
+	}
+	token, source, err := providerToken(store, providerHetzner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if token != "test-token" || source != "state" {
+		t.Fatalf("providerToken = %q/%q, want test-token/state", token, source)
+	}
+	deleted, err := deleteProviderToken(store, providerHetzner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !deleted {
+		t.Fatal("deleteProviderToken = false, want true")
+	}
+	token, source, err = providerToken(store, providerHetzner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if token != "" || source != "" {
+		t.Fatalf("providerToken after delete = %q/%q, want empty", token, source)
+	}
+}
+
+func TestProviderTokenFallsBackToEnv(t *testing.T) {
+	t.Setenv("DEVOPSELLENCE_HETZNER_API_TOKEN", "env-token")
+	store := state.New(filepath.Join(t.TempDir(), "providers.json"))
+	token, source, err := providerToken(store, providerHetzner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if token != "env-token" || source != "DEVOPSELLENCE_HETZNER_API_TOKEN" {
+		t.Fatalf("providerToken = %q/%q, want env-token/DEVOPSELLENCE_HETZNER_API_TOKEN", token, source)
+	}
+}

--- a/cli/internal/workflow/root.go
+++ b/cli/internal/workflow/root.go
@@ -445,6 +445,48 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 	authCommand.AddCommand(authTokenCommand)
 	root.AddCommand(authCommand)
 
+	var providerLoginOpts ProviderLoginOptions
+	var providerStatusOpts ProviderStatusOptions
+	var providerLogoutOpts ProviderLogoutOptions
+	providerCommand := &cobra.Command{Use: "provider", Short: "Manage infrastructure provider credentials"}
+	providerLoginCommand := &cobra.Command{
+		Use:   "login <provider>",
+		Short: "Save a provider API token",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			providerLoginOpts.Provider = args[0]
+			return runWithTimeout(cmd, func(ctx context.Context) error {
+				return app.ProviderLogin(ctx, providerLoginOpts)
+			})
+		},
+	}
+	providerLoginCommand.Flags().StringVar(&providerLoginOpts.Token, "token", "", "Provider API token")
+	providerLoginCommand.Flags().BoolVar(&providerLoginOpts.TokenStdin, "stdin", false, "Read provider API token from stdin")
+	providerStatusCommand := &cobra.Command{
+		Use:   "status <provider>",
+		Short: "Check provider credential status",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			providerStatusOpts.Provider = args[0]
+			return runWithTimeout(cmd, func(ctx context.Context) error {
+				return app.ProviderStatus(ctx, providerStatusOpts)
+			})
+		},
+	}
+	providerLogoutCommand := &cobra.Command{
+		Use:   "logout <provider>",
+		Short: "Remove a stored provider API token",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			providerLogoutOpts.Provider = args[0]
+			return runWithTimeout(cmd, func(ctx context.Context) error {
+				return app.ProviderLogout(ctx, providerLogoutOpts)
+			})
+		},
+	}
+	providerCommand.AddCommand(providerLoginCommand, providerStatusCommand, providerLogoutCommand)
+	root.AddCommand(providerCommand)
+
 	aliasCommand := &cobra.Command{Use: "alias", Short: "Manage local command aliases"}
 	aliasCommand.AddCommand(&cobra.Command{
 		Use:   "lfg",
@@ -459,7 +501,7 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 		Short: "Prepare the current workspace for its selected mode",
 		Long: strings.Join([]string{
 			"Mode-driven workspace setup.",
-			"  solo   - initialize config if needed, add a server, and install the agent",
+			"  solo   - initialize config if needed, add a node, and install the agent",
 			"  shared - sign in, create/select org/project/env, and write workspace config",
 		}, "\n"),
 		RunE: runByMode(func(ctx context.Context) error {
@@ -609,11 +651,13 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 	root.AddCommand(secretCommand)
 
 	var nodeRegisterOpts NodeBootstrapOptions
+	var nodeCreateSoloOpts DirectNodeCreateOptions
 	var nodeListSharedOpts NodeListOptions
 	var nodeListSoloOpts DirectNodeListOptions
 	var nodeAttachOpts NodeAssignOptions
 	var nodeDetachOpts NodeUnassignOptions
-	var nodeRemoveOpts NodeDeleteOptions
+	var nodeRemoveSoloOpts DirectNodeRemoveOptions
+	var nodeRemoveSharedOpts NodeDeleteOptions
 	var nodeLabelSharedOpts NodeLabelSetOptions
 	var nodeLabelSoloOpts DirectNodeLabelSetOptions
 	var nodeDiagnoseOpts NodeDiagnoseOptions
@@ -635,6 +679,27 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 	nodeRegisterCommand.Flags().StringVar(&nodeRegisterOpts.Project, "project", "", "Project name override")
 	nodeRegisterCommand.Flags().StringVar(&nodeRegisterOpts.Environment, "env", "", "Environment name override")
 	nodeRegisterCommand.Flags().BoolVar(&nodeRegisterOpts.Unassigned, "unassigned", false, "Register the node without auto-attaching it to the current environment")
+	nodeCreateCommand := &cobra.Command{
+		Use:   "create <name>",
+		Short: "Create a provider-managed solo node",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			nodeCreateSoloOpts.Name = args[0]
+			return runByMode(func(ctx context.Context) error {
+				return app.DirectNodeCreate(ctx, nodeCreateSoloOpts)
+			}, func(context.Context) error {
+				return ExitError{Code: 2, Err: fmt.Errorf("node create is not available in shared mode yet")}
+			})(cmd, args)
+		},
+	}
+	nodeCreateCommand.Flags().StringVar(&nodeCreateSoloOpts.Provider, "provider", "hetzner", "Provider")
+	nodeCreateCommand.Flags().StringVar(&nodeCreateSoloOpts.Region, "region", "ash", "Provider region")
+	nodeCreateCommand.Flags().StringVar(&nodeCreateSoloOpts.Size, "size", "cx22", "Provider machine size")
+	nodeCreateCommand.Flags().StringVar(&nodeCreateSoloOpts.Image, "image", "", "Provider image")
+	nodeCreateCommand.Flags().StringVar(&nodeCreateSoloOpts.Labels, "labels", "", "Comma-separated labels")
+	nodeCreateCommand.Flags().StringVar(&nodeCreateSoloOpts.SSHPublicKey, "ssh-public-key", "", "SSH public key path")
+	nodeCreateCommand.Flags().BoolVar(&nodeCreateSoloOpts.NoInstall, "no-install", false, "Create the provider machine without installing the agent")
+	nodeCreateCommand.Flags().BoolVar(&nodeCreateSoloOpts.Deploy, "deploy", false, "Install the agent and deploy after create")
 	nodeListCommand := &cobra.Command{
 		Use:   "list",
 		Short: "List nodes",
@@ -679,20 +744,24 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 		},
 	}
 	nodeRemoveCommand := &cobra.Command{
-		Use:   "remove <id>",
-		Short: "Remove a shared node",
+		Use:   "remove <target>",
+		Short: "Remove a node",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			id, parseErr := strconv.Atoi(args[0])
-			if parseErr != nil {
-				return ExitError{Code: 2, Err: fmt.Errorf("invalid node id %q: must be a number", args[0])}
-			}
-			nodeRemoveOpts.NodeID = id
-			return runSharedOnly("node remove", func(ctx context.Context) error {
-				return app.NodeDelete(ctx, nodeRemoveOpts)
+			return runByMode(func(ctx context.Context) error {
+				nodeRemoveSoloOpts.Name = args[0]
+				return app.DirectNodeRemove(ctx, nodeRemoveSoloOpts)
+			}, func(ctx context.Context) error {
+				id, parseErr := strconv.Atoi(args[0])
+				if parseErr != nil {
+					return ExitError{Code: 2, Err: fmt.Errorf("invalid node id %q: must be a number", args[0])}
+				}
+				nodeRemoveSharedOpts.NodeID = id
+				return app.NodeDelete(ctx, nodeRemoveSharedOpts)
 			})(cmd, args)
 		},
 	}
+	nodeRemoveCommand.Flags().BoolVar(&nodeRemoveSoloOpts.Yes, "yes", false, "Confirm solo node removal")
 	nodeLabelSetCommand := &cobra.Command{
 		Use:   "set <target>",
 		Short: "Replace a node's labels",
@@ -744,48 +813,8 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 		},
 	}
 	nodeLogsCommand.Flags().BoolVarP(&nodeLogsOpts.Follow, "follow", "f", false, "Follow log output")
-	nodeCommand.AddCommand(nodeRegisterCommand, nodeListCommand, nodeAttachCommand, nodeDetachCommand, nodeRemoveCommand, nodeLabelCommand, nodeDiagnoseCommand, nodeLogsCommand)
+	nodeCommand.AddCommand(nodeRegisterCommand, nodeCreateCommand, nodeListCommand, nodeAttachCommand, nodeDetachCommand, nodeRemoveCommand, nodeLabelCommand, nodeDiagnoseCommand, nodeLogsCommand)
 	root.AddCommand(nodeCommand)
-
-	var serverCreateOpts DirectServerCreateOptions
-	var serverDeleteOpts DirectServerDeleteOptions
-	serverCommand := &cobra.Command{
-		Use:   "server",
-		Short: "Manage solo server provisioning",
-	}
-	serverCreateCommand := &cobra.Command{
-		Use:   "create <name>",
-		Short: "Create a provider-managed solo server",
-		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			serverCreateOpts.Name = args[0]
-			return runSoloOnly("server create", func(ctx context.Context) error {
-				return app.DirectServerCreate(ctx, serverCreateOpts)
-			})(cmd, args)
-		},
-	}
-	serverCreateCommand.Flags().StringVar(&serverCreateOpts.Provider, "provider", "hetzner", "Server provider")
-	serverCreateCommand.Flags().StringVar(&serverCreateOpts.Region, "region", "ash", "Provider region")
-	serverCreateCommand.Flags().StringVar(&serverCreateOpts.Size, "size", "cx22", "Provider server size")
-	serverCreateCommand.Flags().StringVar(&serverCreateOpts.Image, "image", "", "Provider image")
-	serverCreateCommand.Flags().StringVar(&serverCreateOpts.Labels, "labels", "", "Comma-separated labels")
-	serverCreateCommand.Flags().StringVar(&serverCreateOpts.SSHPublicKey, "ssh-public-key", "", "SSH public key path")
-	serverCreateCommand.Flags().BoolVar(&serverCreateOpts.Install, "install", false, "Install the agent after create")
-	serverCreateCommand.Flags().BoolVar(&serverCreateOpts.Deploy, "deploy", false, "Install the agent and deploy after create")
-	serverDeleteCommand := &cobra.Command{
-		Use:   "delete <name>",
-		Short: "Delete a provider-managed solo server",
-		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			serverDeleteOpts.Name = args[0]
-			return runSoloOnly("server delete", func(ctx context.Context) error {
-				return app.DirectServerDelete(ctx, serverDeleteOpts)
-			})(cmd, args)
-		},
-	}
-	serverDeleteCommand.Flags().BoolVar(&serverDeleteOpts.Yes, "yes", false, "Confirm server deletion")
-	serverCommand.AddCommand(serverCreateCommand, serverDeleteCommand)
-	root.AddCommand(serverCommand)
 
 	var agentInstallOpts DirectAgentInstallOptions
 	agentCommand := &cobra.Command{

--- a/cli/internal/workflow/root.go
+++ b/cli/internal/workflow/root.go
@@ -651,7 +651,8 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 	root.AddCommand(secretCommand)
 
 	var nodeRegisterOpts NodeBootstrapOptions
-	var nodeCreateSoloOpts DirectNodeCreateOptions
+	var nodeCreateOpts DirectNodeCreateOptions
+	var nodeCreateBootstrapOpts NodeBootstrapOptions
 	var nodeListSharedOpts NodeListOptions
 	var nodeListSoloOpts DirectNodeListOptions
 	var nodeAttachOpts NodeAssignOptions
@@ -681,25 +682,32 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 	nodeRegisterCommand.Flags().BoolVar(&nodeRegisterOpts.Unassigned, "unassigned", false, "Register the node without auto-attaching it to the current environment")
 	nodeCreateCommand := &cobra.Command{
 		Use:   "create <name>",
-		Short: "Create a provider-managed solo node",
+		Short: "Create a provider-managed node",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			nodeCreateSoloOpts.Name = args[0]
+			nodeCreateOpts.Name = args[0]
 			return runByMode(func(ctx context.Context) error {
-				return app.DirectNodeCreate(ctx, nodeCreateSoloOpts)
-			}, func(context.Context) error {
-				return ExitError{Code: 2, Err: fmt.Errorf("node create is not available in shared mode yet")}
+				return app.DirectNodeCreate(ctx, nodeCreateOpts)
+			}, func(ctx context.Context) error {
+				return app.SharedNodeCreate(ctx, SharedNodeCreateOptions{
+					DirectNodeCreateOptions: nodeCreateOpts,
+					NodeBootstrapOptions:    nodeCreateBootstrapOpts,
+				})
 			})(cmd, args)
 		},
 	}
-	nodeCreateCommand.Flags().StringVar(&nodeCreateSoloOpts.Provider, "provider", "hetzner", "Provider")
-	nodeCreateCommand.Flags().StringVar(&nodeCreateSoloOpts.Region, "region", "ash", "Provider region")
-	nodeCreateCommand.Flags().StringVar(&nodeCreateSoloOpts.Size, "size", "cx22", "Provider machine size")
-	nodeCreateCommand.Flags().StringVar(&nodeCreateSoloOpts.Image, "image", "", "Provider image")
-	nodeCreateCommand.Flags().StringVar(&nodeCreateSoloOpts.Labels, "labels", "", "Comma-separated labels")
-	nodeCreateCommand.Flags().StringVar(&nodeCreateSoloOpts.SSHPublicKey, "ssh-public-key", "", "SSH public key path")
-	nodeCreateCommand.Flags().BoolVar(&nodeCreateSoloOpts.NoInstall, "no-install", false, "Create the provider machine without installing the agent")
-	nodeCreateCommand.Flags().BoolVar(&nodeCreateSoloOpts.Deploy, "deploy", false, "Install the agent and deploy after create")
+	nodeCreateCommand.Flags().StringVar(&nodeCreateOpts.Provider, "provider", "hetzner", "Provider")
+	nodeCreateCommand.Flags().StringVar(&nodeCreateOpts.Region, "region", "ash", "Provider region")
+	nodeCreateCommand.Flags().StringVar(&nodeCreateOpts.Size, "size", "cx22", "Provider machine size")
+	nodeCreateCommand.Flags().StringVar(&nodeCreateOpts.Image, "image", "", "Provider image")
+	nodeCreateCommand.Flags().StringVar(&nodeCreateOpts.Labels, "labels", "", "Comma-separated labels")
+	nodeCreateCommand.Flags().StringVar(&nodeCreateOpts.SSHPublicKey, "ssh-public-key", "", "SSH public key path")
+	nodeCreateCommand.Flags().BoolVar(&nodeCreateOpts.NoInstall, "no-install", false, "Create the provider machine without installing the agent")
+	nodeCreateCommand.Flags().BoolVar(&nodeCreateOpts.Deploy, "deploy", false, "Install the agent and deploy after create (solo mode only)")
+	nodeCreateCommand.Flags().StringVar(&nodeCreateBootstrapOpts.Organization, "org", "", "Shared-mode organization name override")
+	nodeCreateCommand.Flags().StringVar(&nodeCreateBootstrapOpts.Project, "project", "", "Shared-mode project name override")
+	nodeCreateCommand.Flags().StringVar(&nodeCreateBootstrapOpts.Environment, "env", "", "Shared-mode environment name override")
+	nodeCreateCommand.Flags().BoolVar(&nodeCreateBootstrapOpts.Unassigned, "unassigned", false, "Shared mode: register without auto-attaching to the current environment")
 	nodeListCommand := &cobra.Command{
 		Use:   "list",
 		Short: "List nodes",

--- a/cli/internal/workflow/root_test.go
+++ b/cli/internal/workflow/root_test.go
@@ -87,6 +87,7 @@ func TestRootHelpShowsModeFirstFlows(t *testing.T) {
 		"context",
 		"mode",
 		"node",
+		"provider",
 		"secret",
 	} {
 		if !strings.Contains(text, snippet) {
@@ -99,6 +100,7 @@ func TestRootHelpShowsModeFirstFlows(t *testing.T) {
 		"project     ",
 		"org         ",
 		"env         ",
+		"server",
 	} {
 		if strings.Contains(text, hidden) {
 			t.Fatalf("help output unexpectedly showed legacy command %q: %q", hidden, text)
@@ -141,7 +143,7 @@ func TestNodeHelpShowsSharedAndSoloActions(t *testing.T) {
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
-	for _, snippet := range []string{"register", "attach", "detach", "remove", "logs"} {
+	for _, snippet := range []string{"register", "create", "attach", "detach", "remove", "logs"} {
 		if !strings.Contains(stdout.String(), snippet) {
 			t.Fatalf("help output = %q, want %q command", stdout.String(), snippet)
 		}

--- a/cli/internal/workflow/root_test.go
+++ b/cli/internal/workflow/root_test.go
@@ -131,6 +131,27 @@ func TestNodeRegisterHelpSignalsTrialPolicy(t *testing.T) {
 	}
 }
 
+func TestNodeCreateRunsInSharedMode(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, t.TempDir())
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{"--mode", "shared", "node", "create", "prod-1", "--deploy"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() error = nil, want shared node create to run")
+	}
+	if !strings.Contains(err.Error(), "only available in solo mode") {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if strings.Contains(err.Error(), "not available in shared mode") {
+		t.Fatalf("Execute() still used old shared-mode guard: %v", err)
+	}
+}
+
 func TestNodeHelpShowsSharedAndSoloActions(t *testing.T) {
 	t.Parallel()
 

--- a/cli/skills/devopsellence/SKILL.md
+++ b/cli/skills/devopsellence/SKILL.md
@@ -94,6 +94,8 @@ Use these in solo mode when the user wants direct SSH workflows without the cont
 
 ```bash
 devopsellence mode use solo
+devopsellence provider login hetzner
+devopsellence node create prod-1
 devopsellence setup
 devopsellence deploy
 devopsellence node logs <name> --follow

--- a/cli/skills/devopsellence/SKILL.md
+++ b/cli/skills/devopsellence/SKILL.md
@@ -83,6 +83,8 @@ Use these in shared mode when the user wants to run on their own machine or VM:
 
 ```bash
 devopsellence mode use shared
+devopsellence provider login hetzner
+devopsellence node create prod-1
 devopsellence node register
 devopsellence node list --json
 devopsellence node attach <id>

--- a/control-plane/app/views/marketing/docs.html.erb
+++ b/control-plane/app/views/marketing/docs.html.erb
@@ -192,11 +192,11 @@
 
   <section class="prose-section" id="solo-mode">
     <h2>Solo mode</h2>
-    <p>Solo mode deploys over SSH without the control plane. The CLI builds the image locally, streams it to each configured server, writes desired state on the server, and the agent reconciles containers from local files.</p>
+    <p>Solo mode deploys over SSH without the control plane. The CLI builds the image locally, streams it to each configured node, writes desired state on the node, and the agent reconciles containers from local files.</p>
     <p>Today, solo mode exposes web traffic through Envoy on <code>http://&lt;node-host&gt;:8000</code>. Shared-style tunnel mode and automatic SSL for solo mode are planned, but not available yet.</p>
 
-    <h3>Set up a server</h3>
-    <p>Use the setup wizard for an existing SSH server or a Hetzner server created by the CLI:</p>
+    <h3>Set up a node</h3>
+    <p>Use the setup wizard for an existing SSH node or a Hetzner node created by the CLI:</p>
     <div class="terminal">
       <div class="terminal-bar">
         <span class="dot dot-red"></span>
@@ -206,14 +206,14 @@
       <div class="terminal-body">
         <div class="tl"><span class="tp">$</span> devopsellence mode use solo</div>
         <div class="tl"><span class="tp">$</span> devopsellence setup</div>
-        <div class="tl tl-muted"># Existing server: prompts for host, user, labels, and SSH private key path.</div>
+        <div class="tl tl-muted"># Existing node: prompts for host, user, labels, and SSH private key path.</div>
         <div class="tl tl-muted"># Hetzner: prompts for region, size, labels, and SSH public key path.</div>
       </div>
     </div>
     <p>The wizard creates <code>devopsellence.yml</code> when needed, writes the solo node inventory, installs Docker when supported, installs <code>devopsellence-agent</code>, starts the <code>devopsellence-agent</code> systemd service, and runs <code>doctor</code>.</p>
 
-    <h3>Create a Hetzner server</h3>
-    <p>Provider tokens stay outside the config file. For Hetzner, set <code>DEVOPSELLENCE_HETZNER_API_TOKEN</code> or <code>HCLOUD_TOKEN</code>:</p>
+    <h3>Create a Hetzner node</h3>
+    <p>Provider tokens stay outside the config file. Save a Hetzner token locally, or set <code>DEVOPSELLENCE_HETZNER_API_TOKEN</code> or <code>HCLOUD_TOKEN</code>:</p>
     <div class="terminal">
       <div class="terminal-bar">
         <span class="dot dot-red"></span>
@@ -221,13 +221,12 @@
         <span class="dot dot-green"></span>
       </div>
       <div class="terminal-body">
-        <div class="tl"><span class="tp">$</span> export HCLOUD_TOKEN=...</div>
-        <div class="tl"><span class="tp">$</span> devopsellence server create prod-1 \</div>
+        <div class="tl"><span class="tp">$</span> devopsellence provider login hetzner</div>
+        <div class="tl"><span class="tp">$</span> devopsellence node create prod-1 \</div>
         <div class="tl">    --provider hetzner \</div>
         <div class="tl">    --region ash \</div>
         <div class="tl">    --size cx22 \</div>
-        <div class="tl">    --ssh-public-key ~/.ssh/id_ed25519.pub \</div>
-        <div class="tl">    --install</div>
+        <div class="tl">    --ssh-public-key ~/.ssh/id_ed25519.pub</div>
       </div>
     </div>
     <p>Provider-managed nodes record non-secret metadata like provider name, server ID, region, size, public host, SSH user, and labels in <code>devopsellence.yml</code>. The provider API token and SSH private key value are not written to config.</p>
@@ -869,12 +868,16 @@ release_command: bundle exec rails db:migrate</code></pre>
         <dd>Replace labels for a solo node in <code>devopsellence.yml</code>.</dd>
       </div>
       <div class="docs-field">
-        <dt><code>devopsellence server create &lt;name&gt;</code></dt>
-        <dd>Create a provider-managed solo server. Hetzner is supported with <code>--provider hetzner</code>.</dd>
+        <dt><code>devopsellence provider login hetzner</code></dt>
+        <dd>Save and validate a local Hetzner API token for solo node provisioning.</dd>
       </div>
       <div class="docs-field">
-        <dt><code>devopsellence server delete &lt;name&gt; --yes</code></dt>
-        <dd>Delete a provider-managed solo server recorded in local config.</dd>
+        <dt><code>devopsellence node create &lt;name&gt;</code></dt>
+        <dd>Create a provider-managed solo node. Hetzner is supported with <code>--provider hetzner</code>.</dd>
+      </div>
+      <div class="docs-field">
+        <dt><code>devopsellence node remove &lt;name&gt; --yes</code></dt>
+        <dd>Delete a provider-managed solo node recorded in local config.</dd>
       </div>
     </dl>
 
@@ -964,7 +967,7 @@ release_command: bundle exec rails db:migrate</code></pre>
       </div>
       <div class="docs-field">
         <dt><code>DEVOPSELLENCE_HETZNER_API_TOKEN</code></dt>
-        <dd>Hetzner API token for <code>devopsellence server create</code>. <code>HCLOUD_TOKEN</code> is also supported.</dd>
+        <dd>Hetzner API token for <code>devopsellence node create</code>. <code>HCLOUD_TOKEN</code> is also supported.</dd>
       </div>
       <div class="docs-field">
         <dt><code>HCLOUD_TOKEN</code></dt>

--- a/control-plane/app/views/marketing/docs.html.erb
+++ b/control-plane/app/views/marketing/docs.html.erb
@@ -123,9 +123,24 @@
 
   <section class="prose-section" id="connect-servers">
     <h2>Shared nodes</h2>
-    <p>In shared mode, nodes are Linux servers or VMs running the devopsellence agent and attached to an organization. Manual node management is available in paid orgs; preview accounts start on managed capacity. When you're ready to attach your own machines, <code>devopsellence node register</code> prints the install command to run on the node.</p>
+    <p>In shared mode, nodes are Linux servers or VMs running the devopsellence agent and attached to an organization. Manual node management is available in paid orgs; preview accounts start on managed capacity. Use <code>devopsellence node create</code> to provision a Hetzner node and register it, or <code>devopsellence node register</code> when the server already exists.</p>
 
-    <h3>Default: auto-attach to the current environment</h3>
+    <h3>Provider create: auto-attach to the current environment</h3>
+    <div class="terminal">
+      <div class="terminal-bar">
+        <span class="dot dot-red"></span>
+        <span class="dot dot-yellow"></span>
+        <span class="dot dot-green"></span>
+      </div>
+      <div class="terminal-body">
+        <div class="tl"><span class="tp">$</span> devopsellence provider login hetzner</div>
+        <div class="tl"><span class="tp">$</span> devopsellence node create prod-1 --provider hetzner</div>
+        <div class="tl tl-muted"># Server is created, the agent is installed, and the node is registered.</div>
+      </div>
+    </div>
+    <p>In shared mode, create uses the same provider flags as solo mode, then runs the registration install command on the new server.</p>
+
+    <h3>Existing server: auto-attach to the current environment</h3>
     <div class="terminal">
       <div class="terminal-bar">
         <span class="dot dot-red"></span>
@@ -800,6 +815,10 @@ release_command: bundle exec rails db:migrate</code></pre>
         <dd>List nodes for the current mode. In shared mode this shows assignment and agent status.</dd>
       </div>
       <div class="docs-field">
+        <dt><code>devopsellence node create &lt;name&gt;</code></dt>
+        <dd>Create a provider-managed node. In shared mode this provisions the server, installs the agent, and registers the node.</dd>
+      </div>
+      <div class="docs-field">
         <dt><code>devopsellence node attach</code></dt>
         <dd>Attach a node to an environment. Usage: <code>devopsellence node attach &lt;id&gt; --env production</code>.</dd>
       </div>
@@ -869,7 +888,7 @@ release_command: bundle exec rails db:migrate</code></pre>
       </div>
       <div class="docs-field">
         <dt><code>devopsellence provider login hetzner</code></dt>
-        <dd>Save and validate a local Hetzner API token for solo node provisioning.</dd>
+        <dd>Save and validate a local Hetzner API token for node provisioning.</dd>
       </div>
       <div class="docs-field">
         <dt><code>devopsellence node create &lt;name&gt;</code></dt>


### PR DESCRIPTION
## Summary

- Add local provider credential management for Hetzner via `devopsellence provider login/status/logout hetzner`.
- Move provider provisioning onto the shared-friendly `node create/remove` surface and remove the public `server` command path.
- Make `node remove` mode-aware: solo deletes the provider server recorded in local config; shared keeps the existing control-plane node removal behavior.
- Make `node create` mode-aware: solo creates the provider server, writes `direct.nodes`, and installs the direct agent; shared creates the provider server and runs the shared registration install command over SSH.
- Extend Hetzner provisioning to validate tokens, create/reuse SSH keys by public-key content, create/reuse a devopsellence firewall for ports 22/80/443, attach it during server creation, and install agents by default.
- Update README, generated AGENTS guidance, CLI skill docs, and marketing docs to teach the unified node flow.

## Why

Solo mode should become production-usable without creating a CLI surface that diverges from future shared mode. This keeps provider-specific machine work behind a stable node-oriented workflow while leaving desired state as the runtime control surface.

## Validation

- `mise run test` from `cli/`
- `git diff --check`
