### PR TITLE
Improve solo vs shared mode messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,16 @@ Pick a workspace mode.
 - `solo` keeps the loop local: your app, your VM, SSH, Docker, and the `devopsellence` CLI.
 - `shared` keeps the same app model but adds sign-in, org/project/env context, hosted APIs, and team workflows.
 
+|  | Solo | Shared |
+|---|---|---|
+| Infrastructure | SSH + your VMs | Control plane + your VMs |
+| Auth | SSH keys | Browser (GitHub / Google) |
+| Secrets | Local `.env` file | Encrypted server-side |
+| Images | Streamed over SSH | Pushed to registry |
+| HTTPS | Coming soon | Built-in (tunnel or Let's Encrypt) |
+| Team workflows | Single operator | Orgs, projects, environments |
+| Best for | Side projects, single-dev apps | Teams, production, multi-env |
+
 ## Start Here: solo mode
 
 Install the CLI:
@@ -122,6 +132,8 @@ The product layering is deliberate:
 - solo mode first.
 - shared mode when coordination matters.
 - hosted or self-hosted depending on how much convenience you want.
+
+When you outgrow solo, `devopsellence mode use shared` switches to control-plane workflows. Same config, same agent, same deploy verbs.
 
 The design rationale lives in [`docs/vision.md`](docs/vision.md).
 

--- a/control-plane/app/assets/stylesheets/marketing.css
+++ b/control-plane/app/assets/stylesheets/marketing.css
@@ -1729,6 +1729,204 @@ details[open] > .blog-series-summary::before {
   white-space: pre;
 }
 
+/* ── Mode comparison (homepage) ── */
+
+.mode-compare {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 32px;
+  padding: 0;
+}
+
+.mode-card {
+  padding: 28px;
+  border-radius: 12px;
+  border: 1px solid #e5e7eb;
+  background: #fafafa;
+}
+
+.mode-card h3 {
+  margin: 0 0 4px;
+  font-size: 1.15rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.mode-card .mode-tagline {
+  margin: 0 0 20px;
+  font-size: 0.88rem;
+  color: #666;
+  line-height: 1.6;
+}
+
+.mode-card dl {
+  margin: 0;
+}
+
+.mode-row {
+  display: grid;
+  grid-template-columns: 110px 1fr;
+  gap: 8px;
+  padding: 7px 0;
+  border-bottom: 1px solid #f0f0f0;
+  font-size: 0.86rem;
+  align-items: baseline;
+}
+
+.mode-row:last-child {
+  border-bottom: none;
+}
+
+.mode-row dt {
+  color: #999;
+  font-weight: 500;
+}
+
+.mode-row dd {
+  margin: 0;
+  color: #333;
+}
+
+.mode-lead {
+  margin-top: 12px;
+  font-size: 0.92rem;
+  color: #555;
+  line-height: 1.6;
+  text-align: center;
+}
+
+/* ── Mode badge (docs section headers) ── */
+
+.mode-badge {
+  display: inline-block;
+  font-size: 0.65rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  padding: 2px 7px;
+  border-radius: 4px;
+  vertical-align: middle;
+  margin-left: 8px;
+}
+
+.mode-badge--both {
+  background: #f3f4f6;
+  color: #888;
+}
+
+.mode-badge--solo {
+  background: #eff6ff;
+  color: #1e40af;
+}
+
+.mode-badge--shared {
+  background: #f0fdf4;
+  color: #166534;
+}
+
+/* ── Compare table (docs feature matrix) ── */
+
+.compare-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 20px 0;
+  font-size: 0.88rem;
+}
+
+.compare-table th {
+  text-align: left;
+  padding: 10px 12px;
+  font-weight: 600;
+  font-size: 0.84rem;
+  color: #111;
+  border-bottom: 2px solid #e5e7eb;
+}
+
+.compare-table th:first-child {
+  color: #999;
+  font-weight: 500;
+}
+
+.compare-table td {
+  padding: 9px 12px;
+  border-bottom: 1px solid #f5f5f5;
+  color: #444;
+  line-height: 1.5;
+}
+
+.compare-table td:first-child {
+  font-weight: 500;
+  color: #333;
+}
+
+.compare-table tr:last-child td {
+  border-bottom: none;
+}
+
+.compare-table .compare-na {
+  color: #ccc;
+  font-style: italic;
+}
+
+/* ── Architecture layers diagram ── */
+
+.arch-layers {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  margin: 20px 0;
+}
+
+.arch-layer {
+  padding: 16px 20px;
+  border: 1px solid;
+  text-align: center;
+}
+
+.arch-layer:first-child {
+  border-radius: 8px 8px 0 0;
+}
+
+.arch-layer:last-child {
+  border-radius: 0 0 8px 8px;
+}
+
+.arch-layer strong {
+  display: block;
+  font-size: 0.92rem;
+  margin-bottom: 2px;
+}
+
+.arch-layer span {
+  font-size: 0.82rem;
+  line-height: 1.4;
+}
+
+.arch-layer--optional {
+  background: #f9fafb;
+  border-color: #e5e7eb;
+  border-style: dashed;
+}
+
+.arch-layer--optional strong { color: #666; }
+.arch-layer--optional span { color: #999; }
+
+.arch-layer--cli {
+  background: #eff6ff;
+  border-color: #bfdbfe;
+}
+
+.arch-layer--cli strong { color: #1e40af; }
+.arch-layer--cli span { color: #555; }
+
+.arch-layer--agent {
+  background: #f0fdf4;
+  border-color: #bbf7d0;
+}
+
+.arch-layer--agent strong { color: #166534; }
+.arch-layer--agent span { color: #555; }
+
 /* ── Responsive ── */
 
 @media (max-width: 768px) {
@@ -1843,6 +2041,12 @@ details[open] > .blog-series-summary::before {
     overflow-x: auto;
     text-overflow: clip;
     -webkit-overflow-scrolling: touch;
+  }
+
+  /* Mode comparison */
+  .mode-compare {
+    grid-template-columns: 1fr;
+    gap: 24px;
   }
 
   /* Split sections */

--- a/control-plane/app/views/marketing/architecture.html.erb
+++ b/control-plane/app/views/marketing/architecture.html.erb
@@ -7,12 +7,49 @@
   </header>
 
   <section class="prose-section">
-    <h2>The split</h2>
-    <p>The control plane tracks organizations, environments, releases, and rollout state. Nodes pull their current target, verify signed desired state, and reconcile containers locally. The control plane decides. VM agents execute.</p>
+    <h2>Two modes, one agent</h2>
+    <p>devopsellence has two deployment modes. Both use the same agent and the same reconciliation loop. What changes is how desired state and images reach the agent.</p>
+    <div class="arch-layers">
+      <div class="arch-layer arch-layer--optional">
+        <strong>Control plane</strong>
+        <span>Shared mode only &mdash; tracks orgs, releases, HTTPS, rollout state</span>
+      </div>
+      <div class="arch-layer arch-layer--cli">
+        <strong>CLI</strong>
+        <span>Both modes &mdash; builds images, publishes releases or writes state over SSH</span>
+      </div>
+      <div class="arch-layer arch-layer--agent">
+        <strong>Agent</strong>
+        <span>Both modes &mdash; reconciles containers, runs health checks, manages Envoy</span>
+      </div>
+    </div>
+    <p>In <strong>solo mode</strong>, the CLI sends everything over SSH: images via <code>docker save/load</code>, desired state as a JSON file, secrets pre-resolved. No registry, no cloud services. In <strong>shared mode</strong>, the control plane coordinates: images go to a registry, desired state is signed and published, agents pull independently.</p>
   </section>
 
   <section class="prose-section">
-    <h2>Deploy flow</h2>
+    <h2>Solo deploy flow</h2>
+    <ol class="flow-list">
+      <li>
+        <strong>Build</strong>
+        <span>CLI builds the Docker image locally.</span>
+      </li>
+      <li>
+        <strong>Transfer</strong>
+        <span>Image streams over SSH via <code>docker save | gzip | ssh | docker load</code>. No registry, no intermediate files.</span>
+      </li>
+      <li>
+        <strong>Write state</strong>
+        <span>CLI writes desired-state JSON to the node filesystem over SSH. Secrets are pre-resolved and embedded.</span>
+      </li>
+      <li>
+        <strong>Reconcile</strong>
+        <span>The agent picks up the new file within 2 seconds, starts containers, runs health checks, and updates Envoy for zero-downtime traffic switching.</span>
+      </li>
+    </ol>
+  </section>
+
+  <section class="prose-section">
+    <h2>Shared deploy flow</h2>
     <ol class="flow-list">
       <li>
         <strong>Publish</strong>
@@ -36,6 +73,8 @@
   <section class="prose-section">
     <h2>Security</h2>
     <p>Security comes from machine boundaries and provider primitives, not from inventing a new platform layer.</p>
+    <p><strong>Solo mode</strong> relies on SSH security: SSH keys for access, secrets stored locally in a <code>.env</code> file, and no network services to attack.</p>
+    <p><strong>Shared mode</strong> adds infrastructure-level controls:</p>
     <ul>
       <li>Per-environment runtime access scoped through service accounts and IAM bindings.</li>
       <li>Workload Identity for short-lived token exchange instead of long-lived credentials.</li>
@@ -68,6 +107,6 @@
 
   <section class="prose-section">
     <h2>Where this is heading</h2>
-    <p>Two product tracks are emerging: managed control plane plus your servers, and a fully self-hosted standalone edition with no GCP dependency. Both keep VMs as the unit of execution. See the <%= link_to "roadmap", roadmap_path %>.</p>
+    <p>Three product tracks are emerging: solo mode for SSH-first workflows with no infrastructure overhead, managed control plane plus your servers for team workflows, and a fully self-hosted control plane with no GCP dependency. All three keep VMs as the unit of execution and share the same agent. See the <%= link_to "roadmap", roadmap_path %>.</p>
   </section>
 </main>

--- a/control-plane/app/views/marketing/blog/direct-mode-deploy-with-nothing-but-ssh.html.erb
+++ b/control-plane/app/views/marketing/blog/direct-mode-deploy-with-nothing-but-ssh.html.erb
@@ -12,6 +12,8 @@
 
   <article class="article-body">
 
+    <p class="article-note" style="padding:12px 16px;border-radius:8px;background:#eff6ff;border:1px solid #bfdbfe;font-size:0.88rem;color:#1e40af;margin-bottom:24px;"><strong>Note:</strong> This feature was originally called "direct mode" during development. The user-facing name is <strong>solo mode</strong>, which is what you'll see in the CLI and docs.</p>
+
     <p>devopsellence has always been opinionated about how deploys work: agents pull desired state, reconcile containers, and report status. That loop is the same whether you're deploying to a fleet managed by the control plane or to a single VPS you SSH into. But until now, using devopsellence meant running the control plane &mdash; or at minimum, a standalone backend.</p>
 
     <p>Today we're shipping <strong>solo mode</strong>: deploy to any server with nothing but SSH and Docker. No control plane. No cloud services. No registry. One command, and your app is running.</p>

--- a/control-plane/app/views/marketing/docs.html.erb
+++ b/control-plane/app/views/marketing/docs.html.erb
@@ -10,6 +10,7 @@
     <div class="docs-toc-group">
       <h3>Get started</h3>
       <a href="#overview">Overview</a>
+      <a href="#compare-modes">Compare modes</a>
       <a href="#quick-start">Quick start</a>
       <a href="#connect-servers">Shared nodes</a>
       <a href="#solo-mode">Solo mode</a>
@@ -31,6 +32,7 @@
       <h3>Reference</h3>
       <a href="#cli-reference">CLI commands</a>
       <a href="#env-vars">Environment variables</a>
+      <a href="#migrating">Migrating solo &rarr; shared</a>
       <a href="#troubleshooting">Troubleshooting</a>
       <a href="#cleanup">Cleanup &amp; uninstall</a>
     </div>
@@ -40,15 +42,109 @@
 
   <section class="prose-section" id="overview">
     <h2>Overview</h2>
-    <p>devopsellence is a VM-native deployment toolkit for containerized applications. The agent is the core runtime component. The CLI and control plane are convenience layers around it.</p>
+    <p>devopsellence is a VM-native deployment toolkit for containerized applications. It has two modes: <strong>solo</strong> for SSH-first local workflows and <strong>shared</strong> for control-plane-backed team workflows. Both modes use the same agent and the same deploy verbs.</p>
     <p>The system has three parts:</p>
     <ul>
-      <li><strong>Control plane</strong> &mdash; coordination layer for releases, secrets, HTTPS certificates, and rollout state.</li>
-      <li><strong>CLI</strong> &mdash; runs on your workstation or CI. Builds images, publishes releases, manages secrets and nodes.</li>
-      <li><strong>Agent</strong> &mdash; runs on your servers. Pulls desired state periodically, verifies signed envelopes, and reconciles containers with zero-downtime rollouts via Envoy proxy.</li>
+      <li><strong>Agent</strong> &mdash; runs on your servers. Reconciles containers with zero-downtime rollouts via Envoy proxy. Used in both modes.</li>
+      <li><strong>CLI</strong> &mdash; runs on your workstation or CI. Builds images, manages secrets and nodes. Used in both modes.</li>
+      <li><strong>Control plane</strong> &mdash; coordination layer for releases, secrets, HTTPS certificates, and rollout state. Used in shared mode only.</li>
     </ul>
     <p>Any web app packaged as a Docker image can be deployed. The data hierarchy is: <strong>Organization &rarr; Project &rarr; Environment &rarr; Release &rarr; Nodes</strong>. An environment can have many nodes, but each node belongs to one environment at a time.</p>
     <p>devopsellence does not force a database, cache, queue, logging backend, metrics backend, or analytics product. Bring hosted services or self-host the rest of your stack.</p>
+  </section>
+
+  <%# ─── Compare modes ─── %>
+
+  <section class="prose-section" id="compare-modes">
+    <h2>Compare modes</h2>
+    <p>Both modes share the same CLI verbs, the same agent, and the same <code>devopsellence.yml</code> config. The mode decides how state and images reach the agent.</p>
+
+    <table class="compare-table">
+      <thead>
+        <tr>
+          <th></th>
+          <th>Solo</th>
+          <th>Shared</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Control plane</td>
+          <td>None</td>
+          <td>Managed or self-hosted</td>
+        </tr>
+        <tr>
+          <td>Transport</td>
+          <td>SSH</td>
+          <td>Agent pulls from control plane</td>
+        </tr>
+        <tr>
+          <td>Auth</td>
+          <td>SSH keys</td>
+          <td>Browser (GitHub / Google)</td>
+        </tr>
+        <tr>
+          <td>Image delivery</td>
+          <td>Streamed over SSH</td>
+          <td>Pushed to registry</td>
+        </tr>
+        <tr>
+          <td>Secrets</td>
+          <td>Local <code>.env</code> file</td>
+          <td>Encrypted server-side (Secret Manager or database)</td>
+        </tr>
+        <tr>
+          <td>HTTPS</td>
+          <td><span class="compare-na">Planned</span></td>
+          <td>Tunnel mode or Let's Encrypt</td>
+        </tr>
+        <tr>
+          <td>Team workflows</td>
+          <td>Single operator</td>
+          <td>Orgs, projects, environments</td>
+        </tr>
+        <tr>
+          <td>CI / GitHub Actions</td>
+          <td><span class="compare-na">Not yet</span></td>
+          <td>Deploy action with API tokens</td>
+        </tr>
+        <tr>
+          <td>Node provisioning</td>
+          <td>Hetzner from CLI</td>
+          <td>Hetzner from CLI + control plane registration</td>
+        </tr>
+        <tr>
+          <td>Zero-downtime deploys</td>
+          <td>Yes (Envoy)</td>
+          <td>Yes (Envoy)</td>
+        </tr>
+        <tr>
+          <td>Health checks</td>
+          <td>Yes</td>
+          <td>Yes</td>
+        </tr>
+        <tr>
+          <td>Release commands</td>
+          <td>Yes</td>
+          <td>Yes</td>
+        </tr>
+        <tr>
+          <td>Volumes</td>
+          <td>Yes</td>
+          <td>Yes</td>
+        </tr>
+        <tr>
+          <td>Worker services</td>
+          <td>Yes</td>
+          <td>Yes</td>
+        </tr>
+        <tr>
+          <td>Best for</td>
+          <td>Side projects, single-dev apps, staging</td>
+          <td>Teams, production, multi-environment</td>
+        </tr>
+      </tbody>
+    </table>
   </section>
 
   <%# ─── Quick start ─── %>
@@ -122,7 +218,7 @@
   <%# ─── Connect your servers ─── %>
 
   <section class="prose-section" id="connect-servers">
-    <h2>Shared nodes</h2>
+    <h2>Shared nodes <span class="mode-badge mode-badge--shared">shared</span></h2>
     <p>In shared mode, nodes are Linux servers or VMs running the devopsellence agent and attached to an organization. Manual node management is available in paid orgs; preview accounts start on managed capacity. Use <code>devopsellence node create</code> to provision a Hetzner node and register it, or <code>devopsellence node register</code> when the server already exists.</p>
 
     <h3>Provider create: auto-attach to the current environment</h3>
@@ -206,7 +302,7 @@
   <%# ─── Solo mode ─── %>
 
   <section class="prose-section" id="solo-mode">
-    <h2>Solo mode</h2>
+    <h2>Solo mode <span class="mode-badge mode-badge--solo">solo</span></h2>
     <p>Solo mode deploys over SSH without the control plane. The CLI builds the image locally, streams it to each configured node, writes desired state on the node, and the agent reconciles containers from local files.</p>
     <p>Today, solo mode exposes web traffic through Envoy on <code>http://&lt;node-host&gt;:8000</code>. Shared-style tunnel mode and automatic SSL for solo mode are planned, but not available yet.</p>
 
@@ -247,7 +343,7 @@
     <p>Provider-managed nodes record non-secret metadata like provider name, server ID, region, size, public host, SSH user, and labels in <code>devopsellence.yml</code>. The provider API token and SSH private key value are not written to config.</p>
 
     <h3>Solo config</h3>
-    <p>Solo node inventory is part of <code>devopsellence.yml</code>, so it can be committed and used from CI. The current config schema stores this under the <code>direct</code> block. Keep private key material in your SSH agent, local filesystem, or CI secrets.</p>
+    <p>Solo node inventory is part of <code>devopsellence.yml</code>, so it can be committed and used from CI. The config schema stores this under the <code>direct</code> block (the internal name for solo mode). Keep private key material in your SSH agent, local filesystem, or CI secrets.</p>
     <div class="terminal">
       <div class="terminal-bar">
         <span class="dot dot-red"></span>
@@ -345,7 +441,7 @@
   <%# ─── Deploy from GitHub Actions ─── %>
 
   <section class="prose-section" id="deploy-github-actions">
-    <h2>Deploy from GitHub Actions</h2>
+    <h2>Deploy from GitHub Actions <span class="mode-badge mode-badge--shared">shared</span></h2>
     <p>Use the <a href="https://github.com/devopsellence/deploy-action" target="_blank" rel="noopener noreferrer">devopsellence/deploy-action</a> to deploy automatically on push.</p>
 
     <h3>1. Create a deploy token</h3>
@@ -582,11 +678,11 @@ release_command: bundle exec rails db:migrate</code></pre>
       </div>
       <div class="docs-field">
         <dt><code>direct.nodes</code></dt>
-        <dd>Direct-mode node inventory keyed by node name. Each node has <code>host</code>, <code>user</code>, optional <code>port</code>, optional <code>ssh_key</code>, optional <code>agent_state_dir</code>, and <code>labels</code>.</dd>
+        <dd>Solo mode node inventory keyed by node name. Each node has <code>host</code>, <code>user</code>, optional <code>port</code>, optional <code>ssh_key</code>, optional <code>agent_state_dir</code>, and <code>labels</code>. (The config key is <code>direct</code> for historical reasons; the user-facing mode name is <code>solo</code>.)</dd>
       </div>
       <div class="docs-field">
         <dt><code>direct.nodes.*.labels</code></dt>
-        <dd>Service placement labels for solo mode. Supported values are <code>web</code> and <code>worker</code>.</dd>
+        <dd>Service placement labels (solo mode). Supported values are <code>web</code> and <code>worker</code>.</dd>
       </div>
       <div class="docs-field">
         <dt><code>direct.nodes.*.provider</code></dt>
@@ -695,9 +791,8 @@ release_command: bundle exec rails db:migrate</code></pre>
   <%# ─── Ingress ─── %>
 
   <section class="prose-section" id="ingress">
-    <h2>Ingress &amp; HTTPS</h2>
-    <p>Today, the managed ingress modes below apply to shared mode. In solo mode today, the default path is direct HTTP on <code>http://&lt;node-host&gt;:8000</code>.</p>
-    <p>Shared-style tunnel mode and automatic SSL are planned for solo mode too, but have not shipped yet.</p>
+    <h2>Ingress &amp; HTTPS <span class="mode-badge mode-badge--shared">shared</span></h2>
+    <p>The managed ingress modes below apply to shared mode. In solo mode, the app is exposed via Envoy on <code>http://&lt;node-host&gt;:8000</code> (HTTP only). Tunnel mode and automatic SSL for solo mode are planned.</p>
 
     <h3>Tunnel mode (default)</h3>
     <p>The default for getting started quickly. A Cloudflare tunnel routes traffic from a <code>*.devopsellence.io</code> hostname to a single node. No DNS configuration or open ports required.</p>
@@ -993,6 +1088,30 @@ release_command: bundle exec rails db:migrate</code></pre>
         <dd>Alternative Hetzner API token variable used by the Hetzner CLI and supported by solo mode.</dd>
       </div>
     </dl>
+  </section>
+
+  <%# ─── Migrating solo → shared ─── %>
+
+  <section class="prose-section" id="migrating">
+    <h2>Migrating from solo to shared</h2>
+    <p>When you outgrow solo mode, switching to shared keeps most of your setup intact. The agent reconciliation loop, your <code>devopsellence.yml</code> config, your Dockerfile, and your deploy verbs all stay the same.</p>
+
+    <h3>What changes</h3>
+    <ul>
+      <li><strong>Mode</strong> &mdash; run <code>devopsellence mode use shared</code>, then <code>devopsellence setup</code> to sign in and create org/project/env context.</li>
+      <li><strong>Nodes</strong> &mdash; register your existing servers with <code>devopsellence node register</code> and run the install command on each server. The agent switches from file-watching to control-plane polling.</li>
+      <li><strong>Images</strong> &mdash; instead of streaming over SSH, images are pushed to a container registry. The control plane handles registry credentials.</li>
+      <li><strong>Secrets</strong> &mdash; re-create secrets with <code>devopsellence secret set &lt;name&gt; --service web --stdin</code>. They move from your local <code>.env</code> to encrypted server-side storage.</li>
+      <li><strong>Config</strong> &mdash; the <code>direct.nodes</code> block in <code>devopsellence.yml</code> is no longer used. You can remove it or leave it; the CLI ignores it in shared mode.</li>
+    </ul>
+
+    <h3>What stays the same</h3>
+    <ul>
+      <li>Your <code>devopsellence.yml</code> app config (build, web, worker, release_command, healthcheck, volumes).</li>
+      <li>Your Dockerfile and application code.</li>
+      <li>The agent's reconciliation loop, zero-downtime rollouts, health checks, and Envoy proxy.</li>
+      <li>CLI verbs: <code>deploy</code>, <code>status</code>, <code>secret</code>, <code>doctor</code>.</li>
+    </ul>
   </section>
 
   <%# ─── Troubleshooting ─── %>

--- a/control-plane/app/views/marketing/index.html.erb
+++ b/control-plane/app/views/marketing/index.html.erb
@@ -3,7 +3,7 @@
 <main class="page">
   <section class="hero">
     <h1 class="hero-title">VMs are enough.</h1>
-    <p class="hero-sub">devopsellence is a toolkit for deploying and running containerized apps.<br>No PaaS. No platform. No extra abstraction layer.</p>
+    <p class="hero-sub">devopsellence is a toolkit for deploying and running containerized apps.<br>No PaaS. No platform. No extra abstraction layer.<br>Start with SSH. Add a control plane when you need one.</p>
 
     <div class="install-pill">
       <code id="install-cmd"><%= @cli_install_command %></code>
@@ -36,6 +36,38 @@
           <div class="tl tl-muted">Transferring image...</div>
           <div class="tl tl-ok">Deployed revision abc1234 to 1 node(s)</div>
         </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="section">
+    <h2 class="section-center" style="text-align:center;margin:0 auto 8px;font-size:2rem;font-weight:700;letter-spacing:-0.03em;">Two modes. Same deploy verbs.</h2>
+    <p class="mode-lead">Pick the mode that fits today. Switch when your needs change.</p>
+
+    <div class="mode-compare" style="margin-top:32px;">
+      <div class="mode-card">
+        <h3>Solo</h3>
+        <p class="mode-tagline">SSH-first. No control plane. Deploy from your terminal to any Linux server.</p>
+        <dl>
+          <div class="mode-row"><dt>Transport</dt><dd>SSH</dd></div>
+          <div class="mode-row"><dt>Auth</dt><dd>SSH keys</dd></div>
+          <div class="mode-row"><dt>Secrets</dt><dd>Local <code>.env</code> file</dd></div>
+          <div class="mode-row"><dt>Images</dt><dd>Streamed over SSH</dd></div>
+          <div class="mode-row"><dt>HTTPS</dt><dd>Coming soon</dd></div>
+          <div class="mode-row"><dt>Best for</dt><dd>Side projects, single-dev apps, staging</dd></div>
+        </dl>
+      </div>
+      <div class="mode-card">
+        <h3>Shared</h3>
+        <p class="mode-tagline">Control-plane-backed. Team auth, managed HTTPS, org/project/env hierarchy.</p>
+        <dl>
+          <div class="mode-row"><dt>Transport</dt><dd>Agent pulls from control plane</dd></div>
+          <div class="mode-row"><dt>Auth</dt><dd>Browser (GitHub / Google)</dd></div>
+          <div class="mode-row"><dt>Secrets</dt><dd>Encrypted server-side</dd></div>
+          <div class="mode-row"><dt>Images</dt><dd>Pushed to registry</dd></div>
+          <div class="mode-row"><dt>HTTPS</dt><dd>Built-in (tunnel or Let's Encrypt)</dd></div>
+          <div class="mode-row"><dt>Best for</dt><dd>Teams, production, multi-environment</dd></div>
+        </dl>
       </div>
     </div>
   </section>

--- a/control-plane/app/views/marketing/roadmap.html.erb
+++ b/control-plane/app/views/marketing/roadmap.html.erb
@@ -3,12 +3,22 @@
 <main class="page page-prose">
   <header class="page-header">
     <h1>Roadmap</h1>
-    <p class="page-lead">devopsellence is in preview. The core VM-native deploy loop works end to end. The road to general availability is about hardening, visibility, and making the tooling more composable.</p>
+    <p class="page-lead">devopsellence is in preview. Both solo and shared modes work end to end. The road to general availability is about hardening, visibility, and making the tooling more composable.</p>
   </header>
 
   <section class="prose-section">
     <h2>Preview <span class="roadmap-badge roadmap-badge--green">now</span></h2>
     <p>Everything listed here is shipped and working today.</p>
+    <h3>Solo mode</h3>
+    <ul class="checklist">
+      <li class="checklist-done">Solo deploy &mdash; build locally, stream images over SSH, write desired state, agent reconciles. No control plane.</li>
+      <li class="checklist-done">Solo secrets &mdash; local <code>.env</code> file, pre-resolved into desired state during deploy.</li>
+      <li class="checklist-done">Solo node provisioning &mdash; create Hetzner servers from the CLI with <code>node create --provider hetzner</code>.</li>
+      <li class="checklist-done">Solo setup wizard &mdash; guided onboarding for existing SSH nodes or new Hetzner nodes.</li>
+      <li class="checklist-done">Same agent &mdash; zero-downtime rollouts, health checks, Envoy proxy, release commands, volumes.</li>
+    </ul>
+
+    <h3>Shared mode</h3>
     <ul class="checklist">
       <li class="checklist-done">Deploy core &mdash; managed HTTPS, health-check-aware rollouts, zero-downtime redeploys.</li>
       <li class="checklist-done">CLI-first flow &mdash; install, sign in, deploy from your terminal.</li>
@@ -43,7 +53,15 @@
 
   <section class="prose-section">
     <h2>Future</h2>
-    <p>Two product tracks after general availability.</p>
+    <p>Three product tracks after general availability.</p>
+
+    <h3>Solo mode</h3>
+    <p>Solo mode is a first-class product path, not a stepping stone. These features bring it closer to parity with shared mode for single-operator workflows.</p>
+    <ul class="roadmap-future">
+      <li><strong>Automatic SSL for solo</strong> &mdash; tunnel mode and Let's Encrypt certificates without needing a control plane.</li>
+      <li><strong>More providers</strong> &mdash; DigitalOcean and GCP node provisioning alongside Hetzner.</li>
+      <li><strong>Encrypted local secrets</strong> &mdash; encrypt <code>.env</code> at rest so secrets are safer on disk and in CI.</li>
+    </ul>
 
     <h3>Managed control plane + your servers</h3>
     <p>Keep the control plane managed. Run workloads on VMs you already operate, or have devopsellence automate the boring parts of provisioning and bootstrap in your cloud account.</p>
@@ -56,10 +74,10 @@
       <li><strong>Region-aware placement</strong> &mdash; place workloads close to users across multiple regions without changing the one-app-per-VM model.</li>
     </ul>
 
-    <h3>Fully self-hosted standalone</h3>
-    <p>Run the entire devopsellence stack yourself, with no GCP dependency. Keep the same agent model, keep VMs as the unit of execution, and choose your own supporting services.</p>
+    <h3>Self-hosted control plane</h3>
+    <p>Run the entire devopsellence control plane yourself, with no GCP dependency. Keep the same agent model, keep VMs as the unit of execution, and choose your own supporting services.</p>
     <ul class="roadmap-future">
-      <li><strong>Standalone mode</strong> &mdash; drop the GCP requirement entirely for teams that want full control over every layer.</li>
+      <li><strong>GCP-free control plane</strong> &mdash; drop the GCP requirement entirely for teams that want full control over every layer.</li>
       <li><strong>Open-source control plane</strong> &mdash; run devopsellence end to end on your own infrastructure.</li>
     </ul>
   </section>


### PR DESCRIPTION
## Summary

- **Homepage**: Added mode comparison section with side-by-side cards showing solo vs shared features. Updated hero subtitle to signal the progression ("Start with SSH. Add a control plane when you need one.")
- **Architecture page**: Added "Two modes, one agent" section with layered diagram showing control plane as optional. Split deploy flow into solo and shared sections. Added solo context to security section.
- **Roadmap page**: Added solo mode items to the preview checklist. Added solo mode future track (automatic SSL, more providers, encrypted local secrets). Renamed "Fully self-hosted standalone" to "Self-hosted control plane" to avoid confusion with solo mode.
- **Docs page**: Added feature comparison table (15 rows) after overview. Added mode badges (`solo`, `shared`) on section headers where the distinction matters. Added "Migrating from solo to shared" section with what-changes and what-stays-the-same lists. Clarified `direct`/`solo` naming in config field reference.
- **README**: Added comparison table. Added migration one-liner.
- **Blog**: Added terminology note to the "direct mode" post explaining the rename to "solo mode".
- **CSS**: Styles for mode comparison cards, mode badges, compare table, and architecture layer diagram.

## Test plan

- [ ] Verify homepage renders with the new mode comparison section
- [ ] Verify architecture page renders with the new layered diagram and dual deploy flows
- [ ] Verify roadmap page renders with solo mode tracks
- [ ] Verify docs page renders with comparison table, mode badges, and migration section
- [ ] Verify blog post renders with the terminology note
- [ ] Check responsive layout at mobile widths (mode cards should stack)

🤖 Generated with [Claude Code](https://claude.com/claude-code)