### PR TITLE
fix: unblock prerelease installs and solo deploy QA

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,6 @@ build:
 services:
   web:
     kind: web
-    roles: [web]
     ports:
       - name: http
         port: 3000

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -272,3 +272,44 @@ func TestWriteGenericConfigUsesRepoRootPath(t *testing.T) {
 		t.Fatalf("loaded generic config mismatch: %#v", loaded)
 	}
 }
+
+func TestReadmeExampleConfigParses(t *testing.T) {
+	t.Parallel()
+
+	readmePath := filepath.Join("..", "..", "..", "README.md")
+	content, err := os.ReadFile(readmePath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", readmePath, err)
+	}
+
+	marker := "`devopsellence` reads `devopsellence.yml` from the app root:"
+	start := strings.Index(string(content), marker)
+	if start == -1 {
+		t.Fatalf("README marker %q not found", marker)
+	}
+
+	section := string(content[start:])
+	fenceStart := strings.Index(section, "```yaml\n")
+	if fenceStart == -1 {
+		t.Fatal("README yaml fence not found after example config marker")
+	}
+	section = section[fenceStart+len("```yaml\n"):]
+	fenceEnd := strings.Index(section, "\n```")
+	if fenceEnd == -1 {
+		t.Fatal("README yaml closing fence not found")
+	}
+
+	root := t.TempDir()
+	path := filepath.Join(root, FilePath)
+	if err := os.WriteFile(path, []byte(section[:fenceEnd]+"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v", path, err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load(%q) error = %v", path, err)
+	}
+	if cfg == nil {
+		t.Fatal("Load() returned nil config")
+	}
+}

--- a/control-plane/app/controllers/cli_installs_controller.rb
+++ b/control-plane/app/controllers/cli_installs_controller.rb
@@ -74,7 +74,7 @@ class CliInstallsController < ActionController::Base
       validate_version() {
         local version="$1"
 
-        if [[ ! "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+        if [[ ! "$version" =~ ^[0-9A-Za-z][0-9A-Za-z._-]*$ ]]; then
           echo "invalid version: $version" >&2
           exit 1
         fi

--- a/control-plane/app/services/agent_install_script.rb
+++ b/control-plane/app/services/agent_install_script.rb
@@ -62,7 +62,7 @@ class AgentInstallScript
         validate_version() {
           local version="$1"
 
-          if [[ ! "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+          if [[ ! "$version" =~ ^[0-9A-Za-z][0-9A-Za-z._-]*$ ]]; then
             echo "invalid version: $version" >&2
             exit 1
           fi

--- a/control-plane/test/integration/installs_test.rb
+++ b/control-plane/test/integration/installs_test.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+require "digest"
+require "fileutils"
+require "open3"
+require "tempfile"
 require "test_helper"
 
 class InstallsTest < ActionDispatch::IntegrationTest
@@ -83,6 +87,21 @@ class InstallsTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "CLI_VERSION='v0.1.0-rc.1'"
     assert_includes response.body, "missing --version (or use ?version=... or set DEVOPSELLENCE_CLI_VERSION)"
     assert_includes response.body, 'validate_version "$CLI_VERSION"'
+  end
+
+  test "cli install script executes successfully for prerelease tags" do
+    get "/lfg.sh", params: { version: "master-0053792f6aec" }
+
+    assert_response :success
+
+    stdout, stderr, status, installed_cli = run_cli_install_script(
+      response.body,
+      version: "master-0053792f6aec"
+    )
+
+    assert_predicate status, :success?, -> { "stdout:\n#{stdout}\nstderr:\n#{stderr}" }
+    assert_includes stdout, "devopsellence CLI installed"
+    assert_equal "prerelease build\n", installed_cli
   end
 
   test "cli install script derives checksum url after parsing base url overrides" do
@@ -180,5 +199,78 @@ class InstallsTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "docker ps -aq --filter label=devopsellence.system"
     assert_includes response.body, "run_root docker rm -f \"${container_ids[@]}\""
     assert_includes response.body, "run_root docker network rm \"$NETWORK_NAME\" >/dev/null 2>&1 || true"
+  end
+
+  private
+
+  def run_cli_install_script(script_body, version:)
+    Dir.mktmpdir("devopsellence-cli-install-test") do |tmpdir|
+      fixtures_dir = File.join(tmpdir, "fixtures")
+      fakebin_dir = File.join(tmpdir, "fakebin")
+      install_dir = File.join(tmpdir, "install")
+      script_path = File.join(tmpdir, "lfg.sh")
+      artifact_path = File.join(fixtures_dir, "cli-linux-amd64")
+      checksums_path = File.join(fixtures_dir, "cli-SHA256SUMS")
+
+      FileUtils.mkdir_p(fixtures_dir)
+      FileUtils.mkdir_p(fakebin_dir)
+      FileUtils.mkdir_p(install_dir)
+
+      File.write(artifact_path, "prerelease build\n")
+      digest = Digest::SHA256.file(artifact_path).hexdigest
+      File.write(checksums_path, "#{digest}  cli-linux-amd64\n")
+      File.write(script_path, script_body)
+      FileUtils.chmod("u+x", script_path)
+
+      curl_path = File.join(fakebin_dir, "curl")
+      File.write(curl_path, <<~SH)
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        output=""
+        url=""
+        while [[ $# -gt 0 ]]; do
+          case "$1" in
+            -o)
+              output="$2"
+              shift 2
+              ;;
+            -fsSL|-f|-s|-S|-L)
+              shift
+              ;;
+            *)
+              url="$1"
+              shift
+              ;;
+          esac
+        done
+
+        case "$url" in
+          *"/cli/download?"*)
+            cp #{artifact_path.inspect} "$output"
+            ;;
+          *"/cli/checksums?"*)
+            cp #{checksums_path.inspect} "$output"
+            ;;
+          *)
+            echo "unexpected curl url: $url" >&2
+            exit 1
+            ;;
+        esac
+      SH
+      FileUtils.chmod("u+x", curl_path)
+
+      env = {
+        "PATH" => "#{fakebin_dir}:#{ENV.fetch("PATH")}",
+        "HOME" => tmpdir,
+        "DEVOPSELLENCE_CLI_VERSION" => version,
+        "DEVOPSELLENCE_CLI_INSTALL_DIR" => install_dir,
+        "DEVOPSELLENCE_BASE_URL" => "https://downloads.devopsellence.test"
+      }
+
+      stdout, stderr, status = Open3.capture3(env, script_path)
+      installed_cli = File.exist?(File.join(install_dir, "devopsellence")) ? File.read(File.join(install_dir, "devopsellence")) : nil
+      [ stdout, stderr, status, installed_cli ]
+    end
   end
 end

--- a/control-plane/test/integration/installs_test.rb
+++ b/control-plane/test/integration/installs_test.rb
@@ -259,6 +259,25 @@ class InstallsTest < ActionDispatch::IntegrationTest
       SH
       FileUtils.chmod("u+x", curl_path)
 
+      uname_path = File.join(fakebin_dir, "uname")
+      File.write(uname_path, <<~SH)
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        case "${1:-}" in
+          -s)
+            printf 'Linux\n'
+            ;;
+          -m)
+            printf 'x86_64\n'
+            ;;
+          *)
+            exec /usr/bin/uname "$@"
+            ;;
+        esac
+      SH
+      FileUtils.chmod("u+x", uname_path)
+
       env = {
         "PATH" => "#{fakebin_dir}:#{ENV.fetch("PATH")}",
         "HOME" => tmpdir,

--- a/control-plane/test/integration/installs_test.rb
+++ b/control-plane/test/integration/installs_test.rb
@@ -3,7 +3,6 @@
 require "digest"
 require "fileutils"
 require "open3"
-require "tempfile"
 require "test_helper"
 
 class InstallsTest < ActionDispatch::IntegrationTest

--- a/control-plane/test/integration/installs_test.rb
+++ b/control-plane/test/integration/installs_test.rb
@@ -263,6 +263,7 @@ class InstallsTest < ActionDispatch::IntegrationTest
       env = {
         "PATH" => "#{fakebin_dir}:#{ENV.fetch("PATH")}",
         "HOME" => tmpdir,
+        "SHELL" => ENV.fetch("SHELL", "/bin/bash"),
         "DEVOPSELLENCE_CLI_VERSION" => version,
         "DEVOPSELLENCE_CLI_INSTALL_DIR" => install_dir,
         "DEVOPSELLENCE_BASE_URL" => "https://downloads.devopsellence.test"

--- a/control-plane/test/integration/installs_test.rb
+++ b/control-plane/test/integration/installs_test.rb
@@ -3,6 +3,7 @@
 require "digest"
 require "fileutils"
 require "open3"
+require "tmpdir"
 require "test_helper"
 
 class InstallsTest < ActionDispatch::IntegrationTest

--- a/control-plane/test/services/agent_install_script_test.rb
+++ b/control-plane/test/services/agent_install_script_test.rb
@@ -24,4 +24,14 @@ class AgentInstallScriptTest < ActiveSupport::TestCase
     assert_includes script, "AGENT_VERSION='v1.0.0$(rm -rf /)'"
     refute_includes script, 'AGENT_VERSION="${DEVOPSELLENCE_AGENT_VERSION:-v1.0.0$(rm -rf /)}"'
   end
+
+  test "render accepts prerelease-style agent tags" do
+    script = AgentInstallScript.render(
+      base_url: "https://example.com",
+      default_version: "master-0053792f6aec"
+    )
+
+    assert_includes script, "AGENT_VERSION='master-0053792f6aec'"
+    assert_includes script, 'if [[ ! "$version" =~ ^[0-9A-Za-z][0-9A-Za-z._-]*$ ]]; then'
+  end
 end

--- a/test/e2e/solo_e2e.rb
+++ b/test/e2e/solo_e2e.rb
@@ -345,11 +345,17 @@ PY
       FROM debian:bookworm-slim
 
       RUN apt-get update && apt-get install -y --no-install-recommends \
-        openssh-server \
-        docker.io \
         ca-certificates \
         curl \
+        gnupg \
+        openssh-server \
         python3 \
+        && install -m 0755 -d /etc/apt/keyrings \
+        && curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc \
+        && chmod a+r /etc/apt/keyrings/docker.asc \
+        && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian bookworm stable" > /etc/apt/sources.list.d/docker.list \
+        && apt-get update \
+        && apt-get install -y --no-install-recommends docker-ce-cli \
         && rm -rf /var/lib/apt/lists/*
 
       # Configure SSH: key-based auth only, no password.

--- a/test/e2e/solo_e2e.rb
+++ b/test/e2e/solo_e2e.rb
@@ -351,9 +351,11 @@ PY
         openssh-server \
         python3 \
         && install -m 0755 -d /etc/apt/keyrings \
-        && curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc \
-        && chmod a+r /etc/apt/keyrings/docker.asc \
-        && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian bookworm stable" > /etc/apt/sources.list.d/docker.list \
+        && curl -fsSL https://download.docker.com/linux/debian/gpg -o /tmp/docker.asc \
+        && gpg --dearmor -o /etc/apt/keyrings/docker.gpg /tmp/docker.asc \
+        && rm /tmp/docker.asc \
+        && chmod a+r /etc/apt/keyrings/docker.gpg \
+        && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian bookworm stable" > /etc/apt/sources.list.d/docker.list \
         && apt-get update \
         && apt-get install -y --no-install-recommends docker-ce-cli \
         && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- allow prerelease-style release tags in the public CLI and agent install scripts
- keep the README example config aligned with the actual CLI schema and test it directly
- update the solo e2e SSH node image to use a modern Docker CLI so deploy QA can run against a dockerized SSH target

## Test Plan
- [x] mise run test:cli
- [x] mise x ruby@3.4.7 -- mise run test -- test/integration/installs_test.rb test/services/agent_install_script_test.rb
- [x] mise x ruby@3.4.7 -- mise run e2e-solo

## Notes
- The solo e2e deploy now runs against a dockerized SSH target, which answers the VM question: yes, we can QA deploys through a container that exposes SSH and binds the host docker socket.
- The e2e lane still observes the known docker-sock health probe limitation, but the deploy flow, agent install, desired state write, and workload start all complete successfully.