### PR TITLE
[codex] Fix ingress set service handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ devopsellence deploy
 devopsellence status
 ```
 
-Public ingress is Envoy in both modes. For solo HTTPS, point DNS at each web node, then configure hostnames:
+Public ingress is Envoy in both modes. For solo HTTPS, point DNS at each web node, then configure hostnames. Pass `--service` when the target web service is not already obvious:
 
 ```bash
-devopsellence ingress set --host app.example.com --tls-email ops@example.com
+devopsellence ingress set --service web --host app.example.com --tls-email ops@example.com
 devopsellence ingress check --wait 5m
 devopsellence deploy
 ```

--- a/cli/internal/workflow/root.go
+++ b/cli/internal/workflow/root.go
@@ -556,6 +556,7 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 		},
 	}
 	ingressSetCommand.Flags().StringSliceVar(&ingressSetOpts.Hosts, "host", nil, "Hostname, repeatable or comma-separated")
+	ingressSetCommand.Flags().StringVar(&ingressSetOpts.Service, "service", "", "Ingress service name")
 	ingressSetCommand.Flags().StringVar(&ingressSetOpts.TLSMode, "tls-mode", "auto", "TLS mode: auto, manual, or off")
 	ingressSetCommand.Flags().StringVar(&ingressSetOpts.TLSEmail, "tls-email", "", "ACME account email")
 	ingressSetCommand.Flags().StringVar(&ingressSetOpts.TLSCADirectoryURL, "acme-ca", "", "ACME directory URL override")

--- a/cli/internal/workflow/root_test.go
+++ b/cli/internal/workflow/root_test.go
@@ -189,3 +189,22 @@ func TestNodeCreateHelpUsesCurrentHetznerDefaults(t *testing.T) {
 		}
 	}
 }
+
+func TestIngressSetHelpShowsServiceFlag(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, t.TempDir())
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{"ingress", "set", "--help"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	for _, snippet := range []string{"--service string", "Ingress service name"} {
+		if !strings.Contains(stdout.String(), snippet) {
+			t.Fatalf("help output = %q, want %q", stdout.String(), snippet)
+		}
+	}
+}

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -102,6 +102,7 @@ type SoloSetupOptions struct{}
 
 type IngressSetOptions struct {
 	Hosts               []string
+	Service             string
 	TLSMode             string
 	TLSEmail            string
 	TLSCADirectoryURL   string
@@ -1042,6 +1043,17 @@ func (a *App) IngressSet(_ context.Context, opts IngressSetOptions) error {
 	if len(hosts) == 0 {
 		return fmt.Errorf("ingress set requires at least one --host")
 	}
+	serviceName := strings.TrimSpace(opts.Service)
+	if serviceName == "" && cfg.Ingress != nil {
+		serviceName = strings.TrimSpace(cfg.Ingress.Service)
+	}
+	if serviceName == "" {
+		var ok bool
+		serviceName, ok = cfg.PrimaryWebServiceName()
+		if !ok {
+			return fmt.Errorf("ingress set requires --service when the primary web service cannot be inferred")
+		}
+	}
 	tlsMode := strings.TrimSpace(opts.TLSMode)
 	if tlsMode == "" {
 		tlsMode = "auto"
@@ -1056,7 +1068,8 @@ func (a *App) IngressSet(_ context.Context, opts IngressSetOptions) error {
 		redirectHTTP = opts.RedirectHTTP
 	}
 	cfg.Ingress = &config.IngressConfig{
-		Hosts: hosts,
+		Hosts:   hosts,
+		Service: serviceName,
 		TLS: config.IngressTLSConfig{
 			Mode:           tlsMode,
 			Email:          strings.TrimSpace(opts.TLSEmail),

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/devopsellence/cli/internal/config"
 	"github.com/devopsellence/cli/internal/discovery"
+	"github.com/devopsellence/cli/internal/output"
 	"github.com/devopsellence/cli/internal/solo"
 	cliversion "github.com/devopsellence/cli/internal/version"
 )
@@ -449,6 +450,79 @@ func TestSoloDefaultProjectConfigUsesDiscovery(t *testing.T) {
 	web := cfg.Services[config.DefaultWebServiceName]
 	if web.HTTPPort(0) != 8080 || web.Healthcheck.Port != 8080 {
 		t.Fatalf("web port = %d healthcheck port = %d, want 8080", web.HTTPPort(0), web.Healthcheck.Port)
+	}
+}
+
+func TestIngressSetInfersPrimaryWebService(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfg := config.DefaultProjectConfigForType("solo", "demo", config.DefaultEnvironment, config.AppTypeGeneric)
+	if _, err := config.Write(dir, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	app := &App{
+		Cwd:         dir,
+		ConfigStore: config.NewStore(),
+		Printer:     output.New(io.Discard, io.Discard, false),
+	}
+	if err := app.IngressSet(context.Background(), IngressSetOptions{
+		Hosts:   []string{"demo.devopsellence.io"},
+		TLSMode: "auto",
+	}); err != nil {
+		t.Fatalf("IngressSet() error = %v", err)
+	}
+
+	written, err := config.Load(filepath.Join(dir, config.FilePath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if written.Ingress == nil {
+		t.Fatal("ingress = nil, want populated ingress config")
+	}
+	if written.Ingress.Service != config.DefaultWebServiceName {
+		t.Fatalf("ingress.service = %q, want %q", written.Ingress.Service, config.DefaultWebServiceName)
+	}
+}
+
+func TestIngressSetPreservesExistingServiceWhenFlagOmitted(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfg := config.DefaultProjectConfigForType("solo", "demo", config.DefaultEnvironment, config.AppTypeGeneric)
+	cfg.Services["frontend"] = cfg.Services[config.DefaultWebServiceName]
+	delete(cfg.Services, config.DefaultWebServiceName)
+	cfg.Ingress = &config.IngressConfig{
+		Service: "frontend",
+		Hosts:   []string{"old.devopsellence.io"},
+		TLS:     config.IngressTLSConfig{Mode: "manual"},
+	}
+	if _, err := config.Write(dir, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	app := &App{
+		Cwd:         dir,
+		ConfigStore: config.NewStore(),
+		Printer:     output.New(io.Discard, io.Discard, false),
+	}
+	if err := app.IngressSet(context.Background(), IngressSetOptions{
+		Hosts:   []string{"new.devopsellence.io"},
+		TLSMode: "auto",
+	}); err != nil {
+		t.Fatalf("IngressSet() error = %v", err)
+	}
+
+	written, err := config.Load(filepath.Join(dir, config.FilePath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if written.Ingress == nil {
+		t.Fatal("ingress = nil, want populated ingress config")
+	}
+	if written.Ingress.Service != "frontend" {
+		t.Fatalf("ingress.service = %q, want frontend", written.Ingress.Service)
 	}
 }
 

--- a/control-plane/app/views/marketing/docs.html.erb
+++ b/control-plane/app/views/marketing/docs.html.erb
@@ -304,7 +304,7 @@
   <section class="prose-section" id="solo-mode">
     <h2>Solo mode <span class="mode-badge mode-badge--solo">solo</span></h2>
     <p>Solo mode deploys over SSH without the control plane. The CLI builds the image locally, streams it to each configured node, writes desired state on the node, and the agent reconciles containers from local files.</p>
-    <p>Public ingress uses Envoy in solo and shared mode. Add hostnames with <code>devopsellence ingress set</code>; the agent answers HTTP-01 challenges and keeps HTTPS certificates on the node.</p>
+    <p>Public ingress uses Envoy in solo and shared mode. Add hostnames with <code>devopsellence ingress set</code>; pass <code>--service</code> when the target web service is not already obvious. The agent answers HTTP-01 challenges and keeps HTTPS certificates on the node.</p>
 
     <h3>Set up a node</h3>
     <p>Use the setup wizard for an existing SSH node or a Hetzner node created by the CLI:</p>
@@ -965,7 +965,7 @@ tasks:
         <dd>In solo mode, read agent status from configured nodes over SSH.</dd>
       </div>
       <div class="docs-field">
-        <dt><code>devopsellence ingress set --host app.example.com</code></dt>
+        <dt><code>devopsellence ingress set --service web --host app.example.com</code></dt>
         <dd>Set public ingress hostnames and TLS policy. The command surface is shared by solo and shared mode.</dd>
       </div>
       <div class="docs-field">


### PR DESCRIPTION
## What changed
- add `--service` to `devopsellence ingress set` so users can set `ingress.service` directly from the CLI
- preserve an existing `ingress.service` value when updating ingress hosts or TLS settings
- infer the primary web service when the target is unambiguous
- update README and docs examples to show the service-aware command
- add workflow tests for help output and ingress service persistence/inference

## Why
`ingress.service` is required by config validation, but `devopsellence ingress set` did not expose a way to set it and rewrote the ingress block without preserving it. That made the command confusing and could leave users with invalid config.

## Impact
Users can now configure ingress from the CLI without hand-editing YAML, and the help/docs match the actual required config shape.

## Validation
- `cd cli && mise run test`
