### PR TITLE
feat: switch to kubernetes-style command semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,9 @@ services:
 tasks:
   release:
     service: web
-    command: bin/rails db:migrate
+    command:
+      - bin/rails
+      - db:migrate
 ingress:
   service: web
   hosts:

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -57,8 +57,8 @@ type ServicePort struct {
 type ServiceConfig struct {
 	Kind        string            `yaml:"kind" json:"kind"`
 	Image       string            `yaml:"image,omitempty" json:"image,omitempty"`
-	Entrypoint  string            `yaml:"entrypoint,omitempty" json:"entrypoint,omitempty"`
-	Command     string            `yaml:"command,omitempty" json:"command,omitempty"`
+	Command     []string          `yaml:"command,omitempty" json:"command,omitempty"`
+	Args        []string          `yaml:"args,omitempty" json:"args,omitempty"`
 	Env         map[string]string `yaml:"env,omitempty" json:"env,omitempty"`
 	SecretRefs  []SecretRef       `yaml:"secret_refs,omitempty" json:"secret_refs,omitempty"`
 	Ports       []ServicePort     `yaml:"ports,omitempty" json:"ports,omitempty"`
@@ -69,10 +69,10 @@ type ServiceConfig struct {
 type Service = ServiceConfig
 
 type TaskConfig struct {
-	Service    string            `yaml:"service" json:"service"`
-	Entrypoint string            `yaml:"entrypoint,omitempty" json:"entrypoint,omitempty"`
-	Command    string            `yaml:"command,omitempty" json:"command,omitempty"`
-	Env        map[string]string `yaml:"env,omitempty" json:"env,omitempty"`
+	Service string            `yaml:"service" json:"service"`
+	Command []string          `yaml:"command,omitempty" json:"command,omitempty"`
+	Args    []string          `yaml:"args,omitempty" json:"args,omitempty"`
+	Env     map[string]string `yaml:"env,omitempty" json:"env,omitempty"`
 }
 
 type TasksConfig struct {
@@ -492,6 +492,16 @@ func validateService(name string, service ServiceConfig) error {
 	default:
 		return fmt.Errorf("services.%s.kind must be one of %q, %q, or %q", name, ServiceKindWeb, ServiceKindWorker, ServiceKindAccessory)
 	}
+	for _, arg := range service.Command {
+		if strings.TrimSpace(arg) == "" {
+			return fmt.Errorf("services.%s.command entries must be present", name)
+		}
+	}
+	for _, arg := range service.Args {
+		if strings.TrimSpace(arg) == "" {
+			return fmt.Errorf("services.%s.args entries must be present", name)
+		}
+	}
 	for key := range service.Env {
 		if strings.TrimSpace(key) == "" {
 			return fmt.Errorf("services.%s.env keys must be present", name)
@@ -558,8 +568,18 @@ func validateTasks(cfg *ProjectConfig) error {
 	if _, ok := cfg.Services[serviceName]; !ok {
 		return fmt.Errorf("tasks.release.service %q not found in services", serviceName)
 	}
-	if strings.TrimSpace(release.Entrypoint) == "" && strings.TrimSpace(release.Command) == "" {
-		return errors.New("tasks.release must set entrypoint or command")
+	if len(release.Command) == 0 && len(release.Args) == 0 {
+		return errors.New("tasks.release must set command or args")
+	}
+	for _, arg := range release.Command {
+		if strings.TrimSpace(arg) == "" {
+			return errors.New("tasks.release.command entries must be present")
+		}
+	}
+	for _, arg := range release.Args {
+		if strings.TrimSpace(arg) == "" {
+			return errors.New("tasks.release.args entries must be present")
+		}
 	}
 	for key := range release.Env {
 		if strings.TrimSpace(key) == "" {

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -14,12 +14,12 @@ func TestWriteAndLoadFromRoot(t *testing.T) {
 	project := DefaultProjectConfig("acme", "ShopApp", "staging")
 	project.Services["jobs"] = Service{
 		Kind:       ServiceKindWorker,
-		Command:    "./bin/jobs",
+		Command:    []string{"./bin/jobs"},
 		Env:        map[string]string{"QUEUE": "default"},
 		SecretRefs: []SecretRef{{Name: "API_KEY", Secret: "gsm://projects/test/secrets/api-key"}},
 		Volumes:    []Volume{{Source: "app_storage", Target: "/rails/storage"}},
 	}
-	project.Tasks.Release = &TaskConfig{Service: "web", Command: "bundle exec rails db:migrate"}
+	project.Tasks.Release = &TaskConfig{Service: "web", Command: []string{"bundle", "exec", "rails", "db:migrate"}}
 
 	written, err := Write(root, project)
 	if err != nil {
@@ -38,7 +38,7 @@ func TestWriteAndLoadFromRoot(t *testing.T) {
 	if loaded.Organization != "acme" || loaded.Project != "ShopApp" || loaded.DefaultEnvironment != "staging" {
 		t.Fatalf("loaded core fields mismatch: %#v", loaded)
 	}
-	if loaded.Services["jobs"].Command != "./bin/jobs" {
+	if got := loaded.Services["jobs"].Command; len(got) != 1 || got[0] != "./bin/jobs" {
 		t.Fatalf("jobs service mismatch: %#v", loaded.Services["jobs"])
 	}
 	if written.Build.Context != DefaultBuildContext {
@@ -51,7 +51,7 @@ func TestWriteAndLoadFromRoot(t *testing.T) {
 	if strings.Join(loaded.Build.Platforms, ",") != strings.Join(DefaultBuildPlatforms, ",") {
 		t.Fatalf("build platforms = %#v, want %#v", loaded.Build.Platforms, DefaultBuildPlatforms)
 	}
-	if loaded.Tasks.Release == nil || loaded.Tasks.Release.Command != "bundle exec rails db:migrate" {
+	if loaded.Tasks.Release == nil || strings.Join(loaded.Tasks.Release.Command, " ") != "bundle exec rails db:migrate" {
 		t.Fatalf("release task = %#v", loaded.Tasks.Release)
 	}
 	if _, err := os.Stat(filepath.Join(root, FilePath)); err != nil {
@@ -146,13 +146,46 @@ func TestLoadRejectsLegacyInitHook(t *testing.T) {
 	}
 }
 
+func TestLoadRejectsStringCommandSyntax(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	path := filepath.Join(root, FilePath)
+	content := strings.Join([]string{
+		"schema_version: 5",
+		"organization: acme",
+		"project: ShopApp",
+		"default_environment: production",
+		"build:",
+		"  context: .",
+		"  dockerfile: Dockerfile",
+		"services:",
+		"  web:",
+		"    kind: web",
+		"    command: ./bin/server",
+		"    ports:",
+		"      - name: http",
+		"        port: 3000",
+		"    healthcheck:",
+		"      path: /up",
+	}, "\n") + "\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Load(path)
+	if err == nil || !strings.Contains(err.Error(), "cannot unmarshal !!str") || !strings.Contains(err.Error(), "[]string") {
+		t.Fatalf("expected string command type error, got %v", err)
+	}
+}
+
 func TestValidateAcceptsWorkerWithoutExtraPlacementFields(t *testing.T) {
 	t.Parallel()
 
 	project := DefaultProjectConfig("acme", "ShopApp", "production")
 	project.Services["jobs"] = Service{
 		Kind:    ServiceKindWorker,
-		Command: "./bin/jobs",
+		Command: []string{"./bin/jobs"},
 	}
 
 	err := Validate(&project)

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -1,10 +1,13 @@
 package config
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 func TestWriteAndLoadFromRoot(t *testing.T) {
@@ -174,8 +177,12 @@ func TestLoadRejectsStringCommandSyntax(t *testing.T) {
 	}
 
 	_, err := Load(path)
-	if err == nil || !strings.Contains(err.Error(), "cannot unmarshal !!str") || !strings.Contains(err.Error(), "[]string") {
-		t.Fatalf("expected string command type error, got %v", err)
+	if err == nil {
+		t.Fatal("expected string command type error, got nil")
+	}
+	var typeErr *yaml.TypeError
+	if !errors.As(err, &typeErr) {
+		t.Fatalf("expected yaml.TypeError, got %T (%v)", err, err)
 	}
 }
 

--- a/cli/internal/solo/desiredstate.go
+++ b/cli/internal/solo/desiredstate.go
@@ -492,11 +492,11 @@ func buildService(serviceName string, svc config.ServiceConfig, imageTag string,
 		Env:   env,
 	}
 
-	if svc.Entrypoint != "" {
-		c.Entrypoint = shellCommand(svc.Entrypoint)
+	if len(svc.Command) > 0 {
+		c.Entrypoint = append([]string(nil), svc.Command...)
 	}
-	if svc.Command != "" {
-		c.Command = shellCommand(svc.Command)
+	if len(svc.Args) > 0 {
+		c.Command = append([]string(nil), svc.Args...)
 	}
 
 	if svc.Healthcheck != nil {
@@ -547,15 +547,15 @@ func buildReleaseTask(cfg *config.ProjectConfig, imageTag string, secrets map[st
 		Image: image,
 		Env:   env,
 	}
-	if strings.TrimSpace(release.Entrypoint) != "" {
-		task.Entrypoint = shellCommand(release.Entrypoint)
-	} else if strings.TrimSpace(service.Entrypoint) != "" {
-		task.Entrypoint = shellCommand(service.Entrypoint)
+	if len(release.Command) > 0 {
+		task.Entrypoint = append([]string(nil), release.Command...)
+	} else if len(service.Command) > 0 {
+		task.Entrypoint = append([]string(nil), service.Command...)
 	}
-	if strings.TrimSpace(release.Command) != "" {
-		task.Command = shellCommand(release.Command)
-	} else if strings.TrimSpace(service.Command) != "" {
-		task.Command = shellCommand(service.Command)
+	if len(release.Args) > 0 {
+		task.Command = append([]string(nil), release.Args...)
+	} else if len(service.Args) > 0 {
+		task.Command = append([]string(nil), service.Args...)
 	}
 	for _, v := range service.Volumes {
 		task.VolumeMounts = append(task.VolumeMounts, volumeMountJSON{Source: v.Source, Target: v.Target})
@@ -593,13 +593,4 @@ func mergeStringMaps(parts ...map[string]string) map[string]string {
 		}
 	}
 	return merged
-}
-
-// shellCommand wraps a command string as shell -c invocation.
-func shellCommand(cmd string) []string {
-	cmd = strings.TrimSpace(cmd)
-	if cmd == "" {
-		return nil
-	}
-	return []string{"sh", "-c", cmd}
 }

--- a/cli/internal/solo/desiredstate_test.go
+++ b/cli/internal/solo/desiredstate_test.go
@@ -14,7 +14,7 @@ func baseProject() *config.ProjectConfig {
 	cfg := config.DefaultProjectConfig("solo", "myapp", config.DefaultEnvironment)
 	cfg.Services["web"] = config.Service{
 		Kind:    config.ServiceKindWeb,
-		Command: "rails server",
+		Command: []string{"rails", "server"},
 		Env:     map[string]string{"RAILS_ENV": "production"},
 		SecretRefs: []config.SecretRef{
 			{Name: "DATABASE_URL", Secret: "projects/x/secrets/db"},
@@ -63,8 +63,8 @@ func TestBuildDesiredState_WebOnly(t *testing.T) {
 	if len(web.Ports) != 1 || web.Ports[0].Name != "http" || web.Ports[0].Port != 3000 {
 		t.Fatalf("ports = %#v", web.Ports)
 	}
-	if len(web.Command) != 3 || web.Command[0] != "sh" {
-		t.Fatalf("command = %#v", web.Command)
+	if got, want := web.Entrypoint, []string{"rails", "server"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("entrypoint = %#v, want %#v", got, want)
 	}
 }
 
@@ -72,10 +72,10 @@ func TestBuildDesiredState_WithNamedWorkerAndReleaseTask(t *testing.T) {
 	cfg := baseProject()
 	cfg.Services["jobs"] = config.Service{
 		Kind:    config.ServiceKindWorker,
-		Command: "sidekiq",
+		Command: []string{"sidekiq"},
 		Env:     map[string]string{"QUEUE": "default"},
 	}
-	cfg.Tasks.Release = &config.TaskConfig{Service: "web", Command: "rails db:migrate"}
+	cfg.Tasks.Release = &config.TaskConfig{Service: "web", Command: []string{"rails", "db:migrate"}}
 
 	data, err := BuildDesiredState(cfg, "myapp:def5678", "def5678", map[string]string{"DATABASE_URL": "postgres://localhost/mydb"})
 	if err != nil {
@@ -103,13 +103,48 @@ func TestBuildDesiredState_WithNamedWorkerAndReleaseTask(t *testing.T) {
 	}
 }
 
+func TestBuildDesiredState_MapsArgsToContainerCommand(t *testing.T) {
+	cfg := baseProject()
+	cfg.Services["web"] = config.Service{
+		Kind:        config.ServiceKindWeb,
+		Command:     []string{"/app"},
+		Args:        []string{"web", "--port", "3000"},
+		Ports:       []config.ServicePort{{Name: "http", Port: 3000}},
+		Healthcheck: &config.HTTPHealthcheck{Path: "/up", Port: 3000},
+	}
+	cfg.Tasks.Release = &config.TaskConfig{Service: "web", Args: []string{"release"}}
+
+	data, err := BuildDesiredState(cfg, "myapp:def5678", "def5678", map[string]string{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var ds desiredStateJSON
+	if err := json.Unmarshal(data, &ds); err != nil {
+		t.Fatal(err)
+	}
+	service := ds.Environments[0].Services[0]
+	if got, want := service.Entrypoint, []string{"/app"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("entrypoint = %#v, want %#v", got, want)
+	}
+	if got, want := service.Command, []string{"web", "--port", "3000"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("command = %#v, want %#v", got, want)
+	}
+	task := ds.Environments[0].Tasks[0]
+	if got, want := task.Entrypoint, []string{"/app"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("task entrypoint = %#v, want %#v", got, want)
+	}
+	if got, want := task.Command, []string{"release"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("task command = %#v, want %#v", got, want)
+	}
+}
+
 func TestBuildDesiredStateForLabelsFiltersServicesByKindLabel(t *testing.T) {
 	cfg := baseProject()
 	cfg.Services["jobs"] = config.Service{
 		Kind:    config.ServiceKindWorker,
-		Command: "sidekiq",
+		Command: []string{"sidekiq"},
 	}
-	cfg.Tasks.Release = &config.TaskConfig{Service: "web", Command: "rails db:migrate"}
+	cfg.Tasks.Release = &config.TaskConfig{Service: "web", Command: []string{"rails", "db:migrate"}}
 
 	data, err := BuildDesiredStateForLabels(cfg, "myapp:def5678", "def5678", map[string]string{"DATABASE_URL": "postgres://localhost/mydb"}, []string{config.DefaultWorkerRole}, false)
 	if err != nil {
@@ -130,7 +165,7 @@ func TestBuildDesiredStateForLabelsFiltersServicesByKindLabel(t *testing.T) {
 
 func TestBuildDesiredStateForLabelsIncludesReleaseWhenSelected(t *testing.T) {
 	cfg := baseProject()
-	cfg.Tasks.Release = &config.TaskConfig{Service: "web", Command: "rails db:migrate"}
+	cfg.Tasks.Release = &config.TaskConfig{Service: "web", Command: []string{"rails", "db:migrate"}}
 
 	data, err := BuildDesiredStateForLabels(cfg, "myapp:def5678", "def5678", map[string]string{"DATABASE_URL": "postgres://localhost/mydb"}, []string{config.DefaultWebRole}, true)
 	if err != nil {
@@ -192,7 +227,7 @@ func TestBuildDesiredStateForNodeOmitsIngressForNonIngressNode(t *testing.T) {
 	cfg := baseProject()
 	cfg.Services["jobs"] = config.Service{
 		Kind:    config.ServiceKindWorker,
-		Command: "sidekiq",
+		Command: []string{"sidekiq"},
 	}
 	cfg.Ingress = &config.IngressConfig{Hosts: []string{"app.example.com"}, Service: "web"}
 

--- a/cli/internal/solo/state_test.go
+++ b/cli/internal/solo/state_test.go
@@ -328,7 +328,7 @@ func TestRedactDeploySnapshotSecretsRemovesSecretValues(t *testing.T) {
 			Port: 3000,
 		},
 	}
-	cfg.Tasks.Release = &config.TaskConfig{Service: "web", Command: "bin/rails db:migrate"}
+	cfg.Tasks.Release = &config.TaskConfig{Service: "web", Command: []string{"bin/rails", "db:migrate"}}
 
 	snapshot, err := BuildDeploySnapshot(&cfg, "/workspace/demo", "/workspace/demo/devopsellence.yml", "demo:abc1234", "abc1234", map[string]string{"DATABASE_URL": "postgres://secret"})
 	if err != nil {

--- a/cli/internal/workflow/app.go
+++ b/cli/internal/workflow/app.go
@@ -3974,11 +3974,11 @@ func servicePayload(service *config.Service) map[string]any {
 		"ports":       service.Ports,
 		"volumes":     service.Volumes,
 	}
-	if strings.TrimSpace(service.Entrypoint) != "" {
-		payload["entrypoint"] = service.Entrypoint
-	}
-	if strings.TrimSpace(service.Command) != "" {
+	if len(service.Command) > 0 {
 		payload["command"] = service.Command
+	}
+	if len(service.Args) > 0 {
+		payload["args"] = service.Args
 	}
 	if service.Healthcheck != nil && strings.TrimSpace(service.Healthcheck.Path) != "" {
 		payload["healthcheck"] = map[string]any{
@@ -4010,11 +4010,11 @@ func taskPayloads(tasks config.TasksConfig) map[string]any {
 			"service": strings.TrimSpace(tasks.Release.Service),
 			"env":     cloneEnv(tasks.Release.Env),
 		}
-		if strings.TrimSpace(tasks.Release.Entrypoint) != "" {
-			payload["entrypoint"] = tasks.Release.Entrypoint
-		}
-		if strings.TrimSpace(tasks.Release.Command) != "" {
+		if len(tasks.Release.Command) > 0 {
 			payload["command"] = tasks.Release.Command
+		}
+		if len(tasks.Release.Args) > 0 {
+			payload["args"] = tasks.Release.Args
 		}
 		payloads["release"] = payload
 	}

--- a/cli/internal/workflow/management_test.go
+++ b/cli/internal/workflow/management_test.go
@@ -1285,7 +1285,7 @@ func TestDeployAppliesGitHubActionRuntimeOverrides(t *testing.T) {
 	project.Services[config.DefaultWebServiceName] = web
 	project.Services["worker"] = config.Service{
 		Kind:    config.ServiceKindWorker,
-		Command: "./bin/jobs",
+		Command: []string{"./bin/jobs"},
 		Env:     map[string]string{"WORKER_FROM_CONFIG": "1"},
 	}
 	if _, err := config.Write(root, project); err != nil {
@@ -1903,7 +1903,7 @@ func TestDeployRailsSyncsMasterKeySecret(t *testing.T) {
 
 	root := makeGitRailsRoot(t, "ShopApp")
 	project := config.DefaultProjectConfig("default", "ShopApp", "production")
-	project.Services["worker"] = config.ServiceConfig{Kind: config.ServiceKindWorker, Command: "bin/jobs"}
+	project.Services["worker"] = config.ServiceConfig{Kind: config.ServiceKindWorker, Command: []string{"bin/jobs"}}
 	if _, err := config.Write(root, project); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
@@ -3092,7 +3092,7 @@ func TestDeployRailsSecretSyncRunsConcurrently(t *testing.T) {
 
 	root := makeGitRailsRoot(t, "ShopApp")
 	project := config.DefaultProjectConfig("default", "ShopApp", "production")
-	project.Services["worker"] = config.ServiceConfig{Kind: config.ServiceKindWorker, Command: "bin/jobs"}
+	project.Services["worker"] = config.ServiceConfig{Kind: config.ServiceKindWorker, Command: []string{"bin/jobs"}}
 	if _, err := config.Write(root, project); err != nil {
 		t.Fatalf("write config: %v", err)
 	}

--- a/cli/internal/workflow/provider_test.go
+++ b/cli/internal/workflow/provider_test.go
@@ -12,6 +12,7 @@ import (
 
 func TestProviderTokenStoreReadDelete(t *testing.T) {
 	t.Setenv("HCLOUD_TOKEN", "")
+	t.Setenv("DEVOPSELLENCE_HETZNER_API_TOKEN", "")
 
 	store := state.New(filepath.Join(t.TempDir(), "providers.json"))
 	if err := saveProviderToken(store, providerHetzner, "test-token"); err != nil {
@@ -54,6 +55,7 @@ func TestProviderTokenFallsBackToEnv(t *testing.T) {
 
 func TestEnsureInteractiveProviderLogin(t *testing.T) {
 	t.Setenv("HCLOUD_TOKEN", "")
+	t.Setenv("DEVOPSELLENCE_HETZNER_API_TOKEN", "")
 	store := state.New(filepath.Join(t.TempDir(), "providers.json"))
 	app := &App{
 		Printer:       output.New(io.Discard, io.Discard, false),

--- a/cli/internal/workflow/provider_test.go
+++ b/cli/internal/workflow/provider_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestProviderTokenStoreReadDelete(t *testing.T) {
-	t.Parallel()
+	t.Setenv("HCLOUD_TOKEN", "")
 
 	store := state.New(filepath.Join(t.TempDir(), "providers.json"))
 	if err := saveProviderToken(store, providerHetzner, "test-token"); err != nil {
@@ -53,6 +53,7 @@ func TestProviderTokenFallsBackToEnv(t *testing.T) {
 }
 
 func TestEnsureInteractiveProviderLogin(t *testing.T) {
+	t.Setenv("HCLOUD_TOKEN", "")
 	store := state.New(filepath.Join(t.TempDir(), "providers.json"))
 	app := &App{
 		Printer:       output.New(io.Discard, io.Discard, false),

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -57,13 +57,13 @@ func TestValidateSoloNodeScheduleSelectsReleaseNode(t *testing.T) {
 			},
 			"worker": {
 				Kind:    config.ServiceKindWorker,
-				Command: "sidekiq",
+				Command: []string{"sidekiq"},
 			},
 		},
 		Tasks: config.TasksConfig{
 			Release: &config.TaskConfig{
 				Service: config.DefaultWebServiceName,
-				Command: "rails db:migrate",
+				Command: []string{"rails", "db:migrate"},
 			},
 		},
 	}
@@ -94,7 +94,7 @@ func TestValidateSoloNodeScheduleRejectsMissingWorker(t *testing.T) {
 			},
 			"worker": {
 				Kind:    config.ServiceKindWorker,
-				Command: "sidekiq",
+				Command: []string{"sidekiq"},
 			},
 		},
 	}
@@ -206,7 +206,7 @@ func TestCreateProviderNodeNormalizesHetznerProviderBeforeValidation(t *testing.
 
 func TestReleaseNodeForSnapshotSelectsSortedEligibleNode(t *testing.T) {
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")
-	cfg.Tasks.Release = &config.TaskConfig{Service: "web", Command: "bin/rails db:migrate"}
+	cfg.Tasks.Release = &config.TaskConfig{Service: "web", Command: []string{"bin/rails", "db:migrate"}}
 	snapshot, err := solo.BuildDeploySnapshot(&cfg, "/workspace/demo", "/workspace/demo/devopsellence.yml", "demo:abc1234", "abc1234", map[string]string{})
 	if err != nil {
 		t.Fatal(err)

--- a/control-plane/app/models/release.rb
+++ b/control-plane/app/models/release.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 require "json"
-require "shellwords"
 
 class Release < ApplicationRecord
+  InvalidRuntimeConfig = Class.new(StandardError)
   STATUS_DRAFT = "draft"
   STATUS_PUBLISHED = "published"
   STATUSES = [ STATUS_DRAFT, STATUS_PUBLISHED ].freeze
@@ -104,6 +104,8 @@ class Release < ApplicationRecord
   end
 
   def scheduled_services_for(node:)
+    assert_supported_runtime_payload!
+
     environment = node.environment
     service_names.filter_map do |name|
       service = services_config[name]
@@ -114,6 +116,8 @@ class Release < ApplicationRecord
   end
 
   def release_task_for(node:)
+    assert_supported_runtime_payload!
+
     task = release_task_config
     return nil unless task
 
@@ -303,6 +307,41 @@ class Release < ApplicationRecord
 
   def release_task_array_present?(value)
     string_array?(value) && value.present?
+  end
+
+  def assert_supported_runtime_payload!
+    services_config.each do |name, service|
+      assert_supported_runtime_service!(name, service)
+    end
+
+    return unless tasks_config.key?("release")
+
+    task = tasks_config["release"]
+    raise InvalidRuntimeConfig, "tasks.release must decode to an object" unless task.is_a?(Hash)
+
+    assert_deprecated_runtime_key_absent!(task, deprecated_key: "entrypoint", field: "tasks.release.entrypoint")
+    assert_runtime_string_array!(task["command"], field: "tasks.release.command")
+    assert_runtime_string_array!(task["args"], field: "tasks.release.args")
+  end
+
+  def assert_supported_runtime_service!(name, service)
+    raise InvalidRuntimeConfig, "services.#{name} must decode to an object" unless service.is_a?(Hash)
+
+    assert_deprecated_runtime_key_absent!(service, deprecated_key: "entrypoint", field: "services.#{name}.entrypoint")
+    assert_runtime_string_array!(service["command"], field: "services.#{name}.command")
+    assert_runtime_string_array!(service["args"], field: "services.#{name}.args")
+  end
+
+  def assert_deprecated_runtime_key_absent!(hash, deprecated_key:, field:)
+    return unless hash.key?(deprecated_key)
+
+    raise InvalidRuntimeConfig, "#{field} is no longer supported; use command or args"
+  end
+
+  def assert_runtime_string_array!(value, field:)
+    return if value.nil? || string_array?(value)
+
+    raise InvalidRuntimeConfig, "#{field} must be an array of strings"
   end
 
   def string_array?(value)

--- a/control-plane/app/models/release.rb
+++ b/control-plane/app/models/release.rb
@@ -400,6 +400,7 @@ class Release < ApplicationRecord
 
   def string_array(value)
     return nil unless string_array?(value)
+    return nil if value.empty?
 
     value.map(&:dup)
   end

--- a/control-plane/app/models/release.rb
+++ b/control-plane/app/models/release.rb
@@ -184,12 +184,8 @@ class Release < ApplicationRecord
       errors.add(:runtime_json, "services.#{name}.kind must be one of #{SERVICE_KINDS.join(', ')}")
     end
 
-    if service["entrypoint"].present? && !service["entrypoint"].is_a?(String)
-      errors.add(:runtime_json, "services.#{name}.entrypoint must be a string")
-    end
-    if service["command"].present? && !service["command"].is_a?(String)
-      errors.add(:runtime_json, "services.#{name}.command must be a string")
-    end
+    validate_string_array(service, name:, field: "command")
+    validate_string_array(service, name:, field: "args")
     unless service["env"].nil? || service["env"].is_a?(Hash)
       errors.add(:runtime_json, "services.#{name}.env must be an object")
     end
@@ -260,10 +256,10 @@ class Release < ApplicationRecord
       errors.add(:runtime_json, "tasks.release.service must reference an existing service")
       return
     end
-    validate_release_task_string(task, "entrypoint")
-    validate_release_task_string(task, "command")
-    if !release_task_string_present?(task["entrypoint"]) && !release_task_string_present?(task["command"])
-      errors.add(:runtime_json, "tasks.release must set entrypoint or command")
+    validate_release_task_array(task, "command")
+    validate_release_task_array(task, "args")
+    if !release_task_array_present?(task["command"]) && !release_task_array_present?(task["args"])
+      errors.add(:runtime_json, "tasks.release must set command or args")
     end
     unless task["env"].nil? || task["env"].is_a?(Hash)
       errors.add(:runtime_json, "tasks.release.env must be an object")
@@ -291,15 +287,26 @@ class Release < ApplicationRecord
     end
   end
 
-  def validate_release_task_string(task, field)
-    value = task[field]
-    return if value.nil? || value.is_a?(String)
+  def validate_string_array(service, name:, field:)
+    value = service[field]
+    return if value.nil? || string_array?(value)
 
-    errors.add(:runtime_json, "tasks.release.#{field} must be a string")
+    errors.add(:runtime_json, "services.#{name}.#{field} must be an array of strings")
   end
 
-  def release_task_string_present?(value)
-    value.is_a?(String) && value.strip.present?
+  def validate_release_task_array(task, field)
+    value = task[field]
+    return if value.nil? || string_array?(value)
+
+    errors.add(:runtime_json, "tasks.release.#{field} must be an array of strings")
+  end
+
+  def release_task_array_present?(value)
+    string_array?(value) && value.present?
+  end
+
+  def string_array?(value)
+    value.is_a?(Array) && value.all? { |entry| entry.is_a?(String) && entry.strip.present? }
   end
 
   def service_payload(name, service, organization:, environment:)
@@ -308,8 +315,8 @@ class Release < ApplicationRecord
       name: name,
       kind: service_kind(service),
       image: image,
-      entrypoint: shell_words(service["entrypoint"]),
-      command: shell_words(service["command"]),
+      entrypoint: string_array(service["command"]),
+      command: string_array(service["args"]),
       env: service["env"].presence,
       secretRefs: merged_secret_refs_for_agent(service, service_name: name, environment: environment).presence,
       volumeMounts: service_volume_mounts(service, environment: environment).presence
@@ -329,8 +336,8 @@ class Release < ApplicationRecord
     {
       name: name,
       image: image,
-      entrypoint: shell_words(service["entrypoint"]),
-      command: shell_words(service["command"]),
+      entrypoint: string_array(service["command"]),
+      command: string_array(service["args"]),
       env: service["env"].presence,
       secretRefs: resolved_task_secret_refs(service, secret_service_name:, environment:).presence,
       volumeMounts: service_volume_mounts(service, environment: environment).presence
@@ -339,8 +346,8 @@ class Release < ApplicationRecord
 
   def merged_task_service(service, task)
     stringify_hash(service).merge(
-      "entrypoint" => task["entrypoint"].presence || service["entrypoint"],
       "command" => task["command"].presence || service["command"],
+      "args" => task["args"].presence || service["args"],
       "env" => stringify_hash(service["env"]).merge(stringify_hash(task["env"]))
     )
   end
@@ -391,11 +398,10 @@ class Release < ApplicationRecord
     service_kind(service)
   end
 
-  def shell_words(value)
-    text = value.to_s.strip
-    return nil if text.empty?
+  def string_array(value)
+    return nil unless string_array?(value)
 
-    Shellwords.split(text)
+    value.map(&:dup)
   end
 
   def service_secret_refs_for_agent(service)

--- a/control-plane/app/services/releases/runtime_attributes.rb
+++ b/control-plane/app/services/releases/runtime_attributes.rb
@@ -79,6 +79,7 @@ module Releases
 
     def parse_service(value, field:)
       service = parse_hash(value, field:)
+      reject_deprecated_key!(service, deprecated_key: :entrypoint, field: :"#{field}.entrypoint")
       kind = optional_service_string(service["kind"] || service[:kind])
       raise InvalidPayload, "#{field}.kind must be present" if kind.blank?
 
@@ -111,6 +112,7 @@ module Releases
 
     def parse_release_task(value)
       task = parse_hash(value, field: :"tasks.release")
+      reject_deprecated_key!(task, deprecated_key: :entrypoint, field: :"tasks.release.entrypoint")
       {
         "service" => required_service_string(task["service"] || task[:service], field: :"tasks.release.service"),
         "command" => optional_service_array(task["command"] || task[:command], field: :"tasks.release.command"),
@@ -178,11 +180,19 @@ module Releases
     def optional_service_array(value, field:)
       array = parse_array(value, field: field)
       array.each_with_index.map do |entry, index|
-        text = entry.to_s.strip
+        raise InvalidPayload, "#{field}[#{index}] must be a string" unless entry.is_a?(String)
+
+        text = entry.strip
         raise InvalidPayload, "#{field}[#{index}] must be present" if text.blank?
 
         text
       end.presence
+    end
+
+    def reject_deprecated_key!(hash, deprecated_key:, field:)
+      return unless hash.key?(deprecated_key) || hash.key?(deprecated_key.to_s)
+
+      raise InvalidPayload, "#{field} is no longer supported; use command or args"
     end
 
     def required_service_string(value, field:)

--- a/control-plane/app/services/releases/runtime_attributes.rb
+++ b/control-plane/app/services/releases/runtime_attributes.rb
@@ -89,8 +89,8 @@ module Releases
       normalized = {
         "kind" => kind,
         "image" => optional_service_string(service["image"] || service[:image]),
-        "entrypoint" => optional_service_string(service["entrypoint"] || service[:entrypoint]),
-        "command" => optional_service_string(service["command"] || service[:command]),
+        "command" => optional_service_array(service["command"] || service[:command], field: :"#{field}.command"),
+        "args" => optional_service_array(service["args"] || service[:args], field: :"#{field}.args"),
         "env" => parse_hash(service["env"] || service[:env], field: :"#{field}.env"),
         "secret_refs" => parse_array(service["secret_refs"] || service[:secret_refs], field: :"#{field}.secret_refs"),
         "volumes" => parse_array(service["volumes"] || service[:volumes], field: :"#{field}.volumes"),
@@ -113,8 +113,8 @@ module Releases
       task = parse_hash(value, field: :"tasks.release")
       {
         "service" => required_service_string(task["service"] || task[:service], field: :"tasks.release.service"),
-        "entrypoint" => optional_service_string(task["entrypoint"] || task[:entrypoint]),
-        "command" => optional_service_string(task["command"] || task[:command]),
+        "command" => optional_service_array(task["command"] || task[:command], field: :"tasks.release.command"),
+        "args" => optional_service_array(task["args"] || task[:args], field: :"tasks.release.args"),
         "env" => parse_hash(task["env"] || task[:env], field: :"tasks.release.env")
       }.compact
     end
@@ -173,6 +173,16 @@ module Releases
 
     def optional_service_string(value)
       value.to_s.strip.presence
+    end
+
+    def optional_service_array(value, field:)
+      array = parse_array(value, field: field)
+      array.each_with_index.map do |entry, index|
+        text = entry.to_s.strip
+        raise InvalidPayload, "#{field}[#{index}] must be present" if text.blank?
+
+        text
+      end.presence
     end
 
     def required_service_string(value, field:)

--- a/control-plane/test/integration/api_cli_mvp_test.rb
+++ b/control-plane/test/integration/api_cli_mvp_test.rb
@@ -1515,7 +1515,7 @@ class ApiCliMvpTest < ActionDispatch::IntegrationTest
             volumes: [{ source: "app_storage", target: "/rails/storage" }]
           ),
           worker: worker_service_runtime(
-            command: "./bin/jobs",
+            command: ["./bin/jobs"],
             volumes: [{ source: "app_storage", target: "/rails/storage" }]
           )
         },
@@ -1527,7 +1527,7 @@ class ApiCliMvpTest < ActionDispatch::IntegrationTest
     assert_response :created
     release = project.releases.order(:id).last
     runtime = JSON.parse(release.runtime_json)
-    assert_equal "./bin/jobs", runtime.dig("services", "worker", "command")
+    assert_equal ["./bin/jobs"], runtime.dig("services", "worker", "command")
     assert_equal 80, runtime.dig("services", "web", "ports").first.fetch("port")
     assert_equal 80, runtime.dig("services", "web", "healthcheck", "port")
   end

--- a/control-plane/test/jobs/deployments/publish_job_test.rb
+++ b/control-plane/test/jobs/deployments/publish_job_test.rb
@@ -24,7 +24,7 @@ module Deployments
         runtime_json: release_runtime_json(tasks: {
           "release" => {
             "service" => "web",
-            "command" => "bin/rails db:migrate"
+            "command" => ["bin/rails", "db:migrate"]
           }
         }),
         release_task_status: Deployment::RELEASE_TASK_STATUS_PENDING

--- a/control-plane/test/models/deployments_publisher_test.rb
+++ b/control-plane/test/models/deployments_publisher_test.rb
@@ -25,7 +25,7 @@ class DeploymentsPublisherTest < ActiveSupport::TestCase
       image_digest: "sha256:abc",
       image_repository: "api",
       runtime_json: release_runtime_json(tasks: {
-        "release" => { "service" => "web", "command" => "bundle exec rails db:migrate" }
+        "release" => { "service" => "web", "command" => ["bundle", "exec", "rails", "db:migrate"] }
       }),
       revision: "rel-1"
     )
@@ -314,7 +314,7 @@ class DeploymentsPublisherTest < ActiveSupport::TestCase
       image_repository: "api",
       runtime_json: release_runtime_json(services: {
         "web" => web_service_runtime(port: 80, env: { "RAILS_ENV" => "production" }),
-        "worker" => worker_service_runtime(command: "./bin/jobs")
+        "worker" => worker_service_runtime(command: ["./bin/jobs"])
       }),
       revision: "rel-1"
     )
@@ -344,7 +344,7 @@ class DeploymentsPublisherTest < ActiveSupport::TestCase
     desired_state = store.desired_state_payload(bucket: organization.gcs_bucket_name, object_path: node.desired_state_object_path)
     services = desired_state_services(desired_state)
     assert_equal %w[web worker], services.map { |entry| entry.fetch("name") }
-    assert_equal "./bin/jobs", services.second.dig("command", 0)
+    assert_equal "./bin/jobs", services.second.dig("entrypoint", 0)
     assert_equal [ hostname ], desired_state.dig("ingress", "hosts")
   end
 
@@ -368,7 +368,7 @@ class DeploymentsPublisherTest < ActiveSupport::TestCase
       image_repository: "api",
       runtime_json: release_runtime_json(services: {
         "web" => web_service_runtime(volumes: [ { "source" => "app_storage", "target" => "/rails/storage" } ]),
-        "worker" => worker_service_runtime(command: "./bin/jobs", volumes: [ { "source" => "app_storage", "target" => "/rails/storage" } ])
+        "worker" => worker_service_runtime(command: ["./bin/jobs"], volumes: [ { "source" => "app_storage", "target" => "/rails/storage" } ])
       }),
       revision: "rel-1"
     )

--- a/control-plane/test/models/release_test.rb
+++ b/control-plane/test/models/release_test.rb
@@ -66,6 +66,42 @@ class ReleaseTest < ActiveSupport::TestCase
     assert_equal [ "services.web.kind must be present" ], kind_errors
   end
 
+  test "scheduled_services_for fails fast for stored legacy string command" do
+    release = persisted_release(
+      runtime_json: release_runtime_json(
+        services: {
+          "web" => web_service_runtime(command: "./bin/server")
+        }
+      )
+    )
+
+    error = assert_raises(Release::InvalidRuntimeConfig) do
+      release.scheduled_services_for(node: build_node_for(release:))
+    end
+
+    assert_equal "services.web.command must be an array of strings", error.message
+  end
+
+  test "release_task_for fails fast for stored deprecated entrypoint" do
+    release = persisted_release(
+      runtime_json: release_runtime_json(
+        tasks: {
+          "release" => {
+            "service" => "web",
+            "entrypoint" => [ "/bin/sh" ],
+            "command" => [ "bundle", "exec", "rails", "db:migrate" ]
+          }
+        }
+      )
+    )
+
+    error = assert_raises(Release::InvalidRuntimeConfig) do
+      release.release_task_for(node: build_node_for(release:))
+    end
+
+    assert_equal "tasks.release.entrypoint is no longer supported; use command or args", error.message
+  end
+
   private
 
   def build_release(runtime_json:)
@@ -77,5 +113,28 @@ class ReleaseTest < ActiveSupport::TestCase
       image_digest: "sha256:#{"b" * 64}",
       runtime_json: runtime_json
     )
+  end
+
+  def persisted_release(runtime_json:)
+    release = build_release(runtime_json:)
+    release.save!(validate: false)
+    release
+  end
+
+  def build_node_for(release:)
+    organization = release.project.organization
+    ensure_test_organization_runtime!(organization)
+    environment = release.project.environments.create!(
+      name: "Production",
+      gcp_project_id: "gcp-proj-#{SecureRandom.hex(3)}",
+      gcp_project_number: SecureRandom.random_number(10**12).to_s,
+      service_account_email: "svc-#{SecureRandom.hex(4)}@example.test",
+      workload_identity_pool: "pool-#{SecureRandom.hex(3)}",
+      workload_identity_provider: "provider-#{SecureRandom.hex(3)}",
+      runtime_kind: Environment::RUNTIME_CUSTOMER_NODES
+    )
+    node, _access, _refresh = issue_test_node!(organization:, name: "node-#{SecureRandom.hex(3)}")
+    node.update!(environment:)
+    node
   end
 end

--- a/control-plane/test/models/release_test.rb
+++ b/control-plane/test/models/release_test.rb
@@ -33,22 +33,22 @@ class ReleaseTest < ActiveSupport::TestCase
     assert_equal "web", release.ingress_service_name
   end
 
-  test "release task command and entrypoint must be strings" do
+  test "release task command and args must be arrays" do
     release = build_release(
       runtime_json: release_runtime_json(
         tasks: {
           "release" => {
             "service" => "web",
-            "command" => [ "bin/rails", "db:migrate" ],
-            "entrypoint" => [ "/bin/sh" ]
+            "command" => "bin/rails",
+            "args" => "db:migrate"
           }
         }
       )
     )
 
     assert_not release.valid?
-    assert_includes release.errors[:runtime_json], "tasks.release.command must be a string"
-    assert_includes release.errors[:runtime_json], "tasks.release.entrypoint must be a string"
+    assert_includes release.errors[:runtime_json], "tasks.release.command must be an array of strings"
+    assert_includes release.errors[:runtime_json], "tasks.release.args must be an array of strings"
   end
 
   test "blank kind does not contribute required labels and reports one kind error" do

--- a/control-plane/test/services/deployments/progress_recorder_test.rb
+++ b/control-plane/test/services/deployments/progress_recorder_test.rb
@@ -24,7 +24,7 @@ module Deployments
         image_digest: "sha256:abc",
         image_repository: "api",
         runtime_json: release_runtime_json(tasks: {
-          "release" => { "service" => "web", "command" => "bundle exec rails db:migrate" }
+          "release" => { "service" => "web", "command" => ["bundle", "exec", "rails", "db:migrate"] }
         }),
         revision: "rel-1"
       )

--- a/control-plane/test/services/releases/runtime_attributes_test.rb
+++ b/control-plane/test/services/releases/runtime_attributes_test.rb
@@ -37,5 +37,35 @@ module Releases
 
       assert_equal "services.web.kind must be present", error.message
     end
+
+    test "preserves argv arrays for service command and release args" do
+      attrs = RuntimeAttributes.new(
+        params: {
+          git_sha: "a" * 40,
+          image_repository: "api",
+          image_digest: "sha256:#{"b" * 64}",
+          services: {
+            web: {
+              kind: "web",
+              command: ["/app"],
+              args: ["web"],
+              ports: [{ name: "http", port: 3000 }],
+              healthcheck: { path: "/up", port: 3000 }
+            }
+          },
+          tasks: {
+            release: {
+              service: "web",
+              args: ["release"]
+            }
+          }
+        }
+      ).to_h
+
+      runtime = JSON.parse(attrs.fetch(:runtime_json))
+      assert_equal ["/app"], runtime.dig("services", "web", "command")
+      assert_equal ["web"], runtime.dig("services", "web", "args")
+      assert_equal ["release"], runtime.dig("tasks", "release", "args")
+    end
   end
 end

--- a/control-plane/test/services/releases/runtime_attributes_test.rb
+++ b/control-plane/test/services/releases/runtime_attributes_test.rb
@@ -38,6 +38,50 @@ module Releases
       assert_equal "services.web.kind must be present", error.message
     end
 
+    test "rejects deprecated entrypoint fields" do
+      error = assert_raises(RuntimeAttributes::InvalidPayload) do
+        RuntimeAttributes.new(
+          params: {
+            git_sha: "a" * 40,
+            image_repository: "api",
+            image_digest: "sha256:#{"b" * 64}",
+            services: {
+              web: {
+                kind: "web",
+                entrypoint: ["/app"],
+                ports: [{ name: "http", port: 3000 }],
+                healthcheck: { path: "/up", port: 3000 }
+              }
+            }
+          }
+        ).to_h
+      end
+
+      assert_equal "services.web.entrypoint is no longer supported; use command or args", error.message
+    end
+
+    test "rejects non-string argv entries" do
+      error = assert_raises(RuntimeAttributes::InvalidPayload) do
+        RuntimeAttributes.new(
+          params: {
+            git_sha: "a" * 40,
+            image_repository: "api",
+            image_digest: "sha256:#{"b" * 64}",
+            services: {
+              web: {
+                kind: "web",
+                command: ["/app", 123],
+                ports: [{ name: "http", port: 3000 }],
+                healthcheck: { path: "/up", port: 3000 }
+              }
+            }
+          }
+        ).to_h
+      end
+
+      assert_equal "services.web.command[1] must be a string", error.message
+    end
+
     test "preserves argv arrays for service command and release args" do
       attrs = RuntimeAttributes.new(
         params: {

--- a/control-plane/test/test_helper.rb
+++ b/control-plane/test/test_helper.rb
@@ -172,12 +172,12 @@ module ActiveSupport
       bundle
     end
 
-    def web_service_runtime(port: 3000, healthcheck_path: "/up", healthcheck_port: nil, command: nil, entrypoint: nil, env: {}, secret_refs: [], volumes: [], image: nil)
+    def web_service_runtime(port: 3000, healthcheck_path: "/up", healthcheck_port: nil, command: nil, args: nil, env: {}, secret_refs: [], volumes: [], image: nil)
       {
         "kind" => "web",
         "image" => image,
-        "entrypoint" => entrypoint,
         "command" => command,
+        "args" => args,
         "env" => env,
         "secret_refs" => secret_refs,
         "ports" => [ { "name" => "http", "port" => port } ],
@@ -186,12 +186,12 @@ module ActiveSupport
       }.compact
     end
 
-    def worker_service_runtime(command: nil, entrypoint: nil, env: {}, secret_refs: [], volumes: [], image: nil)
+    def worker_service_runtime(command: nil, args: nil, env: {}, secret_refs: [], volumes: [], image: nil)
       {
         "kind" => "worker",
         "image" => image,
-        "entrypoint" => entrypoint,
         "command" => command,
+        "args" => args,
         "env" => env,
         "secret_refs" => secret_refs,
         "volumes" => volumes

--- a/test/e2e/e2e.rb
+++ b/test/e2e/e2e.rb
@@ -801,7 +801,7 @@ class E2E
       config["tasks"].delete("release")
       config["tasks"]["release"] = {
         "service" => "web",
-        "command" => "release-task #{APP_VOLUME_TARGET}/#{RELEASE_MARKER_FILENAME} #{Shellwords.escape(release_marker_value)}"
+        "args" => ["release-task", "#{APP_VOLUME_TARGET}/#{RELEASE_MARKER_FILENAME}", release_marker_value]
       }
       File.write(config_path, YAML.dump(config))
     end

--- a/test/e2e/solo_e2e.rb
+++ b/test/e2e/solo_e2e.rb
@@ -460,7 +460,6 @@ PY
       "services" => {
         "web" => {
           "kind" => "web",
-          "command" => "/server",
           "ports" => [
             { "name" => "http", "port" => APP_PORT }
           ],


### PR DESCRIPTION
## Summary
- hard-break the app config and runtime payloads to use Kubernetes-style argv arrays
- interpret `command` as container entrypoint override and `args` as container args
- remove implicit shell-string semantics from services and release tasks

## What changed
- CLI config now uses array-valued `command` and `args` for services and release tasks
- desired-state publishing maps config/runtime `command` -> agent `entrypoint` and `args` -> agent `command`
- control-plane runtime normalization/validation now requires arrays of strings for these fields
- docs and tests updated to reflect the clean-slate model
- added a config test rejecting legacy string `command:` syntax
- hardened provider workflow tests against ambient `HCLOUD_TOKEN` leakage

## Test plan
- `mise run test:cli`
- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:54329/devopsellence RAILS_ENV=test mise x ruby@4.0.0 -- bundle exec rails db:prepare`
- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:54329/devopsellence RAILS_ENV=test mise x ruby@4.0.0 -- bundle exec rails test test/services/releases/runtime_attributes_test.rb test/models/release_test.rb test/models/deployments_publisher_test.rb test/services/deployments/progress_recorder_test.rb test/jobs/deployments/publish_job_test.rb test/integration/api_cli_mvp_test.rb`
