### PR TITLE
[codex] Use service kind for placement

### DIFF
--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -56,7 +56,6 @@ type ServicePort struct {
 
 type ServiceConfig struct {
 	Kind        string            `yaml:"kind" json:"kind"`
-	Roles       []string          `yaml:"roles" json:"roles"`
 	Image       string            `yaml:"image,omitempty" json:"image,omitempty"`
 	Entrypoint  string            `yaml:"entrypoint,omitempty" json:"entrypoint,omitempty"`
 	Command     string            `yaml:"command,omitempty" json:"command,omitempty"`
@@ -269,7 +268,6 @@ func DefaultProjectConfigForType(organization, project, environment, appType str
 		Services: map[string]ServiceConfig{
 			DefaultWebServiceName: {
 				Kind:       ServiceKindWeb,
-				Roles:      []string{DefaultWebRole},
 				Env:        map[string]string{},
 				SecretRefs: []SecretRef{},
 				Volumes:    []Volume{},
@@ -427,7 +425,6 @@ func applyDefaults(cfg *ProjectConfig) {
 		if service.Volumes == nil {
 			service.Volumes = []Volume{}
 		}
-		service.Roles = normalizeStringList(service.Roles)
 		service.Ports = normalizeServicePorts(service.Ports)
 		if service.Kind == ServiceKindWeb {
 			if len(service.Ports) == 0 {
@@ -540,14 +537,6 @@ func validateService(name string, service ServiceConfig) error {
 	default:
 		return fmt.Errorf("services.%s.kind must be one of %q, %q, or %q", name, ServiceKindWeb, ServiceKindWorker, ServiceKindAccessory)
 	}
-	if len(service.Roles) == 0 {
-		return fmt.Errorf("services.%s.roles must include at least one role", name)
-	}
-	for _, role := range service.Roles {
-		if strings.TrimSpace(role) == "" {
-			return fmt.Errorf("services.%s.roles entries must be present", name)
-		}
-	}
 	for key := range service.Env {
 		if strings.TrimSpace(key) == "" {
 			return fmt.Errorf("services.%s.env keys must be present", name)
@@ -611,12 +600,8 @@ func validateTasks(cfg *ProjectConfig) error {
 	if serviceName == "" {
 		return errors.New("tasks.release.service is required")
 	}
-	service, ok := cfg.Services[serviceName]
-	if !ok {
+	if _, ok := cfg.Services[serviceName]; !ok {
 		return fmt.Errorf("tasks.release.service %q not found in services", serviceName)
-	}
-	if len(service.Roles) == 0 {
-		return fmt.Errorf("tasks.release.service %q must declare at least one role", serviceName)
 	}
 	if strings.TrimSpace(release.Entrypoint) == "" && strings.TrimSpace(release.Command) == "" {
 		return errors.New("tasks.release must set entrypoint or command")

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -14,7 +14,6 @@ func TestWriteAndLoadFromRoot(t *testing.T) {
 	project := DefaultProjectConfig("acme", "ShopApp", "staging")
 	project.Services["jobs"] = Service{
 		Kind:       ServiceKindWorker,
-		Roles:      []string{DefaultWorkerRole},
 		Command:    "./bin/jobs",
 		Env:        map[string]string{"QUEUE": "default"},
 		SecretRefs: []SecretRef{{Name: "API_KEY", Secret: "gsm://projects/test/secrets/api-key"}},
@@ -91,7 +90,6 @@ func TestLoadAppliesDefaultBuildPlatforms(t *testing.T) {
 		"services:",
 		"  web:",
 		"    kind: web",
-		"    roles: [web]",
 		"    ports:",
 		"      - name: http",
 		"        port: 3000",
@@ -130,7 +128,6 @@ func TestLoadRejectsLegacyInitHook(t *testing.T) {
 		"services:",
 		"  web:",
 		"    kind: web",
-		"    roles: [web]",
 		"    ports:",
 		"      - name: http",
 		"        port: 3000",
@@ -149,7 +146,7 @@ func TestLoadRejectsLegacyInitHook(t *testing.T) {
 	}
 }
 
-func TestValidateRejectsWorkerWithoutRoles(t *testing.T) {
+func TestValidateAcceptsWorkerWithoutExtraPlacementFields(t *testing.T) {
 	t.Parallel()
 
 	project := DefaultProjectConfig("acme", "ShopApp", "production")
@@ -159,8 +156,8 @@ func TestValidateRejectsWorkerWithoutRoles(t *testing.T) {
 	}
 
 	err := Validate(&project)
-	if err == nil || !strings.Contains(err.Error(), "services.jobs.roles") {
-		t.Fatalf("expected worker roles validation error, got %v", err)
+	if err != nil {
+		t.Fatalf("expected worker service to validate, got %v", err)
 	}
 }
 
@@ -180,7 +177,6 @@ func TestLoadRejectsLegacyDirectConfig(t *testing.T) {
 		"services:",
 		"  web:",
 		"    kind: web",
-		"    roles: [web]",
 		"    ports:",
 		"      - name: http",
 		"        port: 3000",

--- a/cli/internal/discovery/discovery_test.go
+++ b/cli/internal/discovery/discovery_test.go
@@ -77,7 +77,7 @@ func TestDiscoverFindsGenericWorkspaceFromConfig(t *testing.T) {
 	t.Parallel()
 
 	root := t.TempDir()
-	if err := os.WriteFile(filepath.Join(root, "devopsellence.yml"), []byte("schema_version: 5\norganization: acme\nproject: demo\ndefault_environment: production\nbuild:\n  context: .\n  dockerfile: Dockerfile\nservices:\n  web:\n    kind: web\n    roles: [web]\n    ports:\n      - name: http\n        port: 8080\n    healthcheck:\n      path: /\n      port: 8080\n"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(root, "devopsellence.yml"), []byte("schema_version: 5\norganization: acme\nproject: demo\ndefault_environment: production\nbuild:\n  context: .\n  dockerfile: Dockerfile\nservices:\n  web:\n    kind: web\n    ports:\n      - name: http\n        port: 8080\n    healthcheck:\n      path: /\n      port: 8080\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	start := filepath.Join(root, "src", "api")

--- a/cli/internal/solo/desiredstate.go
+++ b/cli/internal/solo/desiredstate.go
@@ -143,7 +143,7 @@ func BuildDesiredStateForNode(cfg *config.ProjectConfig, imageTag, revision stri
 
 	for _, serviceName := range cfg.ServiceNames() {
 		service := cfg.Services[serviceName]
-		if !shouldScheduleService(labels, service.Roles) {
+		if !shouldScheduleService(labels, service.Kind) {
 			continue
 		}
 		rendered, err := buildService(serviceName, service, imageTag, secrets)
@@ -239,11 +239,11 @@ func normalizedLabels(labels []string) []string {
 	return out
 }
 
-func shouldScheduleService(labels []string, roles []string) bool {
+func shouldScheduleService(labels []string, kind string) bool {
 	if labels == nil {
 		return true
 	}
-	return hasAnyRole(labels, roles)
+	return hasLabel(labels, kind)
 }
 
 func shouldScheduleIngress(labels []string, cfg *config.ProjectConfig) bool {
@@ -254,7 +254,7 @@ func shouldScheduleIngress(labels []string, cfg *config.ProjectConfig) bool {
 	if !ok {
 		return false
 	}
-	return shouldScheduleService(labels, service.Roles)
+	return shouldScheduleService(labels, service.Kind)
 }
 
 func shouldScheduleReleaseTask(labels []string, cfg *config.ProjectConfig) bool {
@@ -266,15 +266,14 @@ func shouldScheduleReleaseTask(labels []string, cfg *config.ProjectConfig) bool 
 	if !ok {
 		return false
 	}
-	return shouldScheduleService(labels, service.Roles)
+	return shouldScheduleService(labels, service.Kind)
 }
 
-func hasAnyRole(labels []string, roles []string) bool {
-	for _, role := range roles {
-		for _, label := range labels {
-			if strings.TrimSpace(label) == strings.TrimSpace(role) {
-				return true
-			}
+func hasLabel(labels []string, want string) bool {
+	want = strings.TrimSpace(want)
+	for _, label := range labels {
+		if strings.TrimSpace(label) == want {
+			return true
 		}
 	}
 	return false

--- a/cli/internal/solo/desiredstate_test.go
+++ b/cli/internal/solo/desiredstate_test.go
@@ -12,7 +12,6 @@ func baseProject() *config.ProjectConfig {
 	cfg := config.DefaultProjectConfig("solo", "myapp", config.DefaultEnvironment)
 	cfg.Services["web"] = config.Service{
 		Kind:    config.ServiceKindWeb,
-		Roles:   []string{config.DefaultWebRole},
 		Command: "rails server",
 		Env:     map[string]string{"RAILS_ENV": "production"},
 		SecretRefs: []config.SecretRef{
@@ -71,7 +70,6 @@ func TestBuildDesiredState_WithNamedWorkerAndReleaseTask(t *testing.T) {
 	cfg := baseProject()
 	cfg.Services["jobs"] = config.Service{
 		Kind:    config.ServiceKindWorker,
-		Roles:   []string{config.DefaultWorkerRole},
 		Command: "sidekiq",
 		Env:     map[string]string{"QUEUE": "default"},
 	}
@@ -103,11 +101,10 @@ func TestBuildDesiredState_WithNamedWorkerAndReleaseTask(t *testing.T) {
 	}
 }
 
-func TestBuildDesiredStateForLabelsFiltersServicesByRole(t *testing.T) {
+func TestBuildDesiredStateForLabelsFiltersServicesByKindLabel(t *testing.T) {
 	cfg := baseProject()
 	cfg.Services["jobs"] = config.Service{
 		Kind:    config.ServiceKindWorker,
-		Roles:   []string{config.DefaultWorkerRole},
 		Command: "sidekiq",
 	}
 	cfg.Tasks.Release = &config.TaskConfig{Service: "web", Command: "rails db:migrate"}
@@ -193,7 +190,6 @@ func TestBuildDesiredStateForNodeOmitsIngressForNonIngressNode(t *testing.T) {
 	cfg := baseProject()
 	cfg.Services["jobs"] = config.Service{
 		Kind:    config.ServiceKindWorker,
-		Roles:   []string{config.DefaultWorkerRole},
 		Command: "sidekiq",
 	}
 	cfg.Ingress = &config.IngressConfig{Hosts: []string{"app.example.com"}, Service: "web"}

--- a/cli/internal/workflow/app.go
+++ b/cli/internal/workflow/app.go
@@ -3965,7 +3965,6 @@ func servicePayload(service *config.Service) map[string]any {
 	}
 	payload := map[string]any{
 		"kind":        service.Kind,
-		"roles":       append([]string(nil), service.Roles...),
 		"image":       strings.TrimSpace(service.Image),
 		"env":         cloneEnv(service.Env),
 		"secret_refs": service.SecretRefs,

--- a/cli/internal/workflow/management_test.go
+++ b/cli/internal/workflow/management_test.go
@@ -1285,7 +1285,6 @@ func TestDeployAppliesGitHubActionRuntimeOverrides(t *testing.T) {
 	project.Services[config.DefaultWebServiceName] = web
 	project.Services["worker"] = config.Service{
 		Kind:    config.ServiceKindWorker,
-		Roles:   []string{config.DefaultWorkerRole},
 		Command: "./bin/jobs",
 		Env:     map[string]string{"WORKER_FROM_CONFIG": "1"},
 	}
@@ -1904,7 +1903,7 @@ func TestDeployRailsSyncsMasterKeySecret(t *testing.T) {
 
 	root := makeGitRailsRoot(t, "ShopApp")
 	project := config.DefaultProjectConfig("default", "ShopApp", "production")
-	project.Services["worker"] = config.ServiceConfig{Kind: config.ServiceKindWorker, Roles: []string{config.DefaultWorkerRole}, Command: "bin/jobs"}
+	project.Services["worker"] = config.ServiceConfig{Kind: config.ServiceKindWorker, Command: "bin/jobs"}
 	if _, err := config.Write(root, project); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
@@ -3093,7 +3092,7 @@ func TestDeployRailsSecretSyncRunsConcurrently(t *testing.T) {
 
 	root := makeGitRailsRoot(t, "ShopApp")
 	project := config.DefaultProjectConfig("default", "ShopApp", "production")
-	project.Services["worker"] = config.ServiceConfig{Kind: config.ServiceKindWorker, Roles: []string{config.DefaultWorkerRole}, Command: "bin/jobs"}
+	project.Services["worker"] = config.ServiceConfig{Kind: config.ServiceKindWorker, Command: "bin/jobs"}
 	if _, err := config.Write(root, project); err != nil {
 		t.Fatalf("write config: %v", err)
 	}

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -307,13 +307,13 @@ func validateSoloNodeSchedule(cfg *config.ProjectConfig, nodes map[string]config
 		service := cfg.Services[serviceName]
 		scheduled := false
 		for _, nodeName := range sortedSoloNodeNames(nodes) {
-			if soloNodeCanRunRoles(nodes[nodeName], service.Roles) {
+			if soloNodeCanRunKind(nodes[nodeName], service.Kind) {
 				scheduled = true
 				break
 			}
 		}
 		if !scheduled {
-			return "", fmt.Errorf("solo deploy requires at least one selected node labeled for service %q (%s)", serviceName, strings.Join(service.Roles, ", "))
+			return "", fmt.Errorf("solo deploy requires at least one selected node labeled %q for service %q", service.Kind, serviceName)
 		}
 	}
 	release := cfg.ReleaseTask()
@@ -321,22 +321,20 @@ func validateSoloNodeSchedule(cfg *config.ProjectConfig, nodes map[string]config
 		return "", nil
 	}
 	for _, nodeName := range sortedSoloNodeNames(nodes) {
-		if soloNodeCanRunRoles(nodes[nodeName], cfg.Services[release.Service].Roles) {
+		if soloNodeCanRunKind(nodes[nodeName], cfg.Services[release.Service].Kind) {
 			return nodeName, nil
 		}
 	}
 	return "", fmt.Errorf("solo deploy requires at least one selected node labeled for release task service %q", release.Service)
 }
 
-func soloNodeCanRunRoles(node config.SoloNode, roles []string) bool {
+func soloNodeCanRunKind(node config.SoloNode, kind string) bool {
 	if node.Labels == nil {
 		return true
 	}
-	for _, role := range roles {
-		for _, nodeLabel := range node.Labels {
-			if strings.TrimSpace(nodeLabel) == strings.TrimSpace(role) {
-				return true
-			}
+	for _, nodeLabel := range node.Labels {
+		if strings.TrimSpace(nodeLabel) == strings.TrimSpace(kind) {
+			return true
 		}
 	}
 	return false
@@ -350,7 +348,7 @@ func soloNodeCanRunIngress(node config.SoloNode, cfg *config.ProjectConfig) bool
 	if !ok {
 		return false
 	}
-	return soloNodeCanRunRoles(node, service.Roles)
+	return soloNodeCanRunKind(node, service.Kind)
 }
 
 func sortedSoloNodeNames(nodes map[string]config.SoloNode) []string {

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -44,7 +44,6 @@ func TestValidateSoloNodeScheduleSelectsReleaseNode(t *testing.T) {
 		Services: map[string]config.ServiceConfig{
 			config.DefaultWebServiceName: {
 				Kind:  config.ServiceKindWeb,
-				Roles: []string{config.DefaultWebRole},
 				Ports: []config.ServicePort{{Name: "http", Port: 3000}},
 				Healthcheck: &config.HTTPHealthcheck{
 					Path: "/up",
@@ -53,7 +52,6 @@ func TestValidateSoloNodeScheduleSelectsReleaseNode(t *testing.T) {
 			},
 			"worker": {
 				Kind:    config.ServiceKindWorker,
-				Roles:   []string{config.DefaultWorkerRole},
 				Command: "sidekiq",
 			},
 		},
@@ -83,7 +81,6 @@ func TestValidateSoloNodeScheduleRejectsMissingWorker(t *testing.T) {
 		Services: map[string]config.ServiceConfig{
 			config.DefaultWebServiceName: {
 				Kind:  config.ServiceKindWeb,
-				Roles: []string{config.DefaultWebRole},
 				Ports: []config.ServicePort{{Name: "http", Port: 3000}},
 				Healthcheck: &config.HTTPHealthcheck{
 					Path: "/up",
@@ -92,7 +89,6 @@ func TestValidateSoloNodeScheduleRejectsMissingWorker(t *testing.T) {
 			},
 			"worker": {
 				Kind:    config.ServiceKindWorker,
-				Roles:   []string{config.DefaultWorkerRole},
 				Command: "sidekiq",
 			},
 		},
@@ -107,7 +103,7 @@ func TestValidateSoloNodeScheduleRejectsMissingWorker(t *testing.T) {
 
 func TestSoloNodeCanRunUnlabeledNode(t *testing.T) {
 	node := config.SoloNode{}
-	if !soloNodeCanRunRoles(node, []string{config.DefaultWebRole}) || !soloNodeCanRunRoles(node, []string{config.DefaultWorkerRole}) {
+	if !soloNodeCanRunKind(node, config.DefaultWebRole) || !soloNodeCanRunKind(node, config.DefaultWorkerRole) {
 		t.Fatal("unlabeled node should run all labels")
 	}
 }
@@ -217,15 +213,13 @@ func TestApplySoloRailsMasterKeyUsesConfigMasterKey(t *testing.T) {
 		Services: map[string]config.ServiceConfig{
 			config.DefaultWebServiceName: {
 				Kind:        config.ServiceKindWeb,
-				Roles:       []string{config.DefaultWebRole},
 				Env:         map[string]string{},
 				Ports:       []config.ServicePort{{Name: "http", Port: 3000}},
 				Healthcheck: &config.HTTPHealthcheck{Path: "/up", Port: 3000},
 			},
 			"worker": {
-				Kind:  config.ServiceKindWorker,
-				Roles: []string{config.DefaultWorkerRole},
-				Env:   map[string]string{},
+				Kind: config.ServiceKindWorker,
+				Env:  map[string]string{},
 			},
 		},
 	}
@@ -262,7 +256,6 @@ func TestApplySoloRailsMasterKeyLetsEnvOverrideMasterKey(t *testing.T) {
 		Services: map[string]config.ServiceConfig{
 			config.DefaultWebServiceName: {
 				Kind:        config.ServiceKindWeb,
-				Roles:       []string{config.DefaultWebRole},
 				Env:         map[string]string{},
 				Ports:       []config.ServicePort{{Name: "http", Port: 3000}},
 				Healthcheck: &config.HTTPHealthcheck{Path: "/up", Port: 3000},

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -103,7 +103,7 @@ func TestValidateSoloNodeScheduleRejectsMissingWorker(t *testing.T) {
 
 func TestSoloNodeCanRunUnlabeledNode(t *testing.T) {
 	node := config.SoloNode{}
-	if !soloNodeCanRunKind(node, config.DefaultWebRole) || !soloNodeCanRunKind(node, config.DefaultWorkerRole) {
+	if !soloNodeCanRunKind(node, config.ServiceKindWeb) || !soloNodeCanRunKind(node, config.ServiceKindWorker) {
 		t.Fatal("unlabeled node should run all labels")
 	}
 }

--- a/control-plane/app/models/release.rb
+++ b/control-plane/app/models/release.rb
@@ -73,7 +73,7 @@ class Release < ApplicationRecord
   end
 
   def required_labels
-    services_config.values.map { |service| service_label(service) }.uniq.sort
+    services_config.values.filter_map { |service| service_label(service).presence }.uniq.sort
   end
 
   def requires_label?(label)
@@ -175,12 +175,13 @@ class Release < ApplicationRecord
     end
 
     kind = service_kind(service)
-    unless SERVICE_KINDS.include?(kind)
-      errors.add(:runtime_json, "services.#{name}.kind must be one of #{SERVICE_KINDS.join(', ')}")
-    end
-
     if kind.blank?
       errors.add(:runtime_json, "services.#{name}.kind must be present")
+      return
+    end
+
+    unless SERVICE_KINDS.include?(kind)
+      errors.add(:runtime_json, "services.#{name}.kind must be one of #{SERVICE_KINDS.join(', ')}")
     end
 
     if service["entrypoint"].present? && !service["entrypoint"].is_a?(String)

--- a/control-plane/app/models/release.rb
+++ b/control-plane/app/models/release.rb
@@ -72,23 +72,24 @@ class Release < ApplicationRecord
     services_config.values.any? { |service| Array(service["volumes"]).any? }
   end
 
-  def required_roles
-    services_config.values.flat_map { |service| service_roles(service) }.uniq.sort
+  def required_labels
+    services_config.values.map { |service| service_label(service) }.uniq.sort
   end
 
-  def requires_role?(label)
-    required_roles.include?(label.to_s.strip)
+  def requires_label?(label)
+    required_labels.include?(label.to_s.strip)
   end
 
-  def service_roles_for(name)
+  def service_label_for(name)
     service = services_config[name.to_s]
-    return [] if service.blank?
+    return nil if service.blank?
 
-    service_roles(service)
+    service_label(service)
   end
 
   def service_scheduled_on?(service_name, node)
-    node.labeled_any?(service_roles_for(service_name))
+    label = service_label_for(service_name)
+    label.present? && node.labeled?(label)
   end
 
   def ingress_service_name
@@ -106,7 +107,7 @@ class Release < ApplicationRecord
     environment = node.environment
     service_names.filter_map do |name|
       service = services_config[name]
-      next unless node.labeled_any?(service_roles(service))
+      next unless node.labeled?(service_label(service))
 
       service_payload(name, service, organization: node.organization, environment: environment)
     end
@@ -119,7 +120,7 @@ class Release < ApplicationRecord
     service_name = task["service"].to_s.strip
     service = services_config[service_name]
     return nil if service.blank?
-    return nil unless node.labeled_any?(service_roles(service))
+    return nil unless node.labeled?(service_label(service))
 
     task_payload(
       "release",
@@ -178,9 +179,8 @@ class Release < ApplicationRecord
       errors.add(:runtime_json, "services.#{name}.kind must be one of #{SERVICE_KINDS.join(', ')}")
     end
 
-    roles = service_roles(service)
-    if roles.empty?
-      errors.add(:runtime_json, "services.#{name}.roles must include at least one role")
+    if kind.blank?
+      errors.add(:runtime_json, "services.#{name}.kind must be present")
     end
 
     if service["entrypoint"].present? && !service["entrypoint"].is_a?(String)
@@ -267,8 +267,8 @@ class Release < ApplicationRecord
     unless task["env"].nil? || task["env"].is_a?(Hash)
       errors.add(:runtime_json, "tasks.release.env must be an object")
     end
-    if service_roles(service).empty?
-      errors.add(:runtime_json, "tasks.release.service must reference a service with roles")
+    if service_kind(service).blank?
+      errors.add(:runtime_json, "tasks.release.service must reference a service with kind")
     end
   end
 
@@ -386,8 +386,8 @@ class Release < ApplicationRecord
     service["kind"].to_s.strip
   end
 
-  def service_roles(service)
-    Array(service["roles"]).filter_map { |role| role.to_s.strip.presence }
+  def service_label(service)
+    service_kind(service)
   end
 
   def shell_words(value)

--- a/control-plane/app/services/deployments/publisher.rb
+++ b/control-plane/app/services/deployments/publisher.rb
@@ -93,7 +93,7 @@ module Deployments
         next if nodes.any? { |node| release.service_scheduled_on?(service_name, node) }
 
         label = release.service_label_for(service_name)
-        raise SchedulingError, "at least one assigned node must match label #{label} for service #{service_name}"
+        raise SchedulingError, "at least one assigned node must match label #{label.inspect} for service #{service_name}"
       end
 
       if environment.direct_dns_ingress? && release.ingress_service_name.present?

--- a/control-plane/app/services/deployments/publisher.rb
+++ b/control-plane/app/services/deployments/publisher.rb
@@ -92,8 +92,8 @@ module Deployments
       release.service_names.each do |service_name|
         next if nodes.any? { |node| release.service_scheduled_on?(service_name, node) }
 
-        roles = release.service_roles_for(service_name)
-        raise SchedulingError, "at least one assigned node must match roles for service #{service_name}: #{roles.join(', ')}"
+        label = release.service_label_for(service_name)
+        raise SchedulingError, "at least one assigned node must match label #{label} for service #{service_name}"
       end
 
       if environment.direct_dns_ingress? && release.ingress_service_name.present?

--- a/control-plane/app/services/managed_nodes/ensure_capacity.rb
+++ b/control-plane/app/services/managed_nodes/ensure_capacity.rb
@@ -90,7 +90,7 @@ module ManagedNodes
     end
 
     def required_labels
-      release.required_roles.presence || [ Node::DEFAULT_LABEL ]
+      release.required_labels.presence || [ Node::DEFAULT_LABEL ]
     end
 
     def update_progress(message)

--- a/control-plane/app/services/releases/runtime_attributes.rb
+++ b/control-plane/app/services/releases/runtime_attributes.rb
@@ -80,6 +80,8 @@ module Releases
     def parse_service(value, field:)
       service = parse_hash(value, field:)
       kind = optional_service_string(service["kind"] || service[:kind])
+      raise InvalidPayload, "#{field}.kind must be present" if kind.blank?
+
       unless SERVICE_KINDS.include?(kind)
         raise InvalidPayload, "#{field}.kind must be one of #{SERVICE_KINDS.join(', ')}"
       end

--- a/control-plane/app/services/releases/runtime_attributes.rb
+++ b/control-plane/app/services/releases/runtime_attributes.rb
@@ -84,12 +84,8 @@ module Releases
         raise InvalidPayload, "#{field}.kind must be one of #{SERVICE_KINDS.join(', ')}"
       end
 
-      roles = parse_array(service["roles"] || service[:roles], field: :"#{field}.roles").map { |role| role.to_s.strip }.reject(&:blank?).uniq
-      raise InvalidPayload, "#{field}.roles must include at least one role" if roles.empty?
-
       normalized = {
         "kind" => kind,
-        "roles" => roles,
         "image" => optional_service_string(service["image"] || service[:image]),
         "entrypoint" => optional_service_string(service["entrypoint"] || service[:entrypoint]),
         "command" => optional_service_string(service["command"] || service[:command]),

--- a/control-plane/app/views/marketing/docs.html.erb
+++ b/control-plane/app/views/marketing/docs.html.erb
@@ -352,15 +352,7 @@
         <span class="terminal-bar-title">devopsellence.yml</span>
       </div>
   <div class="terminal-body">
-        <pre class="config-pre"><code>nodes:
-  prod-1:
-    labels:
-      - web
-  worker-1:
-    labels:
-      - worker
-
-solo:
+        <pre class="config-pre"><code>solo:
   nodes:
     prod-1:
       host: 203.0.113.10
@@ -368,9 +360,13 @@ solo:
       port: 22
       ssh_key: ~/.ssh/id_ed25519
       agent_state_dir: /var/lib/devopsellence
+      labels:
+        - web
     worker-1:
       host: 203.0.113.11
-      user: ubuntu</code></pre>
+      user: ubuntu
+      labels:
+        - worker</code></pre>
       </div>
     </div>
     <p>Labels control placement in solo mode too. <code>web</code> nodes run web services. <code>worker</code> nodes run worker services. A node can have both labels. <code>tasks.release</code> runs once on one node labeled for its configured service.</p>
@@ -682,7 +678,7 @@ tasks:
       </div>
       <div class="docs-field">
         <dt><code>solo.nodes.*.labels</code></dt>
-        <dd>Service placement labels for solo and shared mode. Use labels matching your services' kinds.</dd>
+        <dd>Service placement labels for solo mode. Use labels matching your services' kinds.</dd>
       </div>
       <div class="docs-field">
         <dt><code>solo.nodes.*.provider</code></dt>

--- a/control-plane/app/views/marketing/docs.html.erb
+++ b/control-plane/app/views/marketing/docs.html.erb
@@ -351,14 +351,13 @@
         <span class="dot dot-green"></span>
         <span class="terminal-bar-title">devopsellence.yml</span>
       </div>
-      <div class="terminal-body">
+  <div class="terminal-body">
         <pre class="config-pre"><code>nodes:
   prod-1:
-    roles:
+    labels:
       - web
-    public: true
   worker-1:
-    roles:
+    labels:
       - worker
 
 solo:
@@ -587,7 +586,6 @@ build:
 services:
   web:
     kind: web
-    roles: [web]
     command: bundle exec puma -C config/puma.rb
     env:
       RAILS_ENV: production
@@ -605,7 +603,6 @@ services:
 
   worker:
     kind: worker
-    roles: [worker]
     command: bundle exec sidekiq
     env:
       RAILS_ENV: production
@@ -653,11 +650,7 @@ tasks:
       </div>
       <div class="docs-field">
         <dt><code>services.*.kind</code></dt>
-        <dd>Service kind. Use <code>web</code>, <code>worker</code>, or <code>accessory</code>.</dd>
-      </div>
-      <div class="docs-field">
-        <dt><code>services.*.roles</code></dt>
-        <dd>Placement roles used to match services to nodes.</dd>
+        <dd>Service runtime kind and placement label. Use <code>web</code>, <code>worker</code>, or <code>accessory</code>. A service runs on nodes whose labels include that kind.</dd>
       </div>
       <div class="docs-field">
         <dt><code>services.*.command</code></dt>
@@ -689,7 +682,7 @@ tasks:
       </div>
       <div class="docs-field">
         <dt><code>solo.nodes.*.labels</code></dt>
-        <dd>Service placement labels for solo and shared mode. Use labels matching your services' roles.</dd>
+        <dd>Service placement labels for solo and shared mode. Use labels matching your services' kinds.</dd>
       </div>
       <div class="docs-field">
         <dt><code>solo.nodes.*.provider</code></dt>

--- a/control-plane/app/views/marketing/docs.html.erb
+++ b/control-plane/app/views/marketing/docs.html.erb
@@ -351,7 +351,7 @@
         <span class="dot dot-green"></span>
         <span class="terminal-bar-title">devopsellence.yml</span>
       </div>
-  <div class="terminal-body">
+      <div class="terminal-body">
         <pre class="config-pre"><code>solo:
   nodes:
     prod-1:

--- a/control-plane/test/integration/api_cli_mvp_test.rb
+++ b/control-plane/test/integration/api_cli_mvp_test.rb
@@ -1556,7 +1556,7 @@ class ApiCliMvpTest < ActionDispatch::IntegrationTest
     runtime = JSON.parse(release.runtime_json)
     assert_equal 80, runtime.dig("services", "web", "ports").first.fetch("port")
     assert_not runtime.fetch("services").key?("worker")
-    assert_equal false, release.requires_role?("worker")
+    assert_equal false, release.requires_label?("worker")
   end
 
   test "rejects release create without web runtime config" do

--- a/control-plane/test/models/release_test.rb
+++ b/control-plane/test/models/release_test.rb
@@ -7,8 +7,8 @@ class ReleaseTest < ActiveSupport::TestCase
     release = build_release(
       runtime_json: release_runtime_json(
         services: {
-          "admin" => web_service_runtime(roles: [ "admin" ]),
-          "public" => web_service_runtime(roles: [ "public" ])
+          "admin" => web_service_runtime,
+          "public" => web_service_runtime
         },
         ingress_service: nil
       )
@@ -22,8 +22,8 @@ class ReleaseTest < ActiveSupport::TestCase
     release = build_release(
       runtime_json: release_runtime_json(
         services: {
-          "admin" => web_service_runtime(roles: [ "admin" ]),
-          "web" => web_service_runtime(roles: [ "web" ])
+          "admin" => web_service_runtime,
+          "web" => web_service_runtime
         },
         ingress_service: nil
       )

--- a/control-plane/test/models/release_test.rb
+++ b/control-plane/test/models/release_test.rb
@@ -51,6 +51,21 @@ class ReleaseTest < ActiveSupport::TestCase
     assert_includes release.errors[:runtime_json], "tasks.release.entrypoint must be a string"
   end
 
+  test "blank kind does not contribute required labels and reports one kind error" do
+    release = build_release(
+      runtime_json: release_runtime_json(
+        services: {
+          "web" => web_service_runtime.merge("kind" => "")
+        }
+      )
+    )
+
+    assert_equal [], release.required_labels
+    assert_not release.valid?
+    kind_errors = release.errors[:runtime_json].grep(/\Aservices\.web\.kind /)
+    assert_equal [ "services.web.kind must be present" ], kind_errors
+  end
+
   private
 
   def build_release(runtime_json:)

--- a/control-plane/test/services/releases/runtime_attributes_test.rb
+++ b/control-plane/test/services/releases/runtime_attributes_test.rb
@@ -18,5 +18,24 @@ module Releases
 
       assert_equal "services must be valid JSON", error.message
     end
+
+    test "raises invalid payload when service kind is blank" do
+      error = assert_raises(RuntimeAttributes::InvalidPayload) do
+        RuntimeAttributes.new(
+          params: {
+            git_sha: "a" * 40,
+            image_repository: "api",
+            image_digest: "sha256:#{"b" * 64}",
+            services: {
+              web: {
+                kind: "   "
+              }
+            }
+          }
+        ).to_h
+      end
+
+      assert_equal "services.web.kind must be present", error.message
+    end
   end
 end

--- a/control-plane/test/test_helper.rb
+++ b/control-plane/test/test_helper.rb
@@ -172,10 +172,9 @@ module ActiveSupport
       bundle
     end
 
-    def web_service_runtime(port: 3000, healthcheck_path: "/up", healthcheck_port: nil, command: nil, entrypoint: nil, env: {}, secret_refs: [], volumes: [], roles: [ "web" ], image: nil)
+    def web_service_runtime(port: 3000, healthcheck_path: "/up", healthcheck_port: nil, command: nil, entrypoint: nil, env: {}, secret_refs: [], volumes: [], image: nil)
       {
         "kind" => "web",
-        "roles" => roles,
         "image" => image,
         "entrypoint" => entrypoint,
         "command" => command,
@@ -187,10 +186,9 @@ module ActiveSupport
       }.compact
     end
 
-    def worker_service_runtime(command: nil, entrypoint: nil, env: {}, secret_refs: [], volumes: [], roles: [ "worker" ], image: nil)
+    def worker_service_runtime(command: nil, entrypoint: nil, env: {}, secret_refs: [], volumes: [], image: nil)
       {
         "kind" => "worker",
-        "roles" => roles,
         "image" => image,
         "entrypoint" => entrypoint,
         "command" => command,

--- a/test/e2e/e2e.rb
+++ b/test/e2e/e2e.rb
@@ -790,9 +790,8 @@ class E2E
       config.delete("release")
       config.delete("release_command")
       config["services"] ||= {}
-      config["services"]["web"] ||= { "kind" => "web", "roles" => [ "web" ] }
+      config["services"]["web"] ||= { "kind" => "web" }
       config["services"]["web"]["kind"] = "web"
-      config["services"]["web"]["roles"] = [ "web" ]
       config["services"]["web"]["ports"] = [ { "name" => "http", "port" => APP_PORT } ]
       config["services"]["web"]["healthcheck"] = { "path" => APP_HEALTH_PATH, "port" => APP_PORT }
       config["services"]["web"]["env"] ||= {}

--- a/test/e2e/solo_e2e.rb
+++ b/test/e2e/solo_e2e.rb
@@ -278,7 +278,6 @@ class SoloE2E
       "services" => {
         "web" => {
           "kind" => "web",
-          "roles" => ["web"],
           "command" => "/server",
           "ports" => [
             { "name" => "http", "port" => APP_PORT }


### PR DESCRIPTION
## Summary

- remove `services.*.roles` from the config and release payload shape
- schedule services using `services.*.kind` matching node labels in solo and shared flows
- update docs, tests, and e2e fixtures to use the simplified placement model

## Why

Placement is now intentionally dead simple: a service runs on nodes whose labels include its kind.

## Validation

- `mise run test:cli`
- `mise run test:cp -- test/models/release_test.rb test/services/releases/runtime_attributes_test.rb test/models/deployments_publisher_test.rb test/services/managed_nodes/ensure_capacity_test.rb test/integration/api_cli_mvp_test.rb`
