### PR TITLE
[codex] isolate managed node known_hosts

### DIFF
--- a/cli/internal/solo/ssh.go
+++ b/cli/internal/solo/ssh.go
@@ -5,10 +5,13 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 
 	"github.com/devopsellence/cli/internal/config"
+	"github.com/devopsellence/cli/internal/state"
 )
 
 func sshArgs(node config.SoloNode, command string) []string {
@@ -18,6 +21,9 @@ func sshArgs(node config.SoloNode, command string) []string {
 		"-o", "StrictHostKeyChecking=accept-new",
 		"-p", strconv.Itoa(node.Port),
 	}
+	if knownHostsPath := managedKnownHostsPath(node); knownHostsPath != "" {
+		args = append(args, "-o", "UserKnownHostsFile="+knownHostsPath)
+	}
 	if node.SSHKey != "" {
 		args = append(args, "-i", node.SSHKey)
 	}
@@ -25,10 +31,31 @@ func sshArgs(node config.SoloNode, command string) []string {
 	return args
 }
 
+func managedKnownHostsPath(node config.SoloNode) string {
+	if node.Provider == "" || node.ProviderServerID == "" {
+		return ""
+	}
+	return filepath.Join(state.DefaultPath(filepath.Join("devopsellence", "ssh_known_hosts")), node.Provider+"-"+node.ProviderServerID)
+}
+
+func prepareSSH(node config.SoloNode) error {
+	knownHostsPath := managedKnownHostsPath(node)
+	if knownHostsPath == "" {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(knownHostsPath), 0o755); err != nil {
+		return fmt.Errorf("prepare ssh known_hosts for %s@%s: %w", node.User, node.Host, err)
+	}
+	return nil
+}
+
 // RunSSH executes a command on a remote node via ssh.
 // It inherits the user's ~/.ssh/config, agent forwarding, and known hosts.
 // If stdin is non-nil it is piped to the remote command.
 func RunSSH(ctx context.Context, node config.SoloNode, command string, stdin io.Reader) (string, error) {
+	if err := prepareSSH(node); err != nil {
+		return "", err
+	}
 	cmd := exec.CommandContext(ctx, "ssh", sshArgs(node, command)...)
 	if stdin != nil {
 		cmd.Stdin = stdin
@@ -48,6 +75,9 @@ func RunSSH(ctx context.Context, node config.SoloNode, command string, stdin io.
 // stderr directly to the provided writers. Use this for long-running streaming
 // commands like `journalctl -f` where output must not be buffered.
 func RunSSHInteractive(ctx context.Context, node config.SoloNode, command string, stdout, stderr io.Writer) error {
+	if err := prepareSSH(node); err != nil {
+		return err
+	}
 	cmd := exec.CommandContext(ctx, "ssh", sshArgs(node, command)...)
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
@@ -59,6 +89,9 @@ func RunSSHInteractive(ctx context.Context, node config.SoloNode, command string
 }
 
 func RunSSHInteractiveWithStdin(ctx context.Context, node config.SoloNode, command string, stdin io.Reader, stdout, stderr io.Writer) error {
+	if err := prepareSSH(node); err != nil {
+		return err
+	}
 	cmd := exec.CommandContext(ctx, "ssh", sshArgs(node, command)...)
 	cmd.Stdin = stdin
 	cmd.Stdout = stdout
@@ -74,6 +107,9 @@ func RunSSHInteractiveWithStdin(ctx context.Context, node config.SoloNode, comma
 // from the provided reader. Unlike RunSSH it does not capture stdout.
 // This is used for piping docker save output to docker load on the remote.
 func RunSSHStream(ctx context.Context, node config.SoloNode, command string, stdin io.Reader) error {
+	if err := prepareSSH(node); err != nil {
+		return err
+	}
 	cmd := exec.CommandContext(ctx, "ssh", sshArgs(node, command)...)
 	cmd.Stdin = stdin
 

--- a/cli/internal/solo/ssh.go
+++ b/cli/internal/solo/ssh.go
@@ -3,6 +3,8 @@ package solo
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"os"
@@ -35,7 +37,9 @@ func managedKnownHostsPath(node config.SoloNode) string {
 	if node.Provider == "" || node.ProviderServerID == "" {
 		return ""
 	}
-	return filepath.Join(state.DefaultPath(filepath.Join("devopsellence", "ssh_known_hosts")), node.Provider+"-"+node.ProviderServerID)
+	sum := sha256.Sum256([]byte(node.Provider + "\x00" + node.ProviderServerID))
+	filename := node.Provider + "-" + hex.EncodeToString(sum[:])[:16]
+	return filepath.Join(state.DefaultPath(filepath.Join("devopsellence", "ssh_known_hosts")), filename)
 }
 
 func prepareSSH(node config.SoloNode) error {
@@ -50,7 +54,8 @@ func prepareSSH(node config.SoloNode) error {
 }
 
 // RunSSH executes a command on a remote node via ssh.
-// It inherits the user's ~/.ssh/config, agent forwarding, and known hosts.
+// It inherits the user's SSH config and agent behavior; for provider-managed
+// nodes it uses a devopsellence-managed per-server known_hosts file under state.
 // If stdin is non-nil it is piped to the remote command.
 func RunSSH(ctx context.Context, node config.SoloNode, command string, stdin io.Reader) (string, error) {
 	if err := prepareSSH(node); err != nil {

--- a/cli/internal/solo/ssh.go
+++ b/cli/internal/solo/ssh.go
@@ -38,7 +38,7 @@ func managedKnownHostsPath(node config.SoloNode) string {
 		return ""
 	}
 	sum := sha256.Sum256([]byte(node.Provider + "\x00" + node.ProviderServerID))
-	filename := node.Provider + "-" + hex.EncodeToString(sum[:])[:16]
+	filename := "managed-" + hex.EncodeToString(sum[:])[:16]
 	return filepath.Join(state.DefaultPath(filepath.Join("devopsellence", "ssh_known_hosts")), filename)
 }
 

--- a/cli/internal/solo/ssh.go
+++ b/cli/internal/solo/ssh.go
@@ -38,7 +38,7 @@ func managedKnownHostsPath(node config.SoloNode) string {
 		return ""
 	}
 	sum := sha256.Sum256([]byte(node.Provider + "\x00" + node.ProviderServerID))
-	filename := "managed-" + hex.EncodeToString(sum[:])[:16]
+	filename := "managed-" + hex.EncodeToString(sum[:])
 	return filepath.Join(state.DefaultPath(filepath.Join("devopsellence", "ssh_known_hosts")), filename)
 }
 

--- a/cli/internal/solo/ssh_test.go
+++ b/cli/internal/solo/ssh_test.go
@@ -52,7 +52,7 @@ func TestSSHArgsUseManagedKnownHostsForProviderNodes(t *testing.T) {
 		"-o", "ConnectTimeout=10",
 		"-o", "StrictHostKeyChecking=accept-new",
 		"-p", "22",
-		"-o", "UserKnownHostsFile=" + filepath.Join(stateDir, "devopsellence", "ssh_known_hosts", node.Provider+"-"+hex.EncodeToString(sum[:])[:16]),
+		"-o", "UserKnownHostsFile=" + filepath.Join(stateDir, "devopsellence", "ssh_known_hosts", "managed-"+hex.EncodeToString(sum[:])[:16]),
 		"-i", "/tmp/id_ed25519",
 		"root@203.0.113.10",
 		"true",
@@ -75,7 +75,7 @@ func TestManagedKnownHostsPathHashesUntrustedServerID(t *testing.T) {
 	if filepath.Dir(path) != base {
 		t.Fatalf("managedKnownHostsPath() dir = %q, want %q", filepath.Dir(path), base)
 	}
-	if filepath.Base(path) == node.Provider+"-"+node.ProviderServerID {
+	if filepath.Base(path) == node.Provider+"-"+node.ProviderServerID || filepath.Base(path) == "managed-"+node.ProviderServerID {
 		t.Fatalf("managedKnownHostsPath() base = %q, want hashed filename", filepath.Base(path))
 	}
 }

--- a/cli/internal/solo/ssh_test.go
+++ b/cli/internal/solo/ssh_test.go
@@ -1,6 +1,8 @@
 package solo
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -32,7 +34,8 @@ func TestSSHArgsIncludeConnectTimeoutAndKey(t *testing.T) {
 }
 
 func TestSSHArgsUseManagedKnownHostsForProviderNodes(t *testing.T) {
-	t.Setenv("XDG_STATE_HOME", "/tmp/devopsellence-test-state")
+	stateDir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateDir)
 	node := config.SoloNode{
 		User:             "root",
 		Host:             "203.0.113.10",
@@ -42,18 +45,37 @@ func TestSSHArgsUseManagedKnownHostsForProviderNodes(t *testing.T) {
 		ProviderServerID: "123456",
 	}
 
+	sum := sha256.Sum256([]byte(node.Provider + "\x00" + node.ProviderServerID))
 	got := sshArgs(node, "true")
 	want := []string{
 		"-o", "BatchMode=yes",
 		"-o", "ConnectTimeout=10",
 		"-o", "StrictHostKeyChecking=accept-new",
 		"-p", "22",
-		"-o", "UserKnownHostsFile=" + filepath.Join("/tmp/devopsellence-test-state", "devopsellence", "ssh_known_hosts", "hetzner-123456"),
+		"-o", "UserKnownHostsFile=" + filepath.Join(stateDir, "devopsellence", "ssh_known_hosts", node.Provider+"-"+hex.EncodeToString(sum[:])[:16]),
 		"-i", "/tmp/id_ed25519",
 		"root@203.0.113.10",
 		"true",
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("sshArgs() = %#v, want %#v", got, want)
+	}
+}
+
+func TestManagedKnownHostsPathHashesUntrustedServerID(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateDir)
+	node := config.SoloNode{
+		Provider:         "hetzner",
+		ProviderServerID: "../../escape",
+	}
+
+	path := managedKnownHostsPath(node)
+	base := filepath.Join(stateDir, "devopsellence", "ssh_known_hosts")
+	if filepath.Dir(path) != base {
+		t.Fatalf("managedKnownHostsPath() dir = %q, want %q", filepath.Dir(path), base)
+	}
+	if filepath.Base(path) == node.Provider+"-"+node.ProviderServerID {
+		t.Fatalf("managedKnownHostsPath() base = %q, want hashed filename", filepath.Base(path))
 	}
 }

--- a/cli/internal/solo/ssh_test.go
+++ b/cli/internal/solo/ssh_test.go
@@ -1,8 +1,6 @@
 package solo
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -45,14 +43,13 @@ func TestSSHArgsUseManagedKnownHostsForProviderNodes(t *testing.T) {
 		ProviderServerID: "123456",
 	}
 
-	sum := sha256.Sum256([]byte(node.Provider + "\x00" + node.ProviderServerID))
 	got := sshArgs(node, "true")
 	want := []string{
 		"-o", "BatchMode=yes",
 		"-o", "ConnectTimeout=10",
 		"-o", "StrictHostKeyChecking=accept-new",
 		"-p", "22",
-		"-o", "UserKnownHostsFile=" + filepath.Join(stateDir, "devopsellence", "ssh_known_hosts", "managed-"+hex.EncodeToString(sum[:])[:16]),
+		"-o", "UserKnownHostsFile=" + managedKnownHostsPath(node),
 		"-i", "/tmp/id_ed25519",
 		"root@203.0.113.10",
 		"true",

--- a/cli/internal/solo/ssh_test.go
+++ b/cli/internal/solo/ssh_test.go
@@ -1,6 +1,7 @@
 package solo
 
 import (
+	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -21,6 +22,33 @@ func TestSSHArgsIncludeConnectTimeoutAndKey(t *testing.T) {
 		"-o", "ConnectTimeout=10",
 		"-o", "StrictHostKeyChecking=accept-new",
 		"-p", "22",
+		"-i", "/tmp/id_ed25519",
+		"root@203.0.113.10",
+		"true",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("sshArgs() = %#v, want %#v", got, want)
+	}
+}
+
+func TestSSHArgsUseManagedKnownHostsForProviderNodes(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", "/tmp/devopsellence-test-state")
+	node := config.SoloNode{
+		User:             "root",
+		Host:             "203.0.113.10",
+		Port:             22,
+		SSHKey:           "/tmp/id_ed25519",
+		Provider:         "hetzner",
+		ProviderServerID: "123456",
+	}
+
+	got := sshArgs(node, "true")
+	want := []string{
+		"-o", "BatchMode=yes",
+		"-o", "ConnectTimeout=10",
+		"-o", "StrictHostKeyChecking=accept-new",
+		"-p", "22",
+		"-o", "UserKnownHostsFile=" + filepath.Join("/tmp/devopsellence-test-state", "devopsellence", "ssh_known_hosts", "hetzner-123456"),
 		"-i", "/tmp/id_ed25519",
 		"root@203.0.113.10",
 		"true",


### PR DESCRIPTION
## Summary

- isolate provider-managed node SSH host keys into per-server known_hosts files under devopsellence state
- keep existing SSH behavior for unmanaged nodes
- add coverage for provider node SSH args

## Why

Hetzner can reuse public IPv4 addresses. When a managed node inherited a reused IP, OpenSSH compared the new host key against stale entries in the user global ~/.ssh/known_hosts and devopsellence setup timed out waiting for SSH.

## Impact

Provider-managed solo/shared node creation no longer depends on the user manually cleaning stale global known_hosts entries for reused provider IPs.

## Validation

- cd cli && go test ./internal/solo ./internal/workflow
