### PR TITLE
[codex] add local CLI release task

### DIFF
--- a/cli/scripts/release-local.sh
+++ b/cli/scripts/release-local.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CLI_DIR="$ROOT_DIR/cli"
+TARGET_NAME="devopsellence"
+INSTALL_DIR="${DEVOPSELLENCE_CLI_INSTALL_DIR:-}"
+
+OS_RAW="$(uname -s | tr '[:upper:]' '[:lower:]')"
+ARCH_RAW="$(uname -m)"
+
+case "$OS_RAW" in
+  linux) OS="linux" ;;
+  darwin) OS="darwin" ;;
+  *)
+    echo "unsupported operating system: $OS_RAW" >&2
+    exit 1
+    ;;
+esac
+
+case "$ARCH_RAW" in
+  x86_64|amd64) ARCH="amd64" ;;
+  arm64|aarch64) ARCH="arm64" ;;
+  *)
+    echo "unsupported architecture: $ARCH_RAW" >&2
+    exit 1
+    ;;
+esac
+
+if [[ -z "$INSTALL_DIR" ]]; then
+  if [[ "$OS" == "darwin" ]]; then
+    INSTALL_DIR="$HOME/.local/bin"
+  else
+    INSTALL_DIR="/usr/local/bin"
+  fi
+fi
+
+BUILD_DIR="$CLI_DIR/dist/local-head"
+mkdir -p "$BUILD_DIR"
+TMP_BIN="$(mktemp "$BUILD_DIR/devopsellence.XXXXXX")"
+cleanup() { rm -f "$TMP_BIN"; }
+trap cleanup EXIT
+
+COMMIT="$(git -C "$ROOT_DIR" rev-parse --short HEAD)"
+BUILD_TIME="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+MODULE_PATH="github.com/devopsellence/cli/internal/version"
+
+echo "building devopsellence CLI from HEAD for $OS/$ARCH..."
+cd "$CLI_DIR"
+mise install
+mkdir -p .gocache
+GOCACHE="$CLI_DIR/.gocache" mise exec -- go build \
+  -trimpath \
+  -ldflags "-s -w -X ${MODULE_PATH}.Commit=${COMMIT} -X ${MODULE_PATH}.Date=${BUILD_TIME}" \
+  -o "$TMP_BIN" \
+  ./cmd/devopsellence
+
+chmod +x "$TMP_BIN"
+
+if [[ ! -d "$INSTALL_DIR" ]]; then
+  mkdir -p "$INSTALL_DIR"
+fi
+
+if [[ -w "$INSTALL_DIR" ]]; then
+  mv "$TMP_BIN" "$INSTALL_DIR/$TARGET_NAME"
+else
+  if command -v sudo >/dev/null 2>&1; then
+    sudo mv "$TMP_BIN" "$INSTALL_DIR/$TARGET_NAME"
+  else
+    echo "install directory $INSTALL_DIR is not writable and sudo is not available" >&2
+    exit 1
+  fi
+fi
+
+echo "devopsellence CLI installed to $INSTALL_DIR/$TARGET_NAME"
+case ":$PATH:" in
+  *":$INSTALL_DIR:"*) ;;
+  *)
+    PATH_EXPORT='export PATH="'"$INSTALL_DIR"':$PATH"'
+    case "${SHELL##*/}" in
+      zsh)
+        RC_FILE="$HOME/.zprofile"
+        ;;
+      bash)
+        if [[ "$OS" == "darwin" ]]; then
+          RC_FILE="$HOME/.bash_profile"
+        else
+          RC_FILE="$HOME/.bashrc"
+        fi
+        ;;
+      *)
+        RC_FILE=""
+        ;;
+    esac
+
+    if [[ -n "$RC_FILE" ]]; then
+      echo "add $INSTALL_DIR to your PATH:"
+      echo "  echo '$PATH_EXPORT' >> $RC_FILE"
+      echo "  source $RC_FILE"
+    else
+      echo "add $INSTALL_DIR to your PATH:"
+      echo "  $PATH_EXPORT"
+    fi
+    ;;
+esac

--- a/mise.toml
+++ b/mise.toml
@@ -133,6 +133,10 @@ for target in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64; do
 done
 '''
 
+[tasks."release:cli:local"]
+description = "Build the CLI from current HEAD and install it locally like the public installer"
+run = "./cli/scripts/release-local.sh"
+
 [tasks."fmt:agent"]
 description = "Format agent Go files"
 dir = "agent"


### PR DESCRIPTION
## what changed
- add `mise run release:cli:local` at the repo root
- add `cli/scripts/release-local.sh` to build the CLI from current HEAD and install it locally
- mirror the public CLI installer's install-dir defaults, sudo fallback, target path, and PATH guidance for faster CLI-only testing

## why
- make it easy to test CLI-only changes locally without cutting a full release

## impact
- contributors can rebuild and reinstall the CLI from HEAD with one command
- supports safe testing by honoring `DEVOPSELLENCE_CLI_INSTALL_DIR` for temp-dir installs

## validation
- `bash -n cli/scripts/release-local.sh`
- `DEVOPSELLENCE_CLI_INSTALL_DIR=/tmp/tmp.RJLtTmPnmT mise run release:cli:local`
- `/tmp/tmp.RJLtTmPnmT/devopsellence version` -> `dev (9987630, 2026-04-20T20:29:48Z)`
