### PR TITLE
[codex] Keep solo ingress on HTTP until auto TLS is ready

### DIFF
--- a/agent/internal/engine/docker/docker.go
+++ b/agent/internal/engine/docker/docker.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 	"time"
 
@@ -228,11 +229,41 @@ func (e *Engine) Inspect(ctx context.Context, name string) (engine.ContainerInfo
 		return engine.ContainerInfo{}, err
 	}
 
+	publishedPorts := []engine.PortBinding{}
+	if res.Container.HostConfig != nil {
+		for containerPort, bindings := range res.Container.HostConfig.PortBindings {
+			containerPortSpec := strings.TrimSpace(fmt.Sprint(containerPort))
+			containerPortParts := strings.SplitN(containerPortSpec, "/", 2)
+			containerPortValue, parseContainerErr := strconv.Atoi(containerPortParts[0])
+			if parseContainerErr != nil {
+				continue
+			}
+			proto := string(network.TCP)
+			if len(containerPortParts) == 2 && strings.TrimSpace(containerPortParts[1]) != "" {
+				proto = strings.TrimSpace(containerPortParts[1])
+			}
+			for _, binding := range bindings {
+				hostPortValue := containerPortValue
+				if binding.HostPort != "" {
+					if parsedHostPort, parseHostErr := strconv.Atoi(binding.HostPort); parseHostErr == nil {
+						hostPortValue = parsedHostPort
+					}
+				}
+				publishedPorts = append(publishedPorts, engine.PortBinding{
+					ContainerPort: uint16(containerPortValue),
+					HostPort:      uint16(hostPortValue),
+					Protocol:      proto,
+				})
+			}
+		}
+	}
+
 	info := engine.ContainerInfo{
 		Name:            strings.TrimPrefix(res.Container.Name, "/"),
 		Running:         res.Container.State != nil && res.Container.State.Running,
 		HasHealthcheck:  res.Container.State != nil && res.Container.State.Health != nil,
-		PublishHostPort: res.Container.HostConfig != nil && len(res.Container.HostConfig.PortBindings) > 0,
+		PublishHostPort: len(publishedPorts) > 0,
+		PublishedPorts:  publishedPorts,
 		NetworkIP:       map[string]string{},
 	}
 	if res.Container.State != nil && res.Container.State.Health != nil {

--- a/agent/internal/engine/engine.go
+++ b/agent/internal/engine/engine.go
@@ -88,5 +88,6 @@ type ContainerInfo struct {
 	Health          string
 	HasHealthcheck  bool
 	PublishHostPort bool
+	PublishedPorts  []PortBinding
 	NetworkIP       map[string]string
 }

--- a/agent/internal/envoy/manager.go
+++ b/agent/internal/envoy/manager.go
@@ -107,6 +107,7 @@ func (m *Manager) Ensure(ctx context.Context, ingress *desiredstatepb.Ingress) e
 	if err != nil {
 		return err
 	}
+	desiredPorts := portBindingsForIngress(m.config.Port, ingress, publicIngressListener)
 
 	// Start the xDS server once (idempotent); binds a Unix socket alongside the bootstrap.
 	socketPath := xdsSocketPath(m.config.BootstrapPath)
@@ -138,7 +139,7 @@ func (m *Manager) Ensure(ctx context.Context, ingress *desiredstatepb.Ingress) e
 		if !cerrdefs.IsNotFound(err) {
 			return fmt.Errorf("inspect envoy: %w", err)
 		}
-		if err := m.createEnvoy(ctx, ingress); err != nil {
+		if err := m.createEnvoy(ctx, ingress, desiredPorts, publicIngressListener != nil); err != nil {
 			return err
 		}
 		if err := m.waitReady(ctx); err != nil {
@@ -149,9 +150,9 @@ func (m *Manager) Ensure(ctx context.Context, ingress *desiredstatepb.Ingress) e
 		return nil
 	}
 
-	if info.Running && info.PublishHostPort != publishHostPortForIngress(ingress) {
+	if info.Running && !samePublishedPorts(info.PublishedPorts, desiredPorts) {
 		if err := m.engine.Remove(ctx, m.config.ContainerName); err != nil {
-			return fmt.Errorf("remove envoy (publish mode changed): %w", err)
+			return fmt.Errorf("remove envoy (published ports changed): %w", err)
 		}
 		info.Running = false
 	}
@@ -178,7 +179,7 @@ func (m *Manager) Ensure(ctx context.Context, ingress *desiredstatepb.Ingress) e
 			return fmt.Errorf("remove envoy: %w", err)
 		}
 	}
-	if err := m.createEnvoy(ctx, ingress); err != nil {
+	if err := m.createEnvoy(ctx, ingress, desiredPorts, publicIngressListener != nil); err != nil {
 		return err
 	}
 	if err := m.waitReady(ctx); err != nil {
@@ -284,7 +285,7 @@ func (m *Manager) snapshotEndpoints() map[string]*endpointState {
 	return cloned
 }
 
-func (m *Manager) createEnvoy(ctx context.Context, ingress *desiredstatepb.Ingress) error {
+func (m *Manager) createEnvoy(ctx context.Context, ingress *desiredstatepb.Ingress, desiredPorts []engine.PortBinding, publicIngressEnabled bool) error {
 	bootstrapDir := dirOf(m.config.BootstrapPath)
 	mounts := []string{fmt.Sprintf("%s:%s:ro", bootstrapDir, bootstrapDir)}
 	for _, path := range []string{m.config.TLSCertPath, m.config.TLSKeyPath} {
@@ -310,25 +311,16 @@ func (m *Manager) createEnvoy(ctx context.Context, ingress *desiredstatepb.Ingre
 		Health:  m.config.Healthcheck,
 		Restart: engine.RestartPolicyFromString(m.config.RestartPolicy),
 	}
-	if publicIngressListenerConfigEnabled(ingress) {
+	if publicIngressEnabled {
 		spec.ExtraHosts = []string{"host.docker.internal:host-gateway"}
 	}
-	spec.Ports = portBindingsForIngress(m.config.Port, ingress)
+	spec.Ports = desiredPorts
 
 	if err := m.engine.CreateAndStart(ctx, spec); err != nil {
 		return fmt.Errorf("create envoy: %w", err)
 	}
 
 	return nil
-}
-
-func publicIngressListenerConfigEnabled(ingress *desiredstatepb.Ingress) bool {
-	switch normalizedIngressMode(ingress) {
-	case ingressModePublic:
-		return true
-	default:
-		return false
-	}
 }
 
 func (m *Manager) waitReady(ctx context.Context) error {
@@ -401,7 +393,12 @@ func (m *Manager) restart(ctx context.Context) error {
 	if err := m.engine.Remove(ctx, m.config.ContainerName); err != nil {
 		return fmt.Errorf("remove envoy for restart: %w", err)
 	}
-	if err := m.createEnvoy(ctx, m.lastIngress); err != nil {
+	publicIngressListener, err := m.publicIngressListenerConfig(m.lastIngress)
+	if err != nil {
+		return err
+	}
+	desiredPorts := portBindingsForIngress(m.config.Port, m.lastIngress, publicIngressListener)
+	if err := m.createEnvoy(ctx, m.lastIngress, desiredPorts, publicIngressListener != nil); err != nil {
 		return err
 	}
 	if err := m.waitReady(ctx); err != nil {
@@ -511,11 +508,7 @@ func cloneIngressRoutes(ingress *desiredstatepb.Ingress) []*desiredstatepb.Ingre
 	return append([]*desiredstatepb.IngressRoute(nil), ingress.Routes...)
 }
 
-func publishHostPortForIngress(ingress *desiredstatepb.Ingress) bool {
-	return len(portBindingsForIngress(0, ingress)) > 0
-}
-
-func portBindingsForIngress(defaultPort uint16, ingress *desiredstatepb.Ingress) []engine.PortBinding {
+func portBindingsForIngress(defaultPort uint16, ingress *desiredstatepb.Ingress, publicIngress *publicIngressListenerConfig) []engine.PortBinding {
 	switch normalizedIngressMode(ingress) {
 	case ingressModePublic:
 		ports := []engine.PortBinding{{
@@ -523,7 +516,7 @@ func portBindingsForIngress(defaultPort uint16, ingress *desiredstatepb.Ingress)
 			HostPort:      80,
 			Protocol:      "tcp",
 		}}
-		if ingressTLSMode(ingress) != "off" {
+		if publicIngress != nil && publicIngress.TLSEnabled {
 			ports = append(ports, engine.PortBinding{
 				ContainerPort: 8443,
 				HostPort:      443,
@@ -546,6 +539,37 @@ func portBindingsForIngress(defaultPort uint16, ingress *desiredstatepb.Ingress)
 	default:
 		return nil
 	}
+}
+
+func samePublishedPorts(current, desired []engine.PortBinding) bool {
+	if len(current) != len(desired) {
+		return false
+	}
+	currentCounts := map[string]int{}
+	for _, port := range current {
+		currentCounts[portBindingKey(port)]++
+	}
+	for _, port := range desired {
+		key := portBindingKey(port)
+		if currentCounts[key] == 0 {
+			return false
+		}
+		currentCounts[key]--
+	}
+	for _, count := range currentCounts {
+		if count != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func portBindingKey(port engine.PortBinding) string {
+	proto := strings.TrimSpace(port.Protocol)
+	if proto == "" {
+		proto = "tcp"
+	}
+	return fmt.Sprintf("%d:%d/%s", port.HostPort, port.ContainerPort, proto)
 }
 
 func dirOf(path string) string {

--- a/agent/internal/envoy/manager_test.go
+++ b/agent/internal/envoy/manager_test.go
@@ -56,6 +56,7 @@ func (f *fakeEngine) CreateAndStart(ctx context.Context, spec engine.ContainerSp
 		Health:          health,
 		HasHealthcheck:  spec.Health != nil,
 		PublishHostPort: len(spec.Ports) > 0,
+		PublishedPorts:  append([]engine.PortBinding(nil), spec.Ports...),
 		NetworkIP:       map[string]string{spec.Network: networkIP},
 	}
 	return nil
@@ -231,7 +232,7 @@ func TestEnsureRecreatesWhenMissingHealthcheck(t *testing.T) {
 	}
 }
 
-func TestEnsureRecreatesWhenPublishModeChanges(t *testing.T) {
+func TestEnsureRecreatesWhenPublishedPortsChange(t *testing.T) {
 	eng := &fakeEngine{
 		inspectInfo: engine.ContainerInfo{
 			Name:            "devopsellence-envoy",
@@ -239,6 +240,11 @@ func TestEnsureRecreatesWhenPublishModeChanges(t *testing.T) {
 			Health:          "healthy",
 			HasHealthcheck:  true,
 			PublishHostPort: true,
+			PublishedPorts: []engine.PortBinding{{
+				ContainerPort: 8080,
+				HostPort:      80,
+				Protocol:      "tcp",
+			}},
 		},
 	}
 	logger := slog.New(slog.NewJSONHandler(io.Discard, &slog.HandlerOptions{}))
@@ -461,6 +467,96 @@ func TestEnsurePublishesPublicPorts(t *testing.T) {
 	}
 	if eng.createdSpec.Ports[0].HostPort != 80 || eng.createdSpec.Ports[1].HostPort != 443 {
 		t.Fatalf("expected host ports 80/443, got %+v", eng.createdSpec.Ports)
+	}
+}
+
+func TestEnsureAutoTLSPublishesOnlyHTTPUntilCertificateExists(t *testing.T) {
+	eng := &fakeEngine{inspectErr: cerrdefs.ErrNotFound}
+	logger := slog.New(slog.NewJSONHandler(io.Discard, &slog.HandlerOptions{}))
+	bootstrapPath := tempBootstrapPath(t)
+	mgr := New(eng, Config{
+		Image:          "docker.io/envoyproxy/envoy:v1.37.0",
+		ContainerName:  "devopsellence-envoy",
+		NetworkName:    "devopsellence",
+		BootstrapPath:  bootstrapPath,
+		Port:           8000,
+		TLSCertPath:    filepath.Join(t.TempDir(), "ingress.crt"),
+		TLSKeyPath:     filepath.Join(t.TempDir(), "ingress.key"),
+		ClusterName:    "devopsellence_web",
+		RestartPolicy:  "unless-stopped",
+		StartupTimeout: 2 * time.Second,
+	}, logger)
+
+	ingress := &desiredstatepb.Ingress{
+		Mode:  "public",
+		Hosts: []string{"abc123.devopsellence.io"},
+		Tls:   &desiredstatepb.IngressTLS{Mode: "auto"},
+	}
+	if err := mgr.Ensure(context.Background(), ingress); err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+	if eng.createdSpec == nil {
+		t.Fatal("expected CreateAndStart to be called")
+	}
+	if len(eng.createdSpec.Ports) != 1 || eng.createdSpec.Ports[0].HostPort != 80 {
+		t.Fatalf("expected only host port 80 before cert is ready, got %+v", eng.createdSpec.Ports)
+	}
+}
+
+func TestEnsureRecreatesEnvoyWhenAutoTLSCertificateBecomesReady(t *testing.T) {
+	eng := &fakeEngine{
+		inspectInfo: engine.ContainerInfo{
+			Name:            "devopsellence-envoy",
+			Running:         true,
+			Health:          "healthy",
+			HasHealthcheck:  true,
+			PublishHostPort: true,
+			PublishedPorts: []engine.PortBinding{{
+				ContainerPort: 8080,
+				HostPort:      80,
+				Protocol:      "tcp",
+			}},
+			NetworkIP: map[string]string{"devopsellence": "172.18.0.2"},
+		},
+	}
+	logger := slog.New(slog.NewJSONHandler(io.Discard, &slog.HandlerOptions{}))
+	bootstrapPath := tempBootstrapPath(t)
+	certDir := t.TempDir()
+	certPath := filepath.Join(certDir, "ingress.crt")
+	keyPath := filepath.Join(certDir, "ingress.key")
+	if err := os.WriteFile(certPath, []byte("cert"), 0o600); err != nil {
+		t.Fatalf("write cert: %v", err)
+	}
+	if err := os.WriteFile(keyPath, []byte("key"), 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+
+	mgr := New(eng, Config{
+		Image:          "docker.io/envoyproxy/envoy:v1.37.0",
+		ContainerName:  "devopsellence-envoy",
+		NetworkName:    "devopsellence",
+		BootstrapPath:  bootstrapPath,
+		Port:           8000,
+		TLSCertPath:    certPath,
+		TLSKeyPath:     keyPath,
+		ClusterName:    "devopsellence_web",
+		RestartPolicy:  "unless-stopped",
+		StartupTimeout: 2 * time.Second,
+	}, logger)
+
+	ingress := &desiredstatepb.Ingress{
+		Mode:  "public",
+		Hosts: []string{"abc123.devopsellence.io"},
+		Tls:   &desiredstatepb.IngressTLS{Mode: "auto"},
+	}
+	if err := mgr.Ensure(context.Background(), ingress); err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+	if len(eng.removed) == 0 {
+		t.Fatal("expected envoy removal to recreate with https publish")
+	}
+	if eng.createdSpec == nil || len(eng.createdSpec.Ports) != 2 {
+		t.Fatalf("expected recreated envoy with ports 80/443, got %+v", eng.createdSpec)
 	}
 }
 

--- a/agent/internal/reconcile/reconcile.go
+++ b/agent/internal/reconcile/reconcile.go
@@ -211,7 +211,15 @@ func (r *Reconciler) reconcileService(ctx context.Context, ingress *desiredstate
 		}
 		if r.opts.IngressCert != nil {
 			if err := r.opts.IngressCert.Ensure(ctx, ingress, nodePeers); err != nil {
-				return result, fmt.Errorf("ensure ingress certificate: %w", err)
+				if ingressAutoTLSErrorIsNonFatal(ingress) {
+					logger := r.opts.Logger
+					if logger == nil {
+						logger = slog.Default()
+					}
+					logger.Warn("auto tls provisioning failed; serving http until certificate is ready", "error", err)
+				} else {
+					return result, fmt.Errorf("ensure ingress certificate: %w", err)
+				}
 			}
 		}
 		if err := r.opts.Envoy.Ensure(ctx, ingress); err != nil {
@@ -678,6 +686,21 @@ func normalizedIngressMode(ingress *desiredstatepb.Ingress) string {
 		return ingressModeTunnel
 	}
 	return mode
+}
+
+func ingressAutoTLSErrorIsNonFatal(ingress *desiredstatepb.Ingress) bool {
+	if ingress == nil {
+		return false
+	}
+	if normalizedIngressMode(ingress) != "public" {
+		return false
+	}
+	tls := ingress.GetTls()
+	if tls == nil {
+		return true
+	}
+	mode := strings.TrimSpace(tls.GetMode())
+	return mode == "" || mode == "auto"
 }
 
 func secondsToDuration(seconds int64) time.Duration {

--- a/agent/internal/reconcile/reconcile_test.go
+++ b/agent/internal/reconcile/reconcile_test.go
@@ -332,6 +332,61 @@ func TestReconcileEnsuresIngressCertificateForPublicIngress(t *testing.T) {
 	}
 }
 
+func TestReconcileContinuesServingHTTPWhenAutoTLSProvisioningFails(t *testing.T) {
+	eng := newFakeEngine()
+	eng.images["httpbin"] = true
+	envoyManager := &fakeEnvoyManager{engine: eng}
+	ingressCertManager := &fakeIngressCertManager{ensureErr: fmt.Errorf("acme unavailable")}
+	rec := New(eng, Options{
+		Network:     "devopsellence",
+		StopTimeout: 2 * time.Second,
+		WebPort:     3000,
+		Envoy:       envoyManager,
+		IngressCert: ingressCertManager,
+		HTTPProber:  &fakeHTTPProber{statuses: []int{200}},
+	})
+
+	state := desiredState(webService(80, "/up"))
+	state.Ingress = publicIngress()
+
+	result, err := rec.Reconcile(context.Background(), state)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if result.Created != 1 {
+		t.Fatalf("expected web service creation to continue, got %+v", result)
+	}
+	if len(eng.created) != 1 || eng.created[0].Labels[engine.LabelService] != "web" {
+		t.Fatalf("expected created web container, got %+v", eng.created)
+	}
+}
+
+func TestReconcileFailsWhenManualTLSProvisioningFails(t *testing.T) {
+	eng := newFakeEngine()
+	eng.images["httpbin"] = true
+	envoyManager := &fakeEnvoyManager{engine: eng}
+	ingressCertManager := &fakeIngressCertManager{ensureErr: fmt.Errorf("missing certificate")}
+	rec := New(eng, Options{
+		Network:     "devopsellence",
+		StopTimeout: 2 * time.Second,
+		WebPort:     3000,
+		Envoy:       envoyManager,
+		IngressCert: ingressCertManager,
+		HTTPProber:  &fakeHTTPProber{statuses: []int{200}},
+	})
+
+	state := desiredState(webService(80, "/up"))
+	state.Ingress = publicIngress()
+	state.Ingress.Tls = &desiredstatepb.IngressTLS{Mode: "manual"}
+
+	if _, err := rec.Reconcile(context.Background(), state); err == nil {
+		t.Fatal("expected reconcile error")
+	}
+	if len(eng.created) != 0 {
+		t.Fatalf("expected no web container create on manual tls failure, got %+v", eng.created)
+	}
+}
+
 func TestRunTaskTruncatesLogOutput(t *testing.T) {
 	eng := newFakeEngine()
 	eng.images["busybox"] = true


### PR DESCRIPTION
## Summary

This fixes solo-mode public ingress behavior when `tls.mode=auto` is configured but the ACME certificate is not ready yet.

## What changed

- keep the web deploy running on HTTP even if auto TLS provisioning fails
- only enable HTTP->HTTPS redirect once the TLS cert/key are present
- only publish Docker host port `443` once TLS is actually ready
- recreate Envoy only when the published host-port set changes, since xDS can update listeners/routes but cannot change Docker port bindings
- add coverage for the HTTP-only fallback, the delayed `443` publish, and the later HTTP->HTTPS transition when the cert appears

## Why

Before this change, auto TLS failures could block the first web deploy entirely, and Envoy could still publish `443` before a cert was ready. That creates a rough first-run/setup experience.

The intended behavior is smoother:

- port `80` stays available while ACME is failing
- no redirect to HTTPS until the cert is ready
- no `443` listener exposure until Envoy can actually serve TLS

## Impact

Solo users get a safer first deploy and HTTPS enable flow. Failed Let’s Encrypt issuance now degrades to HTTP instead of breaking ingress.

## Validation

- `mise run test:agent -- ./internal/envoy ./internal/reconcile ./internal/engine/docker`
