### PR TITLE
docs: recommend go doc and gopls for Go API/doc inspection in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,7 @@ cd control-plane && mise run test -- test/path/file_test.rb
 ## Conventions
 
 - Go: `gofmt`; no extra linter config.
+- For `agent/` and `cli/` API and documentation inspection, prefer `go doc` and `gopls` (for example, workspace symbol/definition lookups) before ad-hoc text searches.
 - Rails: `.rubocop.yml`.
 - Prefer Rails 8 solid stack, no-build CSS/JS, Tailwind, sqlite where appropriate.
 - Rails migrations: append-only. Once a migration is committed/pushed, do not edit it; add a new migration.


### PR DESCRIPTION
### Motivation
- Make the repository guidance explicit that `agent/` and `cli/` authors and readers should prefer `go doc` and `gopls` for API and documentation inspection to improve discoverability and reduce ad-hoc text searches.

### Description
- Add a single-line convention to `AGENTS.md` under `## Conventions` recommending `go doc` and `gopls` (workspace symbol/definition lookups) for `agent/` and `cli/` API and documentation inspection.

### Testing
- No automated test suites were run because this is a documentation-only change; the file update was committed and verified (`git status`/`git diff`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6e2e491748328b7c534bb441d7796)