### PR TITLE
[codex] add bubble tea install log viewport

### DIFF
--- a/cli/internal/workflow/install_logs.go
+++ b/cli/internal/workflow/install_logs.go
@@ -1,0 +1,303 @@
+package workflow
+
+import (
+	"context"
+	"io"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/devopsellence/cli/internal/output"
+
+	"golang.org/x/term"
+)
+
+const (
+	defaultSoloInstallViewportLines = 8
+	minSoloInstallViewportLines     = 4
+	maxSoloInstallViewportLines     = 12
+	defaultSoloInstallViewportWidth = 100
+	maxSoloInstallBufferedLines     = 256
+	defaultSoloInstallStatus        = "Installing Docker, agent, and systemd service..."
+)
+
+type soloInstallReporter struct {
+	progress func(string)
+	stream   io.Writer
+	close    func()
+}
+
+func newSoloInstallReporter(ctx context.Context, printer output.Printer, nodeName string) soloInstallReporter {
+	if printer.JSON {
+		return soloInstallReporter{
+			progress: func(string) {},
+			stream:   io.Discard,
+			close:    func() {},
+		}
+	}
+
+	if printer.Interactive {
+		return newBubbleTeaSoloInstallReporter(ctx, printer.Out, nodeName)
+	}
+
+	progress := func(message string) {
+		printer.Println("[" + nodeName + "] " + strings.TrimSpace(message))
+	}
+	writer := &lineProgressWriter{progress: progress}
+	return soloInstallReporter{
+		progress: progress,
+		stream:   writer,
+		close:    writer.Flush,
+	}
+}
+
+func newBubbleTeaSoloInstallReporter(ctx context.Context, out io.Writer, nodeName string) soloInstallReporter {
+	program := tea.NewProgram(
+		newInstallLogModel("["+nodeName+"]", soloInstallViewportLines(out), soloInstallViewportWidth(out)),
+		tea.WithContext(ctx),
+		tea.WithInput(nil),
+		tea.WithOutput(out),
+	)
+	writer := &bubbleTeaInstallLogWriter{program: program}
+	done := make(chan struct{})
+	go func() {
+		_, _ = program.Run()
+		close(done)
+	}()
+	return soloInstallReporter{
+		progress: writer.Progress,
+		stream:   writer,
+		close: func() {
+			writer.Close()
+			<-done
+		},
+	}
+}
+
+func (r soloInstallReporter) Progress(message string) {
+	if r.progress != nil {
+		r.progress(message)
+	}
+}
+
+func (r soloInstallReporter) Stream() io.Writer {
+	if r.stream == nil {
+		return io.Discard
+	}
+	return r.stream
+}
+
+func (r soloInstallReporter) Close() {
+	if r.close != nil {
+		r.close()
+	}
+}
+
+type installProgressMsg struct {
+	text string
+}
+
+type installLogLineMsg struct {
+	text string
+}
+
+type installDoneMsg struct{}
+
+type installLogState struct {
+	status   string
+	lines    []string
+	maxLines int
+}
+
+func newInstallLogState(maxLines int) installLogState {
+	if maxLines <= 0 {
+		maxLines = maxSoloInstallBufferedLines
+	}
+	return installLogState{maxLines: maxLines}
+}
+
+func (s *installLogState) SetProgress(message string) {
+	message = strings.TrimSpace(message)
+	if message == "" {
+		return
+	}
+	s.status = message
+}
+
+func (s *installLogState) AddLine(line string) {
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return
+	}
+	s.lines = append(s.lines, line)
+	if len(s.lines) > s.maxLines {
+		s.lines = append([]string(nil), s.lines[len(s.lines)-s.maxLines:]...)
+	}
+}
+
+func (s installLogState) StatusLine(nodeLabel string) string {
+	status := strings.TrimSpace(s.status)
+	if status == "" {
+		status = defaultSoloInstallStatus
+	}
+	return "[+] " + strings.TrimSpace(nodeLabel) + " " + status
+}
+
+func (s installLogState) ViewportContent() string {
+	if len(s.lines) == 0 {
+		return ""
+	}
+	lines := make([]string, 0, len(s.lines))
+	for _, line := range s.lines {
+		lines = append(lines, "-> "+line)
+	}
+	return strings.Join(lines, "\n")
+}
+
+type installLogModel struct {
+	nodeLabel string
+	viewport  viewport.Model
+	state     installLogState
+}
+
+func newInstallLogModel(nodeLabel string, height, width int) installLogModel {
+	if height <= 0 {
+		height = defaultSoloInstallViewportLines
+	}
+	if width <= 0 {
+		width = defaultSoloInstallViewportWidth
+	}
+	vp := viewport.New(width, height)
+	state := newInstallLogState(maxSoloInstallBufferedLines)
+	model := installLogModel{
+		nodeLabel: strings.TrimSpace(nodeLabel),
+		viewport:  vp,
+		state:     state,
+	}
+	model.syncViewport()
+	return model
+}
+
+func (m installLogModel) Init() tea.Cmd {
+	return nil
+}
+
+func (m installLogModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch typed := msg.(type) {
+	case installProgressMsg:
+		m.state.SetProgress(typed.text)
+		m.syncViewport()
+	case installLogLineMsg:
+		m.state.AddLine(typed.text)
+		m.syncViewport()
+	case installDoneMsg:
+		return m, tea.Quit
+	case tea.WindowSizeMsg:
+		m.viewport.Width = typed.Width
+		m.viewport.Height = soloInstallViewportLinesForHeight(typed.Height)
+		m.syncViewport()
+	}
+	return m, nil
+}
+
+func (m installLogModel) View() string {
+	header := m.state.StatusLine(m.nodeLabel)
+	body := m.viewport.View()
+	if body == "" {
+		return header
+	}
+	return header + "\n" + body
+}
+
+func (m *installLogModel) syncViewport() {
+	m.viewport.SetContent(m.state.ViewportContent())
+	m.viewport.GotoBottom()
+}
+
+type bubbleTeaInstallLogWriter struct {
+	mu      sync.Mutex
+	buf     strings.Builder
+	program *tea.Program
+}
+
+func (w *bubbleTeaInstallLogWriter) Progress(message string) {
+	message = strings.TrimSpace(message)
+	if message == "" || w.program == nil {
+		return
+	}
+	w.program.Send(installProgressMsg{text: message})
+}
+
+func (w *bubbleTeaInstallLogWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	for _, r := range string(p) {
+		switch r {
+		case '\n':
+			w.flushLocked()
+		case '\r':
+		default:
+			w.buf.WriteRune(r)
+		}
+	}
+	return len(p), nil
+}
+
+func (w *bubbleTeaInstallLogWriter) Close() {
+	w.mu.Lock()
+	w.flushLocked()
+	w.mu.Unlock()
+	if w.program != nil {
+		w.program.Send(installDoneMsg{})
+	}
+}
+
+func (w *bubbleTeaInstallLogWriter) flushLocked() {
+	line := strings.TrimSpace(w.buf.String())
+	w.buf.Reset()
+	if line == "" || w.program == nil {
+		return
+	}
+	if strings.HasPrefix(line, "progress:") {
+		w.program.Send(installProgressMsg{text: strings.TrimSpace(strings.TrimPrefix(line, "progress:"))})
+		return
+	}
+	w.program.Send(installLogLineMsg{text: line})
+}
+
+func soloInstallViewportLines(writer io.Writer) int {
+	file, ok := writer.(*os.File)
+	if !ok {
+		return defaultSoloInstallViewportLines
+	}
+	_, height, err := term.GetSize(int(file.Fd()))
+	if err != nil || height <= 0 {
+		return defaultSoloInstallViewportLines
+	}
+	return soloInstallViewportLinesForHeight(height)
+}
+
+func soloInstallViewportLinesForHeight(height int) int {
+	lines := height - 6
+	if lines < minSoloInstallViewportLines {
+		return minSoloInstallViewportLines
+	}
+	if lines > maxSoloInstallViewportLines {
+		return maxSoloInstallViewportLines
+	}
+	return lines
+}
+
+func soloInstallViewportWidth(writer io.Writer) int {
+	file, ok := writer.(*os.File)
+	if !ok {
+		return defaultSoloInstallViewportWidth
+	}
+	width, _, err := term.GetSize(int(file.Fd()))
+	if err != nil || width <= 0 {
+		return defaultSoloInstallViewportWidth
+	}
+	return width
+}

--- a/cli/internal/workflow/install_logs_test.go
+++ b/cli/internal/workflow/install_logs_test.go
@@ -1,0 +1,77 @@
+package workflow
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/devopsellence/cli/internal/output"
+)
+
+func TestInstallLogStateKeepsRecentLines(t *testing.T) {
+	state := newInstallLogState(2)
+	state.SetProgress("installing Docker Engine")
+	state.AddLine("Get:1 packages")
+	state.AddLine("Get:2 packages")
+	state.AddLine("Get:3 packages")
+
+	if got, want := state.StatusLine("[prod-2]"), "[+] [prod-2] installing Docker Engine"; got != want {
+		t.Fatalf("StatusLine() = %q, want %q", got, want)
+	}
+	if got, want := state.ViewportContent(), "-> Get:2 packages\n-> Get:3 packages"; got != want {
+		t.Fatalf("ViewportContent() = %q, want %q", got, want)
+	}
+}
+
+func TestInstallLogModelPinsStatusAndShowsLatestLines(t *testing.T) {
+	model := newInstallLogModel("[prod-2]", 2, 80)
+
+	next, _ := model.Update(installProgressMsg{text: "downloading agent binary"})
+	model = next.(installLogModel)
+	next, _ = model.Update(installLogLineMsg{text: "Get:1 packages"})
+	model = next.(installLogModel)
+	next, _ = model.Update(installLogLineMsg{text: "Get:2 packages"})
+	model = next.(installLogModel)
+	next, _ = model.Update(installLogLineMsg{text: "Get:3 packages"})
+	model = next.(installLogModel)
+
+	view := model.View()
+	for _, fragment := range []string{
+		"[+] [prod-2] downloading agent binary",
+		"-> Get:2 packages",
+		"-> Get:3 packages",
+	} {
+		if !strings.Contains(view, fragment) {
+			t.Fatalf("View() = %q, want fragment %q", view, fragment)
+		}
+	}
+	if strings.Contains(view, "-> Get:1 packages") {
+		t.Fatalf("View() = %q, want viewport scrolled past oldest line", view)
+	}
+}
+
+func TestNewSoloInstallReporterNonInteractiveFallsBackToPrefixedLines(t *testing.T) {
+	var out bytes.Buffer
+	reporter := newSoloInstallReporter(t.Context(), output.Printer{Out: &out}, "prod-2")
+
+	reporter.Progress("Installing Docker, agent, and systemd service...")
+	if _, err := reporter.Stream().Write([]byte("progress: downloading agent binary\nplain log\npartial")); err != nil {
+		t.Fatal(err)
+	}
+	reporter.Close()
+
+	text := out.String()
+	for _, fragment := range []string{
+		"[prod-2] Installing Docker, agent, and systemd service...",
+		"[prod-2] downloading agent binary",
+		"[prod-2] plain log",
+		"[prod-2] partial",
+	} {
+		if !strings.Contains(text, fragment) {
+			t.Fatalf("reporter output = %q, want fragment %q", text, fragment)
+		}
+	}
+	if strings.Contains(text, "\x1b[") {
+		t.Fatalf("reporter output = %q, want no ANSI redraw codes", text)
+	}
+}

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -607,7 +607,7 @@ func (a *App) SoloAgentInstall(ctx context.Context, opts SoloAgentInstallOptions
 	if !a.Printer.JSON {
 		a.Printer.Println("Installing solo agent on " + opts.Node + "...")
 	}
-	if err := installSoloAgent(ctx, node, opts, a.soloProgress(opts.Node)); err != nil {
+	if err := a.installSoloAgent(ctx, opts.Node, node, opts); err != nil {
 		return err
 	}
 	if a.Printer.JSON {
@@ -790,7 +790,7 @@ func (a *App) SoloNodeCreate(ctx context.Context, opts SoloNodeCreateOptions) er
 		if err := waitForSoloSSH(ctx, created.Node, 3*time.Minute); err != nil {
 			return err
 		}
-		if err := installSoloAgent(ctx, created.Node, SoloAgentInstallOptions{}, a.soloProgress(opts.Name)); err != nil {
+		if err := a.installSoloAgent(ctx, opts.Name, created.Node, SoloAgentInstallOptions{}); err != nil {
 			return err
 		}
 	}
@@ -1020,7 +1020,7 @@ func (a *App) SoloSetup(ctx context.Context, _ SoloSetupOptions) error {
 	if err := a.writeSoloNode(workspaceRoot, cfg, name, node); err != nil {
 		return err
 	}
-	if err := installSoloAgent(ctx, node, SoloAgentInstallOptions{}, a.soloProgress(name)); err != nil {
+	if err := a.installSoloAgent(ctx, name, node, SoloAgentInstallOptions{}); err != nil {
 		return err
 	}
 	return a.SoloRuntimeDoctor(ctx, SoloDoctorOptions{Nodes: []string{name}})
@@ -1120,6 +1120,12 @@ func (a *App) soloProgress(nodeName string) func(string) {
 	return func(message string) {
 		a.Printer.Println("[" + nodeName + "] " + message)
 	}
+}
+
+func (a *App) installSoloAgent(ctx context.Context, nodeName string, node config.SoloNode, opts SoloAgentInstallOptions) error {
+	reporter := newSoloInstallReporter(ctx, a.Printer, nodeName)
+	defer reporter.Close()
+	return installSoloAgent(ctx, node, opts, reporter)
 }
 
 // loadSoloConfig discovers the workspace root, loads devopsellence.yml,
@@ -1480,13 +1486,10 @@ func addServiceSecretRef(svc *config.ServiceConfig, name string) bool {
 	return true
 }
 
-func installSoloAgent(ctx context.Context, node config.SoloNode, opts SoloAgentInstallOptions, progress func(string)) error {
-	if progress == nil {
-		progress = func(string) {}
-	}
+func installSoloAgent(ctx context.Context, node config.SoloNode, opts SoloAgentInstallOptions, reporter soloInstallReporter) error {
 	if strings.TrimSpace(opts.AgentBinary) != "" {
 		remotePath := fmt.Sprintf("/tmp/devopsellence-agent-%d", time.Now().UnixNano())
-		progress("Uploading agent binary...")
+		reporter.Progress("Uploading agent binary...")
 		file, err := os.Open(opts.AgentBinary)
 		if err != nil {
 			return fmt.Errorf("open agent binary: %w", err)
@@ -1496,27 +1499,25 @@ func installSoloAgent(ctx context.Context, node config.SoloNode, opts SoloAgentI
 			return fmt.Errorf("upload agent binary: %w", err)
 		}
 		defer solo.RunSSHInteractive(ctx, node, "rm -f "+shellQuote(remotePath), io.Discard, io.Discard)
-		progress("Installing Docker, agent, and systemd service...")
+		reporter.Progress("Installing Docker, agent, and systemd service...")
 		return runSoloAgentInstallScript(ctx, node, soloAgentInstallScript(soloAgentInstallScriptOptions{
 			StateDir:        firstNonEmpty(node.AgentStateDir, "/var/lib/devopsellence"),
 			LocalBinaryPath: remotePath,
-		}), progress)
+		}), reporter)
 	}
 
 	baseURL := strings.TrimRight(firstNonEmpty(opts.BaseURL, os.Getenv("DEVOPSELLENCE_BASE_URL"), api.DefaultBaseURL), "/")
-	progress("Installing Docker, agent, and systemd service...")
+	reporter.Progress("Installing Docker, agent, and systemd service...")
 	return runSoloAgentInstallScript(ctx, node, soloAgentInstallScript(soloAgentInstallScriptOptions{
 		StateDir:     firstNonEmpty(node.AgentStateDir, "/var/lib/devopsellence"),
 		BaseURL:      baseURL,
 		AgentVersion: releasedAgentVersionForInstall(),
-	}), progress)
+	}), reporter)
 }
 
-func runSoloAgentInstallScript(ctx context.Context, node config.SoloNode, script string, progress func(string)) error {
-	writer := &lineProgressWriter{progress: progress}
-	err := solo.RunSSHInteractiveWithStdin(ctx, node, "bash -s", strings.NewReader(script), writer, writer)
-	writer.Flush()
-	return err
+func runSoloAgentInstallScript(ctx context.Context, node config.SoloNode, script string, reporter soloInstallReporter) error {
+	writer := reporter.Stream()
+	return solo.RunSSHInteractiveWithStdin(ctx, node, "bash -s", strings.NewReader(script), writer, writer)
 }
 
 type soloAgentInstallScriptOptions struct {


### PR DESCRIPTION
## What changed

This updates solo agent installation output to use a Bubble Tea-powered live log viewport during interactive runs.

Instead of printing every remote apt/curl/systemd line directly to the terminal, the CLI now keeps a pinned status/header line and a fixed-height scrolling log window that follows the latest install output.

Non-interactive and `--json` runs keep the existing plain line-by-line behavior.

## Why

The old install step streamed raw SSH output forever, which could flood the terminal during long package installs and make the current step harder to read.

The root issue was that the install path had no terminal-aware log presentation layer; it only had a line parser that forwarded everything directly to stdout/stderr.

## Impact

Users running `devopsellence setup` or other solo agent install flows in a terminal now get a tighter, docker-build-like experience with:

- a pinned current status line
- a bounded scrolling log tail
- automatic follow-to-bottom as new lines arrive

## Validation

- `mise exec -- go test ./internal/workflow`
- `mise exec -- go test ./internal/solo`
