### PR TITLE
[codex] align solo/shared deploy completion semantics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,7 @@ cd control-plane && mise run test -- test/path/file_test.rb
 
 - Explicit user product direction overrides reviewer suggestions.
 - If user says no legacy / no backward compat / clean slate, do not add backfills, shims, or compat code just to satisfy review comments; leave the thread open and note the rationale.
+- Right after each PR is opened or updated with pushed fixes, request a fresh Copilot review.
 
 ## Architecture
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,7 @@ cd control-plane && mise run test -- test/path/file_test.rb
 
 - Explicit user product direction overrides reviewer suggestions.
 - If user says no legacy / no backward compat / clean slate, do not add backfills, shims, or compat code just to satisfy review comments; leave the thread open and note the rationale.
-- Right after each PR is opened or updated with pushed fixes, request a fresh Copilot review.
+- Right after each PR is opened or updated with pushed fixes, request a fresh Copilot review with `gh pr edit <pr-number> --add-reviewer copilot-pull-request-reviewer`.
 
 ## Architecture
 

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -387,7 +388,7 @@ func parseSoloNodeStatusPayload(data []byte) (soloNodeStatus, json.RawMessage, e
 }
 
 func readSoloNodeStatus(ctx context.Context, node config.SoloNode) (soloNodeStatusResult, error) {
-	statusPath := filepath.Join(firstNonEmpty(node.AgentStateDir, "/var/lib/devopsellence"), "status.json")
+	statusPath := path.Join(firstNonEmpty(node.AgentStateDir, "/var/lib/devopsellence"), "status.json")
 	out, err := solo.RunSSH(ctx, node, remoteReadOptionalFileCommand(statusPath, soloStatusMissingSentinel), nil)
 	if err != nil {
 		return soloNodeStatusResult{}, err

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -383,8 +383,7 @@ func parseSoloNodeStatusPayload(data []byte) (soloNodeStatus, json.RawMessage, e
 	if err := json.Unmarshal(data, &status); err != nil {
 		return soloNodeStatus{}, nil, err
 	}
-	raw := append(json.RawMessage(nil), data...)
-	return status, raw, nil
+	return status, json.RawMessage(data), nil
 }
 
 func readSoloNodeStatus(ctx context.Context, node config.SoloNode) (soloNodeStatusResult, error) {
@@ -421,13 +420,14 @@ func (a *App) waitForSoloRollout(ctx context.Context, nodes map[string]config.So
 
 	lastSummary := ""
 	latestSummary := "rollout pending"
+	nodeNames := sortedSoloNodeNames(nodes)
 	for {
 		pendingCount := 0
 		reconcilingCount := 0
 		settledCount := 0
 		details := []string{}
 
-		for _, name := range sortedSoloNodeNames(nodes) {
+		for _, name := range nodeNames {
 			expectedRevision := strings.TrimSpace(expectedRevisions[name])
 			if expectedRevision == "" {
 				return fmt.Errorf("missing desired state revision for node %s", name)

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -123,6 +123,29 @@ type IngressCheckOptions struct {
 	Wait time.Duration
 }
 
+type soloNodeStatus struct {
+	Phase        string                      `json:"phase"`
+	Revision     string                      `json:"revision"`
+	Error        string                      `json:"error,omitempty"`
+	Environments []soloNodeStatusEnvironment `json:"environments"`
+}
+
+type soloNodeStatusEnvironment struct {
+	Name     string                  `json:"name"`
+	Services []soloNodeStatusService `json:"services"`
+}
+
+type soloNodeStatusService struct {
+	Name  string `json:"name"`
+	State string `json:"state"`
+}
+
+type soloNodeStatusResult struct {
+	Missing bool
+	Raw     json.RawMessage
+	Status  soloNodeStatus
+}
+
 func (a *App) createProviderNode(ctx context.Context, opts SoloNodeCreateOptions, projectName string) (providerNodeCreateResult, error) {
 	if opts.Name == "" {
 		return providerNodeCreateResult{}, fmt.Errorf("node name is required")
@@ -278,6 +301,9 @@ func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 	if err != nil {
 		return err
 	}
+	if err := a.waitForSoloRollout(ctx, nodes, desiredStateRevisions); err != nil {
+		return err
+	}
 
 	if a.Printer.JSON {
 		return a.Printer.PrintJSON(map[string]any{
@@ -349,6 +375,115 @@ func sortedSoloNodeNames(nodes map[string]config.SoloNode) []string {
 	}
 	sort.Strings(names)
 	return names
+}
+
+func parseSoloNodeStatusPayload(data []byte) (soloNodeStatus, json.RawMessage, error) {
+	var status soloNodeStatus
+	if err := json.Unmarshal(data, &status); err != nil {
+		return soloNodeStatus{}, nil, err
+	}
+	raw := append(json.RawMessage(nil), data...)
+	return status, raw, nil
+}
+
+func readSoloNodeStatus(ctx context.Context, node config.SoloNode) (soloNodeStatusResult, error) {
+	statusPath := filepath.Join(firstNonEmpty(node.AgentStateDir, "/var/lib/devopsellence"), "status.json")
+	out, err := solo.RunSSH(ctx, node, remoteReadOptionalFileCommand(statusPath, soloStatusMissingSentinel), nil)
+	if err != nil {
+		return soloNodeStatusResult{}, err
+	}
+	if strings.TrimSpace(out) == soloStatusMissingSentinel {
+		return soloNodeStatusResult{Missing: true}, nil
+	}
+	status, raw, err := parseSoloNodeStatusPayload([]byte(out))
+	if err != nil {
+		return soloNodeStatusResult{}, fmt.Errorf("invalid status JSON: %w", err)
+	}
+	return soloNodeStatusResult{
+		Raw:    raw,
+		Status: status,
+	}, nil
+}
+
+func (a *App) waitForSoloRollout(ctx context.Context, nodes map[string]config.SoloNode, expectedRevisions map[string]string) error {
+	timeout := a.DeployTimeout
+	if timeout <= 0 {
+		timeout = defaultDeployProgressTimeout
+	}
+	pollInterval := a.DeployPollInterval
+	if pollInterval <= 0 {
+		pollInterval = defaultDeployProgressPollInterval
+	}
+
+	rolloutCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	lastSummary := ""
+	latestSummary := "rollout pending"
+	for {
+		pendingCount := 0
+		reconcilingCount := 0
+		settledCount := 0
+		details := []string{}
+
+		for _, name := range sortedSoloNodeNames(nodes) {
+			expectedRevision := strings.TrimSpace(expectedRevisions[name])
+			if expectedRevision == "" {
+				return fmt.Errorf("missing desired state revision for node %s", name)
+			}
+
+			result, err := readSoloNodeStatus(rolloutCtx, nodes[name])
+			if err != nil {
+				if errors.Is(rolloutCtx.Err(), context.DeadlineExceeded) {
+					return ExitError{Code: 1, Err: fmt.Errorf("timed out waiting for solo rollout: %s", latestSummary)}
+				}
+				return fmt.Errorf("[%s] read status: %w", name, err)
+			}
+
+			switch {
+			case result.Missing:
+				pendingCount++
+				details = append(details, name+"=missing")
+			case strings.TrimSpace(result.Status.Revision) != expectedRevision:
+				pendingCount++
+				details = append(details, fmt.Sprintf("%s=revision:%s", name, firstNonEmpty(strings.TrimSpace(result.Status.Revision), "none")))
+			default:
+				switch strings.TrimSpace(result.Status.Phase) {
+				case "settled":
+					settledCount++
+				case "error":
+					message := firstNonEmpty(strings.TrimSpace(result.Status.Error), "node reported phase=error")
+					return ExitError{Code: 1, Err: fmt.Errorf("rollout failed on %s: %s", name, message)}
+				default:
+					reconcilingCount++
+					details = append(details, fmt.Sprintf("%s=%s", name, firstNonEmpty(strings.TrimSpace(result.Status.Phase), "reconciling")))
+				}
+			}
+		}
+
+		latestSummary = fmt.Sprintf("rollout pending=%d reconciling=%d settled=%d", pendingCount, reconcilingCount, settledCount)
+		if len(details) > 0 {
+			latestSummary += " - " + strings.Join(details, ", ")
+		}
+		if !a.Printer.JSON && latestSummary != lastSummary {
+			a.Printer.Println(latestSummary)
+			lastSummary = latestSummary
+		}
+		if pendingCount == 0 && reconcilingCount == 0 {
+			return nil
+		}
+
+		timer := time.NewTimer(pollInterval)
+		select {
+		case <-rolloutCtx.Done():
+			timer.Stop()
+			if errors.Is(rolloutCtx.Err(), context.DeadlineExceeded) {
+				return ExitError{Code: 1, Err: fmt.Errorf("timed out waiting for solo rollout: %s", latestSummary)}
+			}
+			return rolloutCtx.Err()
+		case <-timer.C:
+		}
+	}
 }
 
 func (a *App) readSoloState() (solo.State, error) {
@@ -720,8 +855,7 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 	var jsonResults []map[string]any
 
 	for name, node := range nodes {
-		statusPath := filepath.Join(node.AgentStateDir, "status.json")
-		out, err := solo.RunSSH(ctx, node, remoteReadOptionalFileCommand(statusPath, soloStatusMissingSentinel), nil)
+		result, err := readSoloNodeStatus(ctx, node)
 		if err != nil {
 			if a.Printer.JSON {
 				jsonResults = append(jsonResults, map[string]any{
@@ -734,7 +868,7 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 			continue
 		}
 
-		if strings.TrimSpace(out) == soloStatusMissingSentinel {
+		if result.Missing {
 			message := "no deploy status yet; run `devopsellence deploy`"
 			if a.Printer.JSON {
 				jsonResults = append(jsonResults, map[string]any{
@@ -749,40 +883,16 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 		}
 
 		if a.Printer.JSON {
-			var raw json.RawMessage
-			if err := json.Unmarshal([]byte(out), &raw); err != nil {
-				jsonResults = append(jsonResults, map[string]any{
-					"node":  name,
-					"error": fmt.Sprintf("invalid status JSON: %s", err),
-				})
-				continue
-			}
 			jsonResults = append(jsonResults, map[string]any{
 				"node":   name,
-				"status": raw,
+				"status": result.Raw,
 			})
 		} else {
-			var status struct {
-				Phase        string `json:"phase"`
-				Revision     string `json:"revision"`
-				Error        string `json:"error,omitempty"`
-				Environments []struct {
-					Name     string `json:"name"`
-					Services []struct {
-						Name  string `json:"name"`
-						State string `json:"state"`
-					} `json:"services"`
-				} `json:"environments"`
+			line := fmt.Sprintf("[%s] phase=%s revision=%s", name, result.Status.Phase, result.Status.Revision)
+			if result.Status.Error != "" {
+				line += " error=" + result.Status.Error
 			}
-			if err := json.Unmarshal([]byte(out), &status); err != nil {
-				a.Printer.Printf("[%s] parse error: %s\n", name, err)
-				continue
-			}
-			line := fmt.Sprintf("[%s] phase=%s revision=%s", name, status.Phase, status.Revision)
-			if status.Error != "" {
-				line += " error=" + status.Error
-			}
-			for _, environment := range status.Environments {
+			for _, environment := range result.Status.Environments {
 				for _, service := range environment.Services {
 					line += fmt.Sprintf(" %s/%s=%s", environment.Name, service.Name, service.State)
 				}

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -1241,7 +1241,7 @@ func installFakeSoloCommands(t *testing.T, statusResponses []fakeSSHResponse) st
 	writeExecutable(t, filepath.Join(binDir, "docker"), "#!/usr/bin/env bash\nset -euo pipefail\nif [ \"$1\" = \"build\" ]; then exit 0; fi\necho \"unexpected docker command: $*\" >&2\nexit 1\n")
 	writeExecutable(t, filepath.Join(binDir, "ssh"), `#!/usr/bin/env bash
 set -euo pipefail
-command="${@: -1}"
+command="${!#}"
 
 if [[ "$command" == *"desired-state set-override"* ]]; then
   cat >"$DEVOPSELLENCE_FAKE_SSH_REVISION_FILE"

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -15,6 +17,7 @@ import (
 	"github.com/charmbracelet/keygen"
 	"github.com/devopsellence/cli/internal/config"
 	"github.com/devopsellence/cli/internal/discovery"
+	"github.com/devopsellence/cli/internal/git"
 	"github.com/devopsellence/cli/internal/output"
 	"github.com/devopsellence/cli/internal/solo"
 	cliversion "github.com/devopsellence/cli/internal/version"
@@ -449,6 +452,213 @@ func TestSoloNodeAttachPersistsDesiredStateOnRepublishError(t *testing.T) {
 	}
 	if len(loaded.Attachments) != 1 {
 		t.Fatalf("attachments = %#v, want persisted desired attachment", loaded.Attachments)
+	}
+}
+
+func TestSoloDeployWaitsForSettledStatusBeforeSuccess(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(workspaceRoot, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := config.DefaultProjectConfigForType("solo", "demo", "production", config.AppTypeGeneric)
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	commitTestRepo(t, workspaceRoot)
+
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.SoloNode{
+			"node-a": {Host: "203.0.113.10", User: "root", Port: 22, AgentStateDir: "/var/lib/devopsellence", Labels: []string{config.DefaultWebRole}},
+		},
+		Attachments: map[string]solo.AttachmentRecord{},
+		Snapshots:   map[string]solo.DeploySnapshot{},
+	}
+	if _, _, err := current.AttachNode(workspaceRoot, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	statusCountPath := installFakeSoloCommands(t, []fakeSSHResponse{
+		{stdout: soloStatusMissingSentinel + "\n"},
+		{stdout: `{"revision":"__REVISION__","phase":"reconciling"}` + "\n"},
+		{stdout: `{"revision":"__REVISION__","phase":"settled"}` + "\n"},
+	})
+
+	var stdout bytes.Buffer
+	app := &App{
+		Printer:            output.New(&stdout, io.Discard, false),
+		SoloState:          soloState,
+		ConfigStore:        config.NewStore(),
+		Git:                git.Client{},
+		Cwd:                workspaceRoot,
+		DeployPollInterval: 5 * time.Millisecond,
+		DeployTimeout:      200 * time.Millisecond,
+	}
+
+	if err := app.SoloDeploy(context.Background(), SoloDeployOptions{}); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := readFakeSSHStatusCount(t, statusCountPath); got != 3 {
+		t.Fatalf("status poll count = %d, want 3", got)
+	}
+	outputText := stdout.String()
+	if !strings.Contains(outputText, "Deployed revision") {
+		t.Fatalf("stdout = %q, want deploy success line", outputText)
+	}
+}
+
+func TestWaitForSoloRolloutIgnoresMissingAndStaleStatusUntilExpectedRevisionSettles(t *testing.T) {
+	statusCountPath := installFakeSoloCommands(t, []fakeSSHResponse{
+		{stdout: soloStatusMissingSentinel + "\n"},
+		{stdout: `{"revision":"stale-revision","phase":"settled"}` + "\n"},
+		{stdout: `{"revision":"expected-revision","phase":"reconciling"}` + "\n"},
+		{stdout: `{"revision":"expected-revision","phase":"settled"}` + "\n"},
+	})
+
+	app := &App{
+		Printer:            output.New(io.Discard, io.Discard, false),
+		DeployPollInterval: 5 * time.Millisecond,
+		DeployTimeout:      200 * time.Millisecond,
+	}
+
+	err := app.waitForSoloRollout(context.Background(), map[string]config.SoloNode{
+		"node-a": {Host: "203.0.113.10", User: "root", Port: 22, AgentStateDir: "/var/lib/devopsellence"},
+	}, map[string]string{
+		"node-a": "expected-revision",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := readFakeSSHStatusCount(t, statusCountPath); got != 4 {
+		t.Fatalf("status poll count = %d, want 4", got)
+	}
+}
+
+func TestWaitForSoloRolloutFailsOnExpectedRevisionErrorPhase(t *testing.T) {
+	installFakeSoloCommands(t, []fakeSSHResponse{
+		{stdout: `{"revision":"expected-revision","phase":"error","error":"image pull failed"}` + "\n"},
+	})
+
+	app := &App{
+		Printer:            output.New(io.Discard, io.Discard, false),
+		DeployPollInterval: 5 * time.Millisecond,
+		DeployTimeout:      100 * time.Millisecond,
+	}
+
+	err := app.waitForSoloRollout(context.Background(), map[string]config.SoloNode{
+		"node-a": {Host: "203.0.113.10", User: "root", Port: 22, AgentStateDir: "/var/lib/devopsellence"},
+	}, map[string]string{
+		"node-a": "expected-revision",
+	})
+	if err == nil {
+		t.Fatal("expected rollout failure")
+	}
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("error = %T %v, want ExitError", err, err)
+	}
+	if !strings.Contains(err.Error(), "rollout failed on node-a: image pull failed") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestWaitForSoloRolloutTimesOutWhenExpectedRevisionNeverSettles(t *testing.T) {
+	installFakeSoloCommands(t, []fakeSSHResponse{
+		{stdout: `{"revision":"expected-revision","phase":"reconciling"}` + "\n"},
+		{stdout: `{"revision":"expected-revision","phase":"reconciling"}` + "\n"},
+		{stdout: `{"revision":"expected-revision","phase":"reconciling"}` + "\n"},
+		{stdout: `{"revision":"expected-revision","phase":"reconciling"}` + "\n"},
+		{stdout: `{"revision":"expected-revision","phase":"reconciling"}` + "\n"},
+		{stdout: `{"revision":"expected-revision","phase":"reconciling"}` + "\n"},
+	})
+
+	app := &App{
+		Printer:            output.New(io.Discard, io.Discard, false),
+		DeployPollInterval: 5 * time.Millisecond,
+		DeployTimeout:      20 * time.Millisecond,
+	}
+
+	err := app.waitForSoloRollout(context.Background(), map[string]config.SoloNode{
+		"node-a": {Host: "203.0.113.10", User: "root", Port: 22, AgentStateDir: "/var/lib/devopsellence"},
+	}, map[string]string{
+		"node-a": "expected-revision",
+	})
+	if err == nil {
+		t.Fatal("expected timeout")
+	}
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("error = %T %v, want ExitError", err, err)
+	}
+	if !strings.Contains(err.Error(), "timed out waiting for solo rollout") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestWaitForSoloRolloutFailsClearlyOnStatusReadAndParseErrors(t *testing.T) {
+	tests := []struct {
+		name      string
+		responses []fakeSSHResponse
+		want      string
+	}{
+		{
+			name: "read error",
+			responses: []fakeSSHResponse{
+				{stderr: "permission denied\n", exitCode: 1},
+			},
+			want: "[node-a] read status: ssh root@203.0.113.10:",
+		},
+		{
+			name: "invalid json",
+			responses: []fakeSSHResponse{
+				{stdout: "{not-json}\n"},
+			},
+			want: "[node-a] read status: invalid status JSON:",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			installFakeSoloCommands(t, tt.responses)
+
+			app := &App{
+				Printer:            output.New(io.Discard, io.Discard, false),
+				DeployPollInterval: 5 * time.Millisecond,
+				DeployTimeout:      100 * time.Millisecond,
+			}
+
+			err := app.waitForSoloRollout(context.Background(), map[string]config.SoloNode{
+				"node-a": {Host: "203.0.113.10", User: "root", Port: 22, AgentStateDir: "/var/lib/devopsellence"},
+			}, map[string]string{
+				"node-a": "expected-revision",
+			})
+			if err == nil {
+				t.Fatal("expected failure")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %v, want substring %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseSoloNodeStatusPayload(t *testing.T) {
+	payload := []byte(`{"phase":"settled","revision":"abc123","environments":[{"name":"production","services":[{"name":"web","state":"running"}]}]}`)
+
+	status, raw, err := parseSoloNodeStatusPayload(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Phase != "settled" || status.Revision != "abc123" {
+		t.Fatalf("status = %#v", status)
+	}
+	if string(raw) != string(payload) {
+		t.Fatalf("raw = %q, want %q", raw, payload)
 	}
 }
 
@@ -992,6 +1202,138 @@ func TestIngressSetInfersPrimaryWebService(t *testing.T) {
 	if written.Ingress.Service != config.DefaultWebServiceName {
 		t.Fatalf("ingress.service = %q, want %q", written.Ingress.Service, config.DefaultWebServiceName)
 	}
+}
+
+type fakeSSHResponse struct {
+	stdout   string
+	stderr   string
+	exitCode int
+}
+
+func installFakeSoloCommands(t *testing.T, statusResponses []fakeSSHResponse) string {
+	t.Helper()
+
+	binDir := t.TempDir()
+	statusDir := filepath.Join(t.TempDir(), "status")
+	if err := os.MkdirAll(statusDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for idx, response := range statusResponses {
+		base := filepath.Join(statusDir, fmt.Sprintf("%d", idx+1))
+		if response.stdout != "" {
+			if err := os.WriteFile(base+".stdout", []byte(response.stdout), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if response.stderr != "" {
+			if err := os.WriteFile(base+".stderr", []byte(response.stderr), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+		code := response.exitCode
+		if err := os.WriteFile(base+".code", []byte(fmt.Sprintf("%d\n", code)), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	statusCountPath := filepath.Join(t.TempDir(), "status-count")
+	revisionPath := filepath.Join(t.TempDir(), "desired-state.json")
+	writeExecutable(t, filepath.Join(binDir, "docker"), "#!/usr/bin/env bash\nset -euo pipefail\nif [ \"$1\" = \"build\" ]; then exit 0; fi\necho \"unexpected docker command: $*\" >&2\nexit 1\n")
+	writeExecutable(t, filepath.Join(binDir, "ssh"), `#!/usr/bin/env bash
+set -euo pipefail
+command="${@: -1}"
+
+if [[ "$command" == *"desired-state set-override"* ]]; then
+  cat >"$DEVOPSELLENCE_FAKE_SSH_REVISION_FILE"
+  exit 0
+fi
+
+if [[ "$command" == *"docker image inspect"* ]]; then
+  printf 'present\n'
+  exit 0
+fi
+
+if [[ "$command" == *"docker info"* ]]; then
+  exit 0
+fi
+
+if [[ "$command" == *"status.json"* ]]; then
+  index=0
+  if [[ -f "$DEVOPSELLENCE_FAKE_SSH_STATUS_COUNT" ]]; then
+    index="$(cat "$DEVOPSELLENCE_FAKE_SSH_STATUS_COUNT")"
+  fi
+  index=$((index + 1))
+  printf '%s' "$index" >"$DEVOPSELLENCE_FAKE_SSH_STATUS_COUNT"
+  base="$DEVOPSELLENCE_FAKE_SSH_STATUS_DIR/$index"
+  revision=''
+  if [[ -f "$DEVOPSELLENCE_FAKE_SSH_REVISION_FILE" ]]; then
+    revision="$(sed -n 's/.*"revision"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$DEVOPSELLENCE_FAKE_SSH_REVISION_FILE" | head -n1)"
+  fi
+  if [[ -f "$base.stdout" ]]; then
+    if [[ -n "$revision" ]]; then
+      sed "s/__REVISION__/$revision/g" "$base.stdout"
+    else
+      cat "$base.stdout"
+    fi
+  fi
+  if [[ -f "$base.stderr" ]]; then
+    cat "$base.stderr" >&2
+  fi
+  code=0
+  if [[ -f "$base.code" ]]; then
+    code="$(cat "$base.code")"
+  fi
+  exit "$code"
+fi
+
+echo "unexpected ssh command: $command" >&2
+exit 1
+`)
+
+	t.Setenv("DEVOPSELLENCE_FAKE_SSH_STATUS_DIR", statusDir)
+	t.Setenv("DEVOPSELLENCE_FAKE_SSH_STATUS_COUNT", statusCountPath)
+	t.Setenv("DEVOPSELLENCE_FAKE_SSH_REVISION_FILE", revisionPath)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return statusCountPath
+}
+
+func readFakeSSHStatusCount(t *testing.T, path string) int {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read status count: %v", err)
+	}
+	var count int
+	if _, err := fmt.Sscanf(strings.TrimSpace(string(data)), "%d", &count); err != nil {
+		t.Fatalf("parse status count %q: %v", data, err)
+	}
+	return count
+}
+
+func writeExecutable(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func commitTestRepo(t *testing.T, dir string) string {
+	t.Helper()
+	runTestCommand(t, dir, "git", "init")
+	runTestCommand(t, dir, "git", "add", ".")
+	runTestCommand(t, dir, "git", "-c", "user.name=Test User", "-c", "user.email=test@example.com", "commit", "-m", "init")
+	return strings.TrimSpace(runTestCommand(t, dir, "git", "rev-parse", "HEAD"))
+}
+
+func runTestCommand(t *testing.T, dir, name string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s %s: %v\n%s", name, strings.Join(args, " "), err, out)
+	}
+	return string(out)
 }
 
 func TestIngressSetPreservesExistingServiceWhenFlagOmitted(t *testing.T) {

--- a/test/e2e/solo_e2e.rb
+++ b/test/e2e/solo_e2e.rb
@@ -12,7 +12,7 @@
 #   3. Scaffold a test app with a solo-mode devopsellence.yml
 #   4. Seed global solo state, attach the node, install the agent, set secrets,
 #      deploy, check status
-#   5. Assert: app container running, status.json settled, secrets resolved
+#   5. Assert: app container running, status.json terminal, secrets resolved
 #
 # Usage:
 #   ruby test/e2e/solo_e2e.rb
@@ -568,15 +568,25 @@ PY
   end
 
   def run_deploy!
-    output = run!(
+    result = run_command(
       cli_binary.to_s, "deploy",
       chdir: @app_dir.to_s,
       timeout: 600,
       env: ssh_env
     )
+    output = result.fetch(:output)
+    status = result.fetch(:status)
 
-    raise "deploy did not report success" unless output.include?("Deployed revision")
-    puts "[ok] Deploy completed"
+    if status.success?
+      raise "deploy did not report success" unless output.include?("Deployed revision")
+      puts "[ok] Deploy completed"
+      return
+    end
+
+    unless output.include?("rollout failed on node-1:") && known_probe_error?(output)
+      raise "deploy failed unexpectedly (#{status.exitstatus})\n#{excerpt(output, 20)}"
+    end
+    puts "[ok] Deploy surfaced known rollout failure in solo e2e"
   end
 
   def assert_status_before_first_deploy!
@@ -629,7 +639,7 @@ PY
       puts "[ok] Status settled for revision #{revision}"
     when "error"
       error = status["error"].to_s
-      unless error.include?("http probe") && error.include?("context deadline exceeded")
+      unless known_probe_error?(error)
         raise "unexpected error status: #{status.inspect}"
       end
       puts "[ok] Status captured known docker-sock probe limitation for revision #{revision}"
@@ -701,6 +711,10 @@ PY
 
   def terminal_status_phase?(phase)
     %w[settled error].include?(phase.to_s)
+  end
+
+  def known_probe_error?(text)
+    text.include?("http probe") && text.include?("context deadline exceeded")
   end
 
   # -- Helpers --


### PR DESCRIPTION
## Summary
- make solo `devopsellence deploy` wait for confirmed rollout instead of returning immediately after republish
- reuse a shared solo status reader/parser for both deploy rollout waiting and `solo status`
- add solo rollout tests for success, stale revisions, error phase, timeout, and status read/parse failures

## Why
Shared deploy already succeeds only after rollout is confirmed. Solo deploy was returning as soon as desired state was handed off, so the two modes had different completion semantics.

## Impact
Solo deploy now blocks until each attached node reports the expected desired-state revision as `settled`, or fails/times out clearly.

## Validation
- `cd cli && mise exec -- go test ./internal/workflow`
