### PR TITLE
Handle missing status file gracefully before first deploy

### DIFF
--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -2474,7 +2474,7 @@ func remoteReadFileCommand(path string) string {
 func remoteReadOptionalFileCommand(path, missingSentinel string) string {
 	quotedPath := shellQuote(path)
 	quotedSentinel := shellQuote(missingSentinel)
-	return fmt.Sprintf("if [ -r %[1]s ]; then exec cat %[1]s; fi; if command -v sudo >/dev/null 2>&1 && sudo -n test -r %[1]s >/dev/null 2>&1; then exec sudo -n cat %[1]s; fi; printf '%%s\\n' %[2]s", quotedPath, quotedSentinel)
+	return fmt.Sprintf("if [ -r %[1]s ]; then exec cat %[1]s; fi; if command -v sudo >/dev/null 2>&1 && sudo -n test -r %[1]s >/dev/null 2>&1; then exec sudo -n cat %[1]s; fi; if [ -e %[1]s ]; then echo 'File exists but is not readable; grant read access or enable passwordless sudo.' >&2; exit 1; fi; if command -v sudo >/dev/null 2>&1 && sudo -n test -e %[1]s >/dev/null 2>&1; then echo 'File exists but is not readable; grant read access or enable passwordless sudo.' >&2; exit 1; fi; printf '%%s\\n' %[2]s", quotedPath, quotedSentinel)
 }
 
 func remoteJournalctlCommand(args string) string {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -721,7 +721,7 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 
 	for name, node := range nodes {
 		statusPath := filepath.Join(node.AgentStateDir, "status.json")
-		out, err := solo.RunSSH(ctx, node, remoteReadFileCommand(statusPath), nil)
+		out, err := solo.RunSSH(ctx, node, remoteReadOptionalFileCommand(statusPath, soloStatusMissingSentinel), nil)
 		if err != nil {
 			if a.Printer.JSON {
 				jsonResults = append(jsonResults, map[string]any{
@@ -730,6 +730,20 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 				})
 			} else {
 				a.Printer.Printf("[%s] error: %s\n", name, err)
+			}
+			continue
+		}
+
+		if strings.TrimSpace(out) == soloStatusMissingSentinel {
+			message := "no deploy status yet; run `devopsellence deploy`"
+			if a.Printer.JSON {
+				jsonResults = append(jsonResults, map[string]any{
+					"node":    name,
+					"status":  nil,
+					"message": message,
+				})
+			} else {
+				a.Printer.Printf("[%s] status=missing message=%s\n", name, message)
 			}
 			continue
 		}
@@ -1757,6 +1771,8 @@ type ingressDNSHostResult struct {
 	Error    string   `json:"error,omitempty"`
 }
 
+const soloStatusMissingSentinel = "__DEVOPSELLENCE_STATUS_MISSING__"
+
 func (a *App) checkIngressBeforeDeploy(ctx context.Context, cfg *config.ProjectConfig, nodes map[string]config.SoloNode, skip bool) error {
 	if skip || cfg == nil || cfg.Ingress == nil || cfg.Ingress.TLS.Mode != "auto" {
 		return nil
@@ -2453,6 +2469,12 @@ func remoteDockerImageInspectCommand(imageTag string) string {
 func remoteReadFileCommand(path string) string {
 	quotedPath := shellQuote(path)
 	return fmt.Sprintf("if [ -r %[1]s ]; then exec cat %[1]s; fi; if command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then exec sudo -n cat %[1]s; fi; exec cat %[1]s", quotedPath)
+}
+
+func remoteReadOptionalFileCommand(path, missingSentinel string) string {
+	quotedPath := shellQuote(path)
+	quotedSentinel := shellQuote(missingSentinel)
+	return fmt.Sprintf("if [ -r %[1]s ]; then exec cat %[1]s; fi; if command -v sudo >/dev/null 2>&1 && sudo -n test -r %[1]s >/dev/null 2>&1; then exec sudo -n cat %[1]s; fi; printf '%%s\\n' %[2]s", quotedPath, quotedSentinel)
 }
 
 func remoteJournalctlCommand(args string) string {

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -588,6 +588,19 @@ func TestRemoteReadAndJournalCommandsSupportPasswordlessSudo(t *testing.T) {
 	}
 }
 
+func TestRemoteReadOptionalFileCommandSupportsPasswordlessSudo(t *testing.T) {
+	command := remoteReadOptionalFileCommand("/var/lib/devopsellence/status.json", soloStatusMissingSentinel)
+	for _, want := range []string{
+		"sudo -n test -r '/var/lib/devopsellence/status.json'",
+		"exec sudo -n cat '/var/lib/devopsellence/status.json'",
+		"printf '%s\\n' '__DEVOPSELLENCE_STATUS_MISSING__'",
+	} {
+		if !strings.Contains(command, want) {
+			t.Fatalf("optional read command missing %q: %s", want, command)
+		}
+	}
+}
+
 func TestApplySoloRailsMasterKeyUsesConfigMasterKey(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(dir, "config"), 0o755); err != nil {

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -593,6 +593,9 @@ func TestRemoteReadOptionalFileCommandSupportsPasswordlessSudo(t *testing.T) {
 	for _, want := range []string{
 		"sudo -n test -r '/var/lib/devopsellence/status.json'",
 		"exec sudo -n cat '/var/lib/devopsellence/status.json'",
+		"[ -e '/var/lib/devopsellence/status.json' ]",
+		"sudo -n test -e '/var/lib/devopsellence/status.json'",
+		"File exists but is not readable",
 		"printf '%s\\n' '__DEVOPSELLENCE_STATUS_MISSING__'",
 	} {
 		if !strings.Contains(command, want) {

--- a/test/e2e/solo_e2e.rb
+++ b/test/e2e/solo_e2e.rb
@@ -109,6 +109,7 @@ class SoloE2E
     step("mode") { set_workspace_mode! }
     step("attach node") { attach_node! }
     step("install agent") { install_agent! }
+    step("pre-deploy status") { assert_status_before_first_deploy! }
     step("secrets") { set_secrets! }
     step("deploy") { run_deploy! }
     step("assertions") { assert_runtime_state! }
@@ -569,6 +570,25 @@ PY
 
     raise "deploy did not report success" unless output.include?("Deployed revision")
     puts "[ok] Deploy completed"
+  end
+
+  def assert_status_before_first_deploy!
+    cli_status_output = run!(
+      cli_binary.to_s, "--json", "status",
+      chdir: @app_dir.to_s,
+      timeout: 60,
+      env: ssh_env
+    )
+    cli_status = JSON.parse(cli_status_output)
+    node_status = (cli_status["nodes"] || []).find { |entry| entry["node"] == "node-1" }
+    raise "CLI status missing node-1 before deploy" unless node_status
+    raise "CLI status should not include runtime status before deploy" unless node_status["status"].nil?
+
+    message = node_status["message"].to_s
+    unless message.include?("no deploy status yet") && message.include?("devopsellence deploy")
+      raise "unexpected pre-deploy status message: #{node_status.inspect}"
+    end
+    puts "[ok] CLI status reports no deploy status before first deploy"
   end
 
   def assert_runtime_state!


### PR DESCRIPTION
## Summary
- `devopsellence status` now returns a helpful message instead of an error when run before the first deploy (status.json doesn't exist yet)
- Adds `remoteReadOptionalFileCommand` that uses a sentinel value instead of failing when the file is missing, avoiding an extra SSH round-trip
- Covers both text and JSON output modes, with unit and E2E tests

## Test plan
- [x] Unit test `TestRemoteReadOptionalFileCommandSupportsPasswordlessSudo` passes
- [x] Existing `TestRemoteReadAndJournalCommandsSupportPasswordlessSudo` still passes
- [ ] E2E: `assert_status_before_first_deploy!` step validates the behavior on a real node

🤖 Generated with [Claude Code](https://claude.com/claude-code)