### PR TITLE
feat: synthesize single-env ingress for direct routing

### DIFF
--- a/agent/internal/desiredstate/runtime.go
+++ b/agent/internal/desiredstate/runtime.go
@@ -94,6 +94,94 @@ func RuntimeTasks(state *desiredstatepb.DesiredState) []RuntimeTask {
 	return tasks
 }
 
+func EffectiveIngress(state *desiredstatepb.DesiredState) *desiredstatepb.Ingress {
+	if state == nil {
+		return nil
+	}
+	if state.Ingress != nil {
+		return cloneIngress(state.Ingress)
+	}
+	environmentCount := 0
+	for _, env := range state.Environments {
+		if env != nil {
+			environmentCount++
+		}
+	}
+	if environmentCount != 1 {
+		return nil
+	}
+	webTargets := []RuntimeService{}
+	for _, service := range RuntimeServices(state) {
+		if service.ServiceKind == ServiceKindWeb {
+			webTargets = append(webTargets, service)
+		}
+	}
+	if len(webTargets) != 1 {
+		return nil
+	}
+	target := webTargets[0]
+	environmentName := strings.TrimSpace(target.EnvironmentName)
+	if environmentName == "" {
+		environmentName = DefaultEnvironmentName
+	}
+	return &desiredstatepb.Ingress{
+		Mode: "public",
+		Tls:  &desiredstatepb.IngressTLS{Mode: "off"},
+		Routes: []*desiredstatepb.IngressRoute{{
+			Match: &desiredstatepb.IngressMatch{PathPrefix: "/"},
+			Target: &desiredstatepb.IngressTarget{
+				Environment: environmentName,
+				Service:     strings.TrimSpace(target.ServiceName),
+				Port:        DefaultHTTPPortName,
+			},
+		}},
+	}
+}
+
+func cloneIngress(ingress *desiredstatepb.Ingress) *desiredstatepb.Ingress {
+	if ingress == nil {
+		return nil
+	}
+	cloned := &desiredstatepb.Ingress{
+		Hosts:                append([]string(nil), ingress.Hosts...),
+		Mode:                 ingress.Mode,
+		TunnelToken:          ingress.TunnelToken,
+		TunnelTokenSecretRef: ingress.TunnelTokenSecretRef,
+		RedirectHttp:         ingress.RedirectHttp,
+	}
+	if ingress.Tls != nil {
+		cloned.Tls = &desiredstatepb.IngressTLS{
+			Mode:           ingress.Tls.Mode,
+			Email:          ingress.Tls.Email,
+			CaDirectoryUrl: ingress.Tls.CaDirectoryUrl,
+		}
+	}
+	if len(ingress.Routes) > 0 {
+		cloned.Routes = make([]*desiredstatepb.IngressRoute, 0, len(ingress.Routes))
+		for _, route := range ingress.Routes {
+			if route == nil {
+				continue
+			}
+			clonedRoute := &desiredstatepb.IngressRoute{}
+			if route.Match != nil {
+				clonedRoute.Match = &desiredstatepb.IngressMatch{
+					Hostname:   route.Match.Hostname,
+					PathPrefix: route.Match.PathPrefix,
+				}
+			}
+			if route.Target != nil {
+				clonedRoute.Target = &desiredstatepb.IngressTarget{
+					Environment: route.Target.Environment,
+					Service:     route.Target.Service,
+					Port:        route.Target.Port,
+				}
+			}
+			cloned.Routes = append(cloned.Routes, clonedRoute)
+		}
+	}
+	return cloned
+}
+
 func normalizedServiceKind(service *desiredstatepb.Service) string {
 	if service == nil {
 		return ""

--- a/agent/internal/desiredstate/runtime.go
+++ b/agent/internal/desiredstate/runtime.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/devopsellence/devopsellence/agent/internal/desiredstatepb"
+	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -94,12 +95,28 @@ func RuntimeTasks(state *desiredstatepb.DesiredState) []RuntimeTask {
 	return tasks
 }
 
-func EffectiveIngress(state *desiredstatepb.DesiredState) *desiredstatepb.Ingress {
+func WithEffectiveIngress(state *desiredstatepb.DesiredState) *desiredstatepb.DesiredState {
 	if state == nil {
 		return nil
 	}
 	if state.Ingress != nil {
-		return cloneIngress(state.Ingress)
+		return state
+	}
+	effective := synthesizedIngress(state)
+	if effective == nil {
+		return state
+	}
+	cloned, ok := proto.Clone(state).(*desiredstatepb.DesiredState)
+	if !ok {
+		return state
+	}
+	cloned.Ingress = effective
+	return cloned
+}
+
+func synthesizedIngress(state *desiredstatepb.DesiredState) *desiredstatepb.Ingress {
+	if state == nil || state.Ingress != nil {
+		return nil
 	}
 	environmentCount := 0
 	for _, env := range state.Environments {
@@ -136,50 +153,6 @@ func EffectiveIngress(state *desiredstatepb.DesiredState) *desiredstatepb.Ingres
 			},
 		}},
 	}
-}
-
-func cloneIngress(ingress *desiredstatepb.Ingress) *desiredstatepb.Ingress {
-	if ingress == nil {
-		return nil
-	}
-	cloned := &desiredstatepb.Ingress{
-		Hosts:                append([]string(nil), ingress.Hosts...),
-		Mode:                 ingress.Mode,
-		TunnelToken:          ingress.TunnelToken,
-		TunnelTokenSecretRef: ingress.TunnelTokenSecretRef,
-		RedirectHttp:         ingress.RedirectHttp,
-	}
-	if ingress.Tls != nil {
-		cloned.Tls = &desiredstatepb.IngressTLS{
-			Mode:           ingress.Tls.Mode,
-			Email:          ingress.Tls.Email,
-			CaDirectoryUrl: ingress.Tls.CaDirectoryUrl,
-		}
-	}
-	if len(ingress.Routes) > 0 {
-		cloned.Routes = make([]*desiredstatepb.IngressRoute, 0, len(ingress.Routes))
-		for _, route := range ingress.Routes {
-			if route == nil {
-				continue
-			}
-			clonedRoute := &desiredstatepb.IngressRoute{}
-			if route.Match != nil {
-				clonedRoute.Match = &desiredstatepb.IngressMatch{
-					Hostname:   route.Match.Hostname,
-					PathPrefix: route.Match.PathPrefix,
-				}
-			}
-			if route.Target != nil {
-				clonedRoute.Target = &desiredstatepb.IngressTarget{
-					Environment: route.Target.Environment,
-					Service:     route.Target.Service,
-					Port:        route.Target.Port,
-				}
-			}
-			cloned.Routes = append(cloned.Routes, clonedRoute)
-		}
-	}
-	return cloned
 }
 
 func normalizedServiceKind(service *desiredstatepb.Service) string {

--- a/agent/internal/desiredstate/runtime_test.go
+++ b/agent/internal/desiredstate/runtime_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/devopsellence/devopsellence/agent/internal/desiredstatepb"
 )
 
-func TestEffectiveIngressReturnsExplicitIngressUnchanged(t *testing.T) {
+func TestWithEffectiveIngressReturnsOriginalStateWhenExplicitIngressPresent(t *testing.T) {
 	state := &desiredstatepb.DesiredState{
 		Ingress: &desiredstatepb.Ingress{
 			Mode:  "public",
@@ -19,19 +19,13 @@ func TestEffectiveIngressReturnsExplicitIngressUnchanged(t *testing.T) {
 		},
 	}
 
-	effective := EffectiveIngress(state)
-	if effective == nil {
-		t.Fatal("expected effective ingress")
-	}
-	if effective == state.Ingress {
-		t.Fatal("expected cloned ingress, got original pointer")
-	}
-	if effective.GetMode() != "public" || len(effective.GetHosts()) != 1 || effective.GetHosts()[0] != "app.example.com" {
-		t.Fatalf("unexpected ingress: %+v", effective)
+	normalized := WithEffectiveIngress(state)
+	if normalized != state {
+		t.Fatal("expected explicit-ingress state to be returned unchanged")
 	}
 }
 
-func TestEffectiveIngressSynthesizesSingleEnvironmentSingleWeb(t *testing.T) {
+func TestWithEffectiveIngressSynthesizesSingleEnvironmentSingleWeb(t *testing.T) {
 	state := &desiredstatepb.DesiredState{
 		Environments: []*desiredstatepb.Environment{{
 			Name: "production",
@@ -46,7 +40,14 @@ func TestEffectiveIngressSynthesizesSingleEnvironmentSingleWeb(t *testing.T) {
 		}},
 	}
 
-	effective := EffectiveIngress(state)
+	normalized := WithEffectiveIngress(state)
+	if normalized == state {
+		t.Fatal("expected synthesized state clone")
+	}
+	if state.GetIngress() != nil {
+		t.Fatal("expected original state to remain ingress-free")
+	}
+	effective := normalized.GetIngress()
 	if effective == nil {
 		t.Fatal("expected synthesized ingress")
 	}
@@ -71,7 +72,7 @@ func TestEffectiveIngressSynthesizesSingleEnvironmentSingleWeb(t *testing.T) {
 	}
 }
 
-func TestEffectiveIngressSkipsSynthesisForMultipleEnvironments(t *testing.T) {
+func TestWithEffectiveIngressLeavesStateUnchangedForMultipleEnvironments(t *testing.T) {
 	state := &desiredstatepb.DesiredState{
 		Environments: []*desiredstatepb.Environment{
 			{Name: "production", Services: []*desiredstatepb.Service{{Name: "web", Kind: ServiceKindWeb}}},
@@ -79,12 +80,12 @@ func TestEffectiveIngressSkipsSynthesisForMultipleEnvironments(t *testing.T) {
 		},
 	}
 
-	if effective := EffectiveIngress(state); effective != nil {
-		t.Fatalf("expected no synthesized ingress, got %+v", effective)
+	if normalized := WithEffectiveIngress(state); normalized != state {
+		t.Fatal("expected multi-environment state to remain unchanged")
 	}
 }
 
-func TestEffectiveIngressSkipsSynthesisForMultipleWebServices(t *testing.T) {
+func TestWithEffectiveIngressLeavesStateUnchangedForMultipleWebServices(t *testing.T) {
 	state := &desiredstatepb.DesiredState{
 		Environments: []*desiredstatepb.Environment{{
 			Name: "production",
@@ -95,7 +96,7 @@ func TestEffectiveIngressSkipsSynthesisForMultipleWebServices(t *testing.T) {
 		}},
 	}
 
-	if effective := EffectiveIngress(state); effective != nil {
-		t.Fatalf("expected no synthesized ingress, got %+v", effective)
+	if normalized := WithEffectiveIngress(state); normalized != state {
+		t.Fatal("expected multi-web state to remain unchanged")
 	}
 }

--- a/agent/internal/desiredstate/runtime_test.go
+++ b/agent/internal/desiredstate/runtime_test.go
@@ -1,0 +1,101 @@
+package desiredstate
+
+import (
+	"testing"
+
+	"github.com/devopsellence/devopsellence/agent/internal/desiredstatepb"
+)
+
+func TestEffectiveIngressReturnsExplicitIngressUnchanged(t *testing.T) {
+	state := &desiredstatepb.DesiredState{
+		Ingress: &desiredstatepb.Ingress{
+			Mode:  "public",
+			Hosts: []string{"app.example.com"},
+			Tls:   &desiredstatepb.IngressTLS{Mode: "off"},
+			Routes: []*desiredstatepb.IngressRoute{{
+				Match:  &desiredstatepb.IngressMatch{Hostname: "app.example.com", PathPrefix: "/"},
+				Target: &desiredstatepb.IngressTarget{Environment: "production", Service: "web", Port: "http"},
+			}},
+		},
+	}
+
+	effective := EffectiveIngress(state)
+	if effective == nil {
+		t.Fatal("expected effective ingress")
+	}
+	if effective == state.Ingress {
+		t.Fatal("expected cloned ingress, got original pointer")
+	}
+	if effective.GetMode() != "public" || len(effective.GetHosts()) != 1 || effective.GetHosts()[0] != "app.example.com" {
+		t.Fatalf("unexpected ingress: %+v", effective)
+	}
+}
+
+func TestEffectiveIngressSynthesizesSingleEnvironmentSingleWeb(t *testing.T) {
+	state := &desiredstatepb.DesiredState{
+		Environments: []*desiredstatepb.Environment{{
+			Name: "production",
+			Services: []*desiredstatepb.Service{{
+				Name: "web",
+				Kind: ServiceKindWeb,
+				Ports: []*desiredstatepb.ServicePort{{
+					Name: DefaultHTTPPortName,
+					Port: 3000,
+				}},
+			}},
+		}},
+	}
+
+	effective := EffectiveIngress(state)
+	if effective == nil {
+		t.Fatal("expected synthesized ingress")
+	}
+	if effective.GetMode() != "public" {
+		t.Fatalf("mode = %q, want public", effective.GetMode())
+	}
+	if effective.GetTls().GetMode() != "off" {
+		t.Fatalf("tls mode = %q, want off", effective.GetTls().GetMode())
+	}
+	if len(effective.GetHosts()) != 0 {
+		t.Fatalf("hosts = %#v, want none for wildcard ip routing", effective.GetHosts())
+	}
+	if len(effective.GetRoutes()) != 1 {
+		t.Fatalf("routes = %#v", effective.GetRoutes())
+	}
+	route := effective.GetRoutes()[0]
+	if route.GetMatch().GetHostname() != "" {
+		t.Fatalf("hostname = %q, want blank wildcard match", route.GetMatch().GetHostname())
+	}
+	if route.GetTarget().GetEnvironment() != "production" || route.GetTarget().GetService() != "web" || route.GetTarget().GetPort() != DefaultHTTPPortName {
+		t.Fatalf("unexpected route target: %+v", route.GetTarget())
+	}
+}
+
+func TestEffectiveIngressSkipsSynthesisForMultipleEnvironments(t *testing.T) {
+	state := &desiredstatepb.DesiredState{
+		Environments: []*desiredstatepb.Environment{
+			{Name: "production", Services: []*desiredstatepb.Service{{Name: "web", Kind: ServiceKindWeb}}},
+			{Name: "staging", Services: []*desiredstatepb.Service{{Name: "web", Kind: ServiceKindWeb}}},
+		},
+	}
+
+	if effective := EffectiveIngress(state); effective != nil {
+		t.Fatalf("expected no synthesized ingress, got %+v", effective)
+	}
+}
+
+func TestEffectiveIngressSkipsSynthesisForMultipleWebServices(t *testing.T) {
+	state := &desiredstatepb.DesiredState{
+		Environments: []*desiredstatepb.Environment{{
+			Name: "production",
+			Services: []*desiredstatepb.Service{
+				{Name: "web", Kind: ServiceKindWeb},
+				{Name: "admin", Kind: ServiceKindWeb},
+			},
+		}},
+	}
+
+	if effective := EffectiveIngress(state); effective != nil {
+		t.Fatalf("expected no synthesized ingress, got %+v", effective)
+	}
+}

--- a/agent/internal/envoy/manager.go
+++ b/agent/internal/envoy/manager.go
@@ -508,7 +508,7 @@ func cloneIngressRoutes(ingress *desiredstatepb.Ingress) []*desiredstatepb.Ingre
 	return append([]*desiredstatepb.IngressRoute(nil), ingress.Routes...)
 }
 
-func portBindingsForIngress(defaultPort uint16, ingress *desiredstatepb.Ingress, publicIngress *publicIngressListenerConfig) []engine.PortBinding {
+func portBindingsForIngress(_ uint16, ingress *desiredstatepb.Ingress, publicIngress *publicIngressListenerConfig) []engine.PortBinding {
 	switch normalizedIngressMode(ingress) {
 	case ingressModePublic:
 		ports := []engine.PortBinding{{
@@ -525,17 +525,7 @@ func portBindingsForIngress(defaultPort uint16, ingress *desiredstatepb.Ingress,
 		}
 		return ports
 	case ingressModeTunnel:
-		if ingress != nil {
-			return nil
-		}
-		if defaultPort == 0 {
-			return nil
-		}
-		return []engine.PortBinding{{
-			ContainerPort: defaultPort,
-			HostPort:      defaultPort,
-			Protocol:      "tcp",
-		}}
+		return nil
 	default:
 		return nil
 	}

--- a/agent/internal/envoy/manager_test.go
+++ b/agent/internal/envoy/manager_test.go
@@ -145,8 +145,8 @@ func TestEnsureCreatesEnvoyWithDefaults(t *testing.T) {
 	if eng.createdSpec.Restart == nil || eng.createdSpec.Restart.Name != "unless-stopped" {
 		t.Fatalf("unexpected restart policy: %+v", eng.createdSpec.Restart)
 	}
-	if len(eng.createdSpec.Ports) != 1 {
-		t.Fatalf("expected envoy host port published, got %+v", eng.createdSpec.Ports)
+	if len(eng.createdSpec.Ports) != 0 {
+		t.Fatalf("expected envoy host port publish disabled without ingress, got %+v", eng.createdSpec.Ports)
 	}
 	if eng.pulledImage != "docker.io/envoyproxy/envoy:v1.37.0" {
 		t.Fatalf("expected image pull, got %q", eng.pulledImage)

--- a/agent/internal/envoy/xds_snapshot.go
+++ b/agent/internal/envoy/xds_snapshot.go
@@ -344,34 +344,37 @@ func buildVirtualHosts(domains []string, defaultClusterName string, ingressRoute
 	}
 	hostOrder := []string{}
 	grouped := map[string][]routeEntry{}
+	wildcardEntries := []routeEntry{}
 	for i, ingressRoute := range ingressRoutes {
 		host := strings.TrimSpace(ingressRoute.GetMatch().GetHostname())
+		prefix := strings.TrimSpace(ingressRoute.GetMatch().GetPathPrefix())
+		if prefix == "" {
+			prefix = "/"
+		}
+		entry := routeEntry{
+			prefix:  prefix,
+			cluster: ingressRouteClusterName(ingressRoute),
+			index:   i,
+		}
 		if host == "" {
+			wildcardEntries = append(wildcardEntries, entry)
 			continue
 		}
 		if _, ok := grouped[host]; !ok {
 			hostOrder = append(hostOrder, host)
 		}
-		prefix := strings.TrimSpace(ingressRoute.GetMatch().GetPathPrefix())
-		if prefix == "" {
-			prefix = "/"
-		}
-		grouped[host] = append(grouped[host], routeEntry{
-			prefix:  prefix,
-			cluster: ingressRouteClusterName(ingressRoute),
-			index:   i,
-		})
+		grouped[host] = append(grouped[host], entry)
 	}
 
-	virtualHosts := make([]*routev3.VirtualHost, 0, len(hostOrder))
-	for _, host := range hostOrder {
-		entries := grouped[host]
+	sortEntries := func(entries []routeEntry) {
 		sort.SliceStable(entries, func(i, j int) bool {
 			if len(entries[i].prefix) != len(entries[j].prefix) {
 				return len(entries[i].prefix) > len(entries[j].prefix)
 			}
 			return entries[i].index < entries[j].index
 		})
+	}
+	buildRoutes := func(entries []routeEntry) []*routev3.Route {
 		routes := []*routev3.Route{}
 		if challenge {
 			routes = append(routes, acmeChallengeRoute())
@@ -379,10 +382,29 @@ func buildVirtualHosts(domains []string, defaultClusterName string, ingressRoute
 		for _, entry := range entries {
 			routes = append(routes, clusterRoute(entry.prefix, entry.cluster))
 		}
+		return routes
+	}
+
+	virtualHosts := make([]*routev3.VirtualHost, 0, len(hostOrder)+1)
+	if len(wildcardEntries) > 0 {
+		sortEntries(wildcardEntries)
+		virtualHost := &routev3.VirtualHost{
+			Name:    "public_wildcard",
+			Domains: routeDomains(domains),
+			Routes:  buildRoutes(wildcardEntries),
+		}
+		if len(requestHeaders) > 0 {
+			virtualHost.RequestHeadersToAdd = requestHeaders
+		}
+		virtualHosts = append(virtualHosts, virtualHost)
+	}
+	for _, host := range hostOrder {
+		entries := grouped[host]
+		sortEntries(entries)
 		virtualHost := &routev3.VirtualHost{
 			Name:    sanitizeRouteName("public_" + host),
 			Domains: []string{host},
-			Routes:  routes,
+			Routes:  buildRoutes(entries),
 		}
 		if len(requestHeaders) > 0 {
 			virtualHost.RequestHeadersToAdd = requestHeaders

--- a/agent/internal/envoy/xds_snapshot_test.go
+++ b/agent/internal/envoy/xds_snapshot_test.go
@@ -20,13 +20,22 @@ func TestSnapshotClusterNamesIgnoresStaleEndpointClusters(t *testing.T) {
 	}
 }
 
-func TestBuildVirtualHostsSkipsBlankHostnameRoutes(t *testing.T) {
+func TestBuildVirtualHostsMapsBlankHostnameRoutesToWildcardDomains(t *testing.T) {
 	virtualHosts := buildVirtualHosts(nil, "default", []*desiredstatepb.IngressRoute{{
 		Match:  &desiredstatepb.IngressMatch{Hostname: "", PathPrefix: "/"},
 		Target: &desiredstatepb.IngressTarget{Environment: "prod", Service: "web", Port: "http"},
 	}}, false, nil)
 
-	if len(virtualHosts) != 0 {
-		t.Fatalf("unexpected virtual hosts: %+v", virtualHosts)
+	if len(virtualHosts) != 1 {
+		t.Fatalf("virtual hosts = %+v", virtualHosts)
+	}
+	if got := virtualHosts[0].GetDomains(); len(got) != 1 || got[0] != "*" {
+		t.Fatalf("domains = %#v, want wildcard", got)
+	}
+	if len(virtualHosts[0].GetRoutes()) != 1 {
+		t.Fatalf("routes = %#v", virtualHosts[0].GetRoutes())
+	}
+	if cluster := virtualHosts[0].GetRoutes()[0].GetRoute().GetCluster(); cluster != "env-prod-web-http" {
+		t.Fatalf("cluster = %q", cluster)
 	}
 }

--- a/agent/internal/reconcile/reconcile.go
+++ b/agent/internal/reconcile/reconcile.go
@@ -97,12 +97,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, desired *desiredstatepb.Desi
 		}
 	}
 
+	desired = desiredstate.WithEffectiveIngress(desired)
 	desiredByService := map[string]desiredstate.RuntimeService{}
 	for _, service := range desiredstate.RuntimeServices(desired) {
 		desiredByService[runtimeServiceKey(service.EnvironmentName, service.ServiceName)] = service
 	}
-	effectiveIngress := desiredstate.EffectiveIngress(desired)
-	explicitIngress := desired.GetIngress()
+	ingress := desired.GetIngress()
 
 	existing, err := r.engine.ListManaged(ctx)
 	if err != nil {
@@ -118,7 +118,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, desired *desiredstatepb.Desi
 	}
 
 	for serviceKey, c := range desiredByService {
-		serviceResult, err := r.reconcileService(ctx, explicitIngress, effectiveIngress, desired.GetNodePeers(), c, existingByService[serviceKey])
+		serviceResult, err := r.reconcileService(ctx, ingress, desired.GetNodePeers(), c, existingByService[serviceKey])
 		result.Created += serviceResult.Created
 		result.Updated += serviceResult.Updated
 		result.Removed += serviceResult.Removed
@@ -192,7 +192,7 @@ func (r *Reconciler) RunTask(ctx context.Context, revision string, task *desired
 	return result, nil
 }
 
-func (r *Reconciler) reconcileService(ctx context.Context, explicitIngress, effectiveIngress *desiredstatepb.Ingress, nodePeers []*desiredstatepb.NodePeer, desired desiredstate.RuntimeService, existing []engine.ContainerState) (Result, error) {
+func (r *Reconciler) reconcileService(ctx context.Context, ingress *desiredstatepb.Ingress, nodePeers []*desiredstatepb.NodePeer, desired desiredstate.RuntimeService, existing []engine.ContainerState) (Result, error) {
 	result := Result{}
 	isWeb := desired.ServiceKind == desiredstate.ServiceKindWeb
 	name, hash, spec, err := r.specForService(desired)
@@ -208,12 +208,12 @@ func (r *Reconciler) reconcileService(ctx context.Context, explicitIngress, effe
 		if r.opts.Envoy == nil {
 			return result, fmt.Errorf("envoy manager required for web service")
 		}
-		if err := r.opts.Envoy.Ensure(ctx, effectiveIngress); err != nil {
+		if err := r.opts.Envoy.Ensure(ctx, ingress); err != nil {
 			return result, fmt.Errorf("ensure envoy: %w", err)
 		}
 		if r.opts.IngressCert != nil {
-			if err := r.opts.IngressCert.Ensure(ctx, explicitIngress, nodePeers); err != nil {
-				if ingressAutoTLSErrorIsNonFatal(explicitIngress) {
+			if err := r.opts.IngressCert.Ensure(ctx, ingress, nodePeers); err != nil {
+				if ingressAutoTLSErrorIsNonFatal(ingress) {
 					logger := r.opts.Logger
 					if logger == nil {
 						logger = slog.Default()
@@ -224,12 +224,12 @@ func (r *Reconciler) reconcileService(ctx context.Context, explicitIngress, effe
 				}
 			}
 		}
-		if err := r.opts.Envoy.Ensure(ctx, effectiveIngress); err != nil {
+		if err := r.opts.Envoy.Ensure(ctx, ingress); err != nil {
 			return result, fmt.Errorf("ensure envoy: %w", err)
 		}
 		if r.opts.Cloudflared != nil {
-			tunnelIngress := explicitIngress
-			if normalizedIngressMode(explicitIngress) != ingressModeTunnel {
+			tunnelIngress := ingress
+			if normalizedIngressMode(ingress) != ingressModeTunnel {
 				tunnelIngress = nil
 			}
 			if err := r.opts.Cloudflared.Reconcile(ctx, tunnelIngress); err != nil {

--- a/agent/internal/reconcile/reconcile.go
+++ b/agent/internal/reconcile/reconcile.go
@@ -101,6 +101,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, desired *desiredstatepb.Desi
 	for _, service := range desiredstate.RuntimeServices(desired) {
 		desiredByService[runtimeServiceKey(service.EnvironmentName, service.ServiceName)] = service
 	}
+	effectiveIngress := desiredstate.EffectiveIngress(desired)
+	explicitIngress := desired.GetIngress()
 
 	existing, err := r.engine.ListManaged(ctx)
 	if err != nil {
@@ -116,7 +118,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, desired *desiredstatepb.Desi
 	}
 
 	for serviceKey, c := range desiredByService {
-		serviceResult, err := r.reconcileService(ctx, desired.GetIngress(), desired.GetNodePeers(), c, existingByService[serviceKey])
+		serviceResult, err := r.reconcileService(ctx, explicitIngress, effectiveIngress, desired.GetNodePeers(), c, existingByService[serviceKey])
 		result.Created += serviceResult.Created
 		result.Updated += serviceResult.Updated
 		result.Removed += serviceResult.Removed
@@ -190,7 +192,7 @@ func (r *Reconciler) RunTask(ctx context.Context, revision string, task *desired
 	return result, nil
 }
 
-func (r *Reconciler) reconcileService(ctx context.Context, ingress *desiredstatepb.Ingress, nodePeers []*desiredstatepb.NodePeer, desired desiredstate.RuntimeService, existing []engine.ContainerState) (Result, error) {
+func (r *Reconciler) reconcileService(ctx context.Context, explicitIngress, effectiveIngress *desiredstatepb.Ingress, nodePeers []*desiredstatepb.NodePeer, desired desiredstate.RuntimeService, existing []engine.ContainerState) (Result, error) {
 	result := Result{}
 	isWeb := desired.ServiceKind == desiredstate.ServiceKindWeb
 	name, hash, spec, err := r.specForService(desired)
@@ -206,12 +208,12 @@ func (r *Reconciler) reconcileService(ctx context.Context, ingress *desiredstate
 		if r.opts.Envoy == nil {
 			return result, fmt.Errorf("envoy manager required for web service")
 		}
-		if err := r.opts.Envoy.Ensure(ctx, ingress); err != nil {
+		if err := r.opts.Envoy.Ensure(ctx, effectiveIngress); err != nil {
 			return result, fmt.Errorf("ensure envoy: %w", err)
 		}
 		if r.opts.IngressCert != nil {
-			if err := r.opts.IngressCert.Ensure(ctx, ingress, nodePeers); err != nil {
-				if ingressAutoTLSErrorIsNonFatal(ingress) {
+			if err := r.opts.IngressCert.Ensure(ctx, explicitIngress, nodePeers); err != nil {
+				if ingressAutoTLSErrorIsNonFatal(explicitIngress) {
 					logger := r.opts.Logger
 					if logger == nil {
 						logger = slog.Default()
@@ -222,12 +224,12 @@ func (r *Reconciler) reconcileService(ctx context.Context, ingress *desiredstate
 				}
 			}
 		}
-		if err := r.opts.Envoy.Ensure(ctx, ingress); err != nil {
+		if err := r.opts.Envoy.Ensure(ctx, effectiveIngress); err != nil {
 			return result, fmt.Errorf("ensure envoy: %w", err)
 		}
 		if r.opts.Cloudflared != nil {
-			tunnelIngress := ingress
-			if normalizedIngressMode(ingress) != ingressModeTunnel {
+			tunnelIngress := explicitIngress
+			if normalizedIngressMode(explicitIngress) != ingressModeTunnel {
 				tunnelIngress = nil
 			}
 			if err := r.opts.Cloudflared.Reconcile(ctx, tunnelIngress); err != nil {

--- a/agent/internal/reconcile/reconcile_test.go
+++ b/agent/internal/reconcile/reconcile_test.go
@@ -299,7 +299,7 @@ func TestReconcileWebUsesDesiredPortWhenPresent(t *testing.T) {
 	}
 }
 
-func TestReconcileSynthesizesIngressForSingleEnvironmentWeb(t *testing.T) {
+func TestReconcileInjectsSynthesizedIngressForSingleEnvironmentWeb(t *testing.T) {
 	eng := newFakeEngine()
 	eng.images["httpbin"] = true
 	envoyManager := &fakeEnvoyManager{engine: eng}
@@ -333,7 +333,7 @@ func TestReconcileSynthesizesIngressForSingleEnvironmentWeb(t *testing.T) {
 	}
 }
 
-func TestReconcileSynthesizedIngressSkipsExplicitCertManagement(t *testing.T) {
+func TestReconcileSynthesizedIngressUsesSingleIngressPathForCertManagement(t *testing.T) {
 	eng := newFakeEngine()
 	eng.images["httpbin"] = true
 	envoyManager := &fakeEnvoyManager{engine: eng}
@@ -353,8 +353,11 @@ func TestReconcileSynthesizedIngressSkipsExplicitCertManagement(t *testing.T) {
 	if ingressCertManager.calls != 1 {
 		t.Fatalf("expected one cert-manager call, got %d", ingressCertManager.calls)
 	}
-	if ingressCertManager.ingress != nil {
-		t.Fatalf("expected nil explicit ingress for synthesized case, got %+v", ingressCertManager.ingress)
+	if ingressCertManager.ingress == nil {
+		t.Fatal("expected synthesized ingress to be passed to cert manager")
+	}
+	if ingressCertManager.ingress.GetTls().GetMode() != "off" {
+		t.Fatalf("tls mode = %q, want off", ingressCertManager.ingress.GetTls().GetMode())
 	}
 }
 

--- a/agent/internal/reconcile/reconcile_test.go
+++ b/agent/internal/reconcile/reconcile_test.go
@@ -299,6 +299,100 @@ func TestReconcileWebUsesDesiredPortWhenPresent(t *testing.T) {
 	}
 }
 
+func TestReconcileSynthesizesIngressForSingleEnvironmentWeb(t *testing.T) {
+	eng := newFakeEngine()
+	eng.images["httpbin"] = true
+	envoyManager := &fakeEnvoyManager{engine: eng}
+	cloudflared := &fakeCloudflaredManager{}
+	rec := New(eng, Options{
+		Network:     "devopsellence",
+		StopTimeout: 2 * time.Second,
+		WebPort:     3000,
+		Envoy:       envoyManager,
+		Cloudflared: cloudflared,
+		HTTPProber:  &fakeHTTPProber{statuses: []int{200}},
+	})
+
+	if _, err := rec.Reconcile(context.Background(), desiredState(webService(80, "/up"))); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if envoyManager.ingress == nil {
+		t.Fatal("expected synthesized ingress")
+	}
+	if envoyManager.ingress.GetMode() != "public" {
+		t.Fatalf("mode = %q, want public", envoyManager.ingress.GetMode())
+	}
+	if envoyManager.ingress.GetTls().GetMode() != "off" {
+		t.Fatalf("tls mode = %q, want off", envoyManager.ingress.GetTls().GetMode())
+	}
+	if len(envoyManager.ingress.GetRoutes()) != 1 || envoyManager.ingress.GetRoutes()[0].GetMatch().GetHostname() != "" {
+		t.Fatalf("unexpected synthesized routes: %+v", envoyManager.ingress.GetRoutes())
+	}
+	if len(cloudflared.ingresses) != 1 || cloudflared.ingresses[0] != nil {
+		t.Fatalf("expected no tunnel reconcile for synthesized ingress, got %+v", cloudflared.ingresses)
+	}
+}
+
+func TestReconcileSynthesizedIngressSkipsExplicitCertManagement(t *testing.T) {
+	eng := newFakeEngine()
+	eng.images["httpbin"] = true
+	envoyManager := &fakeEnvoyManager{engine: eng}
+	ingressCertManager := &fakeIngressCertManager{}
+	rec := New(eng, Options{
+		Network:     "devopsellence",
+		StopTimeout: 2 * time.Second,
+		WebPort:     3000,
+		Envoy:       envoyManager,
+		IngressCert: ingressCertManager,
+		HTTPProber:  &fakeHTTPProber{statuses: []int{200}},
+	})
+
+	if _, err := rec.Reconcile(context.Background(), desiredState(webService(80, "/up"))); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if ingressCertManager.calls != 1 {
+		t.Fatalf("expected one cert-manager call, got %d", ingressCertManager.calls)
+	}
+	if ingressCertManager.ingress != nil {
+		t.Fatalf("expected nil explicit ingress for synthesized case, got %+v", ingressCertManager.ingress)
+	}
+}
+
+func TestReconcileDoesNotSynthesizeIngressForMultipleEnvironments(t *testing.T) {
+	eng := newFakeEngine()
+	eng.images["httpbin"] = true
+	envoyManager := &fakeEnvoyManager{engine: eng}
+	rec := New(eng, Options{
+		Network:     "devopsellence",
+		StopTimeout: 2 * time.Second,
+		WebPort:     3000,
+		Envoy:       envoyManager,
+		HTTPProber:  &fakeHTTPProber{statuses: []int{200, 200}},
+	})
+
+	state := &desiredstatepb.DesiredState{
+		SchemaVersion: 2,
+		Revision:      "node-plan-1",
+		Environments: []*desiredstatepb.Environment{
+			{Name: "production", Revision: "rev-1", Services: []*desiredstatepb.Service{webService(80, "/up")}},
+			{Name: "staging", Revision: "rev-2", Services: []*desiredstatepb.Service{{
+				Name:        "web",
+				Kind:        "web",
+				Image:       "httpbin",
+				Ports:       []*desiredstatepb.ServicePort{{Name: "http", Port: 8080}},
+				Healthcheck: &desiredstatepb.Healthcheck{Path: "/up", Port: 8080, Retries: 1, TimeoutSeconds: 1},
+			}}},
+		},
+	}
+
+	if _, err := rec.Reconcile(context.Background(), state); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if envoyManager.ingress != nil {
+		t.Fatalf("expected no synthesized ingress, got %+v", envoyManager.ingress)
+	}
+}
+
 func TestReconcileEnsuresIngressCertificateForPublicIngress(t *testing.T) {
 	eng := newFakeEngine()
 	eng.images["httpbin"] = true


### PR DESCRIPTION
## Summary
- synthesize effective public ingress only for the single-environment single-web case
- stop publishing Envoy host ports for ambiguous no-ingress topologies
- route synthesized blank-host ingress through wildcard Envoy virtual hosts instead of implicit default-cluster fallback

## Test Plan
- [x] mise run test:agent
- [x] mise x go@1.25.8 -- go test ./internal/desiredstate ./internal/envoy ./internal/reconcile ./cmd/devopsellence
