### PR TITLE
[codex] Refactor solo local state and attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ printf '%s' "$RAILS_MASTER_KEY" | devopsellence secret set RAILS_MASTER_KEY --st
 devopsellence secret list
 ```
 
-Solo mode keeps app config workload-only. Solo nodes, local environment attachments, and the latest deployed environment snapshots live in `$XDG_STATE_HOME/devopsellence/solo/state.json` (default: `~/.local/state/devopsellence/solo/state.json` when `XDG_STATE_HOME` is unset).
+Solo mode keeps app config workload-only. Solo nodes, local environment attachments, and the latest desired environment snapshots live in `$XDG_STATE_HOME/devopsellence/solo/state.json` (default: `~/.local/state/devopsellence/solo/state.json` when `XDG_STATE_HOME` is unset).
 
 ## Shared mode
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ devopsellence deploy
 devopsellence status
 ```
 
+Solo deploy scope comes from the nodes attached to the current workspace/environment. Use `devopsellence node attach <name>` and `devopsellence node detach <name>` to change which nodes receive the deploy.
+
 Public ingress is Envoy in both modes. For solo HTTPS, point DNS at each web node, then configure hostnames. Pass `--service` when the target web service is not already obvious:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Or create a Hetzner-backed node from the provider:
 
 ```bash
 devopsellence node create prod-1 --provider hetzner
+devopsellence node attach prod-1
 ```
 
 Deploy over SSH:
@@ -74,7 +75,7 @@ printf '%s' "$RAILS_MASTER_KEY" | devopsellence secret set RAILS_MASTER_KEY --st
 devopsellence secret list
 ```
 
-Solo mode keeps the mental model simple: build locally, transfer the image, write desired state, let the agent reconcile.
+Solo mode keeps app config workload-only. Solo nodes, local environment attachments, and the latest deployed environment snapshots live in `~/.local/state/devopsellence/solo/state.json`.
 
 ## Shared mode
 
@@ -131,14 +132,6 @@ ingress:
     mode: auto
     email: ops@example.com
   redirect_http: true
-solo:
-  nodes:
-    prod-1:
-      host: 203.0.113.10
-      user: root
-      ssh_key: ~/.ssh/id_ed25519
-      labels:
-        - web
 ```
 
 ## Need more than solo mode?

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ printf '%s' "$RAILS_MASTER_KEY" | devopsellence secret set RAILS_MASTER_KEY --st
 devopsellence secret list
 ```
 
-Solo mode keeps app config workload-only. Solo nodes, local environment attachments, and the latest deployed environment snapshots live in `~/.local/state/devopsellence/solo/state.json`.
+Solo mode keeps app config workload-only. Solo nodes, local environment attachments, and the latest deployed environment snapshots live in `$XDG_STATE_HOME/devopsellence/solo/state.json` (default: `~/.local/state/devopsellence/solo/state.json` when `XDG_STATE_HOME` is unset).
 
 ## Shared mode
 

--- a/cli/internal/agentsmd/agentsmd.go
+++ b/cli/internal/agentsmd/agentsmd.go
@@ -83,7 +83,8 @@ Shared mode secrets:
 	- `+"`devopsellence secret set NAME --value ...`"+`
 	- `+"`devopsellence node list`"+`
 	- `+"`devopsellence node logs NODE --follow`"+`
-	- `+"`devopsellence node create prod-1`"+`
+- `+"`devopsellence node create prod-1`"+`
+- `+"`devopsellence node attach prod-1`"+`
 
 Shared mode:
 - `+"`devopsellence mode use shared`"+`
@@ -92,8 +93,8 @@ Shared mode:
 - `+"`devopsellence deploy --image registry.example.com/app@sha256:...`"+`
 - `+"`devopsellence node register`"+`
 - `+"`devopsellence node list`"+`
-- `+"`devopsellence node attach <id>`"+`
-- `+"`devopsellence node detach <id>`"+`
+- `+"`devopsellence node attach <target>`"+`
+- `+"`devopsellence node detach <target>`"+`
 - `+"`devopsellence node remove <id>`"+`
 
 Lifecycle hooks in `+"`devopsellence.yml`"+`:

--- a/cli/internal/agentsmd/agentsmd.go
+++ b/cli/internal/agentsmd/agentsmd.go
@@ -83,8 +83,8 @@ Shared mode secrets:
 	- `+"`devopsellence secret set NAME --value ...`"+`
 	- `+"`devopsellence node list`"+`
 	- `+"`devopsellence node logs NODE --follow`"+`
-- `+"`devopsellence node create prod-1`"+`
-- `+"`devopsellence node attach prod-1`"+`
+	- `+"`devopsellence node create prod-1`"+`
+	- `+"`devopsellence node attach prod-1`"+`
 
 Shared mode:
 - `+"`devopsellence mode use shared`"+`

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -116,10 +116,6 @@ type SoloNode struct {
 	ProviderImage    string   `yaml:"provider_image,omitempty" json:"provider_image,omitempty"`
 }
 
-type SoloConfig struct {
-	Nodes map[string]SoloNode `yaml:"nodes" json:"nodes"`
-}
-
 type ProjectConfig struct {
 	SchemaVersion      int                      `yaml:"schema_version" json:"schema_version"`
 	App                AppConfig                `yaml:"app,omitempty" json:"app,omitempty"`
@@ -130,7 +126,6 @@ type ProjectConfig struct {
 	Services           map[string]ServiceConfig `yaml:"services" json:"services"`
 	Tasks              TasksConfig              `yaml:"tasks,omitempty" json:"tasks,omitempty"`
 	Ingress            *IngressConfig           `yaml:"ingress,omitempty" json:"ingress,omitempty"`
-	Solo               *SoloConfig              `yaml:"solo,omitempty" json:"solo,omitempty"`
 }
 
 type Project = ProjectConfig
@@ -369,27 +364,6 @@ func Validate(cfg *ProjectConfig) error {
 			return fmt.Errorf("ingress.tls.mode must be auto, off, or manual")
 		}
 	}
-	if cfg.Solo != nil {
-		for name, node := range cfg.Solo.Nodes {
-			if strings.TrimSpace(name) == "" {
-				return errors.New("solo.nodes keys must be present")
-			}
-			if strings.TrimSpace(node.Host) == "" {
-				return fmt.Errorf("solo.nodes.%s.host is required", name)
-			}
-			if strings.TrimSpace(node.User) == "" {
-				return fmt.Errorf("solo.nodes.%s.user is required", name)
-			}
-			if len(node.Labels) == 0 {
-				return fmt.Errorf("solo.nodes.%s.labels must include at least one label", name)
-			}
-			for _, label := range node.Labels {
-				if strings.TrimSpace(label) == "" {
-					return fmt.Errorf("solo.nodes.%s.labels entries must be present", name)
-				}
-			}
-		}
-	}
 	return nil
 }
 
@@ -460,25 +434,6 @@ func applyDefaults(cfg *ProjectConfig) {
 		cfg.Ingress.TLS.CADirectoryURL = strings.TrimSpace(cfg.Ingress.TLS.CADirectoryURL)
 		if cfg.Ingress.TLS.Mode == "auto" {
 			cfg.Ingress.RedirectHTTP = true
-		}
-	}
-	if cfg.Solo != nil {
-		if cfg.Solo.Nodes == nil {
-			cfg.Solo.Nodes = map[string]SoloNode{}
-		}
-		for name, node := range cfg.Solo.Nodes {
-			if node.Port == 0 {
-				node.Port = 22
-			}
-			if node.AgentStateDir == "" {
-				node.AgentStateDir = "/var/lib/devopsellence"
-			}
-			labels := normalizeNodeLabels(node.Labels)
-			if len(labels) == 0 {
-				labels = append([]string(nil), SoloDefaultLabels...)
-			}
-			node.Labels = append([]string(nil), labels...)
-			cfg.Solo.Nodes[name] = node
 		}
 	}
 }

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -198,14 +198,40 @@ func TestLoadRejectsLegacyDirectConfig(t *testing.T) {
 	}
 }
 
-func TestValidateAllowsArbitraryNodeLabels(t *testing.T) {
+func TestLoadRejectsLegacySoloConfigBlock(t *testing.T) {
 	t.Parallel()
 
-	project := DefaultProjectConfig("acme", "ShopApp", "production")
-	project.Solo = &SoloConfig{Nodes: map[string]SoloNode{"prod-1": {Host: "203.0.113.10", User: "root", Labels: []string{"edge"}}}}
-	err := Validate(&project)
-	if err != nil {
-		t.Fatalf("expected arbitrary label support, got %v", err)
+	root := t.TempDir()
+	path := filepath.Join(root, FilePath)
+	content := strings.Join([]string{
+		"schema_version: 5",
+		"organization: solo",
+		"project: ShopApp",
+		"default_environment: production",
+		"build:",
+		"  context: .",
+		"  dockerfile: Dockerfile",
+		"services:",
+		"  web:",
+		"    kind: web",
+		"    ports:",
+		"      - name: http",
+		"        port: 3000",
+		"    healthcheck:",
+		"      path: /up",
+		"solo:",
+		"  nodes:",
+		"    prod-1:",
+		"      host: 203.0.113.10",
+		"      user: root",
+	}, "\n") + "\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Load(path)
+	if err == nil || !strings.Contains(err.Error(), "field solo not found") {
+		t.Fatalf("expected unknown solo field error, got %v", err)
 	}
 }
 

--- a/cli/internal/solo/desiredstate.go
+++ b/cli/internal/solo/desiredstate.go
@@ -1,8 +1,11 @@
 package solo
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/devopsellence/cli/internal/config"
@@ -173,6 +176,58 @@ func BuildDesiredStateForNode(cfg *config.ProjectConfig, imageTag, revision stri
 	return data, nil
 }
 
+func BuildAggregatedDesiredState(nodeName string, currentNode config.SoloNode, snapshots []DeploySnapshot, releaseNodes map[string]string, nodePeers []NodePeer) ([]byte, error) {
+	ds := desiredStateJSON{
+		SchemaVersion: 2,
+	}
+	if len(nodePeers) > 0 {
+		ds.NodePeers = buildNodePeers(nodePeers)
+	}
+
+	attached := append([]DeploySnapshot(nil), snapshots...)
+	sort.Slice(attached, func(i, j int) bool {
+		if attached[i].WorkspaceKey != attached[j].WorkspaceKey {
+			return attached[i].WorkspaceKey < attached[j].WorkspaceKey
+		}
+		return attached[i].Environment < attached[j].Environment
+	})
+
+	mergedIngress, err := mergeIngressForNode(currentNode.Labels, attached)
+	if err != nil {
+		return nil, err
+	}
+	ds.Ingress = mergedIngress
+
+	for _, snapshot := range attached {
+		environment := environmentJSON{
+			Name:     defaultEnvironmentName(snapshot.Environment),
+			Revision: strings.TrimSpace(snapshot.Revision),
+		}
+		for _, service := range snapshot.Services {
+			if !shouldScheduleService(currentNode.Labels, service.Kind) {
+				continue
+			}
+			environment.Services = append(environment.Services, service)
+		}
+		if snapshot.ReleaseTask != nil && strings.TrimSpace(releaseNodes[snapshotKey(snapshot)]) == nodeName && shouldScheduleService(currentNode.Labels, snapshot.ReleaseServiceKind) {
+			environment.Tasks = append(environment.Tasks, *snapshot.ReleaseTask)
+		}
+		ds.Environments = append(ds.Environments, environment)
+	}
+
+	revision, err := syntheticRevision(ds)
+	if err != nil {
+		return nil, err
+	}
+	ds.Revision = revision
+
+	data, err := json.MarshalIndent(ds, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal desired state: %w", err)
+	}
+	return data, nil
+}
+
 func buildIngress(ingress *config.IngressConfig, environmentName string) *ingressJSON {
 	if ingress == nil || len(ingress.Hosts) == 0 {
 		return nil
@@ -205,6 +260,76 @@ func buildIngress(ingress *config.IngressConfig, environmentName string) *ingres
 		RedirectHTTP: ingress.RedirectHTTP,
 		Routes:       routes,
 	}
+}
+
+func mergeIngressForNode(labels []string, snapshots []DeploySnapshot) (*ingressJSON, error) {
+	var merged *ingressJSON
+	hostSet := map[string]bool{}
+	routeSet := map[string]bool{}
+
+	for _, snapshot := range snapshots {
+		if snapshot.Ingress == nil || !shouldScheduleService(labels, snapshot.IngressServiceKind) {
+			continue
+		}
+		if merged == nil {
+			merged = &ingressJSON{
+				Mode:         snapshot.Ingress.Mode,
+				TLS:          snapshot.Ingress.TLS,
+				RedirectHTTP: snapshot.Ingress.RedirectHTTP,
+			}
+		} else if merged.TLS != snapshot.Ingress.TLS || merged.RedirectHTTP != snapshot.Ingress.RedirectHTTP || merged.Mode != snapshot.Ingress.Mode {
+			return nil, fmt.Errorf("cannot merge ingress for co-hosted environments with different TLS settings")
+		}
+		for _, host := range snapshot.Ingress.Hosts {
+			if hostSet[host] {
+				continue
+			}
+			hostSet[host] = true
+			merged.Hosts = append(merged.Hosts, host)
+		}
+		for _, route := range snapshot.Ingress.Routes {
+			key := route.Match.Hostname + "\n" + route.Match.PathPrefix + "\n" + route.Target.Environment + "\n" + route.Target.Service + "\n" + route.Target.Port
+			if routeSet[key] {
+				continue
+			}
+			routeSet[key] = true
+			merged.Routes = append(merged.Routes, route)
+		}
+	}
+	if merged == nil {
+		return nil, nil
+	}
+	sort.Strings(merged.Hosts)
+	sort.Slice(merged.Routes, func(i, j int) bool {
+		left := merged.Routes[i]
+		right := merged.Routes[j]
+		if left.Match.Hostname != right.Match.Hostname {
+			return left.Match.Hostname < right.Match.Hostname
+		}
+		if left.Target.Environment != right.Target.Environment {
+			return left.Target.Environment < right.Target.Environment
+		}
+		if left.Target.Service != right.Target.Service {
+			return left.Target.Service < right.Target.Service
+		}
+		return left.Match.PathPrefix < right.Match.PathPrefix
+	})
+	return merged, nil
+}
+
+func syntheticRevision(ds desiredStateJSON) (string, error) {
+	copyValue := ds
+	copyValue.Revision = ""
+	data, err := json.Marshal(copyValue)
+	if err != nil {
+		return "", fmt.Errorf("marshal synthetic revision input: %w", err)
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func snapshotKey(snapshot DeploySnapshot) string {
+	return strings.TrimSpace(snapshot.WorkspaceKey) + "\n" + defaultEnvironmentName(snapshot.Environment)
 }
 
 func buildNodePeers(peers []NodePeer) []nodePeerJSON {

--- a/cli/internal/solo/desiredstate.go
+++ b/cli/internal/solo/desiredstate.go
@@ -191,16 +191,18 @@ func BuildAggregatedDesiredState(nodeName string, currentNode config.SoloNode, s
 		}
 		return attached[i].Environment < attached[j].Environment
 	})
+	environmentNames := aggregatedEnvironmentNames(attached)
 
-	mergedIngress, err := mergeIngressForNode(currentNode.Labels, attached)
+	mergedIngress, err := mergeIngressForNode(currentNode.Labels, attached, environmentNames)
 	if err != nil {
 		return nil, err
 	}
 	ds.Ingress = mergedIngress
 
 	for _, snapshot := range attached {
+		environmentName := environmentNames[snapshotKey(snapshot)]
 		environment := environmentJSON{
-			Name:     defaultEnvironmentName(snapshot.Environment),
+			Name:     environmentName,
 			Revision: strings.TrimSpace(snapshot.Revision),
 		}
 		for _, service := range snapshot.Services {
@@ -226,6 +228,59 @@ func BuildAggregatedDesiredState(nodeName string, currentNode config.SoloNode, s
 		return nil, fmt.Errorf("marshal desired state: %w", err)
 	}
 	return data, nil
+}
+
+func aggregatedEnvironmentNames(snapshots []DeploySnapshot) map[string]string {
+	counts := map[string]int{}
+	names := map[string]string{}
+	for _, snapshot := range snapshots {
+		counts[defaultEnvironmentName(snapshot.Environment)]++
+	}
+	for _, snapshot := range snapshots {
+		key := snapshotKey(snapshot)
+		base := defaultEnvironmentName(snapshot.Environment)
+		if counts[base] == 1 {
+			names[key] = base
+			continue
+		}
+		names[key] = uniqueAggregatedEnvironmentName(snapshot, base)
+	}
+	return names
+}
+
+func uniqueAggregatedEnvironmentName(snapshot DeploySnapshot, base string) string {
+	hashSource := strings.TrimSpace(snapshot.WorkspaceKey)
+	if hashSource == "" {
+		hashSource = strings.TrimSpace(snapshot.WorkspaceRoot)
+	}
+	sum := sha256.Sum256([]byte(hashSource))
+	suffix := hex.EncodeToString(sum[:4])
+	project := normalizeEnvironmentNameToken(snapshot.Metadata.Project)
+	if project == "" {
+		return base + "-" + suffix
+	}
+	return project + "-" + base + "-" + suffix
+}
+
+func normalizeEnvironmentNameToken(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if value == "" {
+		return ""
+	}
+	var b strings.Builder
+	lastDash := false
+	for _, r := range value {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+			lastDash = false
+			continue
+		}
+		if !lastDash {
+			b.WriteByte('-')
+			lastDash = true
+		}
+	}
+	return strings.Trim(b.String(), "-")
 }
 
 func buildIngress(ingress *config.IngressConfig, environmentName string) *ingressJSON {
@@ -262,7 +317,7 @@ func buildIngress(ingress *config.IngressConfig, environmentName string) *ingres
 	}
 }
 
-func mergeIngressForNode(labels []string, snapshots []DeploySnapshot) (*ingressJSON, error) {
+func mergeIngressForNode(labels []string, snapshots []DeploySnapshot, environmentNames map[string]string) (*ingressJSON, error) {
 	var merged *ingressJSON
 	hostSet := map[string]bool{}
 	routeSet := map[string]bool{}
@@ -278,7 +333,17 @@ func mergeIngressForNode(labels []string, snapshots []DeploySnapshot) (*ingressJ
 				RedirectHTTP: snapshot.Ingress.RedirectHTTP,
 			}
 		} else if merged.TLS != snapshot.Ingress.TLS || merged.RedirectHTTP != snapshot.Ingress.RedirectHTTP || merged.Mode != snapshot.Ingress.Mode {
-			return nil, fmt.Errorf("cannot merge ingress for co-hosted environments with different TLS settings")
+			differingSettings := []string{}
+			if merged.TLS != snapshot.Ingress.TLS {
+				differingSettings = append(differingSettings, "TLS")
+			}
+			if merged.Mode != snapshot.Ingress.Mode {
+				differingSettings = append(differingSettings, "mode")
+			}
+			if merged.RedirectHTTP != snapshot.Ingress.RedirectHTTP {
+				differingSettings = append(differingSettings, "redirect_http")
+			}
+			return nil, fmt.Errorf("cannot merge ingress for co-hosted environments with different settings: %s", strings.Join(differingSettings, ", "))
 		}
 		for _, host := range snapshot.Ingress.Hosts {
 			if hostSet[host] {
@@ -288,12 +353,16 @@ func mergeIngressForNode(labels []string, snapshots []DeploySnapshot) (*ingressJ
 			merged.Hosts = append(merged.Hosts, host)
 		}
 		for _, route := range snapshot.Ingress.Routes {
-			key := route.Match.Hostname + "\n" + route.Match.PathPrefix + "\n" + route.Target.Environment + "\n" + route.Target.Service + "\n" + route.Target.Port
+			routeCopy := route
+			if environmentName := environmentNames[snapshotKey(snapshot)]; environmentName != "" {
+				routeCopy.Target.Environment = environmentName
+			}
+			key := routeCopy.Match.Hostname + "\n" + routeCopy.Match.PathPrefix + "\n" + routeCopy.Target.Environment + "\n" + routeCopy.Target.Service + "\n" + routeCopy.Target.Port
 			if routeSet[key] {
 				continue
 			}
 			routeSet[key] = true
-			merged.Routes = append(merged.Routes, route)
+			merged.Routes = append(merged.Routes, routeCopy)
 		}
 	}
 	if merged == nil {

--- a/cli/internal/solo/desiredstate.go
+++ b/cli/internal/solo/desiredstate.go
@@ -312,7 +312,10 @@ func mergeIngressForNode(labels []string, snapshots []DeploySnapshot) (*ingressJ
 		if left.Target.Service != right.Target.Service {
 			return left.Target.Service < right.Target.Service
 		}
-		return left.Match.PathPrefix < right.Match.PathPrefix
+		if left.Match.PathPrefix != right.Match.PathPrefix {
+			return left.Match.PathPrefix < right.Match.PathPrefix
+		}
+		return left.Target.Port < right.Target.Port
 	})
 	return merged, nil
 }

--- a/cli/internal/solo/desiredstate_test.go
+++ b/cli/internal/solo/desiredstate_test.go
@@ -310,3 +310,45 @@ func TestBuildAggregatedDesiredStateMergesEnvironmentsIngressAndPeers(t *testing
 		t.Fatalf("tasks = %#v", ds.Environments)
 	}
 }
+
+func TestMergeIngressForNodeSortsRoutesByPortWhenMatchFieldsTie(t *testing.T) {
+	t.Parallel()
+
+	snapshots := []DeploySnapshot{
+		{
+			Ingress: &ingressJSON{
+				Mode: "public",
+				TLS:  ingressTLSJSON{Mode: "auto"},
+				Routes: []ingressRouteJSON{{
+					Match:  ingressMatchJSON{Hostname: "app.example.com"},
+					Target: ingressTargetJSON{Environment: "production", Service: "web", Port: "metrics"},
+				}},
+			},
+			IngressService:     "web",
+			IngressServiceKind: config.ServiceKindWeb,
+		},
+		{
+			Ingress: &ingressJSON{
+				Mode: "public",
+				TLS:  ingressTLSJSON{Mode: "auto"},
+				Routes: []ingressRouteJSON{{
+					Match:  ingressMatchJSON{Hostname: "app.example.com"},
+					Target: ingressTargetJSON{Environment: "production", Service: "web", Port: "http"},
+				}},
+			},
+			IngressService:     "web",
+			IngressServiceKind: config.ServiceKindWeb,
+		},
+	}
+
+	merged, err := mergeIngressForNode([]string{config.DefaultWebRole}, snapshots)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if merged == nil || len(merged.Routes) != 2 {
+		t.Fatalf("routes = %#v", merged)
+	}
+	if merged.Routes[0].Target.Port != "http" || merged.Routes[1].Target.Port != "metrics" {
+		t.Fatalf("route order = %#v", merged.Routes)
+	}
+}

--- a/cli/internal/solo/desiredstate_test.go
+++ b/cli/internal/solo/desiredstate_test.go
@@ -2,6 +2,8 @@ package solo
 
 import (
 	"encoding/json"
+	"reflect"
+	"sort"
 	"strings"
 	"testing"
 
@@ -341,7 +343,7 @@ func TestMergeIngressForNodeSortsRoutesByPortWhenMatchFieldsTie(t *testing.T) {
 		},
 	}
 
-	merged, err := mergeIngressForNode([]string{config.DefaultWebRole}, snapshots)
+	merged, err := mergeIngressForNode([]string{config.DefaultWebRole}, snapshots, aggregatedEnvironmentNames(snapshots))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -350,5 +352,73 @@ func TestMergeIngressForNodeSortsRoutesByPortWhenMatchFieldsTie(t *testing.T) {
 	}
 	if merged.Routes[0].Target.Port != "http" || merged.Routes[1].Target.Port != "metrics" {
 		t.Fatalf("route order = %#v", merged.Routes)
+	}
+}
+
+func TestBuildAggregatedDesiredStateNamespacesDuplicateEnvironmentNames(t *testing.T) {
+	t.Parallel()
+
+	currentNode := config.SoloNode{Labels: []string{config.DefaultWebRole}}
+	snapshots := []DeploySnapshot{
+		{
+			WorkspaceRoot: "/workspace/a",
+			WorkspaceKey:  "/workspace/a",
+			Environment:   "production",
+			Revision:      "aaa1111",
+			Metadata:      SnapshotMetadata{Project: "alpha"},
+			Services:      []serviceJSON{{Name: "web", Kind: config.ServiceKindWeb, Image: "alpha:aaa1111"}},
+			Ingress: &ingressJSON{
+				Mode:  "public",
+				TLS:   ingressTLSJSON{Mode: "auto"},
+				Hosts: []string{"a.example.com"},
+				Routes: []ingressRouteJSON{{
+					Match:  ingressMatchJSON{Hostname: "a.example.com"},
+					Target: ingressTargetJSON{Environment: "production", Service: "web", Port: "http"},
+				}},
+			},
+			IngressService:     "web",
+			IngressServiceKind: config.ServiceKindWeb,
+		},
+		{
+			WorkspaceRoot: "/workspace/b",
+			WorkspaceKey:  "/workspace/b",
+			Environment:   "production",
+			Revision:      "bbb2222",
+			Metadata:      SnapshotMetadata{Project: "bravo"},
+			Services:      []serviceJSON{{Name: "web", Kind: config.ServiceKindWeb, Image: "bravo:bbb2222"}},
+			Ingress: &ingressJSON{
+				Mode:  "public",
+				TLS:   ingressTLSJSON{Mode: "auto"},
+				Hosts: []string{"b.example.com"},
+				Routes: []ingressRouteJSON{{
+					Match:  ingressMatchJSON{Hostname: "b.example.com"},
+					Target: ingressTargetJSON{Environment: "production", Service: "web", Port: "http"},
+				}},
+			},
+			IngressService:     "web",
+			IngressServiceKind: config.ServiceKindWeb,
+		},
+	}
+
+	data, err := BuildAggregatedDesiredState("web-a", currentNode, snapshots, map[string]string{}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var ds desiredStateJSON
+	if err := json.Unmarshal(data, &ds); err != nil {
+		t.Fatal(err)
+	}
+	if len(ds.Environments) != 2 {
+		t.Fatalf("environments = %#v", ds.Environments)
+	}
+	gotNames := []string{ds.Environments[0].Name, ds.Environments[1].Name}
+	if gotNames[0] == gotNames[1] {
+		t.Fatalf("environment names should be unique: %#v", gotNames)
+	}
+	gotTargets := []string{ds.Ingress.Routes[0].Target.Environment, ds.Ingress.Routes[1].Target.Environment}
+	sort.Strings(gotNames)
+	sort.Strings(gotTargets)
+	if !reflect.DeepEqual(gotNames, gotTargets) {
+		t.Fatalf("ingress targets = %#v, want %#v", gotTargets, gotNames)
 	}
 }

--- a/cli/internal/solo/desiredstate_test.go
+++ b/cli/internal/solo/desiredstate_test.go
@@ -217,3 +217,96 @@ func TestBuildDesiredState_MissingSecretErrors(t *testing.T) {
 		t.Errorf("expected error to mention DATABASE_URL, got: %s", got)
 	}
 }
+
+func TestBuildAggregatedDesiredStateMergesEnvironmentsIngressAndPeers(t *testing.T) {
+	webNode := config.SoloNode{Labels: []string{config.DefaultWebRole}}
+	snapshots := []DeploySnapshot{
+		{
+			WorkspaceRoot:      "/workspace/a",
+			WorkspaceKey:       "/workspace/a",
+			Environment:        "production",
+			Revision:           "aaa1111",
+			Image:              "demo-a:aaa1111",
+			Services:           []serviceJSON{{Name: "web", Kind: config.ServiceKindWeb, Image: "demo-a:aaa1111"}},
+			ReleaseTask:        &taskJSON{Name: "release", Image: "demo-a:aaa1111"},
+			ReleaseService:     "web",
+			ReleaseServiceKind: config.ServiceKindWeb,
+			Ingress: &ingressJSON{
+				Mode:         "public",
+				Hosts:        []string{"a.example.com"},
+				TLS:          ingressTLSJSON{Mode: "auto"},
+				RedirectHTTP: true,
+				Routes: []ingressRouteJSON{{
+					Match:  ingressMatchJSON{Hostname: "a.example.com"},
+					Target: ingressTargetJSON{Environment: "production", Service: "web", Port: "http"},
+				}},
+			},
+			IngressService:     "web",
+			IngressServiceKind: config.ServiceKindWeb,
+		},
+		{
+			WorkspaceRoot:      "/workspace/b",
+			WorkspaceKey:       "/workspace/b",
+			Environment:        "production",
+			Revision:           "bbb2222",
+			Image:              "demo-b:bbb2222",
+			Services:           []serviceJSON{{Name: "web", Kind: config.ServiceKindWeb, Image: "demo-b:bbb2222"}},
+			ReleaseService:     "web",
+			ReleaseServiceKind: config.ServiceKindWeb,
+			Ingress: &ingressJSON{
+				Mode:         "public",
+				Hosts:        []string{"b.example.com"},
+				TLS:          ingressTLSJSON{Mode: "auto"},
+				RedirectHTTP: true,
+				Routes: []ingressRouteJSON{{
+					Match:  ingressMatchJSON{Hostname: "b.example.com"},
+					Target: ingressTargetJSON{Environment: "production", Service: "web", Port: "http"},
+				}},
+			},
+			IngressService:     "web",
+			IngressServiceKind: config.ServiceKindWeb,
+		},
+	}
+	releaseNodes := map[string]string{
+		"/workspace/a\nproduction": "shared-1",
+	}
+	peers := []NodePeer{
+		{Name: "shared-2", Labels: []string{config.DefaultWebRole}, PublicAddress: "203.0.113.12"},
+		{Name: "shared-3", Labels: []string{config.DefaultWorkerRole}, PublicAddress: "203.0.113.13"},
+	}
+
+	first, err := BuildAggregatedDesiredState("shared-1", webNode, snapshots, releaseNodes, peers)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := BuildAggregatedDesiredState("shared-1", webNode, snapshots, releaseNodes, peers)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var ds desiredStateJSON
+	if err := json.Unmarshal(first, &ds); err != nil {
+		t.Fatal(err)
+	}
+	if string(first) != string(second) {
+		t.Fatal("expected deterministic aggregated desired state output")
+	}
+	if len(ds.Environments) != 2 || ds.Environments[0].Revision != "aaa1111" || ds.Environments[1].Revision != "bbb2222" {
+		t.Fatalf("environments = %#v", ds.Environments)
+	}
+	if ds.Ingress == nil || len(ds.Ingress.Routes) != 2 {
+		t.Fatalf("ingress = %#v", ds.Ingress)
+	}
+	if strings.Join(ds.Ingress.Hosts, ",") != "a.example.com,b.example.com" {
+		t.Fatalf("hosts = %#v", ds.Ingress.Hosts)
+	}
+	if len(ds.NodePeers) != 2 || ds.NodePeers[0].Name != "shared-2" || ds.NodePeers[1].Name != "shared-3" {
+		t.Fatalf("node peers = %#v", ds.NodePeers)
+	}
+	if ds.Revision == "" {
+		t.Fatal("synthetic revision empty")
+	}
+	if len(ds.Environments[0].Tasks) != 1 || len(ds.Environments[1].Tasks) != 0 {
+		t.Fatalf("tasks = %#v", ds.Environments)
+	}
+}

--- a/cli/internal/solo/state.go
+++ b/cli/internal/solo/state.go
@@ -1,0 +1,429 @@
+package solo
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/devopsellence/cli/internal/config"
+	"github.com/devopsellence/cli/internal/state"
+)
+
+const soloStateSchemaVersion = 1
+
+type StateStore struct {
+	Path string
+}
+
+type State struct {
+	SchemaVersion int                         `json:"schema_version"`
+	Nodes         map[string]config.SoloNode  `json:"nodes,omitempty"`
+	Attachments   map[string]AttachmentRecord `json:"attachments,omitempty"`
+	Snapshots     map[string]DeploySnapshot   `json:"snapshots,omitempty"`
+}
+
+type AttachmentRecord struct {
+	WorkspaceRoot string   `json:"workspace_root"`
+	WorkspaceKey  string   `json:"workspace_key"`
+	Environment   string   `json:"environment"`
+	NodeNames     []string `json:"node_names,omitempty"`
+}
+
+type SnapshotMetadata struct {
+	AppType    string `json:"app_type,omitempty"`
+	ConfigPath string `json:"config_path,omitempty"`
+	Project    string `json:"project,omitempty"`
+	UpdatedAt  string `json:"updated_at,omitempty"`
+}
+
+type DeploySnapshot struct {
+	WorkspaceRoot      string           `json:"workspace_root"`
+	WorkspaceKey       string           `json:"workspace_key"`
+	Environment        string           `json:"environment"`
+	Revision           string           `json:"revision"`
+	Image              string           `json:"image"`
+	Services           []serviceJSON    `json:"services,omitempty"`
+	ReleaseTask        *taskJSON        `json:"release_task,omitempty"`
+	ReleaseService     string           `json:"release_service,omitempty"`
+	ReleaseServiceKind string           `json:"release_service_kind,omitempty"`
+	Ingress            *ingressJSON     `json:"ingress,omitempty"`
+	IngressService     string           `json:"ingress_service,omitempty"`
+	IngressServiceKind string           `json:"ingress_service_kind,omitempty"`
+	Metadata           SnapshotMetadata `json:"metadata,omitempty"`
+}
+
+func DefaultStatePath() string {
+	return state.DefaultPath(filepath.Join("devopsellence", "solo", "state.json"))
+}
+
+func NewStateStore(path string) *StateStore {
+	return &StateStore{Path: path}
+}
+
+func (s *StateStore) Read() (State, error) {
+	if s == nil || strings.TrimSpace(s.Path) == "" {
+		return newState(), nil
+	}
+	data, err := os.ReadFile(s.Path)
+	if errors.Is(err, os.ErrNotExist) {
+		return newState(), nil
+	}
+	if err != nil {
+		return State{}, err
+	}
+	var current State
+	if err := json.Unmarshal(data, &current); err != nil {
+		return State{}, err
+	}
+	if current.SchemaVersion == 0 {
+		current.SchemaVersion = soloStateSchemaVersion
+	}
+	current.ensureDefaults()
+	return current, nil
+}
+
+func (s *StateStore) Write(current State) error {
+	if s == nil || strings.TrimSpace(s.Path) == "" {
+		return errors.New("solo state store path is required")
+	}
+	current.ensureDefaults()
+	if err := os.MkdirAll(filepath.Dir(s.Path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(current, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(s.Path, data, 0o600); err != nil {
+		return err
+	}
+	return os.Chmod(s.Path, 0o600)
+}
+
+func (s *StateStore) Update(fn func(*State) error) error {
+	current, err := s.Read()
+	if err != nil {
+		return err
+	}
+	if err := fn(&current); err != nil {
+		return err
+	}
+	return s.Write(current)
+}
+
+func CanonicalWorkspaceKey(workspaceRoot string) (string, error) {
+	abs, err := filepath.Abs(strings.TrimSpace(workspaceRoot))
+	if err != nil {
+		return "", err
+	}
+	if resolved, err := filepath.EvalSymlinks(abs); err == nil && strings.TrimSpace(resolved) != "" {
+		abs = resolved
+	}
+	return filepath.Clean(abs), nil
+}
+
+func EnvironmentStateKey(workspaceRoot, environment string) (string, error) {
+	workspaceKey, err := CanonicalWorkspaceKey(workspaceRoot)
+	if err != nil {
+		return "", err
+	}
+	environment = strings.TrimSpace(environment)
+	if environment == "" {
+		environment = config.DefaultEnvironment
+	}
+	return workspaceKey + "\n" + environment, nil
+}
+
+func BuildDeploySnapshot(cfg *config.ProjectConfig, workspaceRoot, configPath, imageTag, revision string, secrets map[string]string) (DeploySnapshot, error) {
+	if cfg == nil {
+		return DeploySnapshot{}, fmt.Errorf("config is required")
+	}
+	workspaceKey, err := CanonicalWorkspaceKey(workspaceRoot)
+	if err != nil {
+		return DeploySnapshot{}, err
+	}
+	environmentName := strings.TrimSpace(cfg.DefaultEnvironment)
+	if environmentName == "" {
+		environmentName = config.DefaultEnvironment
+	}
+	snapshot := DeploySnapshot{
+		WorkspaceRoot: workspaceRoot,
+		WorkspaceKey:  workspaceKey,
+		Environment:   environmentName,
+		Revision:      strings.TrimSpace(revision),
+		Image:         strings.TrimSpace(imageTag),
+		Metadata: SnapshotMetadata{
+			AppType:    strings.TrimSpace(cfg.App.Type),
+			ConfigPath: strings.TrimSpace(configPath),
+			Project:    strings.TrimSpace(cfg.Project),
+			UpdatedAt:  time.Now().UTC().Format(time.RFC3339),
+		},
+	}
+	for _, serviceName := range cfg.ServiceNames() {
+		service := cfg.Services[serviceName]
+		rendered, err := buildService(serviceName, service, imageTag, secrets)
+		if err != nil {
+			return DeploySnapshot{}, fmt.Errorf("build service %s: %w", serviceName, err)
+		}
+		snapshot.Services = append(snapshot.Services, rendered)
+	}
+	if cfg.ReleaseTask() != nil {
+		releaseTask, err := buildReleaseTask(cfg, imageTag, secrets)
+		if err != nil {
+			return DeploySnapshot{}, fmt.Errorf("build release task: %w", err)
+		}
+		snapshot.ReleaseTask = &releaseTask
+		snapshot.ReleaseService = cfg.ReleaseTask().Service
+		if service, ok := cfg.Services[cfg.ReleaseTask().Service]; ok {
+			snapshot.ReleaseServiceKind = service.Kind
+		}
+	}
+	if cfg.Ingress != nil {
+		snapshot.Ingress = buildIngress(cfg.Ingress, environmentName)
+		snapshot.IngressService = cfg.Ingress.Service
+		if service, ok := cfg.Services[cfg.Ingress.Service]; ok {
+			snapshot.IngressServiceKind = service.Kind
+		}
+	}
+	return snapshot, nil
+}
+
+func newState() State {
+	return State{
+		SchemaVersion: soloStateSchemaVersion,
+		Nodes:         map[string]config.SoloNode{},
+		Attachments:   map[string]AttachmentRecord{},
+		Snapshots:     map[string]DeploySnapshot{},
+	}
+}
+
+func (s *State) ensureDefaults() {
+	if s.SchemaVersion == 0 {
+		s.SchemaVersion = soloStateSchemaVersion
+	}
+	if s.Nodes == nil {
+		s.Nodes = map[string]config.SoloNode{}
+	}
+	if s.Attachments == nil {
+		s.Attachments = map[string]AttachmentRecord{}
+	}
+	if s.Snapshots == nil {
+		s.Snapshots = map[string]DeploySnapshot{}
+	}
+	for name, node := range s.Nodes {
+		s.Nodes[name] = NormalizeNode(node)
+	}
+	for key, attachment := range s.Attachments {
+		attachment.NodeNames = normalizeNodeNames(attachment.NodeNames)
+		if attachment.WorkspaceKey == "" {
+			attachment.WorkspaceKey = strings.TrimSpace(strings.SplitN(key, "\n", 2)[0])
+		}
+		if attachment.Environment == "" {
+			parts := strings.SplitN(key, "\n", 2)
+			if len(parts) == 2 {
+				attachment.Environment = strings.TrimSpace(parts[1])
+			}
+		}
+		s.Attachments[key] = attachment
+	}
+}
+
+func NormalizeNode(node config.SoloNode) config.SoloNode {
+	if node.Port == 0 {
+		node.Port = 22
+	}
+	if strings.TrimSpace(node.AgentStateDir) == "" {
+		node.AgentStateDir = "/var/lib/devopsellence"
+	}
+	labels := normalizeNodeLabels(node.Labels)
+	if len(labels) == 0 {
+		labels = append([]string(nil), config.SoloDefaultLabels...)
+	}
+	node.Labels = labels
+	return node
+}
+
+func normalizeNodeLabels(labels []string) []string {
+	seen := map[string]bool{}
+	normalized := make([]string, 0, len(labels))
+	for _, label := range labels {
+		label = strings.TrimSpace(label)
+		if label == "" || seen[label] {
+			continue
+		}
+		seen[label] = true
+		normalized = append(normalized, label)
+	}
+	return normalized
+}
+
+func (s *State) NodeNames() []string {
+	s.ensureDefaults()
+	names := make([]string, 0, len(s.Nodes))
+	for name := range s.Nodes {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func (s *State) SetNode(name string, node config.SoloNode) error {
+	s.ensureDefaults()
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return fmt.Errorf("node name is required")
+	}
+	s.Nodes[name] = NormalizeNode(node)
+	return nil
+}
+
+func (s *State) RemoveNode(name string) {
+	s.ensureDefaults()
+	delete(s.Nodes, strings.TrimSpace(name))
+}
+
+func (s *State) Attachment(workspaceRoot, environment string) (string, AttachmentRecord, bool, error) {
+	s.ensureDefaults()
+	key, err := EnvironmentStateKey(workspaceRoot, environment)
+	if err != nil {
+		return "", AttachmentRecord{}, false, err
+	}
+	record, ok := s.Attachments[key]
+	return key, record, ok, nil
+}
+
+func (s *State) Snapshot(workspaceRoot, environment string) (string, DeploySnapshot, bool, error) {
+	s.ensureDefaults()
+	key, err := EnvironmentStateKey(workspaceRoot, environment)
+	if err != nil {
+		return "", DeploySnapshot{}, false, err
+	}
+	snapshot, ok := s.Snapshots[key]
+	return key, snapshot, ok, nil
+}
+
+func (s *State) SaveSnapshot(snapshot DeploySnapshot) (string, error) {
+	s.ensureDefaults()
+	key, err := EnvironmentStateKey(snapshot.WorkspaceRoot, snapshot.Environment)
+	if err != nil {
+		return "", err
+	}
+	snapshot.WorkspaceKey, _ = CanonicalWorkspaceKey(snapshot.WorkspaceRoot)
+	s.Snapshots[key] = snapshot
+	return key, nil
+}
+
+func (s *State) AttachNode(workspaceRoot, environment, nodeName string) (AttachmentRecord, bool, error) {
+	s.ensureDefaults()
+	nodeName = strings.TrimSpace(nodeName)
+	if _, ok := s.Nodes[nodeName]; !ok {
+		return AttachmentRecord{}, false, fmt.Errorf("node %q not found", nodeName)
+	}
+	key, attachment, _, err := s.Attachment(workspaceRoot, environment)
+	if err != nil {
+		return AttachmentRecord{}, false, err
+	}
+	workspaceKey, _ := CanonicalWorkspaceKey(workspaceRoot)
+	attachment.WorkspaceRoot = workspaceRoot
+	attachment.WorkspaceKey = workspaceKey
+	attachment.Environment = defaultEnvironmentName(environment)
+	before := len(attachment.NodeNames)
+	attachment.NodeNames = append(attachment.NodeNames, nodeName)
+	attachment.NodeNames = normalizeNodeNames(attachment.NodeNames)
+	s.Attachments[key] = attachment
+	return attachment, len(attachment.NodeNames) != before, nil
+}
+
+func (s *State) DetachNode(workspaceRoot, environment, nodeName string) (AttachmentRecord, bool, error) {
+	s.ensureDefaults()
+	key, attachment, ok, err := s.Attachment(workspaceRoot, environment)
+	if err != nil {
+		return AttachmentRecord{}, false, err
+	}
+	if !ok {
+		return AttachmentRecord{}, false, nil
+	}
+	filtered := attachment.NodeNames[:0]
+	changed := false
+	for _, current := range attachment.NodeNames {
+		if strings.TrimSpace(current) == strings.TrimSpace(nodeName) {
+			changed = true
+			continue
+		}
+		filtered = append(filtered, current)
+	}
+	attachment.NodeNames = normalizeNodeNames(filtered)
+	if len(attachment.NodeNames) == 0 {
+		delete(s.Attachments, key)
+		return AttachmentRecord{}, changed, nil
+	}
+	s.Attachments[key] = attachment
+	return attachment, changed, nil
+}
+
+func (s *State) AttachmentKeysForNode(nodeName string) []string {
+	s.ensureDefaults()
+	keys := []string{}
+	for key, attachment := range s.Attachments {
+		for _, current := range attachment.NodeNames {
+			if current == nodeName {
+				keys = append(keys, key)
+				break
+			}
+		}
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func (s *State) AttachmentsForNode(nodeName string) []AttachmentRecord {
+	keys := s.AttachmentKeysForNode(nodeName)
+	result := make([]AttachmentRecord, 0, len(keys))
+	for _, key := range keys {
+		result = append(result, s.Attachments[key])
+	}
+	return result
+}
+
+func (s *State) AttachedNodeNames(workspaceRoot, environment string) ([]string, error) {
+	_, attachment, ok, err := s.Attachment(workspaceRoot, environment)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, nil
+	}
+	return append([]string(nil), attachment.NodeNames...), nil
+}
+
+func (s *State) NodeHasAttachments(nodeName string) bool {
+	return len(s.AttachmentKeysForNode(nodeName)) > 0
+}
+
+func normalizeNodeNames(names []string) []string {
+	seen := map[string]bool{}
+	normalized := make([]string, 0, len(names))
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		normalized = append(normalized, name)
+	}
+	sort.Strings(normalized)
+	return normalized
+}
+
+func defaultEnvironmentName(name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return config.DefaultEnvironment
+	}
+	return name
+}

--- a/cli/internal/solo/state.go
+++ b/cli/internal/solo/state.go
@@ -442,7 +442,7 @@ func (s *State) SaveSnapshot(snapshot DeploySnapshot) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	snapshot.WorkspaceKey, _ = CanonicalWorkspaceKey(snapshot.WorkspaceRoot)
+	snapshot.WorkspaceKey, _ = splitEnvironmentStateKey(key)
 	s.Snapshots[key] = snapshot
 	return key, nil
 }

--- a/cli/internal/solo/state.go
+++ b/cli/internal/solo/state.go
@@ -216,6 +216,40 @@ func BuildDeploySnapshot(cfg *config.ProjectConfig, workspaceRoot, configPath, i
 	return snapshot, nil
 }
 
+func RedactDeploySnapshotSecrets(snapshot DeploySnapshot, cfg *config.ProjectConfig) DeploySnapshot {
+	if cfg == nil {
+		return snapshot
+	}
+	serviceSecretRefs := map[string][]string{}
+	for _, serviceName := range cfg.ServiceNames() {
+		service := cfg.Services[serviceName]
+		for _, ref := range service.SecretRefs {
+			serviceSecretRefs[serviceName] = append(serviceSecretRefs[serviceName], ref.Name)
+		}
+	}
+	for i := range snapshot.Services {
+		snapshot.Services[i].Env = redactedEnv(snapshot.Services[i].Env, serviceSecretRefs[snapshot.Services[i].Name])
+	}
+	if snapshot.ReleaseTask != nil && cfg.ReleaseTask() != nil {
+		snapshot.ReleaseTask.Env = redactedEnv(snapshot.ReleaseTask.Env, serviceSecretRefs[cfg.ReleaseTask().Service])
+	}
+	return snapshot
+}
+
+func redactedEnv(env map[string]string, secretNames []string) map[string]string {
+	if len(env) == 0 || len(secretNames) == 0 {
+		return env
+	}
+	redacted := make(map[string]string, len(env))
+	for key, value := range env {
+		redacted[key] = value
+	}
+	for _, name := range secretNames {
+		delete(redacted, name)
+	}
+	return redacted
+}
+
 func newState() State {
 	return State{
 		SchemaVersion: soloStateSchemaVersion,

--- a/cli/internal/solo/state.go
+++ b/cli/internal/solo/state.go
@@ -535,6 +535,7 @@ func (s *State) DetachNode(workspaceRoot, environment, nodeName string) (Attachm
 
 func (s *State) AttachmentKeysForNode(nodeName string) []string {
 	s.ensureDefaults()
+	nodeName = strings.TrimSpace(nodeName)
 	keys := []string{}
 	for key, attachment := range s.Attachments {
 		for _, current := range attachment.NodeNames {

--- a/cli/internal/solo/state.go
+++ b/cli/internal/solo/state.go
@@ -80,11 +80,15 @@ func (s *StateStore) Read() (State, error) {
 	if err := json.Unmarshal(data, &current); err != nil {
 		return State{}, err
 	}
-	if current.SchemaVersion == 0 {
-		current.SchemaVersion = soloStateSchemaVersion
+	if err := validateStateSchemaVersion(current.SchemaVersion); err != nil {
+		return State{}, err
 	}
+	current.SchemaVersion = soloStateSchemaVersion
 	current.ensureDefaults()
-	current = normalizeState(current)
+	current, err = normalizeState(current)
+	if err != nil {
+		return State{}, err
+	}
 	return current, nil
 }
 
@@ -92,8 +96,16 @@ func (s *StateStore) Write(current State) error {
 	if s == nil || strings.TrimSpace(s.Path) == "" {
 		return errors.New("solo state store path is required")
 	}
+	if err := validateStateSchemaVersion(current.SchemaVersion); err != nil {
+		return err
+	}
+	current.SchemaVersion = soloStateSchemaVersion
 	current.ensureDefaults()
-	current = normalizeState(current)
+	var err error
+	current, err = normalizeState(current)
+	if err != nil {
+		return err
+	}
 	if err := os.MkdirAll(filepath.Dir(s.Path), 0o755); err != nil {
 		return err
 	}
@@ -116,6 +128,15 @@ func (s *StateStore) Update(fn func(*State) error) error {
 		return err
 	}
 	return s.Write(current)
+}
+
+func validateStateSchemaVersion(version int) error {
+	switch version {
+	case 0, soloStateSchemaVersion:
+		return nil
+	default:
+		return fmt.Errorf("unsupported solo state schema_version %d", version)
+	}
 }
 
 func CanonicalWorkspaceKey(workspaceRoot string) (string, error) {
@@ -219,14 +240,18 @@ func (s *State) ensureDefaults() {
 	}
 }
 
-func normalizeState(current State) State {
+func normalizeState(current State) (State, error) {
 	for name, node := range current.Nodes {
-		current.Nodes[name] = NormalizeNode(node)
+		normalized, err := normalizeAndValidateNode(name, node)
+		if err != nil {
+			return State{}, err
+		}
+		current.Nodes[name] = normalized
 	}
 	for key, attachment := range current.Attachments {
 		current.Attachments[key] = normalizeAttachmentRecord(key, attachment)
 	}
-	return current
+	return current, nil
 }
 
 func normalizeAttachmentRecord(key string, attachment AttachmentRecord) AttachmentRecord {
@@ -285,10 +310,11 @@ func (s *State) NodeNames() []string {
 func (s *State) SetNode(name string, node config.SoloNode) error {
 	s.ensureDefaults()
 	name = strings.TrimSpace(name)
-	if name == "" {
-		return fmt.Errorf("node name is required")
+	normalized, err := normalizeAndValidateNode(name, node)
+	if err != nil {
+		return err
 	}
-	s.Nodes[name] = NormalizeNode(node)
+	s.Nodes[name] = normalized
 	return nil
 }
 
@@ -436,4 +462,22 @@ func defaultEnvironmentName(name string) string {
 		return config.DefaultEnvironment
 	}
 	return name
+}
+
+func normalizeAndValidateNode(name string, node config.SoloNode) (config.SoloNode, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return config.SoloNode{}, fmt.Errorf("node name is required")
+	}
+	node = NormalizeNode(node)
+	if strings.TrimSpace(node.Host) == "" {
+		return config.SoloNode{}, fmt.Errorf("node %q host is required", name)
+	}
+	if strings.TrimSpace(node.User) == "" {
+		return config.SoloNode{}, fmt.Errorf("node %q user is required", name)
+	}
+	if node.Port <= 0 || node.Port > 65535 {
+		return config.SoloNode{}, fmt.Errorf("node %q port must be between 1 and 65535", name)
+	}
+	return node, nil
 }

--- a/cli/internal/solo/state.go
+++ b/cli/internal/solo/state.go
@@ -457,13 +457,17 @@ func (s *State) AttachNode(workspaceRoot, environment, nodeName string) (Attachm
 	if err != nil {
 		return AttachmentRecord{}, false, err
 	}
-	workspaceKey, _ := CanonicalWorkspaceKey(workspaceRoot)
-	attachment.WorkspaceRoot = workspaceRoot
+	workspaceKey, keyEnvironment := splitEnvironmentStateKey(key)
+	attachment.WorkspaceRoot = firstNonEmpty(attachment.WorkspaceRoot, strings.TrimSpace(workspaceRoot), workspaceKey)
 	attachment.WorkspaceKey = workspaceKey
 	attachment.Environment = defaultEnvironmentName(environment)
+	if strings.TrimSpace(environment) == "" {
+		attachment.Environment = defaultEnvironmentName(keyEnvironment)
+	}
 	before := len(attachment.NodeNames)
-	attachment.NodeNames = append(attachment.NodeNames, nodeName)
-	attachment.NodeNames = normalizeNodeNames(attachment.NodeNames)
+	nodeNames := append([]string(nil), attachment.NodeNames...)
+	nodeNames = append(nodeNames, nodeName)
+	attachment.NodeNames = normalizeNodeNames(nodeNames)
 	s.Attachments[key] = attachment
 	return attachment, len(attachment.NodeNames) != before, nil
 }

--- a/cli/internal/solo/state.go
+++ b/cli/internal/solo/state.go
@@ -84,6 +84,7 @@ func (s *StateStore) Read() (State, error) {
 		current.SchemaVersion = soloStateSchemaVersion
 	}
 	current.ensureDefaults()
+	current = normalizeState(current)
 	return current, nil
 }
 
@@ -92,6 +93,7 @@ func (s *StateStore) Write(current State) error {
 		return errors.New("solo state store path is required")
 	}
 	current.ensureDefaults()
+	current = normalizeState(current)
 	if err := os.MkdirAll(filepath.Dir(s.Path), 0o755); err != nil {
 		return err
 	}
@@ -215,22 +217,30 @@ func (s *State) ensureDefaults() {
 	if s.Snapshots == nil {
 		s.Snapshots = map[string]DeploySnapshot{}
 	}
-	for name, node := range s.Nodes {
-		s.Nodes[name] = NormalizeNode(node)
+}
+
+func normalizeState(current State) State {
+	for name, node := range current.Nodes {
+		current.Nodes[name] = NormalizeNode(node)
 	}
-	for key, attachment := range s.Attachments {
-		attachment.NodeNames = normalizeNodeNames(attachment.NodeNames)
-		if attachment.WorkspaceKey == "" {
-			attachment.WorkspaceKey = strings.TrimSpace(strings.SplitN(key, "\n", 2)[0])
-		}
-		if attachment.Environment == "" {
-			parts := strings.SplitN(key, "\n", 2)
-			if len(parts) == 2 {
-				attachment.Environment = strings.TrimSpace(parts[1])
-			}
-		}
-		s.Attachments[key] = attachment
+	for key, attachment := range current.Attachments {
+		current.Attachments[key] = normalizeAttachmentRecord(key, attachment)
 	}
+	return current
+}
+
+func normalizeAttachmentRecord(key string, attachment AttachmentRecord) AttachmentRecord {
+	attachment.NodeNames = normalizeNodeNames(attachment.NodeNames)
+	if attachment.WorkspaceKey == "" {
+		attachment.WorkspaceKey = strings.TrimSpace(strings.SplitN(key, "\n", 2)[0])
+	}
+	if attachment.Environment == "" {
+		parts := strings.SplitN(key, "\n", 2)
+		if len(parts) == 2 {
+			attachment.Environment = strings.TrimSpace(parts[1])
+		}
+	}
+	return attachment
 }
 
 func NormalizeNode(node config.SoloNode) config.SoloNode {

--- a/cli/internal/solo/state.go
+++ b/cli/internal/solo/state.go
@@ -241,31 +241,124 @@ func (s *State) ensureDefaults() {
 }
 
 func normalizeState(current State) (State, error) {
-	for name, node := range current.Nodes {
+	nodeNames := make([]string, 0, len(current.Nodes))
+	for name := range current.Nodes {
+		nodeNames = append(nodeNames, name)
+	}
+	sort.Strings(nodeNames)
+	normalizedNodes := make(map[string]config.SoloNode, len(current.Nodes))
+	for _, name := range nodeNames {
+		node := current.Nodes[name]
 		normalized, err := normalizeAndValidateNode(name, node)
 		if err != nil {
 			return State{}, err
 		}
-		current.Nodes[name] = normalized
+		normalizedNodes[name] = normalized
 	}
-	for key, attachment := range current.Attachments {
-		current.Attachments[key] = normalizeAttachmentRecord(key, attachment)
+	current.Nodes = normalizedNodes
+
+	attachmentKeys := make([]string, 0, len(current.Attachments))
+	for key := range current.Attachments {
+		attachmentKeys = append(attachmentKeys, key)
 	}
+	sort.Strings(attachmentKeys)
+	normalizedAttachments := make(map[string]AttachmentRecord, len(current.Attachments))
+	for _, key := range attachmentKeys {
+		normalizedKey, attachment, err := normalizeAttachmentRecord(key, current.Attachments[key])
+		if err != nil {
+			return State{}, fmt.Errorf("normalize attachment %q: %w", key, err)
+		}
+		if existing, ok := normalizedAttachments[normalizedKey]; ok {
+			attachment.NodeNames = normalizeNodeNames(append(existing.NodeNames, attachment.NodeNames...))
+			if strings.TrimSpace(attachment.WorkspaceRoot) == "" {
+				attachment.WorkspaceRoot = existing.WorkspaceRoot
+			}
+		}
+		normalizedAttachments[normalizedKey] = attachment
+	}
+	current.Attachments = normalizedAttachments
+
+	snapshotKeys := make([]string, 0, len(current.Snapshots))
+	for key := range current.Snapshots {
+		snapshotKeys = append(snapshotKeys, key)
+	}
+	sort.Strings(snapshotKeys)
+	normalizedSnapshots := make(map[string]DeploySnapshot, len(current.Snapshots))
+	for _, key := range snapshotKeys {
+		normalizedKey, snapshot, err := normalizeSnapshotRecord(key, current.Snapshots[key])
+		if err != nil {
+			return State{}, fmt.Errorf("normalize snapshot %q: %w", key, err)
+		}
+		normalizedSnapshots[normalizedKey] = snapshot
+	}
+	current.Snapshots = normalizedSnapshots
+
 	return current, nil
 }
 
-func normalizeAttachmentRecord(key string, attachment AttachmentRecord) AttachmentRecord {
-	attachment.NodeNames = normalizeNodeNames(attachment.NodeNames)
-	if attachment.WorkspaceKey == "" {
-		attachment.WorkspaceKey = strings.TrimSpace(strings.SplitN(key, "\n", 2)[0])
+func normalizeAttachmentRecord(key string, attachment AttachmentRecord) (string, AttachmentRecord, error) {
+	workspaceRoot, workspaceKey, err := normalizeWorkspaceIdentity(key, attachment.WorkspaceRoot, attachment.WorkspaceKey)
+	if err != nil {
+		return "", AttachmentRecord{}, err
 	}
-	if attachment.Environment == "" {
-		parts := strings.SplitN(key, "\n", 2)
-		if len(parts) == 2 {
-			attachment.Environment = strings.TrimSpace(parts[1])
+	_, keyEnvironment := splitEnvironmentStateKey(key)
+	environment := defaultEnvironmentName(firstNonEmpty(attachment.Environment, keyEnvironment))
+	attachment.NodeNames = normalizeNodeNames(attachment.NodeNames)
+	attachment.WorkspaceRoot = workspaceRoot
+	attachment.WorkspaceKey = workspaceKey
+	attachment.Environment = environment
+	return workspaceKey + "\n" + environment, attachment, nil
+}
+
+func normalizeSnapshotRecord(key string, snapshot DeploySnapshot) (string, DeploySnapshot, error) {
+	workspaceRoot, workspaceKey, err := normalizeWorkspaceIdentity(key, snapshot.WorkspaceRoot, snapshot.WorkspaceKey)
+	if err != nil {
+		return "", DeploySnapshot{}, err
+	}
+	_, keyEnvironment := splitEnvironmentStateKey(key)
+	snapshot.WorkspaceRoot = workspaceRoot
+	snapshot.WorkspaceKey = workspaceKey
+	snapshot.Environment = defaultEnvironmentName(firstNonEmpty(snapshot.Environment, keyEnvironment))
+	return snapshot.WorkspaceKey + "\n" + snapshot.Environment, snapshot, nil
+}
+
+func normalizeWorkspaceIdentity(key, workspaceRoot, workspaceKey string) (string, string, error) {
+	keyWorkspace, _ := splitEnvironmentStateKey(key)
+	workspaceSource := firstNonEmpty(workspaceRoot, workspaceKey, keyWorkspace)
+	if strings.TrimSpace(workspaceSource) == "" {
+		return "", "", errors.New("workspace identity is required")
+	}
+	canonicalKey, err := CanonicalWorkspaceKey(workspaceSource)
+	if err != nil {
+		return "", "", err
+	}
+	workspaceRoot = strings.TrimSpace(workspaceRoot)
+	if workspaceRoot == "" {
+		workspaceRoot = canonicalKey
+	}
+	return workspaceRoot, canonicalKey, nil
+}
+
+func splitEnvironmentStateKey(key string) (string, string) {
+	parts := strings.SplitN(key, "\n", 2)
+	workspace := ""
+	environment := ""
+	if len(parts) > 0 {
+		workspace = strings.TrimSpace(parts[0])
+	}
+	if len(parts) == 2 {
+		environment = strings.TrimSpace(parts[1])
+	}
+	return workspace, environment
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
 		}
 	}
-	return attachment
+	return ""
 }
 
 func NormalizeNode(node config.SoloNode) config.SoloNode {

--- a/cli/internal/solo/state.go
+++ b/cli/internal/solo/state.go
@@ -384,7 +384,7 @@ func (s *State) DetachNode(workspaceRoot, environment, nodeName string) (Attachm
 	if !ok {
 		return AttachmentRecord{}, false, nil
 	}
-	filtered := attachment.NodeNames[:0]
+	filtered := make([]string, 0, len(attachment.NodeNames))
 	changed := false
 	for _, current := range attachment.NodeNames {
 		if strings.TrimSpace(current) == strings.TrimSpace(nodeName) {

--- a/cli/internal/solo/state_test.go
+++ b/cli/internal/solo/state_test.go
@@ -123,6 +123,39 @@ func TestStateStoreReadNormalizesLegacyData(t *testing.T) {
 	}
 }
 
+func TestStateStoreReadNormalizesLegacySnapshots(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "solo-state.json")
+	if err := os.WriteFile(path, []byte(`{
+  "schema_version": 1,
+  "snapshots": {
+    "/workspace/demo\nproduction": {
+      "workspace_root": "/workspace/demo",
+      "revision": "abc1234",
+      "image": "demo:abc1234"
+    }
+  }
+}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := NewStateStore(path).Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot, ok := loaded.Snapshots["/workspace/demo\nproduction"]
+	if !ok {
+		t.Fatalf("normalized snapshot missing: %#v", loaded.Snapshots)
+	}
+	if snapshot.WorkspaceKey != "/workspace/demo" {
+		t.Fatalf("workspace_key = %q, want /workspace/demo", snapshot.WorkspaceKey)
+	}
+	if snapshot.Environment != "production" {
+		t.Fatalf("environment = %q, want production", snapshot.Environment)
+	}
+}
+
 func TestAttachmentKeysForNodeDoesNotMutateState(t *testing.T) {
 	t.Parallel()
 

--- a/cli/internal/solo/state_test.go
+++ b/cli/internal/solo/state_test.go
@@ -81,6 +81,73 @@ func TestStateStoreRoundTrip(t *testing.T) {
 	}
 }
 
+func TestStateStoreReadNormalizesLegacyData(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "solo-state.json")
+	if err := os.WriteFile(path, []byte(`{
+  "schema_version": 1,
+  "nodes": {
+    "web-a": {
+      "host": "203.0.113.10",
+      "user": "root",
+      "labels": ["web", "web"]
+    }
+  },
+  "attachments": {
+    "/workspace/demo\nproduction": {
+      "workspace_root": "/workspace/demo",
+      "node_names": ["web-b", "web-a", "web-a"]
+    }
+  }
+}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := NewStateStore(path).Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := loaded.Nodes["web-a"].AgentStateDir; got != "/var/lib/devopsellence" {
+		t.Fatalf("agent_state_dir = %q, want default", got)
+	}
+	if got := loaded.Attachments["/workspace/demo\nproduction"].WorkspaceKey; got != "/workspace/demo" {
+		t.Fatalf("workspace_key = %q, want /workspace/demo", got)
+	}
+	if got := loaded.Attachments["/workspace/demo\nproduction"].Environment; got != "production" {
+		t.Fatalf("environment = %q, want production", got)
+	}
+	if got := loaded.Attachments["/workspace/demo\nproduction"].NodeNames; !reflect.DeepEqual(got, []string{"web-a", "web-b"}) {
+		t.Fatalf("node_names = %#v", got)
+	}
+}
+
+func TestAttachmentKeysForNodeDoesNotMutateState(t *testing.T) {
+	t.Parallel()
+
+	current := State{
+		SchemaVersion: soloStateSchemaVersion,
+		Nodes: map[string]config.SoloNode{
+			"web-a": {Host: "203.0.113.10", User: "root"},
+		},
+		Attachments: map[string]AttachmentRecord{
+			"/workspace/demo\nproduction": {
+				WorkspaceRoot: "/workspace/demo",
+				NodeNames:     []string{"web-a", "web-a"},
+			},
+		},
+		Snapshots: map[string]DeploySnapshot{},
+	}
+
+	keys := current.AttachmentKeysForNode("web-a")
+	if want := []string{"/workspace/demo\nproduction"}; !reflect.DeepEqual(keys, want) {
+		t.Fatalf("AttachmentKeysForNode() = %#v, want %#v", keys, want)
+	}
+	if got := current.Attachments["/workspace/demo\nproduction"].NodeNames; !reflect.DeepEqual(got, []string{"web-a", "web-a"}) {
+		t.Fatalf("AttachmentKeysForNode() mutated attachment nodes: %#v", got)
+	}
+}
+
 func TestAttachmentCRUD(t *testing.T) {
 	t.Parallel()
 

--- a/cli/internal/solo/state_test.go
+++ b/cli/internal/solo/state_test.go
@@ -259,3 +259,33 @@ func TestSaveSnapshotPersistsWorkspaceEnvironmentIdentity(t *testing.T) {
 		}
 	}
 }
+
+func TestDetachNodeDoesNotMutatePreviouslyReturnedAttachments(t *testing.T) {
+	t.Parallel()
+
+	current := newState()
+	if err := current.SetNode("web-a", config.SoloNode{Host: "203.0.113.10", User: "root", Labels: []string{config.DefaultWebRole}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := current.SetNode("worker-a", config.SoloNode{Host: "203.0.113.11", User: "root", Labels: []string{config.DefaultWorkerRole}}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := current.AttachNode("/workspace/demo", "production", "web-a"); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := current.AttachNode("/workspace/demo", "production", "worker-a"); err != nil {
+		t.Fatal(err)
+	}
+
+	attachments := current.AttachmentsForNode("web-a")
+	if len(attachments) != 1 {
+		t.Fatalf("attachments = %#v", attachments)
+	}
+	before := attachments[0]
+	if _, _, err := current.DetachNode("/workspace/demo", "production", "worker-a"); err != nil {
+		t.Fatal(err)
+	}
+	if got := before.NodeNames; !reflect.DeepEqual(got, []string{"web-a", "worker-a"}) {
+		t.Fatalf("returned attachment mutated to %#v", got)
+	}
+}

--- a/cli/internal/solo/state_test.go
+++ b/cli/internal/solo/state_test.go
@@ -322,3 +322,30 @@ func TestDetachNodeDoesNotMutatePreviouslyReturnedAttachments(t *testing.T) {
 		t.Fatalf("returned attachment mutated to %#v", got)
 	}
 }
+
+func TestAttachNodeDoesNotMutatePreviouslyReturnedAttachments(t *testing.T) {
+	t.Parallel()
+
+	current := newState()
+	if err := current.SetNode("web-a", config.SoloNode{Host: "203.0.113.10", User: "root", Labels: []string{config.DefaultWebRole}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := current.SetNode("worker-a", config.SoloNode{Host: "203.0.113.11", User: "root", Labels: []string{config.DefaultWorkerRole}}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := current.AttachNode("/workspace/demo", "production", "web-a"); err != nil {
+		t.Fatal(err)
+	}
+
+	attachments := current.AttachmentsForNode("web-a")
+	if len(attachments) != 1 {
+		t.Fatalf("attachments = %#v", attachments)
+	}
+	before := attachments[0]
+	if _, _, err := current.AttachNode("/workspace/demo", "production", "worker-a"); err != nil {
+		t.Fatal(err)
+	}
+	if got := before.NodeNames; !reflect.DeepEqual(got, []string{"web-a"}) {
+		t.Fatalf("returned attachment mutated to %#v", got)
+	}
+}

--- a/cli/internal/solo/state_test.go
+++ b/cli/internal/solo/state_test.go
@@ -182,6 +182,25 @@ func TestAttachmentKeysForNodeDoesNotMutateState(t *testing.T) {
 	}
 }
 
+func TestAttachmentKeysForNodeTrimsInput(t *testing.T) {
+	t.Parallel()
+
+	current := State{
+		SchemaVersion: soloStateSchemaVersion,
+		Attachments: map[string]AttachmentRecord{
+			"/workspace/demo\nproduction": {
+				WorkspaceRoot: "/workspace/demo",
+				NodeNames:     []string{"web-a"},
+			},
+		},
+	}
+
+	keys := current.AttachmentKeysForNode("  web-a  ")
+	if want := []string{"/workspace/demo\nproduction"}; !reflect.DeepEqual(keys, want) {
+		t.Fatalf("AttachmentKeysForNode() = %#v, want %#v", keys, want)
+	}
+}
+
 func TestSetNodeRejectsMissingConnectionFields(t *testing.T) {
 	t.Parallel()
 

--- a/cli/internal/solo/state_test.go
+++ b/cli/internal/solo/state_test.go
@@ -1,0 +1,167 @@
+package solo
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/devopsellence/cli/internal/config"
+)
+
+func TestCanonicalWorkspaceKeyResolvesSymlinks(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	realRoot := filepath.Join(root, "real")
+	if err := os.MkdirAll(realRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	linkRoot := filepath.Join(root, "link")
+	if err := os.Symlink(realRoot, linkRoot); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := CanonicalWorkspaceKey(filepath.Join(linkRoot, "."))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != realRoot {
+		t.Fatalf("CanonicalWorkspaceKey() = %q, want %q", got, realRoot)
+	}
+}
+
+func TestStateStoreRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	store := NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := newState()
+	if err := current.SetNode("web-a", config.SoloNode{
+		Host:   "203.0.113.10",
+		User:   "root",
+		Labels: []string{config.DefaultWebRole},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	attachment, changed, err := current.AttachNode("/workspace/demo", "production", "web-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("AttachNode() changed = false, want true")
+	}
+	current.Attachments[attachment.WorkspaceKey+"\n"+attachment.Environment] = attachment
+	current.Snapshots[attachment.WorkspaceKey+"\n"+attachment.Environment] = DeploySnapshot{
+		WorkspaceRoot: "/workspace/demo",
+		WorkspaceKey:  attachment.WorkspaceKey,
+		Environment:   "production",
+		Revision:      "abc1234",
+		Image:         "demo:abc1234",
+		Metadata:      SnapshotMetadata{Project: "demo"},
+	}
+	if err := store.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := store.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.SchemaVersion != soloStateSchemaVersion {
+		t.Fatalf("schema_version = %d, want %d", loaded.SchemaVersion, soloStateSchemaVersion)
+	}
+	if got := loaded.Nodes["web-a"].AgentStateDir; got != "/var/lib/devopsellence" {
+		t.Fatalf("agent_state_dir = %q, want default", got)
+	}
+	if got := loaded.Attachments[attachment.WorkspaceKey+"\nproduction"].NodeNames; !reflect.DeepEqual(got, []string{"web-a"}) {
+		t.Fatalf("attachment nodes = %#v", got)
+	}
+	if got := loaded.Snapshots[attachment.WorkspaceKey+"\nproduction"].Image; got != "demo:abc1234" {
+		t.Fatalf("snapshot image = %q", got)
+	}
+}
+
+func TestAttachmentCRUD(t *testing.T) {
+	t.Parallel()
+
+	current := newState()
+	if err := current.SetNode("web-a", config.SoloNode{Host: "203.0.113.10", User: "root", Labels: []string{config.DefaultWebRole}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := current.SetNode("worker-a", config.SoloNode{Host: "203.0.113.11", User: "root", Labels: []string{config.DefaultWorkerRole}}); err != nil {
+		t.Fatal(err)
+	}
+
+	attachment, changed, err := current.AttachNode("/workspace/demo", "production", "worker-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("first attach changed = false")
+	}
+	if _, changed, err := current.AttachNode("/workspace/demo", "production", "web-a"); err != nil {
+		t.Fatal(err)
+	} else if !changed {
+		t.Fatal("second attach changed = false")
+	}
+	if _, changed, err := current.AttachNode("/workspace/demo", "production", "web-a"); err != nil {
+		t.Fatal(err)
+	} else if changed {
+		t.Fatal("duplicate attach changed = true")
+	}
+
+	nodes, err := current.AttachedNodeNames("/workspace/demo", "production")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{"web-a", "worker-a"}; !reflect.DeepEqual(nodes, want) {
+		t.Fatalf("AttachedNodeNames() = %#v, want %#v", nodes, want)
+	}
+
+	_, changed, err = current.DetachNode("/workspace/demo", "production", "worker-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("detach changed = false")
+	}
+	nodes, err = current.AttachedNodeNames("/workspace/demo", "production")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{"web-a"}; !reflect.DeepEqual(nodes, want) {
+		t.Fatalf("after detach nodes = %#v, want %#v", nodes, want)
+	}
+
+	if got := attachment.WorkspaceKey; got == "" {
+		t.Fatal("workspace key empty")
+	}
+}
+
+func TestSaveSnapshotPersistsWorkspaceEnvironmentIdentity(t *testing.T) {
+	t.Parallel()
+
+	current := newState()
+	cfg := config.DefaultProjectConfig("solo", "demo", "staging")
+	snapshot, err := BuildDeploySnapshot(&cfg, "/workspace/demo", "/workspace/demo/devopsellence.yml", "demo:abc1234", "abc1234", map[string]string{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	key, err := current.SaveSnapshot(snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapshot, ok := current.Snapshots[key]; !ok {
+		t.Fatalf("snapshot %q missing", key)
+	} else {
+		if snapshot.WorkspaceKey == "" {
+			t.Fatal("snapshot workspace_key empty")
+		}
+		if snapshot.Environment != "staging" {
+			t.Fatalf("snapshot environment = %q, want staging", snapshot.Environment)
+		}
+		if snapshot.Metadata.ConfigPath != "/workspace/demo/devopsellence.yml" {
+			t.Fatalf("config path = %q", snapshot.Metadata.ConfigPath)
+		}
+	}
+}

--- a/cli/internal/solo/state_test.go
+++ b/cli/internal/solo/state_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/devopsellence/cli/internal/config"
@@ -145,6 +146,32 @@ func TestAttachmentKeysForNodeDoesNotMutateState(t *testing.T) {
 	}
 	if got := current.Attachments["/workspace/demo\nproduction"].NodeNames; !reflect.DeepEqual(got, []string{"web-a", "web-a"}) {
 		t.Fatalf("AttachmentKeysForNode() mutated attachment nodes: %#v", got)
+	}
+}
+
+func TestSetNodeRejectsMissingConnectionFields(t *testing.T) {
+	t.Parallel()
+
+	current := newState()
+	if err := current.SetNode("web-a", config.SoloNode{User: "root"}); err == nil || !strings.Contains(err.Error(), "host is required") {
+		t.Fatalf("expected host validation error, got %v", err)
+	}
+	if err := current.SetNode("web-a", config.SoloNode{Host: "203.0.113.10"}); err == nil || !strings.Contains(err.Error(), "user is required") {
+		t.Fatalf("expected user validation error, got %v", err)
+	}
+}
+
+func TestStateStoreReadRejectsUnsupportedSchemaVersion(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "solo-state.json")
+	if err := os.WriteFile(path, []byte(`{"schema_version": 2}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := NewStateStore(path).Read()
+	if err == nil || !strings.Contains(err.Error(), "unsupported solo state schema_version 2") {
+		t.Fatalf("expected schema version error, got %v", err)
 	}
 }
 

--- a/cli/internal/solo/state_test.go
+++ b/cli/internal/solo/state_test.go
@@ -293,6 +293,43 @@ func TestSaveSnapshotPersistsWorkspaceEnvironmentIdentity(t *testing.T) {
 	}
 }
 
+func TestRedactDeploySnapshotSecretsRemovesSecretValues(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	cfg.Services["web"] = config.ServiceConfig{
+		Kind: config.ServiceKindWeb,
+		Env:  map[string]string{"PLAIN": "value"},
+		SecretRefs: []config.SecretRef{
+			{Name: "DATABASE_URL"},
+		},
+		Ports: []config.ServicePort{{Name: "http", Port: 3000}},
+		Healthcheck: &config.HTTPHealthcheck{
+			Path: "/up",
+			Port: 3000,
+		},
+	}
+	cfg.Tasks.Release = &config.TaskConfig{Service: "web", Command: "bin/rails db:migrate"}
+
+	snapshot, err := BuildDeploySnapshot(&cfg, "/workspace/demo", "/workspace/demo/devopsellence.yml", "demo:abc1234", "abc1234", map[string]string{"DATABASE_URL": "postgres://secret"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	redacted := RedactDeploySnapshotSecrets(snapshot, &cfg)
+	if _, ok := redacted.Services[0].Env["DATABASE_URL"]; ok {
+		t.Fatalf("service env still includes DATABASE_URL: %#v", redacted.Services[0].Env)
+	}
+	if redacted.ReleaseTask == nil {
+		t.Fatal("release task missing")
+	}
+	if _, ok := redacted.ReleaseTask.Env["DATABASE_URL"]; ok {
+		t.Fatalf("release env still includes DATABASE_URL: %#v", redacted.ReleaseTask.Env)
+	}
+	if got := redacted.Services[0].Env["PLAIN"]; got != "value" {
+		t.Fatalf("plain env = %q, want value", got)
+	}
+}
+
 func TestDetachNodeDoesNotMutatePreviouslyReturnedAttachments(t *testing.T) {
 	t.Parallel()
 

--- a/cli/internal/workflow/app.go
+++ b/cli/internal/workflow/app.go
@@ -29,6 +29,7 @@ import (
 	"github.com/devopsellence/cli/internal/docker"
 	"github.com/devopsellence/cli/internal/git"
 	"github.com/devopsellence/cli/internal/output"
+	"github.com/devopsellence/cli/internal/solo"
 	"github.com/devopsellence/cli/internal/state"
 	"github.com/devopsellence/cli/internal/ui"
 
@@ -69,6 +70,7 @@ type App struct {
 	State              *state.Store
 	WorkspaceState     *state.Store
 	ProviderState      *state.Store
+	SoloState          *solo.StateStore
 	ConfigStore        config.Store
 	Docker             DockerClient
 	Git                git.Client
@@ -337,6 +339,7 @@ func NewApp(in io.Reader, out, err io.Writer, jsonMode bool, cwd string) *App {
 	store := state.New(state.DefaultPath(filepath.Join("devopsellence", "auth.json")))
 	workspaceStore := state.New(state.DefaultPath(filepath.Join("devopsellence", "workspace.json")))
 	providerStore := state.New(state.DefaultPath(filepath.Join("devopsellence", "providers.json")))
+	soloStateStore := solo.NewStateStore(solo.DefaultStatePath())
 	return &App{
 		In:                 in,
 		Printer:            output.New(out, err, jsonMode),
@@ -345,6 +348,7 @@ func NewApp(in io.Reader, out, err io.Writer, jsonMode bool, cwd string) *App {
 		State:              store,
 		WorkspaceState:     workspaceStore,
 		ProviderState:      providerStore,
+		SoloState:          soloStateStore,
 		ConfigStore:        config.NewStore(),
 		Docker:             docker.Runner{},
 		Git:                git.Client{},
@@ -3326,7 +3330,6 @@ func (a *App) initializeWorkspace(ctx context.Context, callAuth authCall, opts I
 		projectConfig.Services = existing.Services
 		projectConfig.Tasks = existing.Tasks
 		projectConfig.Ingress = existing.Ingress
-		projectConfig.Solo = existing.Solo
 		projectConfig.App = existing.App
 		projectConfig.Organization = org.Name
 		projectConfig.Project = project.Name

--- a/cli/internal/workflow/management_test.go
+++ b/cli/internal/workflow/management_test.go
@@ -3360,14 +3360,15 @@ func newTestAppWithTransport(t *testing.T, cwd string, transport http.RoundTripp
 }
 
 type fakeDocker struct {
-	digest         string
-	buildPlatforms []string
-	buildTarget    string
-	configDir      string
-	loginRegistry  string
-	updates        []string
-	delay          time.Duration
-	imageMetadata  docker.ImageMetadata
+	digest           string
+	buildPlatforms   []string
+	buildTarget      string
+	configDir        string
+	loginRegistry    string
+	updates          []string
+	delay            time.Duration
+	imageMetadata    docker.ImageMetadata
+	imageMetadataErr error
 }
 
 func (f *fakeDocker) Installed() bool { return true }
@@ -3399,7 +3400,7 @@ func (f *fakeDocker) BuildAndPush(_ context.Context, _contextPath, _dockerfile, 
 }
 
 func (f *fakeDocker) ImageMetadata(_ context.Context, _ string) (docker.ImageMetadata, error) {
-	return f.imageMetadata, nil
+	return f.imageMetadata, f.imageMetadataErr
 }
 
 type dockerUnavailableStub struct{}

--- a/cli/internal/workflow/mode.go
+++ b/cli/internal/workflow/mode.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/devopsellence/cli/internal/config"
 	"github.com/devopsellence/cli/internal/discovery"
+	"github.com/devopsellence/cli/internal/solo"
 	"github.com/devopsellence/cli/internal/ui"
 )
 
@@ -84,11 +85,35 @@ func (a *App) suggestedMode() Mode {
 	if err != nil {
 		return ModeSolo
 	}
-	cfg, err := a.ConfigStore.Read(discovered.WorkspaceRoot)
-	if err == nil && cfg != nil && strings.EqualFold(strings.TrimSpace(cfg.Organization), "solo") {
+	if a.workspaceHasSoloState(discovered.WorkspaceRoot) {
 		return ModeSolo
 	}
 	return ModeShared
+}
+
+func (a *App) workspaceHasSoloState(workspaceRoot string) bool {
+	if a.SoloState == nil {
+		return false
+	}
+	current, err := a.SoloState.Read()
+	if err != nil {
+		return false
+	}
+	workspaceKey, err := solo.CanonicalWorkspaceKey(workspaceRoot)
+	if err != nil {
+		return false
+	}
+	for _, attachment := range current.Attachments {
+		if attachment.WorkspaceKey == workspaceKey {
+			return true
+		}
+	}
+	for _, snapshot := range current.Snapshots {
+		if snapshot.WorkspaceKey == workspaceKey {
+			return true
+		}
+	}
+	return false
 }
 
 func (a *App) ResolveMode(explicit string, interactive bool) (Mode, error) {

--- a/cli/internal/workflow/mode.go
+++ b/cli/internal/workflow/mode.go
@@ -85,7 +85,7 @@ func (a *App) suggestedMode() Mode {
 		return ModeSolo
 	}
 	cfg, err := a.ConfigStore.Read(discovered.WorkspaceRoot)
-	if err == nil && cfg != nil && cfg.Solo != nil && len(cfg.Solo.Nodes) > 0 {
+	if err == nil && cfg != nil && strings.EqualFold(strings.TrimSpace(cfg.Organization), "solo") {
 		return ModeSolo
 	}
 	return ModeShared

--- a/cli/internal/workflow/mode_test.go
+++ b/cli/internal/workflow/mode_test.go
@@ -1,0 +1,63 @@
+package workflow
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/devopsellence/cli/internal/config"
+	"github.com/devopsellence/cli/internal/solo"
+)
+
+func TestSuggestedModeUsesSoloStateForWorkspace(t *testing.T) {
+	t.Parallel()
+
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("acme", "shop", "production")
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	statePath := filepath.Join(t.TempDir(), "solo-state.json")
+	store := solo.NewStateStore(statePath)
+	current := solo.State{
+		Nodes:       map[string]config.SoloNode{},
+		Attachments: map[string]solo.AttachmentRecord{},
+		Snapshots:   map[string]solo.DeploySnapshot{},
+	}
+	if err := current.SetNode("node-1", config.SoloNode{Host: "203.0.113.10", User: "root"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := current.AttachNode(workspaceRoot, "production", "node-1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	app := &App{
+		ConfigStore: config.NewStore(),
+		SoloState:   store,
+		Cwd:         workspaceRoot,
+	}
+	if got := app.suggestedMode(); got != ModeSolo {
+		t.Fatalf("suggestedMode() = %q, want %q", got, ModeSolo)
+	}
+}
+
+func TestSuggestedModeDefaultsSharedWithoutSoloState(t *testing.T) {
+	t.Parallel()
+
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "shop", "production")
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	app := &App{
+		ConfigStore: config.NewStore(),
+		Cwd:         workspaceRoot,
+	}
+	if got := app.suggestedMode(); got != ModeShared {
+		t.Fatalf("suggestedMode() = %q, want %q", got, ModeShared)
+	}
+}

--- a/cli/internal/workflow/root.go
+++ b/cli/internal/workflow/root.go
@@ -527,7 +527,6 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 			return app.Deploy(ctx, deploySharedOpts)
 		}),
 	}
-	deployCommand.Flags().StringSliceVar(&deploySoloOpts.Nodes, "nodes", nil, "Comma-separated node names (solo mode)")
 	deployCommand.Flags().BoolVar(&deploySoloOpts.SkipDNSCheck, "skip-dns-check", false, "Skip ingress DNS readiness check before deploy (solo mode)")
 	deployCommand.Flags().StringVar(&deploySharedOpts.Organization, "org", os.Getenv("DEVOPSELLENCE_ORGANIZATION"), "Organization name override (shared mode)")
 	deployCommand.Flags().StringVar(&deploySharedOpts.Project, "project", os.Getenv("DEVOPSELLENCE_PROJECT"), "Project name override (shared mode)")

--- a/cli/internal/workflow/root.go
+++ b/cli/internal/workflow/root.go
@@ -521,6 +521,11 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 	deployCommand := &cobra.Command{
 		Use:   "deploy",
 		Short: "Deploy the current app using the selected workspace mode",
+		Long: strings.Join([]string{
+			"Deploy the current app using the selected workspace mode.",
+			"  solo   - deploys to nodes attached to the current workspace/environment; use `devopsellence node attach|detach` to change scope",
+			"  shared - deploys through the control plane using org/project/environment context",
+		}, "\n"),
 		RunE: runByMode(func(ctx context.Context) error {
 			return app.SoloDeploy(ctx, deploySoloOpts)
 		}, func(ctx context.Context) error {

--- a/cli/internal/workflow/root.go
+++ b/cli/internal/workflow/root.go
@@ -501,7 +501,7 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 		Short: "Prepare the current workspace for its selected mode",
 		Long: strings.Join([]string{
 			"Mode-driven workspace setup.",
-			"  solo   - initialize config if needed, add a node, and install the agent",
+			"  solo   - initialize config if needed, register or create a node, attach it, and install the agent",
 			"  shared - sign in, create/select org/project/env, and write workspace config",
 		}, "\n"),
 		RunE: runByMode(func(ctx context.Context) error {
@@ -693,7 +693,9 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 	var nodeCreateBootstrapOpts NodeBootstrapOptions
 	var nodeListSharedOpts NodeListOptions
 	var nodeListSoloOpts SoloNodeListOptions
+	var nodeAttachSoloOpts SoloNodeAttachOptions
 	var nodeAttachOpts NodeAssignOptions
+	var nodeDetachSoloOpts SoloNodeDetachOptions
 	var nodeDetachOpts NodeUnassignOptions
 	var nodeRemoveSoloOpts SoloNodeRemoveOptions
 	var nodeRemoveSharedOpts NodeDeleteOptions
@@ -702,6 +704,7 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 	var nodeDiagnoseOpts NodeDiagnoseOptions
 	var nodeLogsOpts SoloLogsOptions
 	var nodeLabels string
+	var nodeAttachEnvironment string
 	nodeCommand := &cobra.Command{
 		Use:   "node",
 		Short: "Manage nodes for the selected workspace mode",
@@ -757,38 +760,47 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 	}
 	nodeListCommand.Flags().StringVar(&nodeListSharedOpts.Organization, "org", "", "Organization name override (shared mode)")
 	nodeAttachCommand := &cobra.Command{
-		Use:   "attach <id>",
-		Short: "Attach an unassigned shared node to the current environment",
+		Use:   "attach <target>",
+		Short: "Attach a node to the current environment",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			id, parseErr := strconv.Atoi(args[0])
-			if parseErr != nil {
-				return ExitError{Code: 2, Err: fmt.Errorf("invalid node id %q: must be a number", args[0])}
-			}
-			nodeAttachOpts.NodeID = id
-			return runSharedOnly("node attach", func(ctx context.Context) error {
+			nodeAttachSoloOpts.Node = args[0]
+			nodeAttachSoloOpts.Environment = nodeAttachEnvironment
+			nodeAttachOpts.Environment = nodeAttachEnvironment
+			return runByMode(func(ctx context.Context) error {
+				return app.SoloNodeAttach(ctx, nodeAttachSoloOpts)
+			}, func(ctx context.Context) error {
+				id, parseErr := strconv.Atoi(args[0])
+				if parseErr != nil {
+					return ExitError{Code: 2, Err: fmt.Errorf("invalid node id %q: must be a number", args[0])}
+				}
+				nodeAttachOpts.NodeID = id
 				return app.NodeAssign(ctx, nodeAttachOpts)
 			})(cmd, args)
 		},
 	}
+	nodeAttachCommand.Flags().StringVar(&nodeAttachEnvironment, "env", "", "Environment name override (solo/shared)")
 	nodeAttachCommand.Flags().StringVar(&nodeAttachOpts.Organization, "org", "", "Organization name override")
 	nodeAttachCommand.Flags().StringVar(&nodeAttachOpts.Project, "project", "", "Project name override")
-	nodeAttachCommand.Flags().StringVar(&nodeAttachOpts.Environment, "env", "", "Environment name override")
 	nodeDetachCommand := &cobra.Command{
-		Use:   "detach <id>",
-		Short: "Detach a shared node from its current environment",
+		Use:   "detach <target>",
+		Short: "Detach a node from the current environment",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			id, parseErr := strconv.Atoi(args[0])
-			if parseErr != nil {
-				return ExitError{Code: 2, Err: fmt.Errorf("invalid node id %q: must be a number", args[0])}
-			}
-			nodeDetachOpts.NodeID = id
-			return runSharedOnly("node detach", func(ctx context.Context) error {
+			nodeDetachSoloOpts.Node = args[0]
+			return runByMode(func(ctx context.Context) error {
+				return app.SoloNodeDetach(ctx, nodeDetachSoloOpts)
+			}, func(ctx context.Context) error {
+				id, parseErr := strconv.Atoi(args[0])
+				if parseErr != nil {
+					return ExitError{Code: 2, Err: fmt.Errorf("invalid node id %q: must be a number", args[0])}
+				}
+				nodeDetachOpts.NodeID = id
 				return app.NodeUnassign(ctx, nodeDetachOpts)
 			})(cmd, args)
 		},
 	}
+	nodeDetachCommand.Flags().StringVar(&nodeDetachSoloOpts.Environment, "env", "", "Environment name override (solo mode)")
 	nodeRemoveCommand := &cobra.Command{
 		Use:   "remove <target>",
 		Short: "Remove a node",

--- a/cli/internal/workflow/root.go
+++ b/cli/internal/workflow/root.go
@@ -759,8 +759,8 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 	}
 	nodeListCommand.Flags().StringVar(&nodeListSharedOpts.Organization, "org", "", "Organization name override (shared mode)")
 	nodeAttachCommand := &cobra.Command{
-		Use:   "attach <target>",
-		Short: "Attach a node to the current environment",
+		Use:   "attach <name|id>",
+		Short: "Attach a node to the current environment (solo: name, shared: numeric id)",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			nodeAttachSoloOpts.Node = args[0]
@@ -782,8 +782,8 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 	nodeAttachCommand.Flags().StringVar(&nodeAttachOpts.Organization, "org", "", "Organization name override")
 	nodeAttachCommand.Flags().StringVar(&nodeAttachOpts.Project, "project", "", "Project name override")
 	nodeDetachCommand := &cobra.Command{
-		Use:   "detach <target>",
-		Short: "Detach a node from the current environment",
+		Use:   "detach <name|id>",
+		Short: "Detach a node from the current environment (solo: name, shared: numeric id)",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			nodeDetachSoloOpts.Node = args[0]

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -392,6 +392,12 @@ func (a *App) republishSoloNodes(ctx context.Context, current solo.State, nodeNa
 	if len(nodeNames) == 0 {
 		return map[string]string{}, nil
 	}
+	type preparedSoloNodeState struct {
+		snapshots    []solo.DeploySnapshot
+		releaseNodes map[string]string
+		peers        []solo.NodePeer
+		images       []string
+	}
 	var mu sync.Mutex
 	var errs []string
 	revisions := map[string]string{}
@@ -401,38 +407,37 @@ func (a *App) republishSoloNodes(ctx context.Context, current solo.State, nodeNa
 	if err != nil {
 		return nil, err
 	}
-	for _, nodeName := range sortedSoloNodeNames(nodes) {
+	sortedNodeNames := sortedSoloNodeNames(nodes)
+	prepared := make(map[string]preparedSoloNodeState, len(sortedNodeNames))
+	resolvedSnapshotCache := map[string]solo.DeploySnapshot{}
+	allImages := map[string]bool{}
+	for _, nodeName := range sortedNodeNames {
+		inputs, err := a.preparedSoloNodeDesiredStateInputs(current, nodeName, nodes[nodeName], resolvedSnapshotCache)
+		if err != nil {
+			return nil, err
+		}
+		prepared[nodeName] = inputs
+		for _, image := range inputs.images {
+			allImages[image] = true
+		}
+	}
+	images := make([]string, 0, len(allImages))
+	for image := range allImages {
+		images = append(images, image)
+	}
+	sort.Strings(images)
+	for _, image := range images {
+		if err := a.ensureLocalSoloSnapshotImage(ctx, image); err != nil {
+			return nil, err
+		}
+	}
+	for _, nodeName := range sortedNodeNames {
 		node := nodes[nodeName]
+		inputs := prepared[nodeName]
 		wg.Add(1)
-		go func(name string, node config.SoloNode) {
+		go func(name string, node config.SoloNode, inputs preparedSoloNodeState) {
 			defer wg.Done()
-			snapshots, releaseNodes, peers, images, err := soloNodeDesiredStateInputs(current, name)
-			if err != nil {
-				mu.Lock()
-				errs = append(errs, fmt.Sprintf("[%s] build desired state inputs: %s", name, err))
-				mu.Unlock()
-				return
-			}
-			resolvedSnapshots := make([]solo.DeploySnapshot, 0, len(snapshots))
-			for _, snapshot := range snapshots {
-				resolvedSnapshot, err := a.resolveStoredDeploySnapshot(snapshot)
-				if err != nil {
-					mu.Lock()
-					errs = append(errs, fmt.Sprintf("[%s] hydrate snapshot: %s", name, err))
-					mu.Unlock()
-					return
-				}
-				resolvedSnapshots = append(resolvedSnapshots, resolvedSnapshot)
-			}
-			for _, image := range images {
-				if err := a.ensureLocalSoloSnapshotImage(ctx, image); err != nil {
-					mu.Lock()
-					errs = append(errs, fmt.Sprintf("[%s] local image precheck: %s", name, err))
-					mu.Unlock()
-					return
-				}
-			}
-			if len(images) > 0 {
+			if len(inputs.images) > 0 {
 				if _, err := solo.RunSSH(ctx, node, remoteDockerCheckCommand(), nil); err != nil {
 					mu.Lock()
 					errs = append(errs, fmt.Sprintf("[%s] remote docker check: %s", name, err))
@@ -440,7 +445,7 @@ func (a *App) republishSoloNodes(ctx context.Context, current solo.State, nodeNa
 					return
 				}
 			}
-			for _, image := range images {
+			for _, image := range inputs.images {
 				present, err := remoteNodeHasImage(ctx, node, image)
 				if err != nil {
 					mu.Lock()
@@ -461,7 +466,7 @@ func (a *App) republishSoloNodes(ctx context.Context, current solo.State, nodeNa
 					return
 				}
 			}
-			desiredStateJSON, err := solo.BuildAggregatedDesiredState(name, node, resolvedSnapshots, releaseNodes, peers)
+			desiredStateJSON, err := solo.BuildAggregatedDesiredState(name, node, inputs.snapshots, inputs.releaseNodes, inputs.peers)
 			if err != nil {
 				mu.Lock()
 				errs = append(errs, fmt.Sprintf("[%s] build desired state: %s", name, err))
@@ -489,7 +494,7 @@ func (a *App) republishSoloNodes(ctx context.Context, current solo.State, nodeNa
 			mu.Lock()
 			revisions[name] = revision
 			mu.Unlock()
-		}(nodeName, node)
+		}(nodeName, node, inputs)
 	}
 	wg.Wait()
 	if len(errs) > 0 {
@@ -518,6 +523,72 @@ func (a *App) resolveStoredDeploySnapshot(snapshot solo.DeploySnapshot) (solo.De
 		configPath = a.ConfigStore.PathFor(snapshot.WorkspaceRoot)
 	}
 	return solo.BuildDeploySnapshot(cfg, snapshot.WorkspaceRoot, configPath, snapshot.Image, snapshot.Revision, secrets)
+}
+
+func (a *App) preparedSoloNodeDesiredStateInputs(current solo.State, nodeName string, node config.SoloNode, resolvedSnapshotCache map[string]solo.DeploySnapshot) (struct {
+	snapshots    []solo.DeploySnapshot
+	releaseNodes map[string]string
+	peers        []solo.NodePeer
+	images       []string
+}, error) {
+	storedSnapshots, releaseNodes, peers, _, err := soloNodeDesiredStateInputs(current, nodeName)
+	if err != nil {
+		return struct {
+			snapshots    []solo.DeploySnapshot
+			releaseNodes map[string]string
+			peers        []solo.NodePeer
+			images       []string
+		}{}, fmt.Errorf("build desired state inputs: %w", err)
+	}
+	resolvedSnapshots := make([]solo.DeploySnapshot, 0, len(storedSnapshots))
+	imageSet := map[string]bool{}
+	for _, snapshot := range storedSnapshots {
+		key := strings.TrimSpace(snapshot.WorkspaceKey) + "\n" + strings.TrimSpace(snapshot.Environment)
+		resolvedSnapshot, ok := resolvedSnapshotCache[key]
+		if !ok {
+			resolvedSnapshot, err = a.resolveStoredDeploySnapshot(snapshot)
+			if err != nil {
+				return struct {
+					snapshots    []solo.DeploySnapshot
+					releaseNodes map[string]string
+					peers        []solo.NodePeer
+					images       []string
+				}{}, fmt.Errorf("hydrate snapshot: %w", err)
+			}
+			resolvedSnapshotCache[key] = resolvedSnapshot
+		}
+		resolvedSnapshots = append(resolvedSnapshots, resolvedSnapshot)
+		if snapshotNeedsImageOnNode(resolvedSnapshot, node, releaseNodes[key] == nodeName) {
+			if image := strings.TrimSpace(resolvedSnapshot.Image); image != "" {
+				imageSet[image] = true
+			}
+		}
+	}
+	images := make([]string, 0, len(imageSet))
+	for image := range imageSet {
+		images = append(images, image)
+	}
+	sort.Strings(images)
+	return struct {
+		snapshots    []solo.DeploySnapshot
+		releaseNodes map[string]string
+		peers        []solo.NodePeer
+		images       []string
+	}{
+		snapshots:    resolvedSnapshots,
+		releaseNodes: releaseNodes,
+		peers:        peers,
+		images:       images,
+	}, nil
+}
+
+func snapshotNeedsImageOnNode(snapshot solo.DeploySnapshot, node config.SoloNode, runReleaseTask bool) bool {
+	for _, service := range snapshot.Services {
+		if soloNodeCanRunKind(node, service.Kind) {
+			return true
+		}
+	}
+	return snapshot.ReleaseTask != nil && runReleaseTask
 }
 
 func desiredStateRevision(data []byte) (string, error) {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1223,7 +1223,7 @@ func (a *App) SoloNodeRemove(ctx context.Context, opts SoloNodeRemoveOptions) er
 
 func (a *App) SoloSetup(ctx context.Context, _ SoloSetupOptions) error {
 	if !a.Printer.Interactive {
-		return fmt.Errorf("solo setup requires an interactive terminal; use node create or edit devopsellence.yml")
+		return fmt.Errorf("solo setup requires an interactive terminal; use `devopsellence node create`, or add a node to %s and run `devopsellence node attach`", solo.DefaultStatePath())
 	}
 	mode, err := a.promptLine("Node source (existing/hetzner)", "existing")
 	if err != nil {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -413,6 +413,12 @@ func (a *App) republishSoloNodes(ctx context.Context, current solo.State, nodeNa
 				return
 			}
 			for _, image := range images {
+				if err := a.ensureLocalSoloSnapshotImage(ctx, image); err != nil {
+					mu.Lock()
+					errs = append(errs, fmt.Sprintf("[%s] image transfer: %s", name, err))
+					mu.Unlock()
+					return
+				}
 				if !a.Printer.JSON {
 					a.Printer.Println(fmt.Sprintf("[%s] Transferring image %s...", name, image))
 				}
@@ -446,6 +452,19 @@ func (a *App) republishSoloNodes(ctx context.Context, current solo.State, nodeNa
 	wg.Wait()
 	if len(errs) > 0 {
 		return fmt.Errorf("republish errors:\n  %s", strings.Join(errs, "\n  "))
+	}
+	return nil
+}
+
+func (a *App) ensureLocalSoloSnapshotImage(ctx context.Context, imageTag string) error {
+	if strings.TrimSpace(imageTag) == "" {
+		return nil
+	}
+	if a.Docker == nil {
+		return errors.New("docker client is not configured")
+	}
+	if _, err := a.Docker.ImageMetadata(ctx, imageTag); err != nil {
+		return fmt.Errorf("local snapshot image %q is unavailable; rebuild or redeploy the attached workspace before republishing solo node state: %w", imageTag, err)
 	}
 	return nil
 }

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -269,11 +269,13 @@ func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 	if _, err := current.SaveSnapshot(solo.RedactDeploySnapshotSecrets(snapshot, cfg)); err != nil {
 		return err
 	}
-	desiredStateRevisions, err := a.republishSoloNodes(ctx, current, attachedNodeNames)
-	if err != nil {
+	// Persist desired local state first so follow-up republish operations can
+	// recover cleanly from partial remote updates.
+	if err := a.writeSoloState(current); err != nil {
 		return err
 	}
-	if err := a.writeSoloState(current); err != nil {
+	desiredStateRevisions, err := a.republishSoloNodes(ctx, current, attachedNodeNames)
+	if err != nil {
 		return err
 	}
 
@@ -821,13 +823,13 @@ func (a *App) SoloNodeAttach(ctx context.Context, opts SoloNodeAttachOptions) er
 	if err != nil {
 		return err
 	}
+	if err := a.writeSoloState(current); err != nil {
+		return err
+	}
 	if _, ok := current.Snapshots[attachment.WorkspaceKey+"\n"+attachment.Environment]; ok {
 		if _, err := a.republishSoloNodes(ctx, current, attachment.NodeNames); err != nil {
 			return err
 		}
-	}
-	if err := a.writeSoloState(current); err != nil {
-		return err
 	}
 	if a.Printer.JSON {
 		return a.Printer.PrintJSON(map[string]any{
@@ -868,10 +870,10 @@ func (a *App) SoloNodeDetach(ctx context.Context, opts SoloNodeDetachOptions) er
 	}
 	affectedNodeNames := append([]string{opts.Node}, nodeNamesBefore...)
 	affectedNodeNames = normalizeSoloNames(affectedNodeNames)
-	if _, err := a.republishSoloNodes(ctx, current, affectedNodeNames); err != nil {
+	if err := a.writeSoloState(current); err != nil {
 		return err
 	}
-	if err := a.writeSoloState(current); err != nil {
+	if _, err := a.republishSoloNodes(ctx, current, affectedNodeNames); err != nil {
 		return err
 	}
 	if a.Printer.JSON {
@@ -938,10 +940,10 @@ func (a *App) SoloNodeLabelSet(ctx context.Context, opts SoloNodeLabelSetOptions
 	}
 	node.Labels = labels
 	current.Nodes[opts.Node] = solo.NormalizeNode(node)
-	if _, err := a.republishSoloNodes(ctx, current, soloAffectedNodesForNode(current, opts.Node)); err != nil {
+	if err := a.writeSoloState(current); err != nil {
 		return err
 	}
-	if err := a.writeSoloState(current); err != nil {
+	if _, err := a.republishSoloNodes(ctx, current, soloAffectedNodesForNode(current, opts.Node)); err != nil {
 		return err
 	}
 	if a.Printer.JSON {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -419,6 +419,26 @@ func (a *App) republishSoloNodes(ctx context.Context, current solo.State, nodeNa
 					mu.Unlock()
 					return
 				}
+			}
+			if len(images) > 0 {
+				if _, err := solo.RunSSH(ctx, node, remoteDockerCheckCommand(), nil); err != nil {
+					mu.Lock()
+					errs = append(errs, fmt.Sprintf("[%s] remote docker check: %s", name, err))
+					mu.Unlock()
+					return
+				}
+			}
+			for _, image := range images {
+				present, err := remoteNodeHasImage(ctx, node, image)
+				if err != nil {
+					mu.Lock()
+					errs = append(errs, fmt.Sprintf("[%s] remote image check: %s", name, err))
+					mu.Unlock()
+					return
+				}
+				if present {
+					continue
+				}
 				if !a.Printer.JSON {
 					a.Printer.Println(fmt.Sprintf("[%s] Transferring image %s...", name, image))
 				}
@@ -477,6 +497,14 @@ func desiredStateRevision(data []byte) (string, error) {
 		return "", errors.New("revision is missing")
 	}
 	return payload.Revision, nil
+}
+
+func remoteNodeHasImage(ctx context.Context, node config.SoloNode, imageTag string) (bool, error) {
+	out, err := solo.RunSSH(ctx, node, remoteDockerImageInspectCommand(imageTag), nil)
+	if err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(out) == "present", nil
 }
 
 func (a *App) ensureLocalSoloSnapshotImage(ctx context.Context, imageTag string) error {
@@ -2302,6 +2330,11 @@ func remoteDockerCheckCommand() string {
 
 func remoteDockerLoadCommand() string {
 	return "if docker info >/dev/null 2>&1; then gunzip | docker load; elif command -v sudo >/dev/null 2>&1 && sudo -n docker info >/dev/null 2>&1; then gunzip | sudo -n docker load; else echo 'Docker is not reachable. Add this SSH user to the docker group or enable passwordless sudo for docker.' >&2; docker info >/dev/null 2>&1; exit 1; fi"
+}
+
+func remoteDockerImageInspectCommand(imageTag string) string {
+	quotedImage := shellQuote(imageTag)
+	return fmt.Sprintf("if docker image inspect %s >/dev/null 2>&1; then echo present; elif command -v sudo >/dev/null 2>&1 && sudo -n docker image inspect %s >/dev/null 2>&1; then echo present; else echo missing; fi", quotedImage, quotedImage)
 }
 
 func remoteReadFileCommand(path string) string {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -27,7 +27,6 @@ import (
 )
 
 type SoloDeployOptions struct {
-	Nodes        []string
 	SkipDNSCheck bool
 }
 
@@ -208,9 +207,6 @@ func (a *App) createProviderNode(ctx context.Context, opts SoloNodeCreateOptions
 }
 
 func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
-	if len(opts.Nodes) > 0 {
-		return fmt.Errorf("solo deploy --nodes is no longer supported; attach or detach nodes instead")
-	}
 	cfg, workspaceRoot, err := a.loadSoloProjectConfig()
 	if err != nil {
 		return err
@@ -415,7 +411,7 @@ func (a *App) republishSoloNodes(ctx context.Context, current solo.State, nodeNa
 			for _, image := range images {
 				if err := a.ensureLocalSoloSnapshotImage(ctx, image); err != nil {
 					mu.Lock()
-					errs = append(errs, fmt.Sprintf("[%s] image transfer: %s", name, err))
+					errs = append(errs, fmt.Sprintf("[%s] local image precheck: %s", name, err))
 					mu.Unlock()
 					return
 				}

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -224,12 +224,12 @@ func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 	if err != nil {
 		return err
 	}
+	if len(attachedNodeNames) == 0 {
+		return fmt.Errorf("no nodes attached to %s; run `devopsellence node attach <name>`", environmentName)
+	}
 	nodes, err := a.resolveSoloNodes(current, attachedNodeNames)
 	if err != nil {
 		return err
-	}
-	if len(nodes) == 0 {
-		return fmt.Errorf("no nodes attached to %s; run `devopsellence node attach <name>`", environmentName)
 	}
 	if _, err := validateSoloNodeSchedule(cfg, nodes); err != nil {
 		return err
@@ -1392,6 +1392,9 @@ func (a *App) IngressCheck(ctx context.Context, opts IngressCheckOptions) error 
 	if err != nil {
 		return err
 	}
+	if len(nodeNames) == 0 {
+		return fmt.Errorf("no nodes are attached to the current environment")
+	}
 	nodes, err := a.resolveSoloNodes(current, nodeNames)
 	if err != nil {
 		return err
@@ -1494,6 +1497,9 @@ func (a *App) soloStatusNodes(opts SoloStatusOptions) (map[string]config.SoloNod
 	nodeNames, err := current.AttachedNodeNames(workspaceRoot, soloEnvironmentName(cfg, ""))
 	if err != nil {
 		return nil, err
+	}
+	if len(nodeNames) == 0 {
+		return map[string]config.SoloNode{}, nil
 	}
 	return a.resolveSoloNodes(current, nodeNames)
 }

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -445,7 +445,7 @@ func (a *App) republishSoloNodes(ctx context.Context, current solo.State, nodeNa
 	}
 	wg.Wait()
 	if len(errs) > 0 {
-		return fmt.Errorf("deploy errors:\n  %s", strings.Join(errs, "\n  "))
+		return fmt.Errorf("republish errors:\n  %s", strings.Join(errs, "\n  "))
 	}
 	return nil
 }
@@ -687,7 +687,8 @@ func (a *App) SoloNodeList(_ context.Context, _ SoloNodeListOptions) error {
 	if a.Printer.JSON {
 		return a.Printer.PrintJSON(map[string]any{
 			"schema_version": outputSchemaVersion,
-			"nodes":          items,
+			"nodes":          current.Nodes,
+			"node_items":     items,
 		})
 	}
 	if len(items) == 0 {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -273,16 +273,19 @@ func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 		return err
 	}
 
-	if err := a.republishSoloNodes(ctx, current, attachedNodeNames); err != nil {
+	desiredStateRevisions, err := a.republishSoloNodes(ctx, current, attachedNodeNames)
+	if err != nil {
 		return err
 	}
 
 	if a.Printer.JSON {
 		return a.Printer.PrintJSON(map[string]any{
-			"revision":    shortSHA,
-			"image":       imageTag,
-			"environment": environmentName,
-			"nodes":       sortedSoloNodeNames(nodes),
+			"schema_version":          outputSchemaVersion,
+			"workload_revision":       shortSHA,
+			"desired_state_revisions": desiredStateRevisions,
+			"image":                   imageTag,
+			"environment":             environmentName,
+			"nodes":                   sortedSoloNodeNames(nodes),
 		})
 	}
 	a.Printer.Println(fmt.Sprintf("Deployed revision %s to %d node(s)", shortSHA, len(nodes)))
@@ -384,17 +387,18 @@ func (a *App) resolveSoloNodes(current solo.State, names []string) (map[string]c
 	return result, nil
 }
 
-func (a *App) republishSoloNodes(ctx context.Context, current solo.State, nodeNames []string) error {
+func (a *App) republishSoloNodes(ctx context.Context, current solo.State, nodeNames []string) (map[string]string, error) {
 	if len(nodeNames) == 0 {
-		return nil
+		return map[string]string{}, nil
 	}
 	var mu sync.Mutex
 	var errs []string
+	revisions := map[string]string{}
 	var wg sync.WaitGroup
 
 	nodes, err := a.resolveSoloNodes(current, nodeNames)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	for _, nodeName := range sortedSoloNodeNames(nodes) {
 		node := nodes[nodeName]
@@ -443,13 +447,36 @@ func (a *App) republishSoloNodes(ctx context.Context, current solo.State, nodeNa
 				mu.Unlock()
 				return
 			}
+			revision, err := desiredStateRevision(desiredStateJSON)
+			if err != nil {
+				mu.Lock()
+				errs = append(errs, fmt.Sprintf("[%s] parse desired state revision: %s", name, err))
+				mu.Unlock()
+				return
+			}
+			mu.Lock()
+			revisions[name] = revision
+			mu.Unlock()
 		}(nodeName, node)
 	}
 	wg.Wait()
 	if len(errs) > 0 {
-		return fmt.Errorf("republish errors:\n  %s", strings.Join(errs, "\n  "))
+		return nil, fmt.Errorf("republish errors:\n  %s", strings.Join(errs, "\n  "))
 	}
-	return nil
+	return revisions, nil
+}
+
+func desiredStateRevision(data []byte) (string, error) {
+	var payload struct {
+		Revision string `json:"revision"`
+	}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(payload.Revision) == "" {
+		return "", errors.New("revision is missing")
+	}
+	return payload.Revision, nil
 }
 
 func (a *App) ensureLocalSoloSnapshotImage(ctx context.Context, imageTag string) error {
@@ -738,7 +765,7 @@ func (a *App) SoloNodeAttach(ctx context.Context, opts SoloNodeAttachOptions) er
 		return err
 	}
 	if _, ok := current.Snapshots[attachment.WorkspaceKey+"\n"+attachment.Environment]; ok {
-		if err := a.republishSoloNodes(ctx, current, attachment.NodeNames); err != nil {
+		if _, err := a.republishSoloNodes(ctx, current, attachment.NodeNames); err != nil {
 			return err
 		}
 	}
@@ -784,7 +811,7 @@ func (a *App) SoloNodeDetach(ctx context.Context, opts SoloNodeDetachOptions) er
 	if err := a.writeSoloState(current); err != nil {
 		return err
 	}
-	if err := a.republishSoloNodes(ctx, current, affectedNodeNames); err != nil {
+	if _, err := a.republishSoloNodes(ctx, current, affectedNodeNames); err != nil {
 		return err
 	}
 	if a.Printer.JSON {
@@ -854,7 +881,7 @@ func (a *App) SoloNodeLabelSet(ctx context.Context, opts SoloNodeLabelSetOptions
 	if err := a.writeSoloState(current); err != nil {
 		return err
 	}
-	if err := a.republishSoloNodes(ctx, current, soloAffectedNodesForNode(current, opts.Node)); err != nil {
+	if _, err := a.republishSoloNodes(ctx, current, soloAffectedNodesForNode(current, opts.Node)); err != nil {
 		return err
 	}
 	if a.Printer.JSON {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -398,6 +398,10 @@ func (a *App) republishSoloNodes(ctx context.Context, current solo.State, nodeNa
 		peers        []solo.NodePeer
 		images       []string
 	}
+	type localImageCheck struct {
+		once sync.Once
+		err  error
+	}
 	var mu sync.Mutex
 	var errs []string
 	revisions := map[string]string{}
@@ -410,27 +414,15 @@ func (a *App) republishSoloNodes(ctx context.Context, current solo.State, nodeNa
 	sortedNodeNames := sortedSoloNodeNames(nodes)
 	prepared := make(map[string]preparedSoloNodeState, len(sortedNodeNames))
 	resolvedSnapshotCache := map[string]solo.DeploySnapshot{}
-	allImages := map[string]bool{}
 	for _, nodeName := range sortedNodeNames {
 		inputs, err := a.preparedSoloNodeDesiredStateInputs(current, nodeName, nodes[nodeName], resolvedSnapshotCache)
 		if err != nil {
 			return nil, err
 		}
 		prepared[nodeName] = inputs
-		for _, image := range inputs.images {
-			allImages[image] = true
-		}
 	}
-	images := make([]string, 0, len(allImages))
-	for image := range allImages {
-		images = append(images, image)
-	}
-	sort.Strings(images)
-	for _, image := range images {
-		if err := a.ensureLocalSoloSnapshotImage(ctx, image); err != nil {
-			return nil, err
-		}
-	}
+	var localImageChecksMu sync.Mutex
+	localImageChecks := map[string]*localImageCheck{}
 	for _, nodeName := range sortedNodeNames {
 		node := nodes[nodeName]
 		inputs := prepared[nodeName]
@@ -455,6 +447,22 @@ func (a *App) republishSoloNodes(ctx context.Context, current solo.State, nodeNa
 				}
 				if present {
 					continue
+				}
+				localImageChecksMu.Lock()
+				check, ok := localImageChecks[image]
+				if !ok {
+					check = &localImageCheck{}
+					localImageChecks[image] = check
+				}
+				localImageChecksMu.Unlock()
+				check.once.Do(func() {
+					check.err = a.ensureLocalSoloSnapshotImage(ctx, image)
+				})
+				if check.err != nil {
+					mu.Lock()
+					errs = append(errs, fmt.Sprintf("[%s] local image precheck: %s", name, check.err))
+					mu.Unlock()
+					return
 				}
 				if !a.Printer.JSON {
 					a.Printer.Println(fmt.Sprintf("[%s] Transferring image %s...", name, image))

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1252,6 +1252,10 @@ func (a *App) SoloSetup(ctx context.Context, _ SoloSetupOptions) error {
 	if err != nil {
 		return err
 	}
+	cfg, workspaceRoot, err := a.ensureSoloProjectConfig()
+	if err != nil {
+		return err
+	}
 	if strings.EqualFold(strings.TrimSpace(mode), "hetzner") {
 		region, err := a.promptLine("Hetzner region", defaultHetznerRegion)
 		if err != nil {
@@ -1292,10 +1296,6 @@ func (a *App) SoloSetup(ctx context.Context, _ SoloSetupOptions) error {
 	if err != nil {
 		return err
 	}
-	cfg, workspaceRoot, err := a.loadProjectConfigForSoloUpdate()
-	if err != nil {
-		return err
-	}
 	current, err := a.readSoloState()
 	if err != nil {
 		return err
@@ -1325,6 +1325,26 @@ func (a *App) SoloSetup(ctx context.Context, _ SoloSetupOptions) error {
 		return err
 	}
 	return a.SoloRuntimeDoctor(ctx, SoloDoctorOptions{Nodes: []string{name}})
+}
+
+func (a *App) ensureSoloProjectConfig() (*config.ProjectConfig, string, error) {
+	discovered, err := discovery.Discover(a.Cwd)
+	if err != nil {
+		return nil, "", err
+	}
+	cfg, err := a.ConfigStore.Read(discovered.WorkspaceRoot)
+	if err != nil {
+		return nil, "", err
+	}
+	if cfg != nil {
+		return cfg, discovered.WorkspaceRoot, nil
+	}
+	defaultCfg := soloDefaultProjectConfig(discovered)
+	written, err := a.ConfigStore.Write(discovered.WorkspaceRoot, *defaultCfg)
+	if err != nil {
+		return nil, "", err
+	}
+	return &written, discovered.WorkspaceRoot, nil
 }
 
 func (a *App) IngressSet(_ context.Context, opts IngressSetOptions) error {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -281,6 +281,7 @@ func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 	if a.Printer.JSON {
 		return a.Printer.PrintJSON(map[string]any{
 			"schema_version":          outputSchemaVersion,
+			"revision":                shortSHA,
 			"workload_revision":       shortSHA,
 			"desired_state_revisions": desiredStateRevisions,
 			"image":                   imageTag,

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -266,15 +266,14 @@ func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 	if err != nil {
 		return err
 	}
-	if _, err := current.SaveSnapshot(snapshot); err != nil {
+	if _, err := current.SaveSnapshot(solo.RedactDeploySnapshotSecrets(snapshot, cfg)); err != nil {
+		return err
+	}
+	desiredStateRevisions, err := a.republishSoloNodes(ctx, current, attachedNodeNames)
+	if err != nil {
 		return err
 	}
 	if err := a.writeSoloState(current); err != nil {
-		return err
-	}
-
-	desiredStateRevisions, err := a.republishSoloNodes(ctx, current, attachedNodeNames)
-	if err != nil {
 		return err
 	}
 
@@ -412,6 +411,17 @@ func (a *App) republishSoloNodes(ctx context.Context, current solo.State, nodeNa
 				mu.Unlock()
 				return
 			}
+			resolvedSnapshots := make([]solo.DeploySnapshot, 0, len(snapshots))
+			for _, snapshot := range snapshots {
+				resolvedSnapshot, err := a.resolveStoredDeploySnapshot(snapshot)
+				if err != nil {
+					mu.Lock()
+					errs = append(errs, fmt.Sprintf("[%s] hydrate snapshot: %s", name, err))
+					mu.Unlock()
+					return
+				}
+				resolvedSnapshots = append(resolvedSnapshots, resolvedSnapshot)
+			}
 			for _, image := range images {
 				if err := a.ensureLocalSoloSnapshotImage(ctx, image); err != nil {
 					mu.Lock()
@@ -449,7 +459,7 @@ func (a *App) republishSoloNodes(ctx context.Context, current solo.State, nodeNa
 					return
 				}
 			}
-			desiredStateJSON, err := solo.BuildAggregatedDesiredState(name, node, snapshots, releaseNodes, peers)
+			desiredStateJSON, err := solo.BuildAggregatedDesiredState(name, node, resolvedSnapshots, releaseNodes, peers)
 			if err != nil {
 				mu.Lock()
 				errs = append(errs, fmt.Sprintf("[%s] build desired state: %s", name, err))
@@ -484,6 +494,28 @@ func (a *App) republishSoloNodes(ctx context.Context, current solo.State, nodeNa
 		return nil, fmt.Errorf("republish errors:\n  %s", strings.Join(errs, "\n  "))
 	}
 	return revisions, nil
+}
+
+func (a *App) resolveStoredDeploySnapshot(snapshot solo.DeploySnapshot) (solo.DeploySnapshot, error) {
+	cfg, err := a.ConfigStore.Read(snapshot.WorkspaceRoot)
+	if err != nil {
+		return solo.DeploySnapshot{}, err
+	}
+	if cfg == nil {
+		return solo.DeploySnapshot{}, fmt.Errorf("missing devopsellence.yml for %s", snapshot.WorkspaceRoot)
+	}
+	secrets, err := solo.LoadSecrets(snapshot.WorkspaceRoot)
+	if err != nil {
+		return solo.DeploySnapshot{}, fmt.Errorf("load secrets for %s: %w", snapshot.WorkspaceRoot, err)
+	}
+	if _, err := applySoloRailsMasterKey(snapshot.WorkspaceRoot, cfg, secrets); err != nil {
+		return solo.DeploySnapshot{}, err
+	}
+	configPath := strings.TrimSpace(snapshot.Metadata.ConfigPath)
+	if configPath == "" {
+		configPath = a.ConfigStore.PathFor(snapshot.WorkspaceRoot)
+	}
+	return solo.BuildDeploySnapshot(cfg, snapshot.WorkspaceRoot, configPath, snapshot.Image, snapshot.Revision, secrets)
 }
 
 func desiredStateRevision(data []byte) (string, error) {
@@ -789,13 +821,13 @@ func (a *App) SoloNodeAttach(ctx context.Context, opts SoloNodeAttachOptions) er
 	if err != nil {
 		return err
 	}
-	if err := a.writeSoloState(current); err != nil {
-		return err
-	}
 	if _, ok := current.Snapshots[attachment.WorkspaceKey+"\n"+attachment.Environment]; ok {
 		if _, err := a.republishSoloNodes(ctx, current, attachment.NodeNames); err != nil {
 			return err
 		}
+	}
+	if err := a.writeSoloState(current); err != nil {
+		return err
 	}
 	if a.Printer.JSON {
 		return a.Printer.PrintJSON(map[string]any{
@@ -836,10 +868,10 @@ func (a *App) SoloNodeDetach(ctx context.Context, opts SoloNodeDetachOptions) er
 	}
 	affectedNodeNames := append([]string{opts.Node}, nodeNamesBefore...)
 	affectedNodeNames = normalizeSoloNames(affectedNodeNames)
-	if err := a.writeSoloState(current); err != nil {
+	if _, err := a.republishSoloNodes(ctx, current, affectedNodeNames); err != nil {
 		return err
 	}
-	if _, err := a.republishSoloNodes(ctx, current, affectedNodeNames); err != nil {
+	if err := a.writeSoloState(current); err != nil {
 		return err
 	}
 	if a.Printer.JSON {
@@ -906,10 +938,10 @@ func (a *App) SoloNodeLabelSet(ctx context.Context, opts SoloNodeLabelSetOptions
 	}
 	node.Labels = labels
 	current.Nodes[opts.Node] = solo.NormalizeNode(node)
-	if err := a.writeSoloState(current); err != nil {
+	if _, err := a.republishSoloNodes(ctx, current, soloAffectedNodesForNode(current, opts.Node)); err != nil {
 		return err
 	}
-	if _, err := a.republishSoloNodes(ctx, current, soloAffectedNodesForNode(current, opts.Node)); err != nil {
+	if err := a.writeSoloState(current); err != nil {
 		return err
 	}
 	if a.Printer.JSON {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -281,7 +281,6 @@ func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 	if a.Printer.JSON {
 		return a.Printer.PrintJSON(map[string]any{
 			"schema_version":          outputSchemaVersion,
-			"revision":                shortSHA,
 			"workload_revision":       shortSHA,
 			"desired_state_revisions": desiredStateRevisions,
 			"image":                   imageTag,

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -49,6 +49,16 @@ type SoloSecretsDeleteOptions struct {
 
 type SoloNodeListOptions struct{}
 
+type SoloNodeAttachOptions struct {
+	Node        string
+	Environment string
+}
+
+type SoloNodeDetachOptions struct {
+	Node        string
+	Environment string
+}
+
 type SoloLogsOptions struct {
 	Node   string
 	Follow bool
@@ -198,27 +208,36 @@ func (a *App) createProviderNode(ctx context.Context, opts SoloNodeCreateOptions
 }
 
 func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
-	cfg, workspaceRoot, err := a.loadSoloConfig()
+	if len(opts.Nodes) > 0 {
+		return fmt.Errorf("solo deploy --nodes is no longer supported; attach or detach nodes instead")
+	}
+	cfg, workspaceRoot, err := a.loadSoloProjectConfig()
 	if err != nil {
 		return err
 	}
-
-	nodes, err := a.resolveNodes(cfg.Solo, opts.Nodes)
+	current, err := a.readSoloState()
+	if err != nil {
+		return err
+	}
+	environmentName := soloEnvironmentName(cfg, "")
+	attachedNodeNames, err := current.AttachedNodeNames(workspaceRoot, environmentName)
+	if err != nil {
+		return err
+	}
+	nodes, err := a.resolveSoloNodes(current, attachedNodeNames)
 	if err != nil {
 		return err
 	}
 	if len(nodes) == 0 {
-		return fmt.Errorf("no nodes configured; add solo.nodes to devopsellence.yml")
+		return fmt.Errorf("no nodes attached to %s; run `devopsellence node attach <name>`", environmentName)
 	}
-	releaseNode, err := validateSoloNodeSchedule(cfg, nodes)
-	if err != nil {
+	if _, err := validateSoloNodeSchedule(cfg, nodes); err != nil {
 		return err
 	}
 	if err := a.checkIngressBeforeDeploy(ctx, cfg, nodes, opts.SkipDNSCheck); err != nil {
 		return err
 	}
 
-	// Get git SHA for revision and image tag.
 	sha, err := a.Git.CurrentSHA(workspaceRoot)
 	if err != nil {
 		return fmt.Errorf("get git SHA: %w", err)
@@ -228,8 +247,6 @@ func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 		shortSHA = shortSHA[:7]
 	}
 	imageTag := soloImageTag(cfg.Project, shortSHA)
-
-	// Build Docker image.
 	if !a.Printer.JSON {
 		a.Printer.Println("Building image " + imageTag + " ...")
 	}
@@ -239,7 +256,6 @@ func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 		return fmt.Errorf("docker build: %w", err)
 	}
 
-	// Load local secrets and build desired state.
 	secrets, err := solo.LoadSecrets(workspaceRoot)
 	if err != nil {
 		return fmt.Errorf("load secrets: %w", err)
@@ -250,64 +266,27 @@ func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 		a.Printer.Println("Rails: " + notice)
 	}
 
-	// Deploy to each node in parallel.
-	var mu sync.Mutex
-	var errs []string
-	var wg sync.WaitGroup
-
-	for _, name := range sortedSoloNodeNames(nodes) {
-		node := nodes[name]
-		wg.Add(1)
-		go func(name string, node config.SoloNode) {
-			defer wg.Done()
-			desiredStateJSON, err := solo.BuildDesiredStateForNode(cfg, imageTag, shortSHA, secrets, node.Labels, soloNodeCanRunIngress(node, cfg), name == releaseNode, soloNodePeers(cfg, name))
-			if err != nil {
-				mu.Lock()
-				errs = append(errs, fmt.Sprintf("[%s] build desired state: %s", name, err))
-				mu.Unlock()
-				return
-			}
-
-			if !a.Printer.JSON {
-				a.Printer.Println(fmt.Sprintf("[%s] Transferring image...", name))
-			}
-			if err := transferImage(ctx, node, imageTag, a.soloProgress(name)); err != nil {
-				mu.Lock()
-				errs = append(errs, fmt.Sprintf("[%s] image transfer: %s", name, err))
-				mu.Unlock()
-				return
-			}
-
-			if !a.Printer.JSON {
-				a.Printer.Println(fmt.Sprintf("[%s] Writing desired state...", name))
-			}
-			overridePath := filepath.Join(node.AgentStateDir, "desired-state-override.json")
-			cmd := remoteDesiredStateOverrideCommand(overridePath)
-			if _, err := solo.RunSSH(ctx, node, cmd, strings.NewReader(string(desiredStateJSON))); err != nil {
-				mu.Lock()
-				errs = append(errs, fmt.Sprintf("[%s] write desired state: %s", name, err))
-				mu.Unlock()
-				return
-			}
-
-			if !a.Printer.JSON {
-				a.Printer.Println(fmt.Sprintf("[%s] Deployed %s", name, shortSHA))
-			}
-		}(name, node)
+	snapshot, err := solo.BuildDeploySnapshot(cfg, workspaceRoot, a.ConfigStore.PathFor(workspaceRoot), imageTag, shortSHA, secrets)
+	if err != nil {
+		return err
+	}
+	if _, err := current.SaveSnapshot(snapshot); err != nil {
+		return err
+	}
+	if err := a.writeSoloState(current); err != nil {
+		return err
 	}
 
-	wg.Wait()
-	if len(errs) > 0 {
-		return fmt.Errorf("deploy errors:\n  %s", strings.Join(errs, "\n  "))
+	if err := a.republishSoloNodes(ctx, current, attachedNodeNames); err != nil {
+		return err
 	}
 
 	if a.Printer.JSON {
-		nodeNames := make([]string, 0, len(nodes))
-		nodeNames = append(nodeNames, sortedSoloNodeNames(nodes)...)
 		return a.Printer.PrintJSON(map[string]any{
-			"revision": shortSHA,
-			"image":    imageTag,
-			"nodes":    nodeNames,
+			"revision":    shortSHA,
+			"image":       imageTag,
+			"environment": environmentName,
+			"nodes":       sortedSoloNodeNames(nodes),
 		})
 	}
 	a.Printer.Println(fmt.Sprintf("Deployed revision %s to %d node(s)", shortSHA, len(nodes)))
@@ -372,18 +351,187 @@ func sortedSoloNodeNames(nodes map[string]config.SoloNode) []string {
 	return names
 }
 
-func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
-	cfg, _, err := a.loadSoloConfig()
+func (a *App) readSoloState() (solo.State, error) {
+	if a.SoloState == nil {
+		return solo.State{}, fmt.Errorf("solo state store is required")
+	}
+	return a.SoloState.Read()
+}
+
+func (a *App) writeSoloState(current solo.State) error {
+	if a.SoloState == nil {
+		return fmt.Errorf("solo state store is required")
+	}
+	return a.SoloState.Write(current)
+}
+
+func (a *App) resolveSoloNodes(current solo.State, names []string) (map[string]config.SoloNode, error) {
+	if len(names) == 0 {
+		result := make(map[string]config.SoloNode, len(current.Nodes))
+		for name, node := range current.Nodes {
+			result[name] = node
+		}
+		return result, nil
+	}
+	result := make(map[string]config.SoloNode, len(names))
+	unknown := []string{}
+	for _, name := range names {
+		if node, ok := current.Nodes[name]; ok {
+			result[name] = node
+		} else {
+			unknown = append(unknown, name)
+		}
+	}
+	if len(unknown) > 0 {
+		return nil, fmt.Errorf("unknown node(s): %s (available: %s)", strings.Join(unknown, ", "), strings.Join(current.NodeNames(), ", "))
+	}
+	return result, nil
+}
+
+func (a *App) republishSoloNodes(ctx context.Context, current solo.State, nodeNames []string) error {
+	if len(nodeNames) == 0 {
+		return nil
+	}
+	var mu sync.Mutex
+	var errs []string
+	var wg sync.WaitGroup
+
+	nodes, err := a.resolveSoloNodes(current, nodeNames)
 	if err != nil {
 		return err
 	}
+	for _, nodeName := range sortedSoloNodeNames(nodes) {
+		node := nodes[nodeName]
+		wg.Add(1)
+		go func(name string, node config.SoloNode) {
+			defer wg.Done()
+			snapshots, releaseNodes, peers, images, err := soloNodeDesiredStateInputs(current, name)
+			if err != nil {
+				mu.Lock()
+				errs = append(errs, fmt.Sprintf("[%s] build desired state inputs: %s", name, err))
+				mu.Unlock()
+				return
+			}
+			for _, image := range images {
+				if !a.Printer.JSON {
+					a.Printer.Println(fmt.Sprintf("[%s] Transferring image %s...", name, image))
+				}
+				if err := transferImage(ctx, node, image, a.soloProgress(name)); err != nil {
+					mu.Lock()
+					errs = append(errs, fmt.Sprintf("[%s] image transfer: %s", name, err))
+					mu.Unlock()
+					return
+				}
+			}
+			desiredStateJSON, err := solo.BuildAggregatedDesiredState(name, node, snapshots, releaseNodes, peers)
+			if err != nil {
+				mu.Lock()
+				errs = append(errs, fmt.Sprintf("[%s] build desired state: %s", name, err))
+				mu.Unlock()
+				return
+			}
+			if !a.Printer.JSON {
+				a.Printer.Println(fmt.Sprintf("[%s] Writing desired state...", name))
+			}
+			overridePath := filepath.Join(node.AgentStateDir, "desired-state-override.json")
+			cmd := remoteDesiredStateOverrideCommand(overridePath)
+			if _, err := solo.RunSSH(ctx, node, cmd, strings.NewReader(string(desiredStateJSON))); err != nil {
+				mu.Lock()
+				errs = append(errs, fmt.Sprintf("[%s] write desired state: %s", name, err))
+				mu.Unlock()
+				return
+			}
+		}(nodeName, node)
+	}
+	wg.Wait()
+	if len(errs) > 0 {
+		return fmt.Errorf("deploy errors:\n  %s", strings.Join(errs, "\n  "))
+	}
+	return nil
+}
 
-	nodes, err := a.resolveNodes(cfg.Solo, opts.Nodes)
+func soloNodeDesiredStateInputs(current solo.State, nodeName string) ([]solo.DeploySnapshot, map[string]string, []solo.NodePeer, []string, error) {
+	snapshots := []solo.DeploySnapshot{}
+	releaseNodes := map[string]string{}
+	peerMap := map[string]solo.NodePeer{}
+	imageSet := map[string]bool{}
+
+	for _, key := range current.AttachmentKeysForNode(nodeName) {
+		attachment := current.Attachments[key]
+		snapshot, ok := current.Snapshots[key]
+		if !ok {
+			continue
+		}
+		snapshots = append(snapshots, snapshot)
+		if image := strings.TrimSpace(snapshot.Image); image != "" && !imageSet[image] {
+			imageSet[image] = true
+		}
+		releaseNode, err := releaseNodeForSnapshot(snapshot, attachment, current.Nodes)
+		if err != nil {
+			return nil, nil, nil, nil, err
+		}
+		if releaseNode != "" {
+			releaseNodes[key] = releaseNode
+		}
+		for _, peerName := range attachment.NodeNames {
+			if peerName == nodeName {
+				continue
+			}
+			peerNode, ok := current.Nodes[peerName]
+			if !ok || strings.TrimSpace(peerNode.Host) == "" {
+				continue
+			}
+			peerMap[peerName] = solo.NodePeer{
+				Name:          peerName,
+				Labels:        append([]string(nil), peerNode.Labels...),
+				PublicAddress: peerNode.Host,
+			}
+		}
+	}
+
+	peers := make([]solo.NodePeer, 0, len(peerMap))
+	for _, name := range sortedSoloPeerNames(peerMap) {
+		peers = append(peers, peerMap[name])
+	}
+	images := make([]string, 0, len(imageSet))
+	for image := range imageSet {
+		images = append(images, image)
+	}
+	sort.Strings(images)
+	return snapshots, releaseNodes, peers, images, nil
+}
+
+func releaseNodeForSnapshot(snapshot solo.DeploySnapshot, attachment solo.AttachmentRecord, nodes map[string]config.SoloNode) (string, error) {
+	if snapshot.ReleaseTask == nil {
+		return "", nil
+	}
+	nodeNames := append([]string(nil), attachment.NodeNames...)
+	sort.Strings(nodeNames)
+	for _, nodeName := range nodeNames {
+		node, ok := nodes[nodeName]
+		if ok && soloNodeCanRunKind(node, snapshot.ReleaseServiceKind) {
+			return nodeName, nil
+		}
+	}
+	return "", fmt.Errorf("environment %s in %s requires at least one attached node labeled %q for release task service %q", snapshot.Environment, snapshot.WorkspaceKey, snapshot.ReleaseServiceKind, snapshot.ReleaseService)
+}
+
+func sortedSoloPeerNames(peers map[string]solo.NodePeer) []string {
+	names := make([]string, 0, len(peers))
+	for name := range peers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
+	nodes, err := a.soloStatusNodes(opts)
 	if err != nil {
 		return err
 	}
 	if len(nodes) == 0 {
-		return fmt.Errorf("no nodes configured")
+		return fmt.Errorf("no nodes attached to the current environment")
 	}
 
 	var jsonResults []map[string]any
@@ -466,7 +614,7 @@ func (a *App) SoloSecretsSet(_ context.Context, opts SoloSecretsSetOptions) erro
 	if strings.TrimSpace(opts.Value) == "" {
 		return ExitError{Code: 2, Err: errors.New("secret value is required")}
 	}
-	_, workspaceRoot, err := a.loadSoloConfig()
+	_, workspaceRoot, err := a.loadSoloProjectConfig()
 	if err != nil {
 		return err
 	}
@@ -481,7 +629,7 @@ func (a *App) SoloSecretsSet(_ context.Context, opts SoloSecretsSetOptions) erro
 }
 
 func (a *App) SoloSecretsList(_ context.Context, _ SoloSecretsListOptions) error {
-	_, workspaceRoot, err := a.loadSoloConfig()
+	_, workspaceRoot, err := a.loadSoloProjectConfig()
 	if err != nil {
 		return err
 	}
@@ -503,30 +651,139 @@ func (a *App) SoloSecretsList(_ context.Context, _ SoloSecretsListOptions) error
 }
 
 func (a *App) SoloNodeList(_ context.Context, _ SoloNodeListOptions) error {
-	cfg, _, err := a.loadSoloConfig()
+	current, err := a.readSoloState()
 	if err != nil {
 		return err
+	}
+	currentWorkspaceKey := ""
+	currentEnvironment := ""
+	if discovered, cfg, cfgErr := a.optionalWorkspaceConfig(); cfgErr == nil && cfg != nil {
+		currentWorkspaceKey, _ = solo.CanonicalWorkspaceKey(discovered.WorkspaceRoot)
+		currentEnvironment = soloEnvironmentName(cfg, "")
+	}
+	type nodeListItem struct {
+		Name                    string                  `json:"name"`
+		Node                    config.SoloNode         `json:"node"`
+		Attachments             []solo.AttachmentRecord `json:"attachments,omitempty"`
+		CurrentEnvironmentBound bool                    `json:"current_environment_bound,omitempty"`
+	}
+	items := make([]nodeListItem, 0, len(current.Nodes))
+	for _, name := range current.NodeNames() {
+		attachments := current.AttachmentsForNode(name)
+		bound := false
+		for _, attachment := range attachments {
+			if attachment.WorkspaceKey == currentWorkspaceKey && attachment.Environment == currentEnvironment {
+				bound = true
+				break
+			}
+		}
+		items = append(items, nodeListItem{
+			Name:                    name,
+			Node:                    current.Nodes[name],
+			Attachments:             attachments,
+			CurrentEnvironmentBound: bound,
+		})
 	}
 	if a.Printer.JSON {
 		return a.Printer.PrintJSON(map[string]any{
 			"schema_version": outputSchemaVersion,
-			"nodes":          cfg.Solo.Nodes,
+			"nodes":          items,
 		})
 	}
-	names := sortedSoloNodeNames(cfg.Solo.Nodes)
-	if len(names) == 0 {
+	if len(items) == 0 {
 		a.Printer.Println("No nodes.")
 		return nil
 	}
-	for _, name := range names {
-		node := cfg.Solo.Nodes[name]
-		a.Printer.Println(fmt.Sprintf("%s  host=%s  labels=%s", name, node.Host, strings.Join(node.Labels, ",")))
+	for _, item := range items {
+		line := fmt.Sprintf("%s  host=%s  labels=%s  attachments=%d", item.Name, item.Node.Host, strings.Join(item.Node.Labels, ","), len(item.Attachments))
+		if item.CurrentEnvironmentBound {
+			line += "  current=yes"
+		}
+		a.Printer.Println(line)
 	}
 	return nil
 }
 
+func (a *App) SoloNodeAttach(ctx context.Context, opts SoloNodeAttachOptions) error {
+	cfg, workspaceRoot, err := a.loadSoloProjectConfig()
+	if err != nil {
+		return err
+	}
+	current, err := a.readSoloState()
+	if err != nil {
+		return err
+	}
+	environmentName := soloEnvironmentName(cfg, opts.Environment)
+	attachment, changed, err := a.attachSoloNode(&current, workspaceRoot, environmentName, opts.Node)
+	if err != nil {
+		return err
+	}
+	if err := a.writeSoloState(current); err != nil {
+		return err
+	}
+	if _, ok := current.Snapshots[attachment.WorkspaceKey+"\n"+attachment.Environment]; ok {
+		if err := a.republishSoloNodes(ctx, current, attachment.NodeNames); err != nil {
+			return err
+		}
+	}
+	if a.Printer.JSON {
+		return a.Printer.PrintJSON(map[string]any{
+			"node":        opts.Node,
+			"environment": environmentName,
+			"changed":     changed,
+		})
+	}
+	if changed {
+		a.Printer.Println("Attached solo node " + opts.Node + " to " + environmentName)
+	} else {
+		a.Printer.Println("Solo node " + opts.Node + " already attached to " + environmentName)
+	}
+	return nil
+}
+
+func (a *App) SoloNodeDetach(ctx context.Context, opts SoloNodeDetachOptions) error {
+	cfg, workspaceRoot, err := a.loadSoloProjectConfig()
+	if err != nil {
+		return err
+	}
+	current, err := a.readSoloState()
+	if err != nil {
+		return err
+	}
+	environmentName := soloEnvironmentName(cfg, opts.Environment)
+	nodeNamesBefore, err := current.AttachedNodeNames(workspaceRoot, environmentName)
+	if err != nil {
+		return err
+	}
+	if len(nodeNamesBefore) == 0 {
+		return fmt.Errorf("environment %s has no attached nodes", environmentName)
+	}
+	if _, changed, err := current.DetachNode(workspaceRoot, environmentName, opts.Node); err != nil {
+		return err
+	} else if !changed {
+		return fmt.Errorf("node %q is not attached to %s", opts.Node, environmentName)
+	}
+	affectedNodeNames := append([]string{opts.Node}, nodeNamesBefore...)
+	affectedNodeNames = normalizeSoloNames(affectedNodeNames)
+	if err := a.writeSoloState(current); err != nil {
+		return err
+	}
+	if err := a.republishSoloNodes(ctx, current, affectedNodeNames); err != nil {
+		return err
+	}
+	if a.Printer.JSON {
+		return a.Printer.PrintJSON(map[string]any{
+			"node":        opts.Node,
+			"environment": environmentName,
+			"changed":     true,
+		})
+	}
+	a.Printer.Println("Detached solo node " + opts.Node + " from " + environmentName)
+	return nil
+}
+
 func (a *App) SoloSecretsDelete(_ context.Context, opts SoloSecretsDeleteOptions) error {
-	_, workspaceRoot, err := a.loadSoloConfig()
+	_, workspaceRoot, err := a.loadSoloProjectConfig()
 	if err != nil {
 		return err
 	}
@@ -541,16 +798,14 @@ func (a *App) SoloSecretsDelete(_ context.Context, opts SoloSecretsDeleteOptions
 }
 
 func (a *App) SoloLogs(ctx context.Context, opts SoloLogsOptions) error {
-	cfg, _, err := a.loadSoloConfig()
+	current, err := a.readSoloState()
 	if err != nil {
 		return err
 	}
-
-	soloNode, ok := cfg.Solo.Nodes[opts.Node]
+	node, ok := current.Nodes[opts.Node]
 	if !ok {
-		return fmt.Errorf("node %q not found in config", opts.Node)
+		return fmt.Errorf("node %q not found", opts.Node)
 	}
-	node := soloNodeFromConfig(soloNode)
 
 	if opts.Follow {
 		// Stream directly to the user's terminal — do not buffer.
@@ -565,30 +820,31 @@ func (a *App) SoloLogs(ctx context.Context, opts SoloLogsOptions) error {
 	return nil
 }
 
-func (a *App) SoloNodeLabelSet(_ context.Context, opts SoloNodeLabelSetOptions) error {
-	cfg, workspaceRoot, err := a.loadSoloConfig()
+func (a *App) SoloNodeLabelSet(ctx context.Context, opts SoloNodeLabelSetOptions) error {
+	current, err := a.readSoloState()
 	if err != nil {
 		return err
 	}
-	soloNode, ok := cfg.Solo.Nodes[opts.Node]
+	node, ok := current.Nodes[opts.Node]
 	if !ok {
-		return fmt.Errorf("node %q not found in config", opts.Node)
+		return fmt.Errorf("node %q not found", opts.Node)
 	}
-	node := soloNodeFromConfig(soloNode)
 	labels, err := parseSoloLabels(opts.Labels)
 	if err != nil {
 		return err
 	}
 	node.Labels = labels
-	cfg.Solo.Nodes[opts.Node] = config.SoloNode(node)
-	if _, err := a.ConfigStore.Write(workspaceRoot, *cfg); err != nil {
+	current.Nodes[opts.Node] = solo.NormalizeNode(node)
+	if err := a.writeSoloState(current); err != nil {
+		return err
+	}
+	if err := a.republishSoloNodes(ctx, current, soloAffectedNodesForNode(current, opts.Node)); err != nil {
 		return err
 	}
 	if a.Printer.JSON {
 		return a.Printer.PrintJSON(map[string]any{
-			"node":        opts.Node,
-			"labels":      labels,
-			"config_path": a.ConfigStore.PathFor(workspaceRoot),
+			"node":   opts.Node,
+			"labels": labels,
 		})
 	}
 	a.Printer.Println("Updated solo node " + opts.Node + " labels: " + strings.Join(labels, ","))
@@ -596,15 +852,14 @@ func (a *App) SoloNodeLabelSet(_ context.Context, opts SoloNodeLabelSetOptions) 
 }
 
 func (a *App) SoloAgentInstall(ctx context.Context, opts SoloAgentInstallOptions) error {
-	cfg, _, err := a.loadSoloConfig()
+	current, err := a.readSoloState()
 	if err != nil {
 		return err
 	}
-	soloNode, ok := cfg.Solo.Nodes[opts.Node]
+	node, ok := current.Nodes[opts.Node]
 	if !ok {
-		return fmt.Errorf("node %q not found in config", opts.Node)
+		return fmt.Errorf("node %q not found", opts.Node)
 	}
-	node := soloNodeFromConfig(soloNode)
 	if !a.Printer.JSON {
 		a.Printer.Println("Installing solo agent on " + opts.Node + "...")
 	}
@@ -619,11 +874,11 @@ func (a *App) SoloAgentInstall(ctx context.Context, opts SoloAgentInstallOptions
 }
 
 func (a *App) SoloRuntimeDoctor(ctx context.Context, opts SoloDoctorOptions) error {
-	cfg, _, err := a.loadSoloConfig()
+	current, err := a.readSoloState()
 	if err != nil {
 		return err
 	}
-	nodes, err := a.resolveNodes(cfg.Solo, opts.Nodes)
+	nodes, err := a.resolveSoloNodes(current, opts.Nodes)
 	if err != nil {
 		return err
 	}
@@ -708,6 +963,7 @@ func (a *App) SoloDoctor(ctx context.Context) error {
 	})
 
 	var cfg *config.ProjectConfig
+	var current solo.State
 	addCheck("config", func() (string, error) {
 		if discoveryErr != nil {
 			return "", discoveryErr
@@ -724,13 +980,15 @@ func (a *App) SoloDoctor(ctx context.Context) error {
 	})
 
 	addCheck("nodes", func() (string, error) {
-		if cfg == nil {
-			return "", errors.New("No solo nodes configured yet. Run `devopsellence setup`.")
+		var err error
+		current, err = a.readSoloState()
+		if err != nil {
+			return "", err
 		}
-		if cfg.Solo == nil || len(cfg.Solo.Nodes) == 0 {
-			return "", errors.New("No solo nodes configured yet. Run `devopsellence setup`.")
+		if len(current.Nodes) == 0 {
+			return "", errors.New("No solo nodes registered yet. Run `devopsellence node create` or `devopsellence setup`.")
 		}
-		return fmt.Sprintf("%d node(s) configured", len(cfg.Solo.Nodes)), nil
+		return fmt.Sprintf("%d node(s) registered", len(current.Nodes)), nil
 	})
 
 	ok := true
@@ -755,7 +1013,7 @@ func (a *App) SoloDoctor(ctx context.Context) error {
 		}
 		a.Printer.Println(prefix, fmt.Sprintf("%v:", check["name"]), check["detail"])
 	}
-	if ok && cfg != nil && cfg.Solo != nil && len(cfg.Solo.Nodes) > 0 {
+	if ok && len(current.Nodes) > 0 {
 		return a.SoloRuntimeDoctor(ctx, SoloDoctorOptions{})
 	}
 	return nil
@@ -766,22 +1024,27 @@ func (a *App) SoloNodeCreate(ctx context.Context, opts SoloNodeCreateOptions) er
 	if err != nil {
 		return err
 	}
+	current, err := a.readSoloState()
+	if err != nil {
+		return err
+	}
 	if opts.Name == "" {
 		return fmt.Errorf("node name is required")
 	}
 	if opts.Deploy && a.Printer.JSON {
 		return fmt.Errorf("node create --deploy is not supported with --json")
 	}
-	if cfg.Solo != nil {
-		if _, ok := cfg.Solo.Nodes[opts.Name]; ok {
-			return fmt.Errorf("solo node %q already exists", opts.Name)
-		}
+	if _, ok := current.Nodes[opts.Name]; ok {
+		return fmt.Errorf("solo node %q already exists", opts.Name)
 	}
 	created, err := a.createProviderNode(ctx, opts, cfg.Project)
 	if err != nil {
 		return err
 	}
-	if err := a.writeSoloNode(workspaceRoot, cfg, opts.Name, created.Node); err != nil {
+	if err := current.SetNode(opts.Name, created.Node); err != nil {
+		return err
+	}
+	if err := a.writeSoloState(current); err != nil {
 		return err
 	}
 	if !opts.NoInstall || opts.Deploy {
@@ -796,7 +1059,13 @@ func (a *App) SoloNodeCreate(ctx context.Context, opts SoloNodeCreateOptions) er
 		}
 	}
 	if opts.Deploy {
-		if err := a.SoloDeploy(ctx, SoloDeployOptions{Nodes: []string{opts.Name}}); err != nil {
+		if _, _, err := a.attachSoloNode(&current, workspaceRoot, soloEnvironmentName(cfg, ""), opts.Name); err != nil {
+			return err
+		}
+		if err := a.writeSoloState(current); err != nil {
+			return err
+		}
+		if err := a.SoloDeploy(ctx, SoloDeployOptions{}); err != nil {
 			return err
 		}
 	}
@@ -919,15 +1188,17 @@ func (a *App) SoloNodeRemove(ctx context.Context, opts SoloNodeRemoveOptions) er
 	if !opts.Yes {
 		return fmt.Errorf("node remove requires --yes")
 	}
-	cfg, workspaceRoot, err := a.loadSoloConfig()
+	current, err := a.readSoloState()
 	if err != nil {
 		return err
 	}
-	soloNode, ok := cfg.Solo.Nodes[opts.Name]
+	node, ok := current.Nodes[opts.Name]
 	if !ok {
-		return fmt.Errorf("node %q not found in config", opts.Name)
+		return fmt.Errorf("node %q not found", opts.Name)
 	}
-	node := soloNodeFromConfig(soloNode)
+	if current.NodeHasAttachments(opts.Name) {
+		return fmt.Errorf("node %q still has attached environments; detach it first", opts.Name)
+	}
 	if node.Provider == "" || node.ProviderServerID == "" {
 		return fmt.Errorf("node %q does not have provider metadata; refusing provider delete", opts.Name)
 	}
@@ -938,8 +1209,8 @@ func (a *App) SoloNodeRemove(ctx context.Context, opts SoloNodeRemoveOptions) er
 	if err := provider.DeleteServer(ctx, node.ProviderServerID); err != nil {
 		return err
 	}
-	delete(cfg.Solo.Nodes, opts.Name)
-	if _, err := a.ConfigStore.Write(workspaceRoot, *cfg); err != nil {
+	current.RemoveNode(opts.Name)
+	if err := a.writeSoloState(current); err != nil {
 		return err
 	}
 	if a.Printer.JSON {
@@ -988,6 +1259,9 @@ func (a *App) SoloSetup(ctx context.Context, _ SoloSetupOptions) error {
 		}); err != nil {
 			return err
 		}
+		if err := a.SoloNodeAttach(ctx, SoloNodeAttachOptions{Node: name}); err != nil {
+			return err
+		}
 		return a.SoloRuntimeDoctor(ctx, SoloDoctorOptions{Nodes: []string{name}})
 	}
 	host, err := a.promptLine("Host", "")
@@ -1006,6 +1280,10 @@ func (a *App) SoloSetup(ctx context.Context, _ SoloSetupOptions) error {
 	if err != nil {
 		return err
 	}
+	current, err := a.readSoloState()
+	if err != nil {
+		return err
+	}
 	parsedLabels, err := parseSoloLabels(labels)
 	if err != nil {
 		return err
@@ -1018,7 +1296,13 @@ func (a *App) SoloSetup(ctx context.Context, _ SoloSetupOptions) error {
 		AgentStateDir: "/var/lib/devopsellence",
 		Labels:        parsedLabels,
 	}
-	if err := a.writeSoloNode(workspaceRoot, cfg, name, node); err != nil {
+	if err := current.SetNode(name, node); err != nil {
+		return err
+	}
+	if _, _, err := a.attachSoloNode(&current, workspaceRoot, soloEnvironmentName(cfg, ""), name); err != nil {
+		return err
+	}
+	if err := a.writeSoloState(current); err != nil {
 		return err
 	}
 	if err := a.installSoloAgent(ctx, name, node, SoloAgentInstallOptions{}); err != nil {
@@ -1095,13 +1379,25 @@ func (a *App) IngressSet(_ context.Context, opts IngressSetOptions) error {
 }
 
 func (a *App) IngressCheck(ctx context.Context, opts IngressCheckOptions) error {
-	cfg, _, err := a.loadSoloConfig()
+	cfg, workspaceRoot, err := a.loadSoloProjectConfig()
+	if err != nil {
+		return err
+	}
+	current, err := a.readSoloState()
+	if err != nil {
+		return err
+	}
+	nodeNames, err := current.AttachedNodeNames(workspaceRoot, soloEnvironmentName(cfg, ""))
+	if err != nil {
+		return err
+	}
+	nodes, err := a.resolveSoloNodes(current, nodeNames)
 	if err != nil {
 		return err
 	}
 	deadline := time.Now().Add(opts.Wait)
 	for {
-		report, err := ingressDNSReport(ctx, cfg, nil)
+		report, err := ingressDNSReport(ctx, cfg, nodes)
 		if err != nil {
 			return err
 		}
@@ -1141,9 +1437,7 @@ func (a *App) installSoloAgent(ctx context.Context, nodeName string, node config
 	return installSoloAgent(ctx, node, opts, reporter)
 }
 
-// loadSoloConfig discovers the workspace root, loads devopsellence.yml,
-// and validates that solo config is present.
-func (a *App) loadSoloConfig() (*config.ProjectConfig, string, error) {
+func (a *App) loadSoloProjectConfig() (*config.ProjectConfig, string, error) {
 	discovered, err := discovery.Discover(a.Cwd)
 	if err != nil {
 		return nil, "", err
@@ -1155,9 +1449,6 @@ func (a *App) loadSoloConfig() (*config.ProjectConfig, string, error) {
 	}
 	if cfg == nil {
 		return nil, "", fmt.Errorf("no devopsellence.yml found; run `devopsellence setup --mode solo`")
-	}
-	if cfg.Solo == nil || len(cfg.Solo.Nodes) == 0 {
-		return nil, "", fmt.Errorf("no solo.nodes configured in devopsellence.yml")
 	}
 	return cfg, workspaceRoot, nil
 }
@@ -1177,6 +1468,51 @@ func (a *App) loadProjectConfigForSoloUpdate() (*config.ProjectConfig, string, e
 	return cfg, discovered.WorkspaceRoot, nil
 }
 
+func soloEnvironmentName(cfg *config.ProjectConfig, override string) string {
+	if strings.TrimSpace(override) != "" {
+		return strings.TrimSpace(override)
+	}
+	if cfg == nil || strings.TrimSpace(cfg.DefaultEnvironment) == "" {
+		return config.DefaultEnvironment
+	}
+	return strings.TrimSpace(cfg.DefaultEnvironment)
+}
+
+func (a *App) soloStatusNodes(opts SoloStatusOptions) (map[string]config.SoloNode, error) {
+	current, err := a.readSoloState()
+	if err != nil {
+		return nil, err
+	}
+	if len(opts.Nodes) > 0 {
+		return a.resolveSoloNodes(current, opts.Nodes)
+	}
+	cfg, workspaceRoot, err := a.loadSoloProjectConfig()
+	if err != nil {
+		return nil, err
+	}
+	nodeNames, err := current.AttachedNodeNames(workspaceRoot, soloEnvironmentName(cfg, ""))
+	if err != nil {
+		return nil, err
+	}
+	return a.resolveSoloNodes(current, nodeNames)
+}
+
+func (a *App) attachSoloNode(current *solo.State, workspaceRoot, environmentName, nodeName string) (solo.AttachmentRecord, bool, error) {
+	if current == nil {
+		return solo.AttachmentRecord{}, false, fmt.Errorf("solo state is required")
+	}
+	return current.AttachNode(workspaceRoot, environmentName, nodeName)
+}
+
+func soloAffectedNodesForNode(current solo.State, nodeName string) []string {
+	affected := []string{nodeName}
+	for _, key := range current.AttachmentKeysForNode(nodeName) {
+		attachment := current.Attachments[key]
+		affected = append(affected, attachment.NodeNames...)
+	}
+	return normalizeSoloNames(affected)
+}
+
 func soloDefaultProjectConfig(discovered discovery.Result) *config.ProjectConfig {
 	cfg := config.DefaultProjectConfigForType("solo", discovered.ProjectName, config.DefaultEnvironment, discovered.AppType)
 	if discovered.InferredWebPort > 0 {
@@ -1194,56 +1530,6 @@ func soloDefaultProjectConfig(discovered discovery.Result) *config.ProjectConfig
 		}
 	}
 	return &cfg
-}
-
-func (a *App) writeSoloNode(workspaceRoot string, cfg *config.ProjectConfig, name string, node config.SoloNode) error {
-	labels := node.Labels
-	if len(labels) == 0 {
-		labels = append([]string(nil), config.SoloDefaultLabels...)
-	}
-	if cfg.Solo == nil {
-		cfg.Solo = &config.SoloConfig{Nodes: map[string]config.SoloNode{}}
-	}
-	if cfg.Solo.Nodes == nil {
-		cfg.Solo.Nodes = map[string]config.SoloNode{}
-	}
-	node.Labels = labels
-	cfg.Solo.Nodes[name] = config.SoloNode(node)
-	_, err := a.ConfigStore.Write(workspaceRoot, *cfg)
-	return err
-}
-
-// resolveNodes filters nodes by the given names, or returns all if names is empty.
-// Returns an error if any requested name is not present in the config.
-func (a *App) resolveNodes(dc *config.SoloConfig, names []string) (map[string]config.SoloNode, error) {
-	if len(names) == 0 {
-		result := make(map[string]config.SoloNode, len(dc.Nodes))
-		for name, node := range dc.Nodes {
-			result[name] = soloNodeFromConfig(node)
-		}
-		return result, nil
-	}
-	result := make(map[string]config.SoloNode, len(names))
-	var unknown []string
-	for _, name := range names {
-		if node, ok := dc.Nodes[name]; ok {
-			result[name] = soloNodeFromConfig(node)
-		} else {
-			unknown = append(unknown, name)
-		}
-	}
-	if len(unknown) > 0 {
-		available := make([]string, 0, len(dc.Nodes))
-		for name := range dc.Nodes {
-			available = append(available, name)
-		}
-		return nil, fmt.Errorf("unknown node(s): %s (available: %s)", strings.Join(unknown, ", "), strings.Join(available, ", "))
-	}
-	return result, nil
-}
-
-func soloNodeFromConfig(node config.SoloNode) config.SoloNode {
-	return config.SoloNode(node)
 }
 
 type ingressDNSReportResult struct {
@@ -1335,18 +1621,13 @@ func printIngressDNSReport(printer output.Printer, report ingressDNSReportResult
 }
 
 func webNodeIPs(cfg *config.ProjectConfig, selected map[string]config.SoloNode) []string {
-	if cfg == nil || cfg.Solo == nil {
+	if cfg == nil {
 		return nil
 	}
 	seen := map[string]bool{}
 	ips := []string{}
-	for _, name := range sortedSoloNodeNames(cfg.Solo.Nodes) {
-		if selected != nil {
-			if _, ok := selected[name]; !ok {
-				continue
-			}
-		}
-		node := cfg.Solo.Nodes[name]
+	for _, name := range sortedSoloNodeNames(selected) {
+		node := selected[name]
 		if !soloNodeCanRunIngress(node, cfg) {
 			continue
 		}
@@ -1361,29 +1642,6 @@ func webNodeIPs(cfg *config.ProjectConfig, selected map[string]config.SoloNode) 
 	return ips
 }
 
-func soloNodePeers(cfg *config.ProjectConfig, currentNode string) []solo.NodePeer {
-	if cfg == nil || cfg.Solo == nil {
-		return nil
-	}
-	peers := []solo.NodePeer{}
-	for _, name := range sortedSoloNodeNames(cfg.Solo.Nodes) {
-		if name == currentNode {
-			continue
-		}
-		node := cfg.Solo.Nodes[name]
-		host := strings.TrimSpace(node.Host)
-		if host == "" {
-			continue
-		}
-		peers = append(peers, solo.NodePeer{
-			Name:          name,
-			Labels:        append([]string(nil), node.Labels...),
-			PublicAddress: host,
-		})
-	}
-	return peers
-}
-
 func normalizeIngressHosts(values []string) []string {
 	seen := map[string]bool{}
 	normalized := []string{}
@@ -1396,6 +1654,21 @@ func normalizeIngressHosts(values []string) []string {
 			seen[part] = true
 			normalized = append(normalized, part)
 		}
+	}
+	sort.Strings(normalized)
+	return normalized
+}
+
+func normalizeSoloNames(values []string) []string {
+	seen := map[string]bool{}
+	normalized := []string{}
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" || seen[value] {
+			continue
+		}
+		seen[value] = true
+		normalized = append(normalized, value)
 	}
 	sort.Strings(normalized)
 	return normalized

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -400,7 +400,7 @@ func TestEnsureSoloProjectConfigWritesDefaultConfig(t *testing.T) {
 	}
 }
 
-func TestSoloNodeAttachDoesNotPersistOnRepublishError(t *testing.T) {
+func TestSoloNodeAttachPersistsDesiredStateOnRepublishError(t *testing.T) {
 	t.Parallel()
 
 	workspaceRoot := t.TempDir()
@@ -446,8 +446,8 @@ func TestSoloNodeAttachDoesNotPersistOnRepublishError(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(loaded.Attachments) != 0 {
-		t.Fatalf("attachments persisted on republish error: %#v", loaded.Attachments)
+	if len(loaded.Attachments) != 1 {
+		t.Fatalf("attachments = %#v, want persisted desired attachment", loaded.Attachments)
 	}
 }
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -295,6 +295,22 @@ func TestSoloStatusNodesWithoutAttachmentsReturnsEmptySet(t *testing.T) {
 	}
 }
 
+func TestEnsureLocalSoloSnapshotImageReturnsActionableError(t *testing.T) {
+	t.Parallel()
+
+	app := &App{
+		Docker: &fakeDocker{imageMetadataErr: errors.New("Error response from daemon: No such image: demo:missing")},
+	}
+
+	err := app.ensureLocalSoloSnapshotImage(context.Background(), "demo:missing")
+	if err == nil {
+		t.Fatal("expected missing image error")
+	}
+	if !strings.Contains(err.Error(), `local snapshot image "demo:missing" is unavailable`) {
+		t.Fatalf("error = %v", err)
+	}
+}
+
 func TestSoloAgentInstallScriptConfiguresSoloMode(t *testing.T) {
 	script := soloAgentInstallScript(soloAgentInstallScriptOptions{BaseURL: "https://example.test"})
 	for _, want := range []string{

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -311,6 +311,44 @@ func TestEnsureLocalSoloSnapshotImageReturnsActionableError(t *testing.T) {
 	}
 }
 
+func TestRepublishSoloNodesReportsLocalImagePrecheck(t *testing.T) {
+	t.Parallel()
+
+	app := &App{
+		Printer: output.New(io.Discard, io.Discard, false),
+		Docker:  &fakeDocker{imageMetadataErr: errors.New("Error response from daemon: No such image: demo:missing")},
+	}
+	current := solo.State{
+		Nodes: map[string]config.SoloNode{
+			"web-a": {Host: "203.0.113.10", User: "root", Labels: []string{config.DefaultWebRole}},
+		},
+		Attachments: map[string]solo.AttachmentRecord{
+			"/workspace/demo\nproduction": {
+				WorkspaceRoot: "/workspace/demo",
+				WorkspaceKey:  "/workspace/demo",
+				Environment:   "production",
+				NodeNames:     []string{"web-a"},
+			},
+		},
+		Snapshots: map[string]solo.DeploySnapshot{
+			"/workspace/demo\nproduction": {
+				WorkspaceRoot: "/workspace/demo",
+				WorkspaceKey:  "/workspace/demo",
+				Environment:   "production",
+				Image:         "demo:missing",
+			},
+		},
+	}
+
+	err := app.republishSoloNodes(context.Background(), current, []string{"web-a"})
+	if err == nil {
+		t.Fatal("expected republish error")
+	}
+	if !strings.Contains(err.Error(), "[web-a] local image precheck:") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
 func TestSoloAgentInstallScriptConfiguresSoloMode(t *testing.T) {
 	script := soloAgentInstallScript(soloAgentInstallScriptOptions{BaseURL: "https://example.test"})
 	for _, want := range []string{

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -340,12 +340,24 @@ func TestRepublishSoloNodesReportsLocalImagePrecheck(t *testing.T) {
 		},
 	}
 
-	err := app.republishSoloNodes(context.Background(), current, []string{"web-a"})
+	_, err := app.republishSoloNodes(context.Background(), current, []string{"web-a"})
 	if err == nil {
 		t.Fatal("expected republish error")
 	}
 	if !strings.Contains(err.Error(), "[web-a] local image precheck:") {
 		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestDesiredStateRevisionReadsRevision(t *testing.T) {
+	t.Parallel()
+
+	revision, err := desiredStateRevision([]byte(`{"revision":"abc123"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if revision != "abc123" {
+		t.Fatalf("revision = %q, want abc123", revision)
 	}
 }
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -352,7 +352,7 @@ func TestRepublishSoloNodesReportsLocalImagePrecheck(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected republish error")
 	}
-	if !strings.Contains(err.Error(), "[web-a] local image precheck:") {
+	if !strings.Contains(err.Error(), `local snapshot image "demo:missing" is unavailable`) {
 		t.Fatalf("error = %v", err)
 	}
 }

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -259,6 +259,42 @@ func TestSoloAffectedNodesForNodeIncludesCoHostedNodes(t *testing.T) {
 	}
 }
 
+func TestSoloStatusNodesWithoutAttachmentsReturnsEmptySet(t *testing.T) {
+	t.Parallel()
+
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.SoloNode{
+			"node-a": {Host: "203.0.113.10", User: "root"},
+		},
+		Attachments: map[string]solo.AttachmentRecord{},
+		Snapshots:   map[string]solo.DeploySnapshot{},
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	app := &App{
+		Printer:     output.New(io.Discard, io.Discard, true),
+		SoloState:   soloState,
+		ConfigStore: config.NewStore(),
+		Cwd:         workspaceRoot,
+	}
+	nodes, err := app.soloStatusNodes(SoloStatusOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(nodes) != 0 {
+		t.Fatalf("nodes = %#v, want empty", nodes)
+	}
+}
+
 func TestSoloAgentInstallScriptConfiguresSoloMode(t *testing.T) {
 	script := soloAgentInstallScript(soloAgentInstallScriptOptions{BaseURL: "https://example.test"})
 	for _, want := range []string{

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -311,7 +311,7 @@ func TestEnsureLocalSoloSnapshotImageReturnsActionableError(t *testing.T) {
 	}
 }
 
-func TestRepublishSoloNodesReportsLocalImagePrecheck(t *testing.T) {
+func TestRepublishSoloNodesReportsRemoteDockerCheck(t *testing.T) {
 	t.Parallel()
 
 	workspaceRoot := t.TempDir()
@@ -352,7 +352,7 @@ func TestRepublishSoloNodesReportsLocalImagePrecheck(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected republish error")
 	}
-	if !strings.Contains(err.Error(), `local snapshot image "demo:missing" is unavailable`) {
+	if !strings.Contains(err.Error(), "[web-a] remote docker check:") {
 		t.Fatalf("error = %v", err)
 	}
 }

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -124,17 +124,42 @@ func TestParseSoloLabels(t *testing.T) {
 	}
 }
 
-func TestSoloNodePeersUsesOtherConfiguredNodes(t *testing.T) {
-	cfg := &config.ProjectConfig{
-		Solo: &config.SoloConfig{Nodes: map[string]config.SoloNode{
+func TestSoloNodeDesiredStateInputsUsesOtherAttachedNodesAsPeers(t *testing.T) {
+	current := solo.State{
+		Nodes: map[string]config.SoloNode{
 			"web-a":    {Host: "203.0.113.10", Labels: []string{config.DefaultWebRole}},
 			"web-b":    {Host: "203.0.113.11", Labels: []string{config.DefaultWebRole}},
 			"worker-a": {Host: "203.0.113.12", Labels: []string{config.DefaultWorkerRole}},
 			"private":  {Host: "203.0.113.13", Labels: []string{config.DefaultWebRole}},
-		}},
+		},
+		Attachments: map[string]solo.AttachmentRecord{},
+		Snapshots:   map[string]solo.DeploySnapshot{},
+	}
+	attachment, changed, err := current.AttachNode("/workspace/demo", "production", "web-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("AttachNode() changed = false")
+	}
+	for _, nodeName := range []string{"web-b", "worker-a", "private"} {
+		if _, _, err := current.AttachNode("/workspace/demo", "production", nodeName); err != nil {
+			t.Fatal(err)
+		}
+	}
+	key := attachment.WorkspaceKey + "\nproduction"
+	current.Snapshots[key] = solo.DeploySnapshot{
+		WorkspaceRoot: "/workspace/demo",
+		WorkspaceKey:  attachment.WorkspaceKey,
+		Environment:   "production",
+		Revision:      "abc1234",
+		Image:         "demo:abc1234",
 	}
 
-	got := soloNodePeers(cfg, "web-a")
+	_, _, got, _, err := soloNodeDesiredStateInputs(current, "web-a")
+	if err != nil {
+		t.Fatal(err)
+	}
 	want := []solo.NodePeer{
 		{Name: "private", Labels: []string{config.DefaultWebRole}, PublicAddress: "203.0.113.13"},
 		{Name: "web-b", Labels: []string{config.DefaultWebRole}, PublicAddress: "203.0.113.11"},
@@ -176,6 +201,61 @@ func TestCreateProviderNodeNormalizesHetznerProviderBeforeValidation(t *testing.
 	}
 	if !strings.Contains(err.Error(), `Hetzner size "cx22" is deprecated; use "cpx11"`) {
 		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestReleaseNodeForSnapshotSelectsSortedEligibleNode(t *testing.T) {
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	cfg.Tasks.Release = &config.TaskConfig{Service: "web", Command: "bin/rails db:migrate"}
+	snapshot, err := solo.BuildDeploySnapshot(&cfg, "/workspace/demo", "/workspace/demo/devopsellence.yml", "demo:abc1234", "abc1234", map[string]string{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	attachment := solo.AttachmentRecord{
+		WorkspaceKey: "/workspace/demo",
+		Environment:  "production",
+		NodeNames:    []string{"worker-a", "web-b", "web-a"},
+	}
+	nodes := map[string]config.SoloNode{
+		"worker-a": {Labels: []string{config.DefaultWorkerRole}},
+		"web-b":    {Labels: []string{config.DefaultWebRole}},
+		"web-a":    {Labels: []string{config.DefaultWebRole}},
+	}
+
+	got, err := releaseNodeForSnapshot(snapshot, attachment, nodes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "web-a" {
+		t.Fatalf("release node = %q, want web-a", got)
+	}
+}
+
+func TestSoloAffectedNodesForNodeIncludesCoHostedNodes(t *testing.T) {
+	current := solo.State{
+		Nodes: map[string]config.SoloNode{
+			"node-a": {},
+			"node-b": {},
+			"node-c": {},
+		},
+		Attachments: map[string]solo.AttachmentRecord{
+			"/workspace/a\nproduction": {
+				WorkspaceKey: "/workspace/a",
+				Environment:  "production",
+				NodeNames:    []string{"node-a", "node-b"},
+			},
+			"/workspace/b\nproduction": {
+				WorkspaceKey: "/workspace/b",
+				Environment:  "production",
+				NodeNames:    []string{"node-a", "node-c"},
+			},
+		},
+	}
+
+	got := soloAffectedNodesForNode(current, "node-a")
+	want := []string{"node-a", "node-b", "node-c"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("affected nodes = %#v, want %#v", got, want)
 	}
 }
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -349,6 +349,37 @@ func TestRepublishSoloNodesReportsLocalImagePrecheck(t *testing.T) {
 	}
 }
 
+func TestEnsureSoloProjectConfigWritesDefaultConfig(t *testing.T) {
+	t.Parallel()
+
+	workspaceRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(workspaceRoot, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	app := &App{
+		ConfigStore: config.NewStore(),
+		Cwd:         workspaceRoot,
+	}
+
+	cfg, gotRoot, err := app.ensureSoloProjectConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotRoot != workspaceRoot {
+		t.Fatalf("workspace root = %q, want %q", gotRoot, workspaceRoot)
+	}
+	if cfg == nil {
+		t.Fatal("config is nil")
+	}
+	if cfg.Organization != "solo" {
+		t.Fatalf("organization = %q, want solo", cfg.Organization)
+	}
+	if _, err := os.Stat(filepath.Join(workspaceRoot, "devopsellence.yml")); err != nil {
+		t.Fatalf("expected config file: %v", err)
+	}
+}
+
 func TestSoloAgentInstallScriptConfiguresSoloMode(t *testing.T) {
 	script := soloAgentInstallScript(soloAgentInstallScriptOptions{BaseURL: "https://example.test"})
 	for _, want := range []string{

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -314,28 +314,36 @@ func TestEnsureLocalSoloSnapshotImageReturnsActionableError(t *testing.T) {
 func TestRepublishSoloNodesReportsLocalImagePrecheck(t *testing.T) {
 	t.Parallel()
 
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+
 	app := &App{
-		Printer: output.New(io.Discard, io.Discard, false),
-		Docker:  &fakeDocker{imageMetadataErr: errors.New("Error response from daemon: No such image: demo:missing")},
+		Printer:     output.New(io.Discard, io.Discard, false),
+		Docker:      &fakeDocker{imageMetadataErr: errors.New("Error response from daemon: No such image: demo:missing")},
+		ConfigStore: config.NewStore(),
 	}
 	current := solo.State{
 		Nodes: map[string]config.SoloNode{
 			"web-a": {Host: "203.0.113.10", User: "root", Labels: []string{config.DefaultWebRole}},
 		},
 		Attachments: map[string]solo.AttachmentRecord{
-			"/workspace/demo\nproduction": {
-				WorkspaceRoot: "/workspace/demo",
-				WorkspaceKey:  "/workspace/demo",
+			workspaceRoot + "\nproduction": {
+				WorkspaceRoot: workspaceRoot,
+				WorkspaceKey:  workspaceRoot,
 				Environment:   "production",
 				NodeNames:     []string{"web-a"},
 			},
 		},
 		Snapshots: map[string]solo.DeploySnapshot{
-			"/workspace/demo\nproduction": {
-				WorkspaceRoot: "/workspace/demo",
-				WorkspaceKey:  "/workspace/demo",
+			workspaceRoot + "\nproduction": {
+				WorkspaceRoot: workspaceRoot,
+				WorkspaceKey:  workspaceRoot,
 				Environment:   "production",
 				Image:         "demo:missing",
+				Metadata:      solo.SnapshotMetadata{ConfigPath: filepath.Join(workspaceRoot, "devopsellence.yml")},
 			},
 		},
 	}
@@ -389,6 +397,57 @@ func TestEnsureSoloProjectConfigWritesDefaultConfig(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(workspaceRoot, "devopsellence.yml")); err != nil {
 		t.Fatalf("expected config file: %v", err)
+	}
+}
+
+func TestSoloNodeAttachDoesNotPersistOnRepublishError(t *testing.T) {
+	t.Parallel()
+
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.SoloNode{
+			"node-a": {Host: "203.0.113.10", User: "root", Labels: []string{config.DefaultWebRole}},
+		},
+		Attachments: map[string]solo.AttachmentRecord{},
+		Snapshots: map[string]solo.DeploySnapshot{
+			workspaceRoot + "\nproduction": {
+				WorkspaceRoot: workspaceRoot,
+				WorkspaceKey:  workspaceRoot,
+				Environment:   "production",
+				Revision:      "abc1234",
+				Image:         "demo:missing",
+				Metadata:      solo.SnapshotMetadata{ConfigPath: filepath.Join(workspaceRoot, "devopsellence.yml")},
+			},
+		},
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	app := &App{
+		Printer:     output.New(io.Discard, io.Discard, false),
+		SoloState:   soloState,
+		ConfigStore: config.NewStore(),
+		Cwd:         workspaceRoot,
+		Docker:      &fakeDocker{imageMetadataErr: errors.New("Error response from daemon: No such image: demo:missing")},
+	}
+
+	if err := app.SoloNodeAttach(context.Background(), SoloNodeAttachOptions{Node: "node-a"}); err == nil {
+		t.Fatal("expected attach to fail")
+	}
+
+	loaded, err := soloState.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(loaded.Attachments) != 0 {
+		t.Fatalf("attachments persisted on republish error: %#v", loaded.Attachments)
 	}
 }
 

--- a/control-plane/app/views/marketing/docs.html.erb
+++ b/control-plane/app/views/marketing/docs.html.erb
@@ -341,10 +341,10 @@
         <div class="tl"><span class="tp">$</span> devopsellence node attach prod-1</div>
       </div>
     </div>
-    <p>Provider-managed nodes record non-secret metadata like provider name, server ID, region, size, public host, SSH user, and labels in local solo state at <code>~/.local/state/devopsellence/solo/state.json</code>. The provider API token and SSH private key value are not written to app config.</p>
+    <p>Provider-managed nodes record non-secret metadata like provider name, server ID, region, size, public host, SSH user, and labels in local solo state at <code>$XDG_STATE_HOME/devopsellence/solo/state.json</code> (default: <code>~/.local/state/devopsellence/solo/state.json</code> when <code>XDG_STATE_HOME</code> is unset). The provider API token and SSH private key value are not written to app config.</p>
 
     <h3>Solo config</h3>
-    <p><code>devopsellence.yml</code> stays workload-only in solo mode. Solo nodes, workspace/environment attachments, and the latest deployed environment snapshots live in <code>~/.local/state/devopsellence/solo/state.json</code>. SSH private key material stays in your SSH agent, local filesystem, or CI secrets.</p>
+    <p><code>devopsellence.yml</code> stays workload-only in solo mode. Solo nodes, workspace/environment attachments, and the latest deployed environment snapshots live in <code>$XDG_STATE_HOME/devopsellence/solo/state.json</code> (default: <code>~/.local/state/devopsellence/solo/state.json</code> when <code>XDG_STATE_HOME</code> is unset). SSH private key material stays in your SSH agent, local filesystem, or CI secrets.</p>
     <div class="terminal">
       <div class="terminal-bar">
         <span class="dot dot-red"></span>
@@ -683,8 +683,8 @@ tasks:
         <dd>Runs once on a node matching its configured service before the rollout proceeds. Use for migrations. Failure stops the deploy.</dd>
       </div>
       <div class="docs-field">
-        <dt><code>~/.local/state/devopsellence/solo/state.json</code></dt>
-        <dd>Solo mode local state. Stores the global node registry, workspace/environment attachments, and the latest deployed environment snapshots.</dd>
+        <dt><code>$XDG_STATE_HOME/devopsellence/solo/state.json</code></dt>
+        <dd>Solo mode local state. Stores the global node registry, workspace/environment attachments, and the latest deployed environment snapshots. Defaults to <code>~/.local/state/devopsellence/solo/state.json</code> when <code>XDG_STATE_HOME</code> is not set.</dd>
       </div>
     </dl>
   </section>

--- a/control-plane/app/views/marketing/docs.html.erb
+++ b/control-plane/app/views/marketing/docs.html.erb
@@ -344,7 +344,7 @@
     <p>Provider-managed nodes record non-secret metadata like provider name, server ID, region, size, public host, SSH user, and labels in local solo state at <code>$XDG_STATE_HOME/devopsellence/solo/state.json</code> (default: <code>~/.local/state/devopsellence/solo/state.json</code> when <code>XDG_STATE_HOME</code> is unset). The provider API token and SSH private key value are not written to app config.</p>
 
     <h3>Solo config</h3>
-    <p><code>devopsellence.yml</code> stays workload-only in solo mode. Solo nodes, workspace/environment attachments, and the latest deployed environment snapshots live in <code>$XDG_STATE_HOME/devopsellence/solo/state.json</code> (default: <code>~/.local/state/devopsellence/solo/state.json</code> when <code>XDG_STATE_HOME</code> is unset). SSH private key material stays in your SSH agent, local filesystem, or CI secrets.</p>
+    <p><code>devopsellence.yml</code> stays workload-only in solo mode. Solo nodes, workspace/environment attachments, and the latest desired environment snapshots live in <code>$XDG_STATE_HOME/devopsellence/solo/state.json</code> (default: <code>~/.local/state/devopsellence/solo/state.json</code> when <code>XDG_STATE_HOME</code> is unset). SSH private key material stays in your SSH agent, local filesystem, or CI secrets.</p>
     <div class="terminal">
       <div class="terminal-bar">
         <span class="dot dot-red"></span>
@@ -685,7 +685,7 @@ tasks:
       </div>
       <div class="docs-field">
         <dt><code>$XDG_STATE_HOME/devopsellence/solo/state.json</code></dt>
-        <dd>Solo mode local state. Stores the global node registry, workspace/environment attachments, and the latest deployed environment snapshots. Defaults to <code>~/.local/state/devopsellence/solo/state.json</code> when <code>XDG_STATE_HOME</code> is not set.</dd>
+        <dd>Solo mode local state. Stores the global node registry, workspace/environment attachments, and the latest desired environment snapshots. Defaults to <code>~/.local/state/devopsellence/solo/state.json</code> when <code>XDG_STATE_HOME</code> is not set.</dd>
       </div>
     </dl>
   </section>

--- a/control-plane/app/views/marketing/docs.html.erb
+++ b/control-plane/app/views/marketing/docs.html.erb
@@ -395,6 +395,7 @@ tasks:
         <div class="tl"><span class="tp">$</span> devopsellence doctor</div>
       </div>
     </div>
+    <p>Solo deploy scope comes from workspace/environment attachments, not a deploy flag. Use <code>devopsellence node attach &lt;name&gt;</code> and <code>devopsellence node detach &lt;name&gt;</code> to choose which attached nodes receive the rollout.</p>
     <p>During deploy, the CLI shows image transfer phases and compressed bytes sent. Remote Docker access uses plain <code>docker</code> when available and falls back to passwordless <code>sudo</code> for Docker, desired-state writes, status reads, and agent logs.</p>
 
     <h3>Solo secrets and Rails</h3>

--- a/control-plane/app/views/marketing/docs.html.erb
+++ b/control-plane/app/views/marketing/docs.html.erb
@@ -190,7 +190,7 @@
       </div>
       <div class="terminal-body">
         <div class="tl"><span class="tp">$</span> devopsellence setup</div>
-        <div class="tl tl-muted"># solo: initialize config if needed, add a server, and install the agent.</div>
+        <div class="tl tl-muted"># solo: initialize config if needed, register or create a node, attach it, and install the agent.</div>
         <div class="tl tl-muted"># shared: sign in, create or select org/project/env, and write workspace config.</div>
       </div>
     </div>
@@ -321,7 +321,7 @@
         <div class="tl tl-muted"># Hetzner: prompts for region, size, labels, and SSH public key path.</div>
       </div>
     </div>
-    <p>The wizard creates <code>devopsellence.yml</code> when needed, writes the solo node inventory, installs Docker when supported, installs <code>devopsellence-agent</code>, starts the <code>devopsellence-agent</code> systemd service, and runs <code>doctor</code>.</p>
+    <p>The wizard creates <code>devopsellence.yml</code> when needed, records the node and attachment in local solo state, installs Docker when supported, installs <code>devopsellence-agent</code>, starts the <code>devopsellence-agent</code> systemd service, and runs <code>doctor</code>.</p>
 
     <h3>Create a Hetzner node</h3>
     <p>Provider tokens stay outside the config file. Save a Hetzner token locally, or set <code>DEVOPSELLENCE_HETZNER_API_TOKEN</code> or <code>HCLOUD_TOKEN</code>:</p>
@@ -338,12 +338,13 @@
         <div class="tl">    --region ash \</div>
         <div class="tl">    --size cpx11 \</div>
         <div class="tl">    --ssh-public-key ~/.ssh/id_ed25519.pub</div>
+        <div class="tl"><span class="tp">$</span> devopsellence node attach prod-1</div>
       </div>
     </div>
-    <p>Provider-managed nodes record non-secret metadata like provider name, server ID, region, size, public host, SSH user, and labels in <code>devopsellence.yml</code>. The provider API token and SSH private key value are not written to config.</p>
+    <p>Provider-managed nodes record non-secret metadata like provider name, server ID, region, size, public host, SSH user, and labels in local solo state at <code>~/.local/state/devopsellence/solo/state.json</code>. The provider API token and SSH private key value are not written to app config.</p>
 
     <h3>Solo config</h3>
-    <p>Solo node inventory is part of <code>devopsellence.yml</code>, so it can be committed and used from CI. SSH private key material stays in your SSH agent, local filesystem, or CI secrets.</p>
+    <p><code>devopsellence.yml</code> stays workload-only in solo mode. Solo nodes, workspace/environment attachments, and the latest deployed environment snapshots live in <code>~/.local/state/devopsellence/solo/state.json</code>. SSH private key material stays in your SSH agent, local filesystem, or CI secrets.</p>
     <div class="terminal">
       <div class="terminal-bar">
         <span class="dot dot-red"></span>
@@ -352,24 +353,33 @@
         <span class="terminal-bar-title">devopsellence.yml</span>
       </div>
       <div class="terminal-body">
-        <pre class="config-pre"><code>solo:
-  nodes:
-    prod-1:
-      host: 203.0.113.10
-      user: ubuntu
-      port: 22
-      ssh_key: ~/.ssh/id_ed25519
-      agent_state_dir: /var/lib/devopsellence
-      labels:
-        - web
-    worker-1:
-      host: 203.0.113.11
-      user: ubuntu
-      labels:
-        - worker</code></pre>
+        <pre class="config-pre"><code>schema_version: 5
+app:
+  type: rails
+organization: solo
+project: myapp
+default_environment: production
+build:
+  context: .
+  dockerfile: Dockerfile
+  platforms:
+    - linux/amd64
+services:
+  web:
+    kind: web
+    ports:
+      - name: http
+        port: 3000
+    healthcheck:
+      path: /up
+      port: 3000
+tasks:
+  release:
+    service: web
+    command: bin/rails db:migrate</code></pre>
       </div>
     </div>
-    <p>Labels control placement in solo mode too. <code>web</code> nodes run web services. <code>worker</code> nodes run worker services. A node can have both labels. <code>tasks.release</code> runs once on one node labeled for its configured service.</p>
+    <p>Labels still control placement in solo mode. Use <code>devopsellence node attach &lt;name&gt;</code> and <code>devopsellence node label set &lt;name&gt; --labels ...</code> to assign environments and placement roles. <code>tasks.release</code> runs once on the first attached node, sorted by node name, that matches its configured service.</p>
 
     <h3>Deploy and inspect</h3>
     <div class="terminal">
@@ -673,16 +683,8 @@ tasks:
         <dd>Runs once on a node matching its configured service before the rollout proceeds. Use for migrations. Failure stops the deploy.</dd>
       </div>
       <div class="docs-field">
-        <dt><code>solo.nodes</code></dt>
-        <dd>Solo mode connection inventory keyed by node name. Each node has <code>host</code>, <code>user</code>, optional <code>port</code>, optional <code>ssh_key</code>, and optional <code>agent_state_dir</code>.</dd>
-      </div>
-      <div class="docs-field">
-        <dt><code>solo.nodes.*.labels</code></dt>
-        <dd>Service placement labels for solo mode. Use labels matching your services' kinds.</dd>
-      </div>
-      <div class="docs-field">
-        <dt><code>solo.nodes.*.provider</code></dt>
-        <dd>Provider metadata for CLI-created solo servers. Values like provider server ID, region, size, and image are non-secret and can be committed.</dd>
+        <dt><code>~/.local/state/devopsellence/solo/state.json</code></dt>
+        <dd>Solo mode local state. Stores the global node registry, workspace/environment attachments, and the latest deployed environment snapshots.</dd>
       </div>
     </dl>
   </section>

--- a/test/e2e/solo_e2e.rb
+++ b/test/e2e/solo_e2e.rb
@@ -9,8 +9,9 @@
 #      - OpenSSH server for CLI access
 #      - Docker (via docker.sock mount)
 #      - Fake systemctl/journalctl shims so CLI agent install can run in-container
-#   3. Scaffold a test app with devopsellence.yml (solo config under `solo`)
-#   4. CLI installs the agent, sets secrets, deploys, checks status
+#   3. Scaffold a test app with a solo-mode devopsellence.yml
+#   4. Seed global solo state, attach the node, install the agent, set secrets,
+#      deploy, check status
 #   5. Assert: app container running, status.json settled, secrets resolved
 #
 # Usage:
@@ -89,6 +90,7 @@ class SoloE2E
     }
     @ssh_key_dir = @state_dir.join("ssh")
     @ssh_client_home = @state_dir.join("ssh-home")
+    @xdg_state_home = @state_dir.join("xdg-state")
     @project_name = "e2e-solo-#{SecureRandom.hex(3)}"
   end
 
@@ -103,7 +105,9 @@ class SoloE2E
     step("start node") { start_node_container! }
     step("wait for node") { wait_for_node_ready! }
     step("scaffold app") { scaffold_app! }
+    step("seed solo state") { seed_solo_state! }
     step("mode") { set_workspace_mode! }
+    step("attach node") { attach_node! }
     step("install agent") { install_agent! }
     step("secrets") { set_secrets! }
     step("deploy") { run_deploy! }
@@ -130,6 +134,7 @@ class SoloE2E
     FileUtils.mkdir_p(@image_build_dir)
     FileUtils.mkdir_p(@ssh_key_dir)
     FileUtils.mkdir_p(@ssh_client_home.join(".ssh"))
+    FileUtils.mkdir_p(@xdg_state_home)
   end
 
   # Build a Docker image that acts as a remote node:
@@ -436,7 +441,7 @@ PY
   def write_devopsellence_yml!
     config = {
       "schema_version" => 5,
-      "organization" => "e2e-org",
+      "organization" => "solo",
       "project" => @project_name,
       "build" => {
         "context" => ".",
@@ -460,18 +465,6 @@ PY
           "secret_refs" => [
             { "name" => SECRET_VALUE_NAME, "secret" => "projects/x/secrets/e2e" }
           ]
-        }
-      },
-      "solo" => {
-        "nodes" => {
-          "node-1" => {
-            "labels" => ["web"],
-            "host" => "127.0.0.1",
-            "user" => "root",
-            "port" => @ssh_port,
-            "ssh_key" => @ssh_private_key.to_s,
-            "agent_state_dir" => @agent_state_dir
-          }
         }
       }
     }
@@ -579,12 +572,19 @@ PY
   end
 
   def assert_runtime_state!
+    desired = JSON.parse(ssh_to_node!("cat #{@desired_state_path}"))
+    expected_runtime_revision = desired["revision"].to_s
+    raise "desired state missing revision" if expected_runtime_revision.empty?
+    environment_revisions = desired.fetch("environments").map { |environment| environment["revision"] }.compact.uniq
+    raise "unexpected environment revisions: #{environment_revisions.inspect}" unless environment_revisions == [current_revision]
+    workload_revision = environment_revisions.first
+
     # Wait for agent to reconcile and write status for the deployed revision.
     wait_until!(timeout: 120) do
       output = ssh_to_node!("cat #{@status_path} 2>/dev/null || echo '{}'")
       begin
         status = JSON.parse(output)
-        status["revision"] == current_revision && terminal_status_phase?(status["phase"])
+        status["revision"] == expected_runtime_revision && terminal_status_phase?(status["phase"])
       rescue JSON::ParserError
         false
       end
@@ -596,7 +596,7 @@ PY
     status = JSON.parse(status_output)
     revision = status["revision"]
     raise "revision missing from status" if revision.to_s.empty?
-    raise "unexpected status revision: #{revision}" unless revision == current_revision
+    raise "unexpected status revision: #{revision}" unless revision == expected_runtime_revision
     case status["phase"]
     when "settled"
       puts "[ok] Status settled for revision #{revision}"
@@ -616,12 +616,12 @@ PY
       web_containers = ssh_to_node!(
         "docker ps --filter label=devopsellence.managed=true " \
         "--filter label=devopsellence.service=web " \
-        "--filter label=devopsellence.revision=#{Shellwords.escape(revision)} " \
+        "--filter label=devopsellence.revision=#{Shellwords.escape(workload_revision)} " \
         "--format '{{.Names}} {{.Status}}'"
       ).lines.map(&:strip).reject(&:empty?)
       web_containers.any?
     end
-    raise "web container not running for revision #{revision}" if web_containers.empty?
+    raise "web container not running for revision #{workload_revision}" if web_containers.empty?
     puts "[ok] Web container running: #{web_containers.join(', ')}"
 
     # Verify via CLI status command.
@@ -643,9 +643,6 @@ PY
     puts "[ok] CLI status confirms revision #{cli_revision} phase=#{cli_phase}"
 
     # Verify desired state was written to the correct path.
-    ds_output = ssh_to_node!("cat #{@desired_state_path}")
-    desired = JSON.parse(ds_output)
-    raise "desired state missing revision" if desired["revision"].to_s.empty?
     services = desired.fetch("environments").flat_map { |environment| environment.fetch("services", []) }
     raise "desired state missing services" if services.empty?
 
@@ -701,8 +698,29 @@ PY
     {
       "HOME" => @ssh_client_home.to_s,
       "SSH_AUTH_SOCK" => "",
-      "DEVOPSELLENCE_BASE_URL" => artifact_base_url
+      "DEVOPSELLENCE_BASE_URL" => artifact_base_url,
+      "XDG_STATE_HOME" => @xdg_state_home.to_s
     }
+  end
+
+  def seed_solo_state!
+    state_path = @xdg_state_home.join("devopsellence/solo/state.json")
+    FileUtils.mkdir_p(state_path.dirname)
+    state = {
+      "schema_version" => 1,
+      "nodes" => {
+        "node-1" => {
+          "labels" => ["web"],
+          "host" => "127.0.0.1",
+          "user" => "root",
+          "port" => @ssh_port,
+          "ssh_key" => @ssh_private_key.to_s,
+          "agent_state_dir" => @agent_state_dir
+        }
+      }
+    }
+    state_path.write(JSON.pretty_generate(state))
+    puts "[ok] Seeded solo state for node-1"
   end
 
   def set_workspace_mode!
@@ -714,6 +732,17 @@ PY
     )
     raise "mode use solo did not confirm solo mode" unless output.include?("Mode: solo")
     puts "[ok] Workspace mode set to solo"
+  end
+
+  def attach_node!
+    output = run!(
+      cli_binary.to_s, "node", "attach", "node-1",
+      chdir: @app_dir.to_s,
+      timeout: 30,
+      env: ssh_env
+    )
+    raise "node attach did not report success" unless output.include?("Attached solo node node-1 to production")
+    puts "[ok] Solo node attached"
   end
 
   def cli_binary

--- a/test/e2e/solo_e2e.rb
+++ b/test/e2e/solo_e2e.rb
@@ -736,12 +736,17 @@ PY
 
   def attach_node!
     output = run!(
-      cli_binary.to_s, "node", "attach", "node-1",
+      cli_binary.to_s, "node", "attach", "node-1", "--json",
       chdir: @app_dir.to_s,
       timeout: 30,
       env: ssh_env
     )
-    raise "node attach did not report success" unless output.include?("Attached solo node node-1 to production")
+    result = JSON.parse(output)
+    unless result["node"] == "node-1" &&
+           result["environment"] == "production" &&
+           result["changed"]
+      raise "node attach returned unexpected result: #{output}"
+    end
     puts "[ok] Solo node attached"
   end
 


### PR DESCRIPTION
## Summary

This rewires solo mode around machine-global local state instead of embedding node inventory inside each workspace `devopsellence.yml`.

After this PR, solo workspaces are workload-only. Nodes live in a global registry, workspace environments attach to those nodes explicitly, and each node receives one aggregated desired state built from every attached solo environment scheduled onto it.

## What's shipping

- new typed solo state store at `$XDG_STATE_HOME/devopsellence/solo/state.json` (default: `~/.local/state/devopsellence/solo/state.json`)
- new solo state data model for:
  - global node registry
  - workspace/environment -> node attachments
  - persisted desired snapshots used for republish
- removal of `solo:` config support from `devopsellence.yml`; legacy solo config now fails fast
- solo `node attach` / `node detach` become the placement mechanism for environments
- solo deploy now:
  - resolves the current environment into a snapshot
  - persists the desired snapshot before republish so later node operations can recover from partial publish failures
  - republishes full aggregated node desired state for affected nodes
- aggregated desired state now merges co-hosted ingress and peer topology and produces deterministic synthetic desired-state revisions
- `devopsellence setup` now bootstraps a default solo config before node attach/install flows
- `node list --json` keeps the legacy `nodes` map and adds `node_items` for structured consumers
- solo deploy JSON now reports:
  - `workload_revision`
  - `desired_state_revisions`
  - `environment`
  - `image`
  - `nodes`
- snapshots persisted in solo state are redacted so secret values are not written to `state.json`; republish rehydrates from config/local secret sources at publish time
- republish path now avoids unnecessary image work and handles edge cases found in review:
  - missing local image cache
  - images already present remotely
  - environments with no attachments
  - whitespace/normalization issues in node names
  - safer attachment slice handling
- docs/help/AGENTS/e2e updated to match the new solo model

## Why

The previous solo flow mixed workload config, node inventory, and deployment placement in one per-project file. That made solo mode hard to reason about, blocked shared-style attach/detach semantics, and made correct node-level aggregation across multiple local environments awkward.

This PR makes solo mode behave more like shared mode at the workflow level while still keeping local-file-backed state.

## Breaking changes

These are intentional clean-break changes:

- `solo:` blocks in `devopsellence.yml` are no longer supported
- solo deploy is no longer scoped by `--nodes`; attachments define placement
- solo deploy `--json` output changed shape (`workload_revision` / `desired_state_revisions` instead of the old ambiguous `revision` field)
- solo state now lives in the XDG state directory instead of project config

## Reader notes

If you are reviewing behavior, the main user-visible mental model change is:

1. define workload in `devopsellence.yml`
2. register/create solo nodes globally
3. attach an environment to one or more nodes
4. deploy, which snapshots the environment and republishes aggregated node desired state

That means multiple solo workspaces/environments can now co-exist on a node with one merged desired-state payload.

## Validation

Local:

- `mise exec -C cli -- sh -lc 'GOCACHE=$PWD/.gocache go test ./internal/solo ./internal/workflow'`
- `ruby -c test/e2e/solo_e2e.rb`

GitHub Actions on `16ae76935f2612faa0a3e950fa72b2bedcbc2db1`:

- CLI CI `test`
- Control Plane CI `scan_ruby`
- Control Plane CI `scan_js`
- Control Plane CI `lint`
- Control Plane CI `test`
- Control Plane CI `system-test`
- `e2e-solo`
- `e2e-shared`

All passed.