### PR TITLE
[codex] Document core architecture principles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,90 +1,87 @@
-# AGENTS.md — devopsellence monorepo
+# AGENTS.md - devopsellence monorepo
 
 Always write "devopsellence" in all lowercase.
 
-## Repository layout
+## Layout
 
-This is a monorepo with three independent components plus a root-owned test harness:
-
-| Directory | Language | What it is |
+| Path | Stack | Purpose |
 |---|---|---|
-| `agent/` | Go | Single-node reconciliation daemon. Reads desired state from GCS, pulls images from Artifact Registry, manages local containers via Docker. |
-| `cli/` | Go | End-user CLI (`devopsellence` binary). Handles login, deploy, secrets, node management. Talks to the control plane API. |
-| `control-plane/` | Ruby (Rails 8) | Web app + API. Manages tenants, deployments, nodes, GCP resources. Uses PostgreSQL. |
-| `test/e2e/` | Ruby + shell | Hermetic monorepo integration lane spanning `agent/`, `cli/`, `control-plane/`, and in-tree `test/support/gcp-mock/`. |
-| `test/support/gcp-mock/` | Go | Local emulator for the subset of GCP APIs used by the hermetic e2e lane. |
+| `agent/` | Go | Single-node reconciler: desired state, Docker, Envoy, cloudflared, status. |
+| `cli/` | Go | `devopsellence` CLI: login, deploy, secrets, nodes, solo/shared workflows. |
+| `control-plane/` | Rails 8 | Web/API app: tenants, deployments, nodes, GCP/standalone resources. |
+| `test/e2e/` | Ruby + shell | Root-owned integration harness across agent, CLI, control plane, GCP mock. |
+| `test/support/gcp-mock/` | Go | Local emulator for GCP APIs used by hermetic e2e tests. |
 
-Each directory has its own `go.mod` / `Gemfile`, toolchain, tests, and CI. There is no shared build system — treat them as separate projects that happen to live together.
+Each component has its own toolchain, tests, and CI. No shared build system.
 
-## Toolchain
+## Commands
 
-All components use [mise](https://mise.jdx.dev) for tool versions and task running.
+Use `mise`.
 
-Root-level shortcuts (run from repo root):
-
-```
-mise run test:agent     # run agent tests
-mise run test:cli       # run CLI tests
-mise run test:cp        # run control plane tests
-mise run e2e-shared     # run hermetic shared-mode e2e
-mise run e2e-solo       # run hermetic solo-mode e2e
-mise run test:all       # run all tests
-mise run build:agent    # build agent
-mise run build:cli      # build CLI
-mise run fmt:agent      # format agent Go files
-```
-
-Per-component tasks (cd into the component first):
+From repo root:
 
 ```
-# agent/
-mise run build          # build all Go packages
-mise run test           # run tests
-mise run fmt            # format Go files
-mise run protoc         # generate protobuf Go code
-
-# cli/
-mise run build          # build CLI binary to bin/devopsellence
-mise run test           # run tests
-
-# control-plane/
-mise run test           # run tests (starts Postgres automatically)
-bin/dev                 # start dev server
+mise run test:agent
+mise run test:cli
+mise run test:cp
+mise run e2e-shared
+mise run e2e-solo
+mise run test:all
+mise run build:agent
+mise run build:cli
+mise run fmt:agent
 ```
 
-Local override files and machine-specific templates should stay out of this public monorepo.
+Per component:
 
-## Testing
+```
+cd agent && mise run build && mise run test && mise run fmt
+cd agent && mise run protoc
+cd cli && mise run build && mise run test
+cd control-plane && mise run test
+cd control-plane && bin/dev
+```
 
-- **agent/cli:** `mise run test` (Go tests, no external deps).
-- **control-plane:** `mise run test` (needs Postgres via Docker; mise handles startup). Uses Minitest with mocha (stubs/mocks) and webmock (HTTP interception) — both are required in `test/test_helper.rb`. Run a single file with `mise run test -- test/path/file_test.rb`. Never write tests for static pages with no business logic.
-- **e2e:** `mise run e2e-shared` or `mise run e2e-solo` from the repo root. They use in-tree `agent/`, `cli/`, and `test/support/gcp-mock/`.
+Control-plane tests start Postgres via mise. Single file:
 
-## Code structure
+```
+cd control-plane && mise run test -- test/path/file_test.rb
+```
 
-**agent/** — `cmd/devopsellence/` (entrypoint), `internal/` (all packages: engine, reconcile, envoy, gcp, auth, cloudflared, etc.), `proto/` (protobuf definitions).
+## Structure
 
-**cli/** — `cmd/devopsellence/` (entrypoint), `internal/` (packages: api, app, auth, docker, git, workflow, ui, etc.), `skills/` (OpenClaw skill).
-
-**control-plane/** — standard Rails layout: `app/{models,controllers,services,views,jobs}`, `config/`, `db/` (migrations), `test/`, `script/` (local operational scripts only).
-
-**test/e2e/** — root-owned hermetic integration lane: runner Dockerfile, runner wrapper, and the end-to-end smoke script.
-
-**test/support/gcp-mock/** — in-tree GCP emulator used by the hermetic e2e lane.
+- `agent/cmd/devopsellence/`: agent entrypoint.
+- `agent/internal/`: engine, reconcile, envoy, gcp, auth, cloudflared, etc.
+- `agent/proto/`: desired-state protobuf.
+- `cli/cmd/devopsellence/`: CLI entrypoint.
+- `cli/internal/`: api, app, auth, docker, git, workflow, ui, solo, etc.
+- `control-plane/app/`: Rails models, controllers, services, views, jobs.
+- `control-plane/script/`: local operational scripts only.
+- `.github/workflows/`: public CI/release workflows with path filters.
 
 ## Conventions
 
-- Go code uses `gofmt`. No linter config beyond that.
-- Rails code uses `.rubocop.yml` for style.
-- CI workflows live in `.github/workflows/` (root), with path filters per component.
-- Public GitHub Release workflows for agent/CLI live here; private publishing and deploy automation should live outside this repository.
+- Go: `gofmt`; no extra linter config.
+- Rails: `.rubocop.yml`.
+- Prefer Rails 8 solid stack, no-build CSS/JS, Tailwind, sqlite where appropriate.
+- Never test static pages with no business logic.
+- Keep local override files and machine-specific templates out of this repo.
 
-## Public Repo Boundary
+## Architecture
 
-- Keep this repo public-safe: source, tests, CI, and local development tasks.
-- Treat this repo as effectively public at all times; never add secrets, private identifiers, or operational data you would not publish on GitHub.
-- Keep private deploy infrastructure in a separate private repository outside this tree.
-- Keep private publishing and build/release/deploy automation outside this repository.
-- Keep maintainer-only live e2e flows outside this repository.
-- Keep prod deploy/apply, prod console/log/ssh, runtime-env secret sync, and CDN cache busting out of this public repo.
-- Do not add live credentials, cloud project IDs, or tenant-specific operational data to tracked files here.
+- Solo/shared deploy semantics should match. Differences: user/org/project management, ownership, persistence, transport, policy.
+- Shared core owns config interpretation, validation, planning, desired-state generation, ingress, placement constraints, status interpretation.
+- Prefer Go for reusable deployment core logic. CLI calls it in-process for solo; Rails should eventually call it through service/RPC.
+- Rails owns product state: accounts, authz, billing, hosted persistence, API surfaces.
+- Placement is policy, not schema. Shared may require one environment per node; solo may allow multiple environments per node.
+- Desired state is mode-independent node runtime state. A node may carry multiple environment instances; an environment may have multiple named services/workers.
+- Agent runtime must not know product modes like solo/shared. Wire concrete adapters for desired-state source, secret resolver, status sink, registry auth, etc.
+- Core: solid, explicit. Edges: more malleable.
+
+## Public Boundary
+
+This repo is public.
+
+- Keep source, tests, CI, and local dev tasks here.
+- Keep secrets, private identifiers, tenant data, live credentials, cloud project IDs out.
+- Keep private deploy infra, publishing, maintainer live e2e, prod apply/console/log/ssh, runtime-env secret sync, CDN cache busting out.

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -33,6 +33,8 @@ Everything else is optional convenience around that loop.
 
 The CLI is convenience. The control plane is convenience. Hosted workflows are convenience. Those pieces matter, but they are not the essence of the system. The essence is the contract between desired state and the agent that enforces it.
 
+The product should grow from a shared, fundamental core. The closer code is to that core, the more stable, explicit, and mode-independent it should be. The further a feature sits from the core, the more malleable it can become for solo workflows, hosted workflows, managed infrastructure, user interfaces, and policy choices.
+
 devopsellence also does not try to own the rest of the application stack. It does not come with a mandatory database, cache, message queue, logging backend, metrics backend, or analytics product. Users are free to integrate with existing hosted services such as PlanetScale, or run their own supporting services on infrastructure they control. A major goal is to make that choice easy rather than replace it with a devopsellence-specific answer.
 
 ## Assumptions
@@ -40,19 +42,22 @@ devopsellence also does not try to own the rest of the application stack. It doe
 - The VM is already the right unit of isolation for the target user.
 - Docker-level containerization is already a sufficient packaging format.
 - Most target applications are a small set of cooperating services, not a large microservice graph.
-- The common case is one application environment per machine, not many unrelated tenants packed onto one server.
+- A deployment target may choose one environment per machine, but that should be placement policy, not a hard limit in the runtime model.
 - Teams value debuggability and explicitness more than maximum infrastructure utilization.
 - Provider-native primitives are usually better than rebuilding weaker versions of them inside devopsellence.
 - Users should be able to adopt devopsellence incrementally, starting from just the agent.
 
-These assumptions are visible in the code today. The product has a solo path that reads desired state from local files and a shared path that fetches desired state and secrets from external systems. The CLI already has a solo workflow that builds desired state locally, resolves secrets from `.env`, and writes an override file to remote nodes over SSH. That split is not accidental; it reflects the intended shape of the product.
+These assumptions are visible in the code today. The product has a solo path that reads desired state from local files and a shared path that fetches desired state and secrets from external systems. Over time, those paths should converge on the same planning, validation, and desired-state core, with only ownership, persistence, transport, and policy changing by mode.
 
 ## Invariants
 
-- One VM runs services for one application environment only.
-- A node may run a web service, an optional worker, a release task, and runtime sidecars such as Envoy or `cloudflared`, but they all belong to the same application environment.
+- Solo and shared mode should behave the same at the deployment-model level. They differ in user, organization, project, ownership, persistence, and transport concerns.
+- The core runtime model should allow a node to carry one or more environment instances. Whether a deployment target permits that is placement policy.
+- A node may run multiple services for an environment, including multiple workers. Service identity should be explicit, not inferred from fixed names such as one `web` and one `worker`.
 - The agent is the mandatory runtime component. Everything else is replaceable.
 - Desired state is the control surface. The agent should not need imperative per-deploy shell choreography to know what to run.
+- Desired state should describe node runtime state in a mode-independent shape. Solo should be able to use that shape through local function calls and files; shared should be able to use that shape through service calls and remote stores.
+- Mode is management-plane vocabulary, not agent vocabulary. The agent runtime should not branch on solo or shared; it should be wired with concrete adapters for desired-state source, secret resolution, status reporting, registry auth, and related IO.
 - Solo mode uses the local filesystem as the source of truth for desired state and local status artifacts.
 - Shared mode should use simple external primitives: object storage for desired state, a secret manager for secrets, and a container registry for images.
 - The runtime data plane should stay decoupled from the management plane as much as possible.
@@ -60,7 +65,7 @@ These assumptions are visible in the code today. The product has a solo path tha
 - Local override must always remain possible. Operators need an escape hatch.
 - The system should remain understandable with ordinary tools: SSH, Docker, files, logs, JSON, and cloud CLIs.
 
-The "one app per VM" invariant matters most. devopsellence intentionally gives up multi-tenant packing so it can avoid an entire category of scheduler, quota, noisy-neighbor, and cross-tenant isolation complexity. A node is either unassigned or assigned to exactly one environment. That constraint is a feature.
+Placement policy matters, but it should sit outside the core runtime schema. A hosted shared environment may choose one environment per node for isolation, quota, and operational clarity. Solo mode may allow several small environments on one node. Both should use the same core concepts and validation rules wherever possible.
 
 ## Solo And Shared
 
@@ -87,12 +92,14 @@ In shared mode:
 
 Today the repo's main shared path is GCP-shaped: Cloud Storage, Secret Manager, Artifact Registry, and control-plane-issued identity. That is an implementation of the vision, not the vision itself. The deeper idea is that shared mode should still be made of understandable building blocks rather than a proprietary all-in-one substrate.
 
+The two modes should not grow separate deploy semantics. Eventually the shared deployment core should be Go code that can run in-process for CLI solo workflows and behind an RPC boundary for the Rails control plane. Rails should own product state, accounts, billing, authorization, and persistence. The Go core should own the shared deployment model: config interpretation, validation, planning, desired-state generation, placement constraints, ingress model, and status interpretation.
+
 ## Tradeoffs
 
 devopsellence makes deliberate tradeoffs.
 
 - It chooses simplicity over maximum bin-packing efficiency.
-- It chooses explicit machine boundaries over dense multi-tenancy.
+- It chooses explicit placement policy over hidden scheduling.
 - It chooses provider primitives over cross-provider abstraction layers.
 - It chooses reconciliation over ad hoc deploy scripts.
 - It chooses composability over lock-in to one blessed control surface.
@@ -100,7 +107,7 @@ devopsellence makes deliberate tradeoffs.
 
 This means devopsellence leaves some value on the table on purpose.
 
-- It will not squeeze the highest possible utilization out of a server fleet.
+- It will not squeeze the highest possible utilization out of a server fleet by default.
 - It will not hide the fact that you still own machines, images, files, and networks.
 - It will not erase differences between infrastructure providers.
 - It will not make operational complexity disappear for workloads that are inherently complex.
@@ -124,7 +131,7 @@ devopsellence is not a functions platform.
 devopsellence is not Kubernetes-lite.
 
 - It does not want pods as the core user abstraction.
-- It does not want to bin-pack many tenants onto one server.
+- It does not want hidden bin-packing to be required for the system to make sense.
 - It does not want to grow a cluster control plane, scheduler, CNI stack, or CRD ecosystem.
 
 devopsellence is not an abstraction layer over every IaaS API.
@@ -176,7 +183,8 @@ Good signs:
 - less hidden machinery;
 - clearer contracts;
 - better solo and shared composability;
-- stronger "one app per VM" boundaries;
+- clearer separation between core runtime model and placement policy;
+- fewer solo/shared semantic forks;
 - more leverage from existing infrastructure primitives;
 - easier debugging with normal tools.
 


### PR DESCRIPTION
## Summary

- tighten AGENTS.md into a concise repo guide
- update the vision doc around shared core architecture, placement policy, and mode-independent desired state
- document that the agent runtime should be mode-blind and wired through concrete adapters

## Validation

- `git diff --cached --check` before commit

Docs only; no test suite run.