### PR TITLE
[codex] Unify devopsellence releases

### DIFF
--- a/.github/workflows/component-release.yml
+++ b/.github/workflows/component-release.yml
@@ -197,27 +197,13 @@ jobs:
                 ;;
             esac
 
-            local tag_name="${version}"
-            local dist_dir="${workspace_dir}/${working_dir}/dist/${version}"
-            local upload_dir="${dist_dir}/release-assets"
-            local release_notes="devopsellence binary release for ${version} from ${source_ref} at ${target_sha}"
-            rm -rf "$upload_dir"
-            mkdir -p "$upload_dir"
-            cp "${dist_dir}/linux-amd64" "${upload_dir}/${asset_prefix}-linux-amd64"
-            cp "${dist_dir}/linux-arm64" "${upload_dir}/${asset_prefix}-linux-arm64"
-            cp "${dist_dir}/darwin-amd64" "${upload_dir}/${asset_prefix}-darwin-amd64"
-            cp "${dist_dir}/darwin-arm64" "${upload_dir}/${asset_prefix}-darwin-arm64"
-            cp "${dist_dir}/SHA256SUMS" "${upload_dir}/${asset_prefix}-SHA256SUMS"
-            local release_assets=(
-              "${upload_dir}/${asset_prefix}-linux-amd64"
-              "${upload_dir}/${asset_prefix}-linux-arm64"
-              "${upload_dir}/${asset_prefix}-darwin-amd64"
-              "${upload_dir}/${asset_prefix}-darwin-arm64"
-              "${upload_dir}/${asset_prefix}-SHA256SUMS"
-            )
+	            local tag_name="${version}"
+	            local dist_dir="${workspace_dir}/${working_dir}/dist/${version}"
+	            local upload_dir="${dist_dir}/release-assets"
+	            local release_notes="devopsellence binary release for ${version} from ${source_ref} at ${target_sha}"
 
-            if git rev-parse -q --verify "refs/tags/$tag_name" >/dev/null; then
-              tag_target="$(git rev-list -n 1 "$tag_name")"
+	            if git rev-parse -q --verify "refs/tags/$tag_name" >/dev/null; then
+	              tag_target="$(git rev-list -n 1 "$tag_name")"
               if [[ "$tag_target" != "$target_sha" ]]; then
                 echo "tag already exists at a different commit: $tag_name ($tag_target != $target_sha)" >&2
                 exit 1
@@ -227,11 +213,26 @@ jobs:
             DEVOPSELLENCE_RELEASE_VERSION="$version" \
               DEVOPSELLENCE_RELEASE_COMMIT="$short_sha" \
               DEVOPSELLENCE_RELEASE_BUILD_TIME="$build_time" \
-              DEVOPSELLENCE_RELEASE_DIST_DIR="$dist_dir" \
-              mise run "release:build:${component}"
+	              DEVOPSELLENCE_RELEASE_DIST_DIR="$dist_dir" \
+	              mise run "release:build:${component}"
 
-            if gh release view "$tag_name" >/dev/null 2>&1; then
-              gh release edit "$tag_name" \
+	            rm -rf "$upload_dir"
+	            mkdir -p "$upload_dir"
+	            cp "${dist_dir}/linux-amd64" "${upload_dir}/${asset_prefix}-linux-amd64"
+	            cp "${dist_dir}/linux-arm64" "${upload_dir}/${asset_prefix}-linux-arm64"
+	            cp "${dist_dir}/darwin-amd64" "${upload_dir}/${asset_prefix}-darwin-amd64"
+	            cp "${dist_dir}/darwin-arm64" "${upload_dir}/${asset_prefix}-darwin-arm64"
+	            cp "${dist_dir}/SHA256SUMS" "${upload_dir}/${asset_prefix}-SHA256SUMS"
+	            local release_assets=(
+	              "${upload_dir}/${asset_prefix}-linux-amd64"
+	              "${upload_dir}/${asset_prefix}-linux-arm64"
+	              "${upload_dir}/${asset_prefix}-darwin-amd64"
+	              "${upload_dir}/${asset_prefix}-darwin-arm64"
+	              "${upload_dir}/${asset_prefix}-SHA256SUMS"
+	            )
+
+	            if gh release view "$tag_name" >/dev/null 2>&1; then
+	              gh release edit "$tag_name" \
                 --title "devopsellence ${version}" \
                 --notes "$release_notes" \
                 "${prerelease_flag[@]}"

--- a/.github/workflows/component-release.yml
+++ b/.github/workflows/component-release.yml
@@ -222,7 +222,8 @@ jobs:
 	            cp "${dist_dir}/linux-arm64" "${upload_dir}/${asset_prefix}-linux-arm64"
 	            cp "${dist_dir}/darwin-amd64" "${upload_dir}/${asset_prefix}-darwin-amd64"
 	            cp "${dist_dir}/darwin-arm64" "${upload_dir}/${asset_prefix}-darwin-arm64"
-	            cp "${dist_dir}/SHA256SUMS" "${upload_dir}/${asset_prefix}-SHA256SUMS"
+	            awk -v prefix="${asset_prefix}-" '{ print $1 "  " prefix $2 }' \
+	              "${dist_dir}/SHA256SUMS" > "${upload_dir}/${asset_prefix}-SHA256SUMS"
 	            local release_assets=(
 	              "${upload_dir}/${asset_prefix}-linux-amd64"
 	              "${upload_dir}/${asset_prefix}-linux-arm64"

--- a/.github/workflows/component-release.yml
+++ b/.github/workflows/component-release.yml
@@ -1,4 +1,4 @@
-name: Component Release
+name: devopsellence Release
 
 on:
   workflow_dispatch:
@@ -181,15 +181,15 @@ jobs:
 
           publish_component() {
             local component="$1"
-            local working_dir release_label
+            local working_dir asset_prefix
             case "$component" in
               agent)
                 working_dir="agent"
-                release_label="Agent"
+                asset_prefix="agent"
                 ;;
               cli)
                 working_dir="cli"
-                release_label="CLI"
+                asset_prefix="cli"
                 ;;
               *)
                 echo "unknown component: $component" >&2
@@ -197,15 +197,23 @@ jobs:
                 ;;
             esac
 
-            local tag_name="${component}-${version}"
+            local tag_name="${version}"
             local dist_dir="${workspace_dir}/${working_dir}/dist/${version}"
-            local release_notes="${release_label} binary release for ${version} from ${source_ref} at ${target_sha}"
+            local upload_dir="${dist_dir}/release-assets"
+            local release_notes="devopsellence binary release for ${version} from ${source_ref} at ${target_sha}"
+            rm -rf "$upload_dir"
+            mkdir -p "$upload_dir"
+            cp "${dist_dir}/linux-amd64" "${upload_dir}/${asset_prefix}-linux-amd64"
+            cp "${dist_dir}/linux-arm64" "${upload_dir}/${asset_prefix}-linux-arm64"
+            cp "${dist_dir}/darwin-amd64" "${upload_dir}/${asset_prefix}-darwin-amd64"
+            cp "${dist_dir}/darwin-arm64" "${upload_dir}/${asset_prefix}-darwin-arm64"
+            cp "${dist_dir}/SHA256SUMS" "${upload_dir}/${asset_prefix}-SHA256SUMS"
             local release_assets=(
-              "${dist_dir}/linux-amd64"
-              "${dist_dir}/linux-arm64"
-              "${dist_dir}/darwin-amd64"
-              "${dist_dir}/darwin-arm64"
-              "${dist_dir}/SHA256SUMS"
+              "${upload_dir}/${asset_prefix}-linux-amd64"
+              "${upload_dir}/${asset_prefix}-linux-arm64"
+              "${upload_dir}/${asset_prefix}-darwin-amd64"
+              "${upload_dir}/${asset_prefix}-darwin-arm64"
+              "${upload_dir}/${asset_prefix}-SHA256SUMS"
             )
 
             if git rev-parse -q --verify "refs/tags/$tag_name" >/dev/null; then
@@ -224,7 +232,7 @@ jobs:
 
             if gh release view "$tag_name" >/dev/null 2>&1; then
               gh release edit "$tag_name" \
-                --title "${release_label} ${version}" \
+                --title "devopsellence ${version}" \
                 --notes "$release_notes" \
                 "${prerelease_flag[@]}"
               gh release upload "$tag_name" "${release_assets[@]}" --clobber
@@ -233,7 +241,7 @@ jobs:
 
             gh release create "$tag_name" \
               "${release_assets[@]}" \
-              --title "${release_label} ${version}" \
+              --title "devopsellence ${version}" \
               --notes "$release_notes" \
               --target "$target_sha" \
               "${prerelease_flag[@]}"

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1664,7 +1664,7 @@ run_root systemctl stop devopsellence-agent || true
 run_root systemctl enable --now devopsellence-agent
 echo "progress: checking devopsellence-agent service"
 run_root systemctl is-active --quiet devopsellence-agent
-`, shellQuote(stateDir), shellQuote(baseURL), shellQuote(agentVersion), shellQuote(localBinary), authStatePath, overridePath, envoyBootstrapPath)
+`, shellQuote(stateDir), shellQuote(baseURL), shellQuote(agentVersion), shellQuote(localBinary), systemdQuoteArg(authStatePath), systemdQuoteArg(overridePath), systemdQuoteArg(envoyBootstrapPath))
 }
 
 func releasedAgentVersionForInstall() string {
@@ -1673,6 +1673,12 @@ func releasedAgentVersionForInstall() string {
 		return version
 	}
 	return ""
+}
+
+func systemdQuoteArg(value string) string {
+	escaped := strings.ReplaceAll(value, `\`, `\\`)
+	escaped = strings.ReplaceAll(escaped, `"`, `\"`)
+	return `"` + escaped + `"`
 }
 
 func waitForSoloProviderServer(ctx context.Context, provider providers.Provider, server providers.Server) (providers.Server, error) {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1678,6 +1678,7 @@ func releasedAgentVersionForInstall() string {
 func systemdQuoteArg(value string) string {
 	escaped := strings.ReplaceAll(value, `\`, `\\`)
 	escaped = strings.ReplaceAll(escaped, `"`, `\"`)
+	escaped = strings.ReplaceAll(escaped, `%`, `%%`)
 	return `"` + escaped + `"`
 }
 

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1520,7 +1520,10 @@ type soloAgentInstallScriptOptions struct {
 	LocalBinaryPath string
 }
 
-var releaseVersionPattern = regexp.MustCompile(`^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$`)
+// Accept stable tags, semver-style prereleases, and workflow-generated
+// prerelease tags such as branch-name-abcdef1 while keeping the value safe
+// for query-string use in the install script.
+var releaseVersionPattern = regexp.MustCompile(`^[0-9A-Za-z._-]+$`)
 
 func soloAgentInstallScript(opts soloAgentInstallScriptOptions) string {
 	stateDir := strings.TrimSpace(opts.StateDir)
@@ -1669,7 +1672,7 @@ run_root systemctl is-active --quiet devopsellence-agent
 
 func releasedAgentVersionForInstall() string {
 	version := strings.TrimSpace(cliversion.Version)
-	if releaseVersionPattern.MatchString(version) {
+	if version != "" && version != "dev" && releaseVersionPattern.MatchString(version) {
 		return version
 	}
 	return ""

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1621,7 +1621,7 @@ else
     arm64|aarch64) ARCH=arm64 ;;
     *) echo "unsupported architecture: $ARCH_RAW" >&2; exit 1 ;;
   esac
-  ARTIFACT_NAME="$OS-$ARCH"
+  ARTIFACT_NAME="agent-$OS-$ARCH"
   DOWNLOAD_URL="$BASE_URL/agent/download?os=$OS&arch=$ARCH"
   CHECKSUM_URL="$BASE_URL/agent/checksums"
   if [ -n "$AGENT_VERSION" ]; then

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -22,6 +23,7 @@ import (
 	"github.com/devopsellence/cli/internal/solo"
 	"github.com/devopsellence/cli/internal/solo/providers"
 	"github.com/devopsellence/cli/internal/ui"
+	cliversion "github.com/devopsellence/cli/internal/version"
 )
 
 type SoloDeployOptions struct {
@@ -1490,6 +1492,7 @@ func installSoloAgent(ctx context.Context, node config.SoloNode, opts SoloAgentI
 		defer solo.RunSSHInteractive(ctx, node, "rm -f "+shellQuote(remotePath), io.Discard, io.Discard)
 		progress("Installing Docker, agent, and systemd service...")
 		return runSoloAgentInstallScript(ctx, node, soloAgentInstallScript(soloAgentInstallScriptOptions{
+			StateDir:        firstNonEmpty(node.AgentStateDir, "/var/lib/devopsellence"),
 			LocalBinaryPath: remotePath,
 		}), progress)
 	}
@@ -1497,7 +1500,9 @@ func installSoloAgent(ctx context.Context, node config.SoloNode, opts SoloAgentI
 	baseURL := strings.TrimRight(firstNonEmpty(opts.BaseURL, os.Getenv("DEVOPSELLENCE_BASE_URL"), api.DefaultBaseURL), "/")
 	progress("Installing Docker, agent, and systemd service...")
 	return runSoloAgentInstallScript(ctx, node, soloAgentInstallScript(soloAgentInstallScriptOptions{
-		BaseURL: baseURL,
+		StateDir:     firstNonEmpty(node.AgentStateDir, "/var/lib/devopsellence"),
+		BaseURL:      baseURL,
+		AgentVersion: releasedAgentVersionForInstall(),
 	}), progress)
 }
 
@@ -1509,15 +1514,23 @@ func runSoloAgentInstallScript(ctx context.Context, node config.SoloNode, script
 }
 
 type soloAgentInstallScriptOptions struct {
+	StateDir        string
 	BaseURL         string
+	AgentVersion    string
 	LocalBinaryPath string
 }
 
+var releaseVersionPattern = regexp.MustCompile(`^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$`)
+
 func soloAgentInstallScript(opts soloAgentInstallScriptOptions) string {
-	stateDir := "/var/lib/devopsellence"
+	stateDir := strings.TrimSpace(opts.StateDir)
+	if stateDir == "" {
+		stateDir = "/var/lib/devopsellence"
+	}
 	authStatePath := stateDir + "/auth.json"
 	overridePath := stateDir + "/desired-state-override.json"
 	envoyBootstrapPath := stateDir + "/envoy/envoy.yaml"
+	agentVersion := strings.TrimSpace(opts.AgentVersion)
 	localBinary := strings.TrimSpace(opts.LocalBinaryPath)
 	baseURL := strings.TrimRight(strings.TrimSpace(opts.BaseURL), "/")
 	return fmt.Sprintf(`set -euo pipefail
@@ -1526,6 +1539,7 @@ STATE_DIR=%s
 AGENT_BIN=/usr/local/bin/devopsellence-agent
 SERVICE_FILE=/etc/systemd/system/devopsellence-agent.service
 BASE_URL=%s
+AGENT_VERSION=%s
 LOCAL_BINARY=%s
 
 if [ "$(id -u)" -ne 0 ]; then
@@ -1608,8 +1622,14 @@ else
     *) echo "unsupported architecture: $ARCH_RAW" >&2; exit 1 ;;
   esac
   ARTIFACT_NAME="$OS-$ARCH"
-  curl -fsSL "$BASE_URL/agent/download?os=$OS&arch=$ARCH" -o "$TMP_BIN"
-  curl -fsSL "$BASE_URL/agent/checksums" -o "$TMP_SUMS"
+  DOWNLOAD_URL="$BASE_URL/agent/download?os=$OS&arch=$ARCH"
+  CHECKSUM_URL="$BASE_URL/agent/checksums"
+  if [ -n "$AGENT_VERSION" ]; then
+    DOWNLOAD_URL="$DOWNLOAD_URL&version=$AGENT_VERSION"
+    CHECKSUM_URL="$CHECKSUM_URL?version=$AGENT_VERSION"
+  fi
+  curl -fsSL "$DOWNLOAD_URL" -o "$TMP_BIN"
+  curl -fsSL "$CHECKSUM_URL" -o "$TMP_SUMS"
   expected="$(awk -v name="$ARTIFACT_NAME" '$2 == name { print $1; exit }' "$TMP_SUMS")"
   if [ -z "$expected" ]; then
     echo "missing checksum entry for $ARTIFACT_NAME" >&2
@@ -1644,7 +1664,15 @@ run_root systemctl stop devopsellence-agent || true
 run_root systemctl enable --now devopsellence-agent
 echo "progress: checking devopsellence-agent service"
 run_root systemctl is-active --quiet devopsellence-agent
-`, shellQuote(stateDir), shellQuote(baseURL), shellQuote(localBinary), authStatePath, overridePath, envoyBootstrapPath)
+`, shellQuote(stateDir), shellQuote(baseURL), shellQuote(agentVersion), shellQuote(localBinary), authStatePath, overridePath, envoyBootstrapPath)
+}
+
+func releasedAgentVersionForInstall() string {
+	version := strings.TrimSpace(cliversion.Version)
+	if releaseVersionPattern.MatchString(version) {
+		return version
+	}
+	return ""
 }
 
 func waitForSoloProviderServer(ctx context.Context, provider providers.Provider, server providers.Server) (providers.Server, error) {

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/devopsellence/cli/internal/config"
 	"github.com/devopsellence/cli/internal/discovery"
 	"github.com/devopsellence/cli/internal/solo"
+	cliversion "github.com/devopsellence/cli/internal/version"
 )
 
 func TestSoloImageTagSlugifiesProjectName(t *testing.T) {
@@ -172,6 +173,56 @@ func TestSoloAgentInstallScriptConfiguresSoloMode(t *testing.T) {
 		if !strings.Contains(script, want) {
 			t.Fatalf("install script missing %q", want)
 		}
+	}
+}
+
+func TestSoloAgentInstallScriptUsesConfiguredStateDir(t *testing.T) {
+	script := soloAgentInstallScript(soloAgentInstallScriptOptions{
+		StateDir: "/tmp/devopsellence-test-state",
+		BaseURL:  "https://example.test",
+	})
+
+	for _, want := range []string{
+		"STATE_DIR='/tmp/devopsellence-test-state'",
+		"--auth-state-path=/tmp/devopsellence-test-state/auth.json",
+		"--desired-state-override-path=/tmp/devopsellence-test-state/desired-state-override.json",
+		"--envoy-bootstrap-path=/tmp/devopsellence-test-state/envoy/envoy.yaml",
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("install script missing %q", want)
+		}
+	}
+}
+
+func TestSoloAgentInstallScriptPinsReleasedAgentVersionWhenProvided(t *testing.T) {
+	script := soloAgentInstallScript(soloAgentInstallScriptOptions{
+		BaseURL:      "https://example.test",
+		AgentVersion: "v0.1.1",
+	})
+
+	for _, want := range []string{
+		`AGENT_VERSION='v0.1.1'`,
+		`DOWNLOAD_URL="$DOWNLOAD_URL&version=$AGENT_VERSION"`,
+		`CHECKSUM_URL="$CHECKSUM_URL?version=$AGENT_VERSION"`,
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("install script missing %q", want)
+		}
+	}
+}
+
+func TestReleasedAgentVersionForInstall(t *testing.T) {
+	original := cliversion.Version
+	t.Cleanup(func() { cliversion.Version = original })
+
+	cliversion.Version = "v0.1.1"
+	if got := releasedAgentVersionForInstall(); got != "v0.1.1" {
+		t.Fatalf("releasedAgentVersionForInstall() = %q, want v0.1.1", got)
+	}
+
+	cliversion.Version = "dev"
+	if got := releasedAgentVersionForInstall(); got != "" {
+		t.Fatalf("releasedAgentVersionForInstall() = %q, want empty for dev build", got)
 	}
 }
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -238,9 +238,19 @@ func TestReleasedAgentVersionForInstall(t *testing.T) {
 		t.Fatalf("releasedAgentVersionForInstall() = %q, want v0.1.1", got)
 	}
 
+	cliversion.Version = "feature-branch-abc1234"
+	if got := releasedAgentVersionForInstall(); got != "feature-branch-abc1234" {
+		t.Fatalf("releasedAgentVersionForInstall() = %q, want prerelease tag", got)
+	}
+
 	cliversion.Version = "dev"
 	if got := releasedAgentVersionForInstall(); got != "" {
 		t.Fatalf("releasedAgentVersionForInstall() = %q, want empty for dev build", got)
+	}
+
+	cliversion.Version = "bad version?"
+	if got := releasedAgentVersionForInstall(); got != "" {
+		t.Fatalf("releasedAgentVersionForInstall() = %q, want empty for unsafe version", got)
 	}
 }
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -196,14 +196,14 @@ func TestSoloAgentInstallScriptUsesConfiguredStateDir(t *testing.T) {
 
 func TestSoloAgentInstallScriptQuotesSystemdExecStartPaths(t *testing.T) {
 	script := soloAgentInstallScript(soloAgentInstallScriptOptions{
-		StateDir: `/tmp/devopsellence state/"quoted"`,
+		StateDir: `/tmp/devopsellence state/"quoted"%value`,
 		BaseURL:  "https://example.test",
 	})
 
 	for _, want := range []string{
-		`--auth-state-path="/tmp/devopsellence state/\"quoted\"/auth.json"`,
-		`--desired-state-override-path="/tmp/devopsellence state/\"quoted\"/desired-state-override.json"`,
-		`--envoy-bootstrap-path="/tmp/devopsellence state/\"quoted\"/envoy/envoy.yaml"`,
+		`--auth-state-path="/tmp/devopsellence state/\"quoted\"%%value/auth.json"`,
+		`--desired-state-override-path="/tmp/devopsellence state/\"quoted\"%%value/desired-state-override.json"`,
+		`--envoy-bootstrap-path="/tmp/devopsellence state/\"quoted\"%%value/envoy/envoy.yaml"`,
 	} {
 		if !strings.Contains(script, want) {
 			t.Fatalf("install script missing %q", want)

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -166,6 +166,7 @@ func TestSoloAgentInstallScriptConfiguresSoloMode(t *testing.T) {
 		`--auth-state-path="/var/lib/devopsellence/auth.json"`,
 		`--desired-state-override-path="/var/lib/devopsellence/desired-state-override.json"`,
 		"AGENT_BIN=/usr/local/bin/devopsellence-agent",
+		`ARTIFACT_NAME="agent-$OS-$ARCH"`,
 		"BASE_URL='https://example.test'",
 		"$BASE_URL/agent/download",
 		"$BASE_URL/agent/checksums",

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -163,8 +163,8 @@ func TestSoloAgentInstallScriptConfiguresSoloMode(t *testing.T) {
 	script := soloAgentInstallScript(soloAgentInstallScriptOptions{BaseURL: "https://example.test"})
 	for _, want := range []string{
 		"--mode=solo",
-		"--auth-state-path=/var/lib/devopsellence/auth.json",
-		"--desired-state-override-path=/var/lib/devopsellence/desired-state-override.json",
+		`--auth-state-path="/var/lib/devopsellence/auth.json"`,
+		`--desired-state-override-path="/var/lib/devopsellence/desired-state-override.json"`,
 		"AGENT_BIN=/usr/local/bin/devopsellence-agent",
 		"BASE_URL='https://example.test'",
 		"$BASE_URL/agent/download",
@@ -184,9 +184,26 @@ func TestSoloAgentInstallScriptUsesConfiguredStateDir(t *testing.T) {
 
 	for _, want := range []string{
 		"STATE_DIR='/tmp/devopsellence-test-state'",
-		"--auth-state-path=/tmp/devopsellence-test-state/auth.json",
-		"--desired-state-override-path=/tmp/devopsellence-test-state/desired-state-override.json",
-		"--envoy-bootstrap-path=/tmp/devopsellence-test-state/envoy/envoy.yaml",
+		`--auth-state-path="/tmp/devopsellence-test-state/auth.json"`,
+		`--desired-state-override-path="/tmp/devopsellence-test-state/desired-state-override.json"`,
+		`--envoy-bootstrap-path="/tmp/devopsellence-test-state/envoy/envoy.yaml"`,
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("install script missing %q", want)
+		}
+	}
+}
+
+func TestSoloAgentInstallScriptQuotesSystemdExecStartPaths(t *testing.T) {
+	script := soloAgentInstallScript(soloAgentInstallScriptOptions{
+		StateDir: `/tmp/devopsellence state/"quoted"`,
+		BaseURL:  "https://example.test",
+	})
+
+	for _, want := range []string{
+		`--auth-state-path="/tmp/devopsellence state/\"quoted\"/auth.json"`,
+		`--desired-state-override-path="/tmp/devopsellence state/\"quoted\"/desired-state-override.json"`,
+		`--envoy-bootstrap-path="/tmp/devopsellence state/\"quoted\"/envoy/envoy.yaml"`,
 	} {
 		if !strings.Contains(script, want) {
 			t.Fatalf("install script missing %q", want)

--- a/control-plane/app/controllers/agent_checksums_controller.rb
+++ b/control-plane/app/controllers/agent_checksums_controller.rb
@@ -27,7 +27,7 @@ class AgentChecksumsController < ActionController::Base
   def requested_version
     params[:version].to_s.presence || Devopsellence::RuntimeConfig.current.agent_stable_version.presence || raise(
       AgentReleases::Fetcher::NotConfiguredError,
-      "set DEVOPSELLENCE_AGENT_STABLE_VERSION or pass ?version="
+      "set DEVOPSELLENCE_STABLE_VERSION (or DEVOPSELLENCE_AGENT_STABLE_VERSION) or pass ?version="
     )
   end
 end

--- a/control-plane/app/controllers/agent_downloads_controller.rb
+++ b/control-plane/app/controllers/agent_downloads_controller.rb
@@ -33,7 +33,7 @@ class AgentDownloadsController < ActionController::Base
   def requested_version
     params[:version].to_s.presence || Devopsellence::RuntimeConfig.current.agent_stable_version.presence || raise(
       AgentReleases::Fetcher::NotConfiguredError,
-      "set DEVOPSELLENCE_AGENT_STABLE_VERSION or pass ?version="
+      "set DEVOPSELLENCE_STABLE_VERSION (or DEVOPSELLENCE_AGENT_STABLE_VERSION) or pass ?version="
     )
   end
 end

--- a/control-plane/app/controllers/cli_checksums_controller.rb
+++ b/control-plane/app/controllers/cli_checksums_controller.rb
@@ -27,7 +27,7 @@ class CliChecksumsController < ActionController::Base
   def requested_version
     params[:version].to_s.presence || Devopsellence::RuntimeConfig.current.cli_stable_version.presence || raise(
       CliReleases::Fetcher::NotConfiguredError,
-      "set DEVOPSELLENCE_CLI_STABLE_VERSION or pass ?version="
+      "set DEVOPSELLENCE_STABLE_VERSION (or DEVOPSELLENCE_CLI_STABLE_VERSION) or pass ?version="
     )
   end
 end

--- a/control-plane/app/controllers/cli_downloads_controller.rb
+++ b/control-plane/app/controllers/cli_downloads_controller.rb
@@ -33,7 +33,7 @@ class CliDownloadsController < ActionController::Base
   def requested_version
     params[:version].to_s.presence || Devopsellence::RuntimeConfig.current.cli_stable_version.presence || raise(
       CliReleases::Fetcher::NotConfiguredError,
-      "set DEVOPSELLENCE_CLI_STABLE_VERSION or pass ?version="
+      "set DEVOPSELLENCE_STABLE_VERSION (or DEVOPSELLENCE_CLI_STABLE_VERSION) or pass ?version="
     )
   end
 end

--- a/control-plane/app/services/agent_releases/fetcher.rb
+++ b/control-plane/app/services/agent_releases/fetcher.rb
@@ -10,7 +10,7 @@ module AgentReleases
     Artifact = Struct.new(:url, :filename, :source_name, keyword_init: true)
 
     DEFAULT_BASE_DOWNLOAD_URL = "https://github.com/devopsellence/devopsellence/releases/download"
-    DEFAULT_TAG_PREFIX = "agent-"
+    DEFAULT_ASSET_PREFIX = "agent"
     SUPPORTED_OSES = %w[linux darwin].freeze
     SUPPORTED_ARCHES = %w[amd64 arm64].freeze
 
@@ -18,9 +18,9 @@ module AgentReleases
       new
     end
 
-    def initialize(base_download_url: DEFAULT_BASE_DOWNLOAD_URL, tag_prefix: DEFAULT_TAG_PREFIX)
+    def initialize(base_download_url: DEFAULT_BASE_DOWNLOAD_URL, asset_prefix: DEFAULT_ASSET_PREFIX)
       @base_download_url = base_download_url.to_s.delete_suffix("/")
-      @tag_prefix = tag_prefix.to_s
+      @asset_prefix = asset_prefix.to_s
     end
 
     def fetch(version:, os:, arch:)
@@ -36,15 +36,15 @@ module AgentReleases
 
     def fetch_checksums(version:)
       Artifact.new(
-        url: download_url(version:, source_name: "SHA256SUMS"),
+        url: download_url(version:, source_name: "#{asset_prefix}-SHA256SUMS"),
         filename: "SHA256SUMS",
-        source_name: "SHA256SUMS"
+        source_name: "#{asset_prefix}-SHA256SUMS"
       )
     end
 
     private
 
-    attr_reader :base_download_url, :tag_prefix
+    attr_reader :asset_prefix, :base_download_url
 
     def validate_target!(os:, arch:)
       return if SUPPORTED_OSES.include?(os) && SUPPORTED_ARCHES.include?(arch)
@@ -53,11 +53,11 @@ module AgentReleases
     end
 
     def artifact_name(os:, arch:)
-      "#{os}-#{arch}"
+      "#{asset_prefix}-#{os}-#{arch}"
     end
 
     def download_url(version:, source_name:)
-      encoded_tag = ERB::Util.url_encode("#{tag_prefix}#{version}")
+      encoded_tag = ERB::Util.url_encode(version)
       encoded_source_name = ERB::Util.url_encode(source_name)
       "#{base_download_url}/#{encoded_tag}/#{encoded_source_name}"
     end

--- a/control-plane/app/services/cli_releases/fetcher.rb
+++ b/control-plane/app/services/cli_releases/fetcher.rb
@@ -10,7 +10,7 @@ module CliReleases
     Artifact = Struct.new(:url, :filename, :source_name, keyword_init: true)
 
     DEFAULT_BASE_DOWNLOAD_URL = "https://github.com/devopsellence/devopsellence/releases/download"
-    DEFAULT_TAG_PREFIX = "cli-"
+    DEFAULT_ASSET_PREFIX = "cli"
     SUPPORTED_OSES = %w[linux darwin].freeze
     SUPPORTED_ARCHES = %w[amd64 arm64].freeze
 
@@ -18,9 +18,9 @@ module CliReleases
       new
     end
 
-    def initialize(base_download_url: DEFAULT_BASE_DOWNLOAD_URL, tag_prefix: DEFAULT_TAG_PREFIX)
+    def initialize(base_download_url: DEFAULT_BASE_DOWNLOAD_URL, asset_prefix: DEFAULT_ASSET_PREFIX)
       @base_download_url = base_download_url.to_s.delete_suffix("/")
-      @tag_prefix = tag_prefix.to_s
+      @asset_prefix = asset_prefix.to_s
     end
 
     def fetch(version:, os:, arch:)
@@ -36,15 +36,15 @@ module CliReleases
 
     def fetch_checksums(version:)
       Artifact.new(
-        url: download_url(version:, source_name: "SHA256SUMS"),
+        url: download_url(version:, source_name: "#{asset_prefix}-SHA256SUMS"),
         filename: "SHA256SUMS",
-        source_name: "SHA256SUMS"
+        source_name: "#{asset_prefix}-SHA256SUMS"
       )
     end
 
     private
 
-    attr_reader :base_download_url, :tag_prefix
+    attr_reader :asset_prefix, :base_download_url
 
     def validate_target!(os:, arch:)
       return if SUPPORTED_OSES.include?(os) && SUPPORTED_ARCHES.include?(arch)
@@ -53,11 +53,11 @@ module CliReleases
     end
 
     def artifact_name(os:, arch:)
-      "#{os}-#{arch}"
+      "#{asset_prefix}-#{os}-#{arch}"
     end
 
     def download_url(version:, source_name:)
-      encoded_tag = ERB::Util.url_encode("#{tag_prefix}#{version}")
+      encoded_tag = ERB::Util.url_encode(version)
       encoded_source_name = ERB::Util.url_encode(source_name)
       "#{base_download_url}/#{encoded_tag}/#{encoded_source_name}"
     end

--- a/control-plane/lib/devopsellence/runtime_config.rb
+++ b/control-plane/lib/devopsellence/runtime_config.rb
@@ -76,8 +76,7 @@ module Devopsellence
       acme_account_key_path: ["DEVOPSELLENCE_ACME_ACCOUNT_KEY_PATH", Rails.root.join("tmp/acme-account-key.pem").to_s],
       acme_contact_email: ["DEVOPSELLENCE_ACME_CONTACT_EMAIL", DEFAULT_ACME_CONTACT_EMAIL],
       acme_directory_url: ["DEVOPSELLENCE_ACME_DIRECTORY_URL", DEFAULT_ACME_DIRECTORY_URL],
-      agent_stable_version: ["DEVOPSELLENCE_AGENT_STABLE_VERSION", ""],
-      cli_stable_version: ["DEVOPSELLENCE_CLI_STABLE_VERSION", ""],
+      stable_version: ["DEVOPSELLENCE_STABLE_VERSION", ""],
       agent_container_image: ["DEVOPSELLENCE_AGENT_CONTAINER_IMAGE", ""],
       agent_container_repository: ["DEVOPSELLENCE_AGENT_CONTAINER_REPOSITORY", ""],
       managed_default_provider: ["DEVOPSELLENCE_MANAGED_DEFAULT_PROVIDER", DEFAULT_MANAGED_PROVIDER],
@@ -122,6 +121,9 @@ module Devopsellence
         OPTIONAL_DEFAULTS.each do |name, (key, fallback)|
           config[name] = env.fetch(key, fallback).to_s.strip
         end
+        stable_version = config.stable_version.to_s.strip
+        config.agent_stable_version = env.fetch("DEVOPSELLENCE_AGENT_STABLE_VERSION", stable_version).to_s.strip
+        config.cli_stable_version = env.fetch("DEVOPSELLENCE_CLI_STABLE_VERSION", stable_version).to_s.strip
         config.managed_pool_candidates = build_managed_pool_candidates(config)
         validate_runtime_backend!(config)
         validate_workload_identity_resource_names!(config)

--- a/control-plane/lib/devopsellence/runtime_config.rb
+++ b/control-plane/lib/devopsellence/runtime_config.rb
@@ -122,8 +122,8 @@ module Devopsellence
           config[name] = env.fetch(key, fallback).to_s.strip
         end
         stable_version = config.stable_version.to_s.strip
-        config.agent_stable_version = env.fetch("DEVOPSELLENCE_AGENT_STABLE_VERSION", stable_version).to_s.strip
-        config.cli_stable_version = env.fetch("DEVOPSELLENCE_CLI_STABLE_VERSION", stable_version).to_s.strip
+        config.agent_stable_version = env["DEVOPSELLENCE_AGENT_STABLE_VERSION"].to_s.strip.presence || stable_version
+        config.cli_stable_version = env["DEVOPSELLENCE_CLI_STABLE_VERSION"].to_s.strip.presence || stable_version
         config.managed_pool_candidates = build_managed_pool_candidates(config)
         validate_runtime_backend!(config)
         validate_workload_identity_resource_names!(config)

--- a/control-plane/test/integration/agent_downloads_test.rb
+++ b/control-plane/test/integration/agent_downloads_test.rb
@@ -23,7 +23,7 @@ class AgentDownloadsTest < ActionDispatch::IntegrationTest
   end
 
   test "returns service unavailable when no version is requested and no stable version is configured" do
-    with_env("DEVOPSELLENCE_AGENT_STABLE_VERSION" => nil) do
+    with_env("DEVOPSELLENCE_STABLE_VERSION" => nil, "DEVOPSELLENCE_AGENT_STABLE_VERSION" => nil) do
       get agent_download_path
     end
 
@@ -32,14 +32,14 @@ class AgentDownloadsTest < ActionDispatch::IntegrationTest
   end
 
   test "redirects explicit version to the configured release asset url" do
-    fetcher = FakeFetcher.new(result: FakeArtifact.new(url: "https://github.com/devopsellence/devopsellence/releases/download/agent-v0.1.0/linux-arm64", filename: "devopsellence-agent"))
+    fetcher = FakeFetcher.new(result: FakeArtifact.new(url: "https://github.com/devopsellence/devopsellence/releases/download/v0.1.0/agent-linux-arm64", filename: "devopsellence-agent"))
 
     with_agent_release_fetcher(fetcher) do
       get agent_download_path, params: { version: "v0.1.0", os: "linux", arch: "arm64" }
     end
 
     assert_response :redirect
-    assert_equal "https://github.com/devopsellence/devopsellence/releases/download/agent-v0.1.0/linux-arm64", response.location
+    assert_equal "https://github.com/devopsellence/devopsellence/releases/download/v0.1.0/agent-linux-arm64", response.location
     assert_equal [{ version: "v0.1.0", os: "linux", arch: "arm64" }], fetcher.calls
     assert_includes response.headers["Cache-Control"], "public"
     assert_includes response.headers["Cache-Control"], "max-age=31536000"
@@ -49,7 +49,7 @@ class AgentDownloadsTest < ActionDispatch::IntegrationTest
   test "redirects unversioned requests to the stable version without downloading" do
     fetcher = FakeFetcher.new(result: FakeArtifact.new(url: "https://example.test/unused", filename: "devopsellence-agent"))
 
-    with_env("DEVOPSELLENCE_AGENT_STABLE_VERSION" => "v1.2.3") do
+    with_env("DEVOPSELLENCE_STABLE_VERSION" => "v1.2.3", "DEVOPSELLENCE_AGENT_STABLE_VERSION" => nil) do
       with_agent_release_fetcher(fetcher) do
         get agent_download_path
       end
@@ -57,6 +57,20 @@ class AgentDownloadsTest < ActionDispatch::IntegrationTest
 
     assert_response :redirect
     assert_equal "http://www.example.com/agent/download?version=v1.2.3", response.location
+    assert_empty fetcher.calls
+  end
+
+  test "component-specific stable version overrides shared stable version" do
+    fetcher = FakeFetcher.new(result: FakeArtifact.new(url: "https://example.test/unused", filename: "devopsellence-agent"))
+
+    with_env("DEVOPSELLENCE_STABLE_VERSION" => "v1.2.3", "DEVOPSELLENCE_AGENT_STABLE_VERSION" => "v1.2.4") do
+      with_agent_release_fetcher(fetcher) do
+        get agent_download_path
+      end
+    end
+
+    assert_response :redirect
+    assert_equal "http://www.example.com/agent/download?version=v1.2.4", response.location
     assert_empty fetcher.calls
   end
 

--- a/control-plane/test/integration/api_cli_mvp_test.rb
+++ b/control-plane/test/integration/api_cli_mvp_test.rb
@@ -913,7 +913,7 @@ class ApiCliMvpTest < ActionDispatch::IntegrationTest
     with_env(
       "DEVOPSELLENCE_AGENT_CONTAINER_IMAGE" => nil,
       "DEVOPSELLENCE_AGENT_CONTAINER_REPOSITORY" => "us-east1-docker.pkg.dev/devopsellence/agents/devopsellence-agent",
-      "DEVOPSELLENCE_AGENT_STABLE_VERSION" => "v1.2.3"
+      "DEVOPSELLENCE_STABLE_VERSION" => "v1.2.3"
     ) do
       post "/api/v1/cli/organizations/#{organization.id}/node_bootstrap_tokens",
         headers: auth_headers_for(user),

--- a/control-plane/test/integration/cli_downloads_test.rb
+++ b/control-plane/test/integration/cli_downloads_test.rb
@@ -23,7 +23,7 @@ class CliDownloadsTest < ActionDispatch::IntegrationTest
   end
 
   test "returns service unavailable when no version is requested and no stable version is configured" do
-    with_env("DEVOPSELLENCE_CLI_STABLE_VERSION" => nil) do
+    with_env("DEVOPSELLENCE_STABLE_VERSION" => nil, "DEVOPSELLENCE_CLI_STABLE_VERSION" => nil) do
       get cli_download_path
     end
 
@@ -32,14 +32,14 @@ class CliDownloadsTest < ActionDispatch::IntegrationTest
   end
 
   test "redirects explicit version to the configured release asset url" do
-    fetcher = FakeFetcher.new(result: FakeArtifact.new(url: "https://github.com/devopsellence/devopsellence/releases/download/cli-v0.1.0/darwin-arm64", filename: "devopsellence"))
+    fetcher = FakeFetcher.new(result: FakeArtifact.new(url: "https://github.com/devopsellence/devopsellence/releases/download/v0.1.0/cli-darwin-arm64", filename: "devopsellence"))
 
     with_cli_release_fetcher(fetcher) do
       get cli_download_path, params: { version: "v0.1.0", os: "darwin", arch: "arm64" }
     end
 
     assert_response :redirect
-    assert_equal "https://github.com/devopsellence/devopsellence/releases/download/cli-v0.1.0/darwin-arm64", response.location
+    assert_equal "https://github.com/devopsellence/devopsellence/releases/download/v0.1.0/cli-darwin-arm64", response.location
     assert_equal [{ version: "v0.1.0", os: "darwin", arch: "arm64" }], fetcher.calls
     assert_includes response.headers["Cache-Control"], "public"
     assert_includes response.headers["Cache-Control"], "max-age=31536000"
@@ -49,7 +49,7 @@ class CliDownloadsTest < ActionDispatch::IntegrationTest
   test "redirects unversioned requests to the stable version without downloading" do
     fetcher = FakeFetcher.new(result: FakeArtifact.new(url: "https://example.test/unused", filename: "devopsellence"))
 
-    with_env("DEVOPSELLENCE_CLI_STABLE_VERSION" => "v1.2.3") do
+    with_env("DEVOPSELLENCE_STABLE_VERSION" => "v1.2.3", "DEVOPSELLENCE_CLI_STABLE_VERSION" => nil) do
       with_cli_release_fetcher(fetcher) do
         get cli_download_path, params: { os: "darwin", arch: "arm64" }
       end
@@ -57,6 +57,20 @@ class CliDownloadsTest < ActionDispatch::IntegrationTest
 
     assert_response :redirect
     assert_equal "http://www.example.com/cli/download?arch=arm64&os=darwin&version=v1.2.3", response.location
+    assert_empty fetcher.calls
+  end
+
+  test "component-specific stable version overrides shared stable version" do
+    fetcher = FakeFetcher.new(result: FakeArtifact.new(url: "https://example.test/unused", filename: "devopsellence"))
+
+    with_env("DEVOPSELLENCE_STABLE_VERSION" => "v1.2.3", "DEVOPSELLENCE_CLI_STABLE_VERSION" => "v1.2.4") do
+      with_cli_release_fetcher(fetcher) do
+        get cli_download_path, params: { os: "darwin", arch: "arm64" }
+      end
+    end
+
+    assert_response :redirect
+    assert_equal "http://www.example.com/cli/download?arch=arm64&os=darwin&version=v1.2.4", response.location
     assert_empty fetcher.calls
   end
 

--- a/control-plane/test/integration/release_checksums_test.rb
+++ b/control-plane/test/integration/release_checksums_test.rb
@@ -22,7 +22,7 @@ class ReleaseChecksumsTest < ActionDispatch::IntegrationTest
   test "cli checksums redirect unversioned requests to the stable version" do
     fetcher = FakeFetcher.new(result: FakeArtifact.new(url: "https://example.test/unused", filename: "SHA256SUMS"))
 
-    with_env("DEVOPSELLENCE_CLI_STABLE_VERSION" => "v1.2.3") do
+    with_env("DEVOPSELLENCE_STABLE_VERSION" => "v1.2.3", "DEVOPSELLENCE_CLI_STABLE_VERSION" => nil) do
       with_cli_release_fetcher(fetcher) do
         get cli_checksums_path
       end
@@ -34,14 +34,14 @@ class ReleaseChecksumsTest < ActionDispatch::IntegrationTest
   end
 
   test "cli checksums redirect explicit version requests to the release asset url" do
-    fetcher = FakeFetcher.new(result: FakeArtifact.new(url: "https://github.com/devopsellence/devopsellence/releases/download/cli-v0.1.0/SHA256SUMS", filename: "SHA256SUMS"))
+    fetcher = FakeFetcher.new(result: FakeArtifact.new(url: "https://github.com/devopsellence/devopsellence/releases/download/v0.1.0/cli-SHA256SUMS", filename: "SHA256SUMS"))
 
     with_cli_release_fetcher(fetcher) do
       get cli_checksums_path, params: { version: "v0.1.0" }
     end
 
     assert_response :redirect
-    assert_equal "https://github.com/devopsellence/devopsellence/releases/download/cli-v0.1.0/SHA256SUMS", response.location
+    assert_equal "https://github.com/devopsellence/devopsellence/releases/download/v0.1.0/cli-SHA256SUMS", response.location
     assert_equal [{ version: "v0.1.0" }], fetcher.calls
     assert_includes response.headers["Cache-Control"], "public"
     assert_includes response.headers["Cache-Control"], "max-age=31536000"
@@ -51,7 +51,7 @@ class ReleaseChecksumsTest < ActionDispatch::IntegrationTest
   test "agent checksums redirect unversioned requests to the stable version" do
     fetcher = FakeFetcher.new(result: FakeArtifact.new(url: "https://example.test/unused", filename: "SHA256SUMS"))
 
-    with_env("DEVOPSELLENCE_AGENT_STABLE_VERSION" => "v2.3.4") do
+    with_env("DEVOPSELLENCE_STABLE_VERSION" => "v2.3.4", "DEVOPSELLENCE_AGENT_STABLE_VERSION" => nil) do
       with_agent_release_fetcher(fetcher) do
         get agent_checksums_path
       end
@@ -63,14 +63,14 @@ class ReleaseChecksumsTest < ActionDispatch::IntegrationTest
   end
 
   test "agent checksums redirect explicit version requests to the release asset url" do
-    fetcher = FakeFetcher.new(result: FakeArtifact.new(url: "https://github.com/devopsellence/devopsellence/releases/download/agent-v0.1.0/SHA256SUMS", filename: "SHA256SUMS"))
+    fetcher = FakeFetcher.new(result: FakeArtifact.new(url: "https://github.com/devopsellence/devopsellence/releases/download/v0.1.0/agent-SHA256SUMS", filename: "SHA256SUMS"))
 
     with_agent_release_fetcher(fetcher) do
       get agent_checksums_path, params: { version: "v0.1.0" }
     end
 
     assert_response :redirect
-    assert_equal "https://github.com/devopsellence/devopsellence/releases/download/agent-v0.1.0/SHA256SUMS", response.location
+    assert_equal "https://github.com/devopsellence/devopsellence/releases/download/v0.1.0/agent-SHA256SUMS", response.location
     assert_equal [{ version: "v0.1.0" }], fetcher.calls
     assert_includes response.headers["Cache-Control"], "public"
     assert_includes response.headers["Cache-Control"], "max-age=31536000"

--- a/control-plane/test/lib/devopsellence/runtime_config_test.rb
+++ b/control-plane/test/lib/devopsellence/runtime_config_test.rb
@@ -62,6 +62,15 @@ module Devopsellence
       end
     end
 
+    test "blank component-specific stable versions fall back to shared stable version" do
+      with_env("DEVOPSELLENCE_STABLE_VERSION" => "v1.2.3", "DEVOPSELLENCE_AGENT_STABLE_VERSION" => "", "DEVOPSELLENCE_CLI_STABLE_VERSION" => "   ") do
+        config = RuntimeConfig.load!(env: ENV.to_h)
+
+        assert_equal "v1.2.3", config.agent_stable_version
+        assert_equal "v1.2.3", config.cli_stable_version
+      end
+    end
+
     test "development defaults acme directory to letsencrypt staging" do
       with_env("DEVOPSELLENCE_ACME_DIRECTORY_URL" => nil) do
         config = RuntimeConfig.load_current!(env: ENV.to_h, rails_env: "development")

--- a/control-plane/test/lib/devopsellence/runtime_config_test.rb
+++ b/control-plane/test/lib/devopsellence/runtime_config_test.rb
@@ -42,6 +42,26 @@ module Devopsellence
       end
     end
 
+    test "shared stable version populates both cli and agent defaults" do
+      with_env("DEVOPSELLENCE_STABLE_VERSION" => "v1.2.3", "DEVOPSELLENCE_AGENT_STABLE_VERSION" => nil, "DEVOPSELLENCE_CLI_STABLE_VERSION" => nil) do
+        config = RuntimeConfig.load!(env: ENV.to_h)
+
+        assert_equal "v1.2.3", config.stable_version
+        assert_equal "v1.2.3", config.agent_stable_version
+        assert_equal "v1.2.3", config.cli_stable_version
+      end
+    end
+
+    test "component-specific stable version overrides shared stable version" do
+      with_env("DEVOPSELLENCE_STABLE_VERSION" => "v1.2.3", "DEVOPSELLENCE_AGENT_STABLE_VERSION" => "v1.2.4", "DEVOPSELLENCE_CLI_STABLE_VERSION" => "v1.2.5") do
+        config = RuntimeConfig.load!(env: ENV.to_h)
+
+        assert_equal "v1.2.3", config.stable_version
+        assert_equal "v1.2.4", config.agent_stable_version
+        assert_equal "v1.2.5", config.cli_stable_version
+      end
+    end
+
     test "development defaults acme directory to letsencrypt staging" do
       with_env("DEVOPSELLENCE_ACME_DIRECTORY_URL" => nil) do
         config = RuntimeConfig.load_current!(env: ENV.to_h, rails_env: "development")

--- a/control-plane/test/services/agent_releases/container_image_test.rb
+++ b/control-plane/test/services/agent_releases/container_image_test.rb
@@ -7,7 +7,7 @@ class AgentReleasesContainerImageTest < ActiveSupport::TestCase
     with_env(
       "DEVOPSELLENCE_AGENT_CONTAINER_IMAGE" => "ghcr.io/devopsellence/agent:v1.2.3",
       "DEVOPSELLENCE_AGENT_CONTAINER_REPOSITORY" => "us-east1-docker.pkg.dev/devopsellence/agents/devopsellence-agent",
-      "DEVOPSELLENCE_AGENT_STABLE_VERSION" => "v9.9.9"
+      "DEVOPSELLENCE_STABLE_VERSION" => "v9.9.9"
     ) do
       assert_equal(
         {
@@ -23,7 +23,7 @@ class AgentReleasesContainerImageTest < ActiveSupport::TestCase
     with_env(
       "DEVOPSELLENCE_AGENT_CONTAINER_IMAGE" => nil,
       "DEVOPSELLENCE_AGENT_CONTAINER_REPOSITORY" => "us-east1-docker.pkg.dev/devopsellence/agents/devopsellence-agent",
-      "DEVOPSELLENCE_AGENT_STABLE_VERSION" => "v1.2.3"
+      "DEVOPSELLENCE_STABLE_VERSION" => "v1.2.3"
     ) do
       assert_equal(
         {
@@ -39,6 +39,7 @@ class AgentReleasesContainerImageTest < ActiveSupport::TestCase
     with_env(
       "DEVOPSELLENCE_AGENT_CONTAINER_IMAGE" => nil,
       "DEVOPSELLENCE_AGENT_CONTAINER_REPOSITORY" => nil,
+      "DEVOPSELLENCE_STABLE_VERSION" => nil,
       "DEVOPSELLENCE_AGENT_STABLE_VERSION" => nil
     ) do
       assert_nil AgentReleases::ContainerImage.metadata

--- a/control-plane/test/services/agent_releases/fetcher_test.rb
+++ b/control-plane/test/services/agent_releases/fetcher_test.rb
@@ -7,15 +7,15 @@ module AgentReleases
     test "fetch builds a github release asset url" do
       artifact = Fetcher.new.fetch(version: "v0.1.0", os: "linux", arch: "amd64")
 
-      assert_equal "https://github.com/devopsellence/devopsellence/releases/download/agent-v0.1.0/linux-amd64", artifact.url
+      assert_equal "https://github.com/devopsellence/devopsellence/releases/download/v0.1.0/agent-linux-amd64", artifact.url
       assert_equal "devopsellence-agent", artifact.filename
-      assert_equal "linux-amd64", artifact.source_name
+      assert_equal "agent-linux-amd64", artifact.source_name
     end
 
     test "fetch_checksums builds a github release asset url" do
       artifact = Fetcher.new.fetch_checksums(version: "v0.1.0")
 
-      assert_equal "https://github.com/devopsellence/devopsellence/releases/download/agent-v0.1.0/SHA256SUMS", artifact.url
+      assert_equal "https://github.com/devopsellence/devopsellence/releases/download/v0.1.0/agent-SHA256SUMS", artifact.url
       assert_equal "SHA256SUMS", artifact.filename
     end
 

--- a/control-plane/test/services/cli_releases/fetcher_test.rb
+++ b/control-plane/test/services/cli_releases/fetcher_test.rb
@@ -7,15 +7,15 @@ module CliReleases
     test "fetch builds a github release asset url" do
       artifact = Fetcher.new.fetch(version: "v0.1.0", os: "darwin", arch: "arm64")
 
-      assert_equal "https://github.com/devopsellence/devopsellence/releases/download/cli-v0.1.0/darwin-arm64", artifact.url
+      assert_equal "https://github.com/devopsellence/devopsellence/releases/download/v0.1.0/cli-darwin-arm64", artifact.url
       assert_equal "devopsellence", artifact.filename
-      assert_equal "darwin-arm64", artifact.source_name
+      assert_equal "cli-darwin-arm64", artifact.source_name
     end
 
     test "fetch_checksums builds a github release asset url" do
       artifact = Fetcher.new.fetch_checksums(version: "v0.1.0")
 
-      assert_equal "https://github.com/devopsellence/devopsellence/releases/download/cli-v0.1.0/SHA256SUMS", artifact.url
+      assert_equal "https://github.com/devopsellence/devopsellence/releases/download/v0.1.0/cli-SHA256SUMS", artifact.url
       assert_equal "SHA256SUMS", artifact.filename
     end
 

--- a/test/e2e/e2e.rb
+++ b/test/e2e/e2e.rb
@@ -382,19 +382,19 @@ class E2E
     def assert_release_downloads!
       assert_artifact_redirect!(
         "/cli/download?version=#{@release_version}&os=linux&arch=amd64",
-        "https://github.com/devopsellence/devopsellence/releases/download/cli-#{@release_version}/linux-amd64"
+        "https://github.com/devopsellence/devopsellence/releases/download/#{@release_version}/cli-linux-amd64"
       )
       assert_artifact_redirect!(
         "/agent/download?version=#{@release_version}&os=linux&arch=amd64",
-        "https://github.com/devopsellence/devopsellence/releases/download/agent-#{@release_version}/linux-amd64"
+        "https://github.com/devopsellence/devopsellence/releases/download/#{@release_version}/agent-linux-amd64"
       )
       assert_artifact_redirect!(
         "/cli/checksums?version=#{@release_version}",
-        "https://github.com/devopsellence/devopsellence/releases/download/cli-#{@release_version}/SHA256SUMS"
+        "https://github.com/devopsellence/devopsellence/releases/download/#{@release_version}/cli-SHA256SUMS"
       )
       assert_artifact_redirect!(
         "/agent/checksums?version=#{@release_version}",
-        "https://github.com/devopsellence/devopsellence/releases/download/agent-#{@release_version}/SHA256SUMS"
+        "https://github.com/devopsellence/devopsellence/releases/download/#{@release_version}/agent-SHA256SUMS"
       )
     end
 
@@ -914,8 +914,7 @@ class E2E
 
     def release_env
       {
-        "DEVOPSELLENCE_AGENT_STABLE_VERSION" => @release_version,
-        "DEVOPSELLENCE_CLI_STABLE_VERSION" => @release_version
+        "DEVOPSELLENCE_STABLE_VERSION" => @release_version
       }
     end
 

--- a/test/e2e/solo_e2e.rb
+++ b/test/e2e/solo_e2e.rb
@@ -8,9 +8,9 @@
 #   2. Start a Docker container acting as the "remote node":
 #      - OpenSSH server for CLI access
 #      - Docker (via docker.sock mount)
-#      - Agent in --mode=solo watching desired-state file
-#   3. Scaffold a test Go app with devopsellence.yml (solo config under `solo`)
-#   4. CLI sets secrets, deploys, checks status
+#      - Fake systemctl/journalctl shims so CLI agent install can run in-container
+#   3. Scaffold a test app with devopsellence.yml (solo config under `solo`)
+#   4. CLI installs the agent, sets secrets, deploys, checks status
 #   5. Assert: app container running, status.json settled, secrets resolved
 #
 # Usage:
@@ -36,6 +36,7 @@ require "socket"
 require "time"
 require "timeout"
 require "tmpdir"
+require "webrick"
 require "yaml"
 require_relative "binary_artifacts"
 
@@ -66,7 +67,8 @@ class SoloE2E
     @app_dir = @app_root_dir.join("app")
     @log_dir = MONOREPO_ROOT.join("test/e2e/log")
     @image_build_dir = @state_dir.join("images")
-    @ssh_port = Integer(ENV.fetch("DEVOPSELLENCE_E2E_SSH_PORT", available_port(12_200).to_s))
+    @ssh_port = Integer(ENV.fetch("DEVOPSELLENCE_E2E_SSH_PORT", available_port(20_000 + SecureRandom.random_number(10_000)).to_s))
+    @artifact_server_port = available_port(31_000 + SecureRandom.random_number(1000))
     @network = "devopsellence-solo-e2e-#{@run_id}"
     @node_container = "devopsellence-solo-node-#{@run_id}"
     @node_image = "devopsellence/solo-e2e-node:#{@run_id}"
@@ -80,6 +82,7 @@ class SoloE2E
       @node_container => @log_dir.join("solo-e2e-node-#{@run_id}.log")
     }
     @ssh_key_dir = @state_dir.join("ssh")
+    @ssh_client_home = @state_dir.join("ssh-home")
     @project_name = "e2e-solo-#{SecureRandom.hex(3)}"
   end
 
@@ -87,6 +90,7 @@ class SoloE2E
     prepare_directories!
 
     step("prepare local binary artifacts") { prepare_binary_artifacts! }
+    step("artifact server") { start_artifact_server! }
     step("build node image") { build_node_image! }
     step("generate SSH keys") { generate_ssh_keys! }
     step("network") { create_network! }
@@ -94,6 +98,7 @@ class SoloE2E
     step("wait for node") { wait_for_node_ready! }
     step("scaffold app") { scaffold_app! }
     step("mode") { set_workspace_mode! }
+    step("install agent") { install_agent! }
     step("secrets") { set_secrets! }
     step("deploy") { run_deploy! }
     step("assertions") { assert_runtime_state! }
@@ -118,18 +123,18 @@ class SoloE2E
     FileUtils.mkdir_p(@app_dir)
     FileUtils.mkdir_p(@image_build_dir)
     FileUtils.mkdir_p(@ssh_key_dir)
+    FileUtils.mkdir_p(@ssh_client_home.join(".ssh"))
   end
 
   # Build a Docker image that acts as a remote node:
   # - OpenSSH server for CLI SSH access
   # - Docker CLI (docker.sock mounted at runtime)
-  # - Agent binary running in solo mode
+  # - Fake systemctl/journalctl so `devopsellence agent install` can exercise
+  #   the real install path inside the container.
   def build_node_image!
     image_dir = @image_build_dir.join("node")
     FileUtils.rm_rf(image_dir)
     FileUtils.mkdir_p(image_dir)
-
-    FileUtils.cp(agent_binary, image_dir.join("devopsellence"))
 
     image_dir.join("entrypoint.sh").write(<<~SH)
       #!/bin/bash
@@ -137,6 +142,8 @@ class SoloE2E
 
       # Ensure state directory exists.
       mkdir -p #{@agent_state_dir}
+      mkdir -p /var/run/devopsellence-fake-systemd
+      touch /var/run/devopsellence-fake-systemd/devopsellence-agent.log
 
       # Copy the host-mounted public key into place so sshd StrictModes sees
       # root-owned authorized_keys even when the Docker host uses another uid.
@@ -149,16 +156,154 @@ class SoloE2E
       /usr/sbin/sshd
 
       echo "[node] sshd started on port 22"
-      echo "[node] starting agent in solo mode..."
+      echo "[node] waiting for CLI-managed agent install..."
 
-      # Run agent in solo mode.
-      exec /usr/local/bin/devopsellence \
-        --mode=solo \
-        --auth-state-path=#{@agent_state_dir}/auth.json \
-        --desired-state-override-path=#{@desired_state_path} \
-        --envoy-bootstrap-path=#{@envoy_bootstrap_path} \
-        --network=#{@network} \
-        --prefetch-system-images=false
+      exec tail -f /dev/null
+    SH
+
+    image_dir.join("systemctl").write(<<~SH)
+      #!/bin/bash
+      set -euo pipefail
+
+      STATE_DIR=/var/run/devopsellence-fake-systemd
+      SERVICE_NAME=devopsellence-agent
+      SERVICE_FILE=/etc/systemd/system/${SERVICE_NAME}.service
+      PID_FILE="$STATE_DIR/${SERVICE_NAME}.pid"
+      LOG_FILE="$STATE_DIR/${SERVICE_NAME}.log"
+
+      mkdir -p "$STATE_DIR"
+      touch "$LOG_FILE"
+
+      cmd="${1:-}"
+      shift || true
+
+      service_matches() {
+        case "${1:-}" in
+          "$SERVICE_NAME"|"$SERVICE_NAME.service") return 0 ;;
+          *) return 1 ;;
+        esac
+      }
+
+      docker_matches() {
+        case "${1:-}" in
+          docker|docker.service) return 0 ;;
+          *) return 1 ;;
+        esac
+      }
+
+      read_exec_start() {
+        sed -n 's/^ExecStart=//p' "$SERVICE_FILE" | head -n 1
+      }
+
+      service_pid_running() {
+        [[ -f "$PID_FILE" ]] && kill -0 "$(cat "$PID_FILE")" 2>/dev/null
+      }
+
+      case "$cmd" in
+        daemon-reload|reset-failed)
+          exit 0
+          ;;
+        enable)
+          if [[ "${1:-}" == "--now" ]]; then
+            shift
+          fi
+          unit="${1:-}"
+          if docker_matches "$unit"; then
+            exit 0
+          fi
+          service_matches "$unit"
+          exec_start="$(read_exec_start)"
+          [[ -n "$exec_start" ]]
+          if service_pid_running; then
+            exit 0
+          fi
+          nohup bash -lc "exec $exec_start" >>"$LOG_FILE" 2>&1 &
+          echo "$!" > "$PID_FILE"
+          exit 0
+          ;;
+        stop)
+          unit="${1:-}"
+          if docker_matches "$unit"; then
+            exit 0
+          fi
+          service_matches "$unit"
+          if [[ -f "$PID_FILE" ]]; then
+            kill "$(cat "$PID_FILE")" 2>/dev/null || true
+            rm -f "$PID_FILE"
+          fi
+          exit 0
+          ;;
+        is-active)
+          if [[ "${1:-}" == "--quiet" ]]; then
+            shift
+          fi
+          unit="${1:-}"
+          service_matches "$unit"
+          if service_pid_running; then
+            exit 0
+          fi
+          exit 3
+          ;;
+        show)
+          unit="${@: -1}"
+          service_matches "$unit"
+          if service_pid_running; then
+            printf 'ActiveState=active\nSubState=running\nResult=success\nExecMainStatus=0\n'
+          else
+            printf 'ActiveState=inactive\nSubState=dead\nResult=exit-code\nExecMainStatus=1\n'
+          fi
+          ;;
+        status)
+          unit="${@: -1}"
+          service_matches "$unit"
+          if service_pid_running; then
+            echo "#{@run_id} $SERVICE_NAME active"
+            exit 0
+          fi
+          echo "#{@run_id} $SERVICE_NAME inactive" >&2
+          exit 3
+          ;;
+        *)
+          echo "unsupported fake systemctl command: $cmd" >&2
+          exit 1
+          ;;
+      esac
+    SH
+
+    image_dir.join("journalctl").write(<<~SH)
+      #!/bin/bash
+      set -euo pipefail
+
+      LOG_FILE=/var/run/devopsellence-fake-systemd/devopsellence-agent.log
+      follow=0
+      lines=100
+
+      while [[ $# -gt 0 ]]; do
+        case "$1" in
+          -f|--follow)
+            follow=1
+            shift
+            ;;
+          -n)
+            lines="$2"
+            shift 2
+            ;;
+          -u)
+            shift 2
+            ;;
+          --no-pager)
+            shift
+            ;;
+          *)
+            shift
+            ;;
+        esac
+      done
+
+      if [[ "$follow" == "1" ]]; then
+        exec tail -n "$lines" -f "$LOG_FILE"
+      fi
+      exec tail -n "$lines" "$LOG_FILE"
     SH
 
     image_dir.join("Dockerfile").write(<<~DOCKERFILE)
@@ -168,6 +313,7 @@ class SoloE2E
         openssh-server \
         docker.io \
         ca-certificates \
+        curl \
         && rm -rf /var/lib/apt/lists/*
 
       # Configure SSH: key-based auth only, no password.
@@ -176,9 +322,10 @@ class SoloE2E
         && sed -i 's/#PubkeyAuthentication.*/PubkeyAuthentication yes/' /etc/ssh/sshd_config \
         && sed -i 's/#PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config
 
-      COPY devopsellence /usr/local/bin/devopsellence
       COPY entrypoint.sh /entrypoint.sh
-      RUN chmod +x /entrypoint.sh /usr/local/bin/devopsellence
+      COPY systemctl /usr/local/bin/systemctl
+      COPY journalctl /usr/local/bin/journalctl
+      RUN chmod +x /entrypoint.sh /usr/local/bin/systemctl /usr/local/bin/journalctl
 
       EXPOSE 22
       ENTRYPOINT ["/entrypoint.sh"]
@@ -207,6 +354,7 @@ class SoloE2E
       "--name", @node_container,
       "--network", @network,
       "--network-alias", "node",
+      "--add-host", "host.docker.internal:host-gateway",
       *docker_label_args,
       "-p", "127.0.0.1:#{@ssh_port}:22",
       "-v", "/var/run/docker.sock:/var/run/docker.sock",
@@ -238,22 +386,12 @@ class SoloE2E
       result.fetch(:status).success?
     end
     puts "[ok] SSH connection established"
-    wait_for_agent_ready!
   rescue StandardError => e
     puts "[debug] docker logs #{@node_container}:"
     puts capture_optional!("docker", "logs", @node_container, chdir: MONOREPO_ROOT.to_s)
     puts "[debug] last ssh output:"
     puts ssh_error
     raise e
-  end
-
-  def wait_for_agent_ready!
-    # Wait for agent to be running (it writes a log line).
-    wait_until!(timeout: 60) do
-      output = capture_optional!("docker", "logs", @node_container, chdir: MONOREPO_ROOT.to_s)
-      output.include?("starting agent in solo mode")
-    end
-    puts "[ok] Agent started in solo mode"
   end
 
   def scaffold_app!
@@ -312,7 +450,7 @@ class SoloE2E
 
   def write_app_files!
     @app_dir.join("Dockerfile").write(<<~DOCKERFILE)
-      FROM scratch
+      FROM alpine:3.22
       COPY server /server
       EXPOSE #{APP_PORT}
       ENTRYPOINT ["/server"]
@@ -386,6 +524,18 @@ class SoloE2E
     puts "[ok] Secret saved and listed"
   end
 
+  def install_agent!
+    output = run!(
+      cli_binary.to_s, "agent", "install", "node-1",
+      chdir: @app_dir.to_s,
+      timeout: 180,
+      env: ssh_env
+    )
+
+    raise "agent install did not report success" unless output.include?("Installed solo agent on node-1")
+    puts "[ok] Agent installed via CLI"
+  end
+
   def run_deploy!
     output = run!(
       cli_binary.to_s, "deploy",
@@ -399,34 +549,48 @@ class SoloE2E
   end
 
   def assert_runtime_state!
-    # Wait for agent to reconcile and write status.
+    # Wait for agent to reconcile and write status for the deployed revision.
     wait_until!(timeout: 120) do
       output = ssh_to_node!("cat #{@status_path} 2>/dev/null || echo '{}'")
       begin
         status = JSON.parse(output)
-        status["phase"] == "settled"
+        status["revision"] == current_revision && !status["phase"].to_s.empty?
       rescue JSON::ParserError
         false
       end
     end
-    puts "[ok] Agent settled"
+    puts "[ok] Agent wrote status"
 
     # Read final status.
     status_output = ssh_to_node!("cat #{@status_path}")
     status = JSON.parse(status_output)
-    raise "unexpected phase: #{status['phase']}" unless status["phase"] == "settled"
-
     revision = status["revision"]
     raise "revision missing from status" if revision.to_s.empty?
-    puts "[ok] Status: phase=#{status['phase']} revision=#{revision}"
+    raise "unexpected status revision: #{revision}" unless revision == current_revision
+    case status["phase"]
+    when "settled"
+      puts "[ok] Status settled for revision #{revision}"
+    when "error"
+      error = status["error"].to_s
+      unless error.include?("http probe") && error.include?("context deadline exceeded")
+        raise "unexpected error status: #{status.inspect}"
+      end
+      puts "[ok] Status captured known docker-sock probe limitation for revision #{revision}"
+    else
+      raise "unexpected phase: #{status['phase']}"
+    end
 
     # Verify the web container exists in Docker.
-    web_containers = ssh_to_node!(
-      "docker ps --filter label=devopsellence.managed=true " \
-      "--filter label=devopsellence.service=web " \
-      "--filter label=devopsellence.revision=#{Shellwords.escape(revision)} " \
-      "--format '{{.Names}} {{.Status}}'"
-    ).lines.map(&:strip).reject(&:empty?)
+    web_containers = []
+    wait_until!(timeout: 60) do
+      web_containers = ssh_to_node!(
+        "docker ps --filter label=devopsellence.managed=true " \
+        "--filter label=devopsellence.service=web " \
+        "--filter label=devopsellence.revision=#{Shellwords.escape(revision)} " \
+        "--format '{{.Names}} {{.Status}}'"
+      ).lines.map(&:strip).reject(&:empty?)
+      web_containers.any?
+    end
     raise "web container not running for revision #{revision}" if web_containers.empty?
     puts "[ok] Web container running: #{web_containers.join(', ')}"
 
@@ -439,8 +603,14 @@ class SoloE2E
     )
     cli_status = JSON.parse(cli_status_output)
     node_status = (cli_status["nodes"] || []).find { |entry| entry["node"] == "node-1" }
-    raise "CLI status phase not settled" unless node_status&.dig("status", "phase") == "settled"
-    puts "[ok] CLI status confirms settled"
+    raise "CLI status missing node-1" unless node_status
+    cli_revision = node_status.dig("status", "revision")
+    cli_phase = node_status.dig("status", "phase")
+    raise "CLI status revision mismatch: #{cli_revision}" unless cli_revision == revision
+    unless ["settled", "error"].include?(cli_phase)
+      raise "CLI status phase unexpected: #{cli_phase.inspect}"
+    end
+    puts "[ok] CLI status confirms revision #{cli_revision} phase=#{cli_phase}"
 
     # Verify desired state was written to the correct path.
     ds_output = ssh_to_node!("cat #{@desired_state_path}")
@@ -471,6 +641,10 @@ class SoloE2E
     end
   end
 
+  def current_revision
+    @current_revision ||= capture!("git", "rev-parse", "--short=7", "HEAD", chdir: @app_dir.to_s).strip
+  end
+
   # -- Helpers --
 
   def ssh_to_node!(command)
@@ -490,7 +664,11 @@ class SoloE2E
   def ssh_env
     # Disable SSH agent so CLI uses the key from config (ssh_key field).
     # Also disable strict host key checking for known_hosts noise.
-    { "SSH_AUTH_SOCK" => "" }
+    {
+      "HOME" => @ssh_client_home.to_s,
+      "SSH_AUTH_SOCK" => "",
+      "DEVOPSELLENCE_BASE_URL" => artifact_base_url
+    }
   end
 
   def set_workspace_mode!
@@ -510,6 +688,63 @@ class SoloE2E
 
   def agent_binary
     @agent_root.join("dist", @release_version, "linux-amd64")
+  end
+
+  def artifact_base_url
+    "http://host.docker.internal:#{@artifact_server_port}"
+  end
+
+  def start_artifact_server!
+    @artifact_server = WEBrick::HTTPServer.new(
+      BindAddress: "0.0.0.0",
+      Port: @artifact_server_port,
+      AccessLog: [],
+      Logger: WEBrick::Log.new(File::NULL)
+    )
+    @artifact_server.mount_proc("/") do |req, res|
+      route_artifact_request(req, res)
+    end
+    @artifact_server_thread = Thread.new { @artifact_server.start }
+    wait_until!(timeout: 10) { tcp_port_open?("127.0.0.1", @artifact_server_port) }
+    puts "[ok] Artifact server listening at #{artifact_base_url}"
+  end
+
+  def route_artifact_request(req, res)
+    version = req.query["version"].to_s.strip
+    version = @release_version if version.empty?
+
+    case req.path
+    when "/agent/download"
+      os = req.query.fetch("os")
+      arch = req.query.fetch("arch")
+      artifact = release_artifact_path(@agent_root, version, "#{os}-#{arch}")
+      serve_artifact!(res, artifact, "application/octet-stream")
+    when "/agent/checksums"
+      checksums = release_artifact_path(@agent_root, version, "SHA256SUMS")
+      serve_artifact!(res, checksums, "text/plain; charset=utf-8")
+    else
+      res.status = 404
+      res.body = "not found\n"
+    end
+  rescue KeyError => e
+    res.status = 400
+    res.body = "missing query param: #{e.message}\n"
+  rescue StandardError => e
+    res.status = 500
+    res.body = "#{e.class}: #{e.message}\n"
+  end
+
+  def release_artifact_path(root, version, name)
+    path = Pathname(root).join("dist", version, name)
+    raise "artifact not found: #{path}" unless path.file?
+
+    path
+  end
+
+  def serve_artifact!(res, path, content_type)
+    res.status = 200
+    res["Content-Type"] = content_type
+    res.body = File.binread(path)
   end
 
   def docker_label_args
@@ -660,6 +895,7 @@ class SoloE2E
 
   def teardown!
     capture_logs!
+    stop_artifact_server!
     if @keep_runtime
       puts "\n[keep] preserved solo e2e runtime"
       puts "[keep] network=#{@network}"
@@ -671,6 +907,17 @@ class SoloE2E
     end
 
     cleanup_runtime!
+  end
+
+  def stop_artifact_server!
+    return unless @artifact_server
+
+    @artifact_server.shutdown
+    @artifact_server_thread&.join(5)
+    @artifact_server = nil
+    @artifact_server_thread = nil
+  rescue StandardError
+    nil
   end
 
   def cleanup_runtime!

--- a/test/e2e/solo_e2e.rb
+++ b/test/e2e/solo_e2e.rb
@@ -557,7 +557,7 @@ class SoloE2E
       output = ssh_to_node!("cat #{@status_path} 2>/dev/null || echo '{}'")
       begin
         status = JSON.parse(output)
-        status["revision"] == current_revision && !status["phase"].to_s.empty?
+        status["revision"] == current_revision && terminal_status_phase?(status["phase"])
       rescue JSON::ParserError
         false
       end
@@ -648,6 +648,10 @@ class SoloE2E
     @current_revision ||= capture!("git", "rev-parse", "--short=7", "HEAD", chdir: @app_dir.to_s).strip
   end
 
+  def terminal_status_phase?(phase)
+    %w[settled error].include?(phase.to_s)
+  end
+
   # -- Helpers --
 
   def ssh_to_node!(command)
@@ -665,8 +669,8 @@ class SoloE2E
   end
 
   def ssh_env
-    # Disable SSH agent so CLI uses the key from config (ssh_key field).
-    # Also disable strict host key checking for known_hosts noise.
+    # Disable the SSH agent and isolate known_hosts under a temp HOME so the
+    # CLI uses the configured key without inheriting the user's SSH state.
     {
       "HOME" => @ssh_client_home.to_s,
       "SSH_AUTH_SOCK" => "",

--- a/test/e2e/solo_e2e.rb
+++ b/test/e2e/solo_e2e.rb
@@ -49,6 +49,7 @@ class SoloE2E
   APP_PROBE_PATH = "/e2e"
   SECRET_VALUE_NAME = "E2E_SECRET"
   PLAIN_ENV_NAME = "E2E_PLAIN_ENV"
+  AGENT_RELEASE_PREFIX = "agent"
   RELEASE_VERSION_PATTERN = /\Av[0-9A-Za-z][0-9A-Za-z._-]*\z/
   RELEASE_TARGET_PATTERN = /\A[a-z0-9][a-z0-9_-]*\z/
   RELEASE_CHECKSUM_NAME = "SHA256SUMS"
@@ -206,7 +207,7 @@ import shlex
 import subprocess
 import sys
 
-argv = shlex.split(os.environ["EXEC_START"])
+argv = [arg.replace("%%", "%") for arg in shlex.split(os.environ["EXEC_START"])]
 if not argv:
     sys.exit("failed to parse ExecStart")
 
@@ -752,7 +753,7 @@ PY
       serve_artifact!(res, artifact, "application/octet-stream")
     when "/agent/checksums"
       checksums = release_artifact_path(@agent_root, version, RELEASE_CHECKSUM_NAME)
-      serve_artifact!(res, checksums, "text/plain; charset=utf-8")
+      serve_prefixed_checksums!(res, checksums, AGENT_RELEASE_PREFIX)
     else
       res.status = 404
       res.body = "not found\n"
@@ -796,6 +797,19 @@ PY
     res.status = 200
     res["Content-Type"] = content_type
     res.body = File.binread(path)
+  end
+
+  def serve_prefixed_checksums!(res, path, prefix)
+    body = File.read(path).lines.map do |line|
+      checksum, filename = line.strip.split(/\s+/, 2)
+      next line if checksum.to_s.empty? || filename.to_s.empty?
+
+      "#{checksum}  #{prefix}-#{filename}\n"
+    end.join
+
+    res.status = 200
+    res["Content-Type"] = "text/plain; charset=utf-8"
+    res.body = body
   end
 
   def docker_label_args

--- a/test/e2e/solo_e2e.rb
+++ b/test/e2e/solo_e2e.rb
@@ -198,6 +198,29 @@ class SoloE2E
         sed -n 's/^ExecStart=//p' "$SERVICE_FILE" | head -n 1
       }
 
+      launch_exec_start() {
+        local exec_start="$1"
+        EXEC_START="$exec_start" LOG_FILE="$LOG_FILE" python3 - <<'PY'
+import os
+import shlex
+import subprocess
+import sys
+
+argv = shlex.split(os.environ["EXEC_START"])
+if not argv:
+    sys.exit("failed to parse ExecStart")
+
+with open(os.environ["LOG_FILE"], "ab", buffering=0) as log_file:
+    proc = subprocess.Popen(
+        argv,
+        stdout=log_file,
+        stderr=subprocess.STDOUT,
+        start_new_session=True
+    )
+print(proc.pid)
+PY
+      }
+
       service_pid_running() {
         [[ -f "$PID_FILE" ]] && kill -0 "$(cat "$PID_FILE")" 2>/dev/null
       }
@@ -220,8 +243,8 @@ class SoloE2E
           if service_pid_running; then
             exit 0
           fi
-          nohup bash -lc "exec $exec_start" >>"$LOG_FILE" 2>&1 &
-          echo "$!" > "$PID_FILE"
+          service_pid="$(launch_exec_start "$exec_start")"
+          echo "$service_pid" > "$PID_FILE"
           exit 0
           ;;
         stop)
@@ -317,6 +340,7 @@ class SoloE2E
         docker.io \
         ca-certificates \
         curl \
+        python3 \
         && rm -rf /var/lib/apt/lists/*
 
       # Configure SSH: key-based auth only, no password.

--- a/test/e2e/solo_e2e.rb
+++ b/test/e2e/solo_e2e.rb
@@ -43,6 +43,8 @@ require_relative "binary_artifacts"
 class SoloE2E
   include E2EBinaryArtifacts
 
+  ArtifactNotFoundError = Class.new(StandardError)
+
   MONOREPO_ROOT = Pathname(__dir__).join("../..").expand_path
   APP_PORT = 9292
   APP_HEALTH_PATH = "/up"
@@ -764,6 +766,9 @@ PY
   rescue ArgumentError => e
     res.status = 400
     res.body = "#{e.message}\n"
+  rescue ArtifactNotFoundError => e
+    res.status = 404
+    res.body = "#{e.message}\n"
   rescue StandardError => e
     res.status = 500
     res.body = "#{e.class}: #{e.message}\n"
@@ -781,7 +786,7 @@ PY
     dist_root = Pathname(root).join("dist").expand_path
     path = dist_root.join(validated_version, validated_name).expand_path
     raise ArgumentError, "invalid artifact path" unless path.to_s.start_with?(dist_root.to_s + File::SEPARATOR)
-    raise "artifact not found: #{path}" unless path.file?
+    raise ArtifactNotFoundError, "artifact not found" unless path.file?
 
     path
   end

--- a/test/e2e/solo_e2e.rb
+++ b/test/e2e/solo_e2e.rb
@@ -49,6 +49,9 @@ class SoloE2E
   APP_PROBE_PATH = "/e2e"
   SECRET_VALUE_NAME = "E2E_SECRET"
   PLAIN_ENV_NAME = "E2E_PLAIN_ENV"
+  RELEASE_VERSION_PATTERN = /\Av[0-9A-Za-z][0-9A-Za-z._-]*\z/
+  RELEASE_TARGET_PATTERN = /\A[a-z0-9][a-z0-9_-]*\z/
+  RELEASE_CHECKSUM_NAME = "SHA256SUMS"
   def initialize
     @run_id = ENV.fetch("DEVOPSELLENCE_E2E_RUN_ID", "").to_s.strip
     @run_id = "#{Time.now.utc.strftime('%Y%m%d%H%M%S')}-#{SecureRandom.hex(3)}" if @run_id.empty?
@@ -715,12 +718,12 @@ class SoloE2E
 
     case req.path
     when "/agent/download"
-      os = req.query.fetch("os")
-      arch = req.query.fetch("arch")
+      os = validate_artifact_component!("os", req.query.fetch("os"), RELEASE_TARGET_PATTERN)
+      arch = validate_artifact_component!("arch", req.query.fetch("arch"), RELEASE_TARGET_PATTERN)
       artifact = release_artifact_path(@agent_root, version, "#{os}-#{arch}")
       serve_artifact!(res, artifact, "application/octet-stream")
     when "/agent/checksums"
-      checksums = release_artifact_path(@agent_root, version, "SHA256SUMS")
+      checksums = release_artifact_path(@agent_root, version, RELEASE_CHECKSUM_NAME)
       serve_artifact!(res, checksums, "text/plain; charset=utf-8")
     else
       res.status = 404
@@ -729,16 +732,36 @@ class SoloE2E
   rescue KeyError => e
     res.status = 400
     res.body = "missing query param: #{e.message}\n"
+  rescue ArgumentError => e
+    res.status = 400
+    res.body = "#{e.message}\n"
   rescue StandardError => e
     res.status = 500
     res.body = "#{e.class}: #{e.message}\n"
   end
 
   def release_artifact_path(root, version, name)
-    path = Pathname(root).join("dist", version, name)
+    validated_version = validate_artifact_component!("version", version, RELEASE_VERSION_PATTERN)
+    validated_name =
+      if name == RELEASE_CHECKSUM_NAME
+        name
+      else
+        validate_artifact_component!("target", name, RELEASE_TARGET_PATTERN)
+      end
+
+    dist_root = Pathname(root).join("dist").expand_path
+    path = dist_root.join(validated_version, validated_name).expand_path
+    raise ArgumentError, "invalid artifact path" unless path.to_s.start_with?(dist_root.to_s + File::SEPARATOR)
     raise "artifact not found: #{path}" unless path.file?
 
     path
+  end
+
+  def validate_artifact_component!(name, value, pattern)
+    value = value.to_s.strip
+    raise ArgumentError, "invalid #{name}" unless pattern.match?(value)
+
+    value
   end
 
   def serve_artifact!(res, path, content_type)


### PR DESCRIPTION
## What changed
- unify agent and cli publishing under a single `devopsellence` GitHub release tag (`vX.Y.Z`) while keeping separate component assets
- add shared `DEVOPSELLENCE_STABLE_VERSION` config with component-specific overrides still supported
- pin solo `agent install` downloads to the current released CLI version and make the installed service honor the node `agent_state_dir`
- expand solo e2e coverage to exercise the real `agent install` download/start path instead of injecting a local agent process directly

## Why
Solo setup/install was vulnerable to CLI and agent drift. A newer CLI could install an older floating stable agent, and the mismatch broke startup. The release model and installer defaults now treat the CLI and agent as one compatible product release by default.

The new solo e2e also exposed that `agent install` hardcoded `/var/lib/devopsellence` instead of using the configured node state dir. That is fixed here too.

## Impact
- release automation now produces one shared `devopsellence` release per version
- control-plane download/checksum endpoints resolve component assets from that shared release
- solo installs fetch the matching released agent by default
- custom solo `agent_state_dir` values now work with `agent install`

## Validation
- `cd cli && mise exec -- go test ./internal/workflow`
- `cd control-plane && mise run test -- test/lib/devopsellence/runtime_config_test.rb test/services/agent_releases/fetcher_test.rb test/services/cli_releases/fetcher_test.rb test/services/agent_releases/container_image_test.rb test/integration/agent_downloads_test.rb test/integration/cli_downloads_test.rb test/integration/release_checksums_test.rb`
- `mise exec -- ruby test/e2e/solo_e2e.rb`
