### PR TITLE
[codex] Prompt for Hetzner login during setup

### DIFF
--- a/cli/internal/workflow/provider.go
+++ b/cli/internal/workflow/provider.go
@@ -19,6 +19,10 @@ const (
 	defaultHetznerSize   = "cpx11"
 )
 
+var runProviderLogin = func(a *App, ctx context.Context, opts ProviderLoginOptions) error {
+	return a.ProviderLogin(ctx, opts)
+}
+
 type ProviderLoginOptions struct {
 	Provider   string
 	Token      string
@@ -136,6 +140,21 @@ func (a *App) resolveSoloProvider(providerSlug string) (providers.Provider, erro
 		return nil, err
 	}
 	return providers.ResolveWithToken(providerSlug, token)
+}
+
+func (a *App) ensureInteractiveProviderLogin(ctx context.Context, provider string) error {
+	providerSlug, err := normalizeProvider(provider)
+	if err != nil {
+		return err
+	}
+	token, _, err := providerToken(a.ProviderState, providerSlug)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(token) != "" || !a.Printer.Interactive {
+		return nil
+	}
+	return runProviderLogin(a, ctx, ProviderLoginOptions{Provider: providerSlug})
 }
 
 func (a *App) providerLoginToken(opts ProviderLoginOptions) (string, error) {

--- a/cli/internal/workflow/provider_test.go
+++ b/cli/internal/workflow/provider_test.go
@@ -1,9 +1,12 @@
 package workflow
 
 import (
+	"context"
+	"io"
 	"path/filepath"
 	"testing"
 
+	"github.com/devopsellence/cli/internal/output"
 	"github.com/devopsellence/cli/internal/state"
 )
 
@@ -46,5 +49,73 @@ func TestProviderTokenFallsBackToEnv(t *testing.T) {
 	}
 	if token != "env-token" || source != "DEVOPSELLENCE_HETZNER_API_TOKEN" {
 		t.Fatalf("providerToken = %q/%q, want env-token/DEVOPSELLENCE_HETZNER_API_TOKEN", token, source)
+	}
+}
+
+func TestEnsureInteractiveProviderLogin(t *testing.T) {
+	store := state.New(filepath.Join(t.TempDir(), "providers.json"))
+	app := &App{
+		Printer:       output.New(io.Discard, io.Discard, false),
+		ProviderState: store,
+	}
+	app.Printer.Interactive = true
+
+	original := runProviderLogin
+	t.Cleanup(func() { runProviderLogin = original })
+
+	var calls int
+	runProviderLogin = func(gotApp *App, _ context.Context, opts ProviderLoginOptions) error {
+		calls++
+		if gotApp != app {
+			t.Fatalf("runProviderLogin app = %#v, want %#v", gotApp, app)
+		}
+		if opts.Provider != providerHetzner {
+			t.Fatalf("runProviderLogin provider = %q, want %q", opts.Provider, providerHetzner)
+		}
+		return nil
+	}
+
+	if err := app.ensureInteractiveProviderLogin(context.Background(), providerHetzner); err != nil {
+		t.Fatal(err)
+	}
+	if calls != 1 {
+		t.Fatalf("runProviderLogin calls = %d, want 1", calls)
+	}
+
+	if err := saveProviderToken(store, providerHetzner, "stored-token"); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.ensureInteractiveProviderLogin(context.Background(), providerHetzner); err != nil {
+		t.Fatal(err)
+	}
+	if calls != 1 {
+		t.Fatalf("runProviderLogin calls after stored token = %d, want 1", calls)
+	}
+}
+
+func TestEnsureInteractiveProviderLoginSkipsEnvAndNonInteractive(t *testing.T) {
+	t.Setenv("DEVOPSELLENCE_HETZNER_API_TOKEN", "env-token")
+
+	original := runProviderLogin
+	t.Cleanup(func() { runProviderLogin = original })
+
+	runProviderLogin = func(*App, context.Context, ProviderLoginOptions) error {
+		t.Fatal("runProviderLogin should not be called")
+		return nil
+	}
+
+	app := &App{
+		Printer:       output.New(io.Discard, io.Discard, false),
+		ProviderState: state.New(filepath.Join(t.TempDir(), "providers.json")),
+	}
+	app.Printer.Interactive = true
+	if err := app.ensureInteractiveProviderLogin(context.Background(), providerHetzner); err != nil {
+		t.Fatal(err)
+	}
+
+	app.Printer.Interactive = false
+	t.Setenv("DEVOPSELLENCE_HETZNER_API_TOKEN", "")
+	if err := app.ensureInteractiveProviderLogin(context.Background(), providerHetzner); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/cli/internal/workflow/root_test.go
+++ b/cli/internal/workflow/root_test.go
@@ -171,7 +171,7 @@ func TestNodeHelpShowsSharedAndSoloActions(t *testing.T) {
 	}
 }
 
-func TestNodeCreateHelpUsesCurrentHetznerSizeDefault(t *testing.T) {
+func TestNodeCreateHelpUsesCurrentHetznerDefaults(t *testing.T) {
 	t.Parallel()
 
 	var stdout bytes.Buffer
@@ -183,7 +183,9 @@ func TestNodeCreateHelpUsesCurrentHetznerSizeDefault(t *testing.T) {
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
-	if !strings.Contains(stdout.String(), "(default \"cpx11\")") {
-		t.Fatalf("help output = %q, want cpx11 default", stdout.String())
+	for _, snippet := range []string{`default "` + defaultHetznerRegion + `"`, `default "` + defaultHetznerSize + `"`} {
+		if !strings.Contains(stdout.String(), snippet) {
+			t.Fatalf("help output = %q, want %q", stdout.String(), snippet)
+		}
 	}
 }

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -129,6 +129,9 @@ func (a *App) createProviderNode(ctx context.Context, opts SoloNodeCreateOptions
 	if providerSlug == providerHetzner && strings.EqualFold(strings.TrimSpace(opts.Size), "cx22") {
 		return providerNodeCreateResult{}, fmt.Errorf("Hetzner size %q is deprecated; use %q", opts.Size, defaultHetznerSize)
 	}
+	if err := a.ensureInteractiveProviderLogin(ctx, providerSlug); err != nil {
+		return providerNodeCreateResult{}, err
+	}
 	provider, err := a.resolveSoloProvider(providerSlug)
 	if err != nil {
 		return providerNodeCreateResult{}, err

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -119,7 +119,10 @@ func (a *App) createProviderNode(ctx context.Context, opts SoloNodeCreateOptions
 	if err != nil {
 		return providerNodeCreateResult{}, err
 	}
-	providerSlug := firstNonEmpty(opts.Provider, "hetzner")
+	providerSlug, err := normalizeProvider(firstNonEmpty(opts.Provider, providerHetzner))
+	if err != nil {
+		return providerNodeCreateResult{}, err
+	}
 	if opts.Region == "" {
 		opts.Region = defaultHetznerRegion
 	}

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -158,6 +158,23 @@ func TestCreateProviderNodeRejectsDeprecatedHetznerSize(t *testing.T) {
 	}
 }
 
+func TestCreateProviderNodeNormalizesHetznerProviderBeforeValidation(t *testing.T) {
+	app := &App{}
+
+	_, err := app.createProviderNode(context.Background(), SoloNodeCreateOptions{
+		Name:     "prod-1",
+		Provider: "Hetzner",
+		Region:   defaultHetznerRegion,
+		Size:     "cx22",
+	}, "")
+	if err == nil {
+		t.Fatal("expected deprecated size error")
+	}
+	if !strings.Contains(err.Error(), `Hetzner size "cx22" is deprecated; use "cpx11"`) {
+		t.Fatalf("error = %v", err)
+	}
+}
+
 func TestSoloAgentInstallScriptConfiguresSoloMode(t *testing.T) {
 	script := soloAgentInstallScript(soloAgentInstallScriptOptions{BaseURL: "https://example.test"})
 	for _, want := range []string{


### PR DESCRIPTION
## What changed
- prompt for Hetzner provider login before interactive Hetzner-backed node creation when no saved or env token exists
- reuse current Hetzner defaults in solo setup and `node create` instead of the stale `cx22` size
- add workflow tests covering the auto-login gate and current help defaults

## Why
`devopsellence setup` let users choose `hetzner`, collected all node details, and then failed during server creation with a late instruction to run `devopsellence provider login hetzner`. The wizard should collect the token when needed as part of that flow.

## Impact
Users selecting Hetzner in the setup wizard now get the provider login prompt at the right time, and previously configured tokens still skip the prompt. Direct interactive provider-backed node creation benefits from the same behavior.

## Root cause
The interactive solo setup flow delegated straight to provider-backed node creation without first ensuring provider credentials existed, and the workflow still carried stale Hetzner default literals in a few places.

## Validation
- `/home/elvin/.local/share/mise/installs/go/1.25.8/bin/go test ./internal/workflow`
