### PR TITLE
[codex] drop per-component stable version env vars

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,7 @@ cd control-plane && mise run test -- test/path/file_test.rb
 ## Architecture
 
 - Solo/shared deploy semantics should match. Differences: user/org/project management, ownership, persistence, transport, policy.
+- Product intent: one shared stable release version for devopsellence. Use `DEVOPSELLENCE_STABLE_VERSION`; do not add per-component stable version env vars or defaults.
 - Shared core owns config interpretation, validation, planning, desired-state generation, ingress, placement constraints, status interpretation.
 - Prefer Go for reusable deployment core logic. CLI calls it in-process for solo; Rails should eventually call it through service/RPC.
 - Rails owns product state: accounts, authz, billing, hosted persistence, API surfaces.

--- a/control-plane/app/controllers/agent_checksums_controller.rb
+++ b/control-plane/app/controllers/agent_checksums_controller.rb
@@ -25,9 +25,9 @@ class AgentChecksumsController < ActionController::Base
   end
 
   def requested_version
-    params[:version].to_s.presence || Devopsellence::RuntimeConfig.current.agent_stable_version.presence || raise(
+    params[:version].to_s.presence || Devopsellence::RuntimeConfig.current.stable_version.presence || raise(
       AgentReleases::Fetcher::NotConfiguredError,
-      "set DEVOPSELLENCE_STABLE_VERSION (or DEVOPSELLENCE_AGENT_STABLE_VERSION) or pass ?version="
+      "set DEVOPSELLENCE_STABLE_VERSION or pass ?version="
     )
   end
 end

--- a/control-plane/app/controllers/agent_downloads_controller.rb
+++ b/control-plane/app/controllers/agent_downloads_controller.rb
@@ -31,9 +31,9 @@ class AgentDownloadsController < ActionController::Base
   end
 
   def requested_version
-    params[:version].to_s.presence || Devopsellence::RuntimeConfig.current.agent_stable_version.presence || raise(
+    params[:version].to_s.presence || Devopsellence::RuntimeConfig.current.stable_version.presence || raise(
       AgentReleases::Fetcher::NotConfiguredError,
-      "set DEVOPSELLENCE_STABLE_VERSION (or DEVOPSELLENCE_AGENT_STABLE_VERSION) or pass ?version="
+      "set DEVOPSELLENCE_STABLE_VERSION or pass ?version="
     )
   end
 end

--- a/control-plane/app/controllers/cli_checksums_controller.rb
+++ b/control-plane/app/controllers/cli_checksums_controller.rb
@@ -25,9 +25,9 @@ class CliChecksumsController < ActionController::Base
   end
 
   def requested_version
-    params[:version].to_s.presence || Devopsellence::RuntimeConfig.current.cli_stable_version.presence || raise(
+    params[:version].to_s.presence || Devopsellence::RuntimeConfig.current.stable_version.presence || raise(
       CliReleases::Fetcher::NotConfiguredError,
-      "set DEVOPSELLENCE_STABLE_VERSION (or DEVOPSELLENCE_CLI_STABLE_VERSION) or pass ?version="
+      "set DEVOPSELLENCE_STABLE_VERSION or pass ?version="
     )
   end
 end

--- a/control-plane/app/controllers/cli_downloads_controller.rb
+++ b/control-plane/app/controllers/cli_downloads_controller.rb
@@ -31,9 +31,9 @@ class CliDownloadsController < ActionController::Base
   end
 
   def requested_version
-    params[:version].to_s.presence || Devopsellence::RuntimeConfig.current.cli_stable_version.presence || raise(
+    params[:version].to_s.presence || Devopsellence::RuntimeConfig.current.stable_version.presence || raise(
       CliReleases::Fetcher::NotConfiguredError,
-      "set DEVOPSELLENCE_STABLE_VERSION (or DEVOPSELLENCE_CLI_STABLE_VERSION) or pass ?version="
+      "set DEVOPSELLENCE_STABLE_VERSION or pass ?version="
     )
   end
 end

--- a/control-plane/app/controllers/cli_installs_controller.rb
+++ b/control-plane/app/controllers/cli_installs_controller.rb
@@ -11,7 +11,7 @@ class CliInstallsController < ActionController::Base
     # For curl | bash installs, default the downloader to the exact host serving
     # the script so callers do not need to pass --base-url explicitly.
     default_base_url = ShellQuoting.single_quote(request.base_url)
-    default_version = ShellQuoting.single_quote(params[:version].to_s.presence || Devopsellence::RuntimeConfig.current.cli_stable_version)
+    default_version = ShellQuoting.single_quote(params[:version].to_s.presence || Devopsellence::RuntimeConfig.current.stable_version)
 
     <<~SH
       #!/usr/bin/env bash

--- a/control-plane/app/controllers/installs_controller.rb
+++ b/control-plane/app/controllers/installs_controller.rb
@@ -13,7 +13,7 @@ class InstallsController < ActionController::Base
 
   def install_script
     base_url = PublicBaseUrl.resolve(request)
-    default_version = params[:version].to_s.presence || Devopsellence::RuntimeConfig.current.agent_stable_version
+    default_version = params[:version].to_s.presence || Devopsellence::RuntimeConfig.current.stable_version
     AgentInstallScript.render(base_url: base_url, default_version: default_version)
   end
 

--- a/control-plane/app/services/agent_releases/container_image.rb
+++ b/control-plane/app/services/agent_releases/container_image.rb
@@ -9,7 +9,7 @@ module AgentReleases
     def initialize(
       image_reference: Devopsellence::RuntimeConfig.current.agent_container_image,
       image_repository: Devopsellence::RuntimeConfig.current.agent_container_repository,
-      stable_version: Devopsellence::RuntimeConfig.current.agent_stable_version
+      stable_version: Devopsellence::RuntimeConfig.current.stable_version
     )
       @image_reference = image_reference.to_s.strip
       @image_repository = image_repository.to_s.strip

--- a/control-plane/app/services/managed_nodes/bootstrap_script.rb
+++ b/control-plane/app/services/managed_nodes/bootstrap_script.rb
@@ -7,7 +7,7 @@ module ManagedNodes
     HEREDOC_MARKER = "DEVOPSELLENCE_INSTALL".freeze
     SSH_HARDENING_CONFIG_PATH = "/etc/ssh/sshd_config.d/60-devopsellence-hardening.conf".freeze
 
-    def initialize(node_name:, bootstrap_token:, base_url:, agent_version: Devopsellence::RuntimeConfig.current.agent_stable_version)
+    def initialize(node_name:, bootstrap_token:, base_url:, agent_version: Devopsellence::RuntimeConfig.current.stable_version)
       @node_name = node_name.to_s.strip
       @bootstrap_token = bootstrap_token.to_s
       @base_url = base_url.to_s.sub(%r{/*$}, "")

--- a/control-plane/lib/devopsellence/runtime_config.rb
+++ b/control-plane/lib/devopsellence/runtime_config.rb
@@ -121,9 +121,6 @@ module Devopsellence
         OPTIONAL_DEFAULTS.each do |name, (key, fallback)|
           config[name] = env.fetch(key, fallback).to_s.strip
         end
-        stable_version = config.stable_version.to_s.strip
-        config.agent_stable_version = env["DEVOPSELLENCE_AGENT_STABLE_VERSION"].to_s.strip.presence || stable_version
-        config.cli_stable_version = env["DEVOPSELLENCE_CLI_STABLE_VERSION"].to_s.strip.presence || stable_version
         config.managed_pool_candidates = build_managed_pool_candidates(config)
         validate_runtime_backend!(config)
         validate_workload_identity_resource_names!(config)

--- a/control-plane/test/integration/agent_downloads_test.rb
+++ b/control-plane/test/integration/agent_downloads_test.rb
@@ -23,7 +23,7 @@ class AgentDownloadsTest < ActionDispatch::IntegrationTest
   end
 
   test "returns service unavailable when no version is requested and no stable version is configured" do
-    with_env("DEVOPSELLENCE_STABLE_VERSION" => nil, "DEVOPSELLENCE_AGENT_STABLE_VERSION" => nil) do
+    with_env("DEVOPSELLENCE_STABLE_VERSION" => nil) do
       get agent_download_path
     end
 
@@ -49,7 +49,7 @@ class AgentDownloadsTest < ActionDispatch::IntegrationTest
   test "redirects unversioned requests to the stable version without downloading" do
     fetcher = FakeFetcher.new(result: FakeArtifact.new(url: "https://example.test/unused", filename: "devopsellence-agent"))
 
-    with_env("DEVOPSELLENCE_STABLE_VERSION" => "v1.2.3", "DEVOPSELLENCE_AGENT_STABLE_VERSION" => nil) do
+    with_env("DEVOPSELLENCE_STABLE_VERSION" => "v1.2.3") do
       with_agent_release_fetcher(fetcher) do
         get agent_download_path
       end
@@ -57,20 +57,6 @@ class AgentDownloadsTest < ActionDispatch::IntegrationTest
 
     assert_response :redirect
     assert_equal "http://www.example.com/agent/download?version=v1.2.3", response.location
-    assert_empty fetcher.calls
-  end
-
-  test "component-specific stable version overrides shared stable version" do
-    fetcher = FakeFetcher.new(result: FakeArtifact.new(url: "https://example.test/unused", filename: "devopsellence-agent"))
-
-    with_env("DEVOPSELLENCE_STABLE_VERSION" => "v1.2.3", "DEVOPSELLENCE_AGENT_STABLE_VERSION" => "v1.2.4") do
-      with_agent_release_fetcher(fetcher) do
-        get agent_download_path
-      end
-    end
-
-    assert_response :redirect
-    assert_equal "http://www.example.com/agent/download?version=v1.2.4", response.location
     assert_empty fetcher.calls
   end
 

--- a/control-plane/test/integration/cli_downloads_test.rb
+++ b/control-plane/test/integration/cli_downloads_test.rb
@@ -23,7 +23,7 @@ class CliDownloadsTest < ActionDispatch::IntegrationTest
   end
 
   test "returns service unavailable when no version is requested and no stable version is configured" do
-    with_env("DEVOPSELLENCE_STABLE_VERSION" => nil, "DEVOPSELLENCE_CLI_STABLE_VERSION" => nil) do
+    with_env("DEVOPSELLENCE_STABLE_VERSION" => nil) do
       get cli_download_path
     end
 
@@ -49,7 +49,7 @@ class CliDownloadsTest < ActionDispatch::IntegrationTest
   test "redirects unversioned requests to the stable version without downloading" do
     fetcher = FakeFetcher.new(result: FakeArtifact.new(url: "https://example.test/unused", filename: "devopsellence"))
 
-    with_env("DEVOPSELLENCE_STABLE_VERSION" => "v1.2.3", "DEVOPSELLENCE_CLI_STABLE_VERSION" => nil) do
+    with_env("DEVOPSELLENCE_STABLE_VERSION" => "v1.2.3") do
       with_cli_release_fetcher(fetcher) do
         get cli_download_path, params: { os: "darwin", arch: "arm64" }
       end
@@ -57,20 +57,6 @@ class CliDownloadsTest < ActionDispatch::IntegrationTest
 
     assert_response :redirect
     assert_equal "http://www.example.com/cli/download?arch=arm64&os=darwin&version=v1.2.3", response.location
-    assert_empty fetcher.calls
-  end
-
-  test "component-specific stable version overrides shared stable version" do
-    fetcher = FakeFetcher.new(result: FakeArtifact.new(url: "https://example.test/unused", filename: "devopsellence"))
-
-    with_env("DEVOPSELLENCE_STABLE_VERSION" => "v1.2.3", "DEVOPSELLENCE_CLI_STABLE_VERSION" => "v1.2.4") do
-      with_cli_release_fetcher(fetcher) do
-        get cli_download_path, params: { os: "darwin", arch: "arm64" }
-      end
-    end
-
-    assert_response :redirect
-    assert_equal "http://www.example.com/cli/download?arch=arm64&os=darwin&version=v1.2.4", response.location
     assert_empty fetcher.calls
   end
 

--- a/control-plane/test/integration/release_checksums_test.rb
+++ b/control-plane/test/integration/release_checksums_test.rb
@@ -22,7 +22,7 @@ class ReleaseChecksumsTest < ActionDispatch::IntegrationTest
   test "cli checksums redirect unversioned requests to the stable version" do
     fetcher = FakeFetcher.new(result: FakeArtifact.new(url: "https://example.test/unused", filename: "SHA256SUMS"))
 
-    with_env("DEVOPSELLENCE_STABLE_VERSION" => "v1.2.3", "DEVOPSELLENCE_CLI_STABLE_VERSION" => nil) do
+    with_env("DEVOPSELLENCE_STABLE_VERSION" => "v1.2.3") do
       with_cli_release_fetcher(fetcher) do
         get cli_checksums_path
       end
@@ -51,7 +51,7 @@ class ReleaseChecksumsTest < ActionDispatch::IntegrationTest
   test "agent checksums redirect unversioned requests to the stable version" do
     fetcher = FakeFetcher.new(result: FakeArtifact.new(url: "https://example.test/unused", filename: "SHA256SUMS"))
 
-    with_env("DEVOPSELLENCE_STABLE_VERSION" => "v2.3.4", "DEVOPSELLENCE_AGENT_STABLE_VERSION" => nil) do
+    with_env("DEVOPSELLENCE_STABLE_VERSION" => "v2.3.4") do
       with_agent_release_fetcher(fetcher) do
         get agent_checksums_path
       end

--- a/control-plane/test/lib/devopsellence/runtime_config_test.rb
+++ b/control-plane/test/lib/devopsellence/runtime_config_test.rb
@@ -42,32 +42,11 @@ module Devopsellence
       end
     end
 
-    test "shared stable version populates both cli and agent defaults" do
-      with_env("DEVOPSELLENCE_STABLE_VERSION" => "v1.2.3", "DEVOPSELLENCE_AGENT_STABLE_VERSION" => nil, "DEVOPSELLENCE_CLI_STABLE_VERSION" => nil) do
+    test "stable version loads from shared runtime env" do
+      with_env("DEVOPSELLENCE_STABLE_VERSION" => "v1.2.3") do
         config = RuntimeConfig.load!(env: ENV.to_h)
 
         assert_equal "v1.2.3", config.stable_version
-        assert_equal "v1.2.3", config.agent_stable_version
-        assert_equal "v1.2.3", config.cli_stable_version
-      end
-    end
-
-    test "component-specific stable version overrides shared stable version" do
-      with_env("DEVOPSELLENCE_STABLE_VERSION" => "v1.2.3", "DEVOPSELLENCE_AGENT_STABLE_VERSION" => "v1.2.4", "DEVOPSELLENCE_CLI_STABLE_VERSION" => "v1.2.5") do
-        config = RuntimeConfig.load!(env: ENV.to_h)
-
-        assert_equal "v1.2.3", config.stable_version
-        assert_equal "v1.2.4", config.agent_stable_version
-        assert_equal "v1.2.5", config.cli_stable_version
-      end
-    end
-
-    test "blank component-specific stable versions fall back to shared stable version" do
-      with_env("DEVOPSELLENCE_STABLE_VERSION" => "v1.2.3", "DEVOPSELLENCE_AGENT_STABLE_VERSION" => "", "DEVOPSELLENCE_CLI_STABLE_VERSION" => "   ") do
-        config = RuntimeConfig.load!(env: ENV.to_h)
-
-        assert_equal "v1.2.3", config.agent_stable_version
-        assert_equal "v1.2.3", config.cli_stable_version
       end
     end
 

--- a/control-plane/test/services/agent_releases/container_image_test.rb
+++ b/control-plane/test/services/agent_releases/container_image_test.rb
@@ -39,8 +39,7 @@ class AgentReleasesContainerImageTest < ActiveSupport::TestCase
     with_env(
       "DEVOPSELLENCE_AGENT_CONTAINER_IMAGE" => nil,
       "DEVOPSELLENCE_AGENT_CONTAINER_REPOSITORY" => nil,
-      "DEVOPSELLENCE_STABLE_VERSION" => nil,
-      "DEVOPSELLENCE_AGENT_STABLE_VERSION" => nil
+      "DEVOPSELLENCE_STABLE_VERSION" => nil
     ) do
       assert_nil AgentReleases::ContainerImage.metadata
     end


### PR DESCRIPTION
## What changed
- removed support for `DEVOPSELLENCE_AGENT_STABLE_VERSION` and `DEVOPSELLENCE_CLI_STABLE_VERSION`
- switched control-plane download, checksum, install, bootstrap, and agent image defaults to `DEVOPSELLENCE_STABLE_VERSION`
- deleted obsolete per-component override tests and codified the single-stable-version product rule in `AGENTS.md`

## Why
- product intent is one shared stable release version for devopsellence
- the per-component env vars only added a second defaulting path without matching product value

## Impact
- unversioned agent and CLI artifact flows now read only `DEVOPSELLENCE_STABLE_VERSION`
- future work has an explicit architecture rule against reintroducing per-component stable-version env vars

## Root cause
- control-plane had retained per-component stable-version override knobs after product intent had simplified to a single shared stable release

## Validation
- `cd control-plane && mise run test -- test/lib/devopsellence/runtime_config_test.rb test/integration/agent_downloads_test.rb test/integration/cli_downloads_test.rb test/integration/release_checksums_test.rb test/integration/installs_test.rb test/services/agent_releases/container_image_test.rb test/integration/api_cli_mvp_test.rb`
