### PR TITLE
[codex] add environment overlays and shared ingress hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ In shared mode, `node create` provisions the server and runs the registration in
 `devopsellence` reads `devopsellence.yml` from the app root:
 
 ```yaml
-schema_version: 5
+schema_version: 6
 app:
   type: rails
 organization: solo
@@ -137,6 +137,16 @@ ingress:
     mode: auto
     email: ops@example.com
   redirect_http: true
+environments:
+  staging:
+    ingress:
+      hosts:
+        - staging.example.com
+  production:
+    services:
+      web:
+        env:
+          RAILS_ENV: production
 ```
 
 ## Need more than solo mode?

--- a/cli/internal/api/client.go
+++ b/cli/internal/api/client.go
@@ -166,9 +166,11 @@ type DeploymentProgressNode struct {
 }
 
 type DeploymentProgressIngress struct {
-	Hostname  string `json:"hostname"`
-	PublicURL string `json:"public_url"`
-	Status    string `json:"status"`
+	Hostname   string   `json:"hostname"`
+	Hosts      []string `json:"hosts,omitempty"`
+	PublicURL  string   `json:"public_url"`
+	PublicURLs []string `json:"public_urls,omitempty"`
+	Status     string   `json:"status"`
 }
 
 type DeploymentProgress struct {
@@ -202,7 +204,7 @@ type ReleaseCreateRequest struct {
 	ImageDigest     string         `json:"image_digest"`
 	Services        map[string]any `json:"services"`
 	Tasks           map[string]any `json:"tasks,omitempty"`
-	IngressService  string         `json:"ingress_service,omitempty"`
+	Ingress         map[string]any `json:"ingress,omitempty"`
 }
 
 func New(baseURL string) *Client {

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -15,7 +15,7 @@ import (
 const (
 	FilePath               = "devopsellence.yml"
 	GenericFilePath        = FilePath
-	SchemaVersion          = 5
+	SchemaVersion          = 6
 	DefaultEnvironment     = "production"
 	DefaultBuildContext    = "."
 	DefaultDockerfile      = "Dockerfile"
@@ -102,6 +102,53 @@ type IngressConfig struct {
 	RedirectHTTP bool             `yaml:"redirect_http,omitempty" json:"redirect_http,omitempty"`
 }
 
+type HTTPHealthcheckOverlay struct {
+	Path *string `yaml:"path,omitempty" json:"path,omitempty"`
+	Port *int    `yaml:"port,omitempty" json:"port,omitempty"`
+}
+
+type ServiceConfigOverlay struct {
+	Kind        *string                 `yaml:"kind,omitempty" json:"kind,omitempty"`
+	Image       *string                 `yaml:"image,omitempty" json:"image,omitempty"`
+	Command     []string                `yaml:"command,omitempty" json:"command,omitempty"`
+	Args        []string                `yaml:"args,omitempty" json:"args,omitempty"`
+	Env         map[string]string       `yaml:"env,omitempty" json:"env,omitempty"`
+	SecretRefs  []SecretRef             `yaml:"secret_refs,omitempty" json:"secret_refs,omitempty"`
+	Ports       []ServicePort           `yaml:"ports,omitempty" json:"ports,omitempty"`
+	Healthcheck *HTTPHealthcheckOverlay `yaml:"healthcheck,omitempty" json:"healthcheck,omitempty"`
+	Volumes     []Volume                `yaml:"volumes,omitempty" json:"volumes,omitempty"`
+}
+
+type TaskConfigOverlay struct {
+	Service *string           `yaml:"service,omitempty" json:"service,omitempty"`
+	Command []string          `yaml:"command,omitempty" json:"command,omitempty"`
+	Args    []string          `yaml:"args,omitempty" json:"args,omitempty"`
+	Env     map[string]string `yaml:"env,omitempty" json:"env,omitempty"`
+}
+
+type TasksConfigOverlay struct {
+	Release *TaskConfigOverlay `yaml:"release,omitempty" json:"release,omitempty"`
+}
+
+type IngressTLSConfigOverlay struct {
+	Mode           *string `yaml:"mode,omitempty" json:"mode,omitempty"`
+	Email          *string `yaml:"email,omitempty" json:"email,omitempty"`
+	CADirectoryURL *string `yaml:"ca_directory_url,omitempty" json:"ca_directory_url,omitempty"`
+}
+
+type IngressConfigOverlay struct {
+	Hosts        []string                 `yaml:"hosts,omitempty" json:"hosts,omitempty"`
+	Service      *string                  `yaml:"service,omitempty" json:"service,omitempty"`
+	TLS          *IngressTLSConfigOverlay `yaml:"tls,omitempty" json:"tls,omitempty"`
+	RedirectHTTP *bool                    `yaml:"redirect_http,omitempty" json:"redirect_http,omitempty"`
+}
+
+type EnvironmentOverlay struct {
+	Ingress  *IngressConfigOverlay           `yaml:"ingress,omitempty" json:"ingress,omitempty"`
+	Services map[string]ServiceConfigOverlay `yaml:"services,omitempty" json:"services,omitempty"`
+	Tasks    *TasksConfigOverlay             `yaml:"tasks,omitempty" json:"tasks,omitempty"`
+}
+
 type SoloNode struct {
 	Host             string   `yaml:"host" json:"host"`
 	User             string   `yaml:"user" json:"user"`
@@ -117,15 +164,16 @@ type SoloNode struct {
 }
 
 type ProjectConfig struct {
-	SchemaVersion      int                      `yaml:"schema_version" json:"schema_version"`
-	App                AppConfig                `yaml:"app,omitempty" json:"app,omitempty"`
-	Organization       string                   `yaml:"organization" json:"organization"`
-	Project            string                   `yaml:"project" json:"project"`
-	DefaultEnvironment string                   `yaml:"default_environment" json:"default_environment"`
-	Build              BuildConfig              `yaml:"build" json:"build"`
-	Services           map[string]ServiceConfig `yaml:"services" json:"services"`
-	Tasks              TasksConfig              `yaml:"tasks,omitempty" json:"tasks,omitempty"`
-	Ingress            *IngressConfig           `yaml:"ingress,omitempty" json:"ingress,omitempty"`
+	SchemaVersion      int                           `yaml:"schema_version" json:"schema_version"`
+	App                AppConfig                     `yaml:"app,omitempty" json:"app,omitempty"`
+	Organization       string                        `yaml:"organization" json:"organization"`
+	Project            string                        `yaml:"project" json:"project"`
+	DefaultEnvironment string                        `yaml:"default_environment" json:"default_environment"`
+	Build              BuildConfig                   `yaml:"build" json:"build"`
+	Services           map[string]ServiceConfig      `yaml:"services" json:"services"`
+	Tasks              TasksConfig                   `yaml:"tasks,omitempty" json:"tasks,omitempty"`
+	Ingress            *IngressConfig                `yaml:"ingress,omitempty" json:"ingress,omitempty"`
+	Environments       map[string]EnvironmentOverlay `yaml:"environments,omitempty" json:"environments,omitempty"`
 }
 
 type Project = ProjectConfig
@@ -300,6 +348,17 @@ func Validate(cfg *ProjectConfig) error {
 	if strings.TrimSpace(cfg.DefaultEnvironment) == "" {
 		return errors.New("default_environment is required")
 	}
+	if err := validateEnvironmentOverlays(cfg); err != nil {
+		return err
+	}
+	resolved, err := ResolveEnvironmentConfig(*cfg, cfg.DefaultEnvironment)
+	if err != nil {
+		return err
+	}
+	return validateResolvedProjectConfig(&resolved)
+}
+
+func validateResolvedProjectConfig(cfg *ProjectConfig) error {
 	if strings.TrimSpace(cfg.Build.Context) == "" {
 		return errors.New("build.context is required")
 	}
@@ -389,6 +448,9 @@ func applyDefaults(cfg *ProjectConfig) {
 	if cfg.Services == nil {
 		cfg.Services = map[string]ServiceConfig{}
 	}
+	if cfg.Environments == nil {
+		cfg.Environments = map[string]EnvironmentOverlay{}
+	}
 	for name, service := range cfg.Services {
 		if service.Env == nil {
 			service.Env = map[string]string{}
@@ -421,6 +483,9 @@ func applyDefaults(cfg *ProjectConfig) {
 		cfg.Services[name] = service
 	}
 	if cfg.Tasks.Release != nil {
+		cfg.Tasks.Release.Service = strings.TrimSpace(cfg.Tasks.Release.Service)
+		cfg.Tasks.Release.Command = normalizeStringListKeepOrder(cfg.Tasks.Release.Command)
+		cfg.Tasks.Release.Args = normalizeStringListKeepOrder(cfg.Tasks.Release.Args)
 		cfg.Tasks.Release.Env = mergeStringMaps(cfg.Tasks.Release.Env)
 	}
 	if cfg.Ingress != nil {
@@ -432,10 +497,44 @@ func applyDefaults(cfg *ProjectConfig) {
 		}
 		cfg.Ingress.TLS.Email = strings.TrimSpace(cfg.Ingress.TLS.Email)
 		cfg.Ingress.TLS.CADirectoryURL = strings.TrimSpace(cfg.Ingress.TLS.CADirectoryURL)
-		if cfg.Ingress.TLS.Mode == "auto" {
-			cfg.Ingress.RedirectHTTP = true
+	}
+}
+
+func ResolveEnvironmentConfig(base ProjectConfig, selectedEnv string) (ProjectConfig, error) {
+	resolved := cloneProjectConfig(base)
+	envName := strings.TrimSpace(selectedEnv)
+	if envName == "" {
+		envName = strings.TrimSpace(base.DefaultEnvironment)
+	}
+	if envName == "" {
+		envName = DefaultEnvironment
+	}
+	resolved.DefaultEnvironment = envName
+
+	overlay, ok := base.Environments[envName]
+	if !ok {
+		applyDefaults(&resolved)
+		return resolved, nil
+	}
+
+	if overlay.Ingress != nil {
+		resolved.Ingress = mergeIngressConfig(resolved.Ingress, overlay.Ingress)
+	}
+	if len(overlay.Services) > 0 {
+		if resolved.Services == nil {
+			resolved.Services = map[string]ServiceConfig{}
+		}
+		for name, entry := range overlay.Services {
+			baseService := resolved.Services[name]
+			resolved.Services[name] = mergeServiceConfig(baseService, entry)
 		}
 	}
+	if overlay.Tasks != nil {
+		resolved.Tasks = mergeTasksConfig(resolved.Tasks, overlay.Tasks)
+	}
+
+	applyDefaults(&resolved)
+	return resolved, nil
 }
 
 func normalizeNodeLabels(labels []string) []string {
@@ -465,6 +564,17 @@ func normalizeStringList(values []string) []string {
 		}
 		seen[value] = true
 		normalized = append(normalized, value)
+	}
+	return normalized
+}
+
+func normalizeStringListKeepOrder(values []string) []string {
+	if values == nil {
+		return nil
+	}
+	normalized := make([]string, 0, len(values))
+	for _, value := range values {
+		normalized = append(normalized, strings.TrimSpace(value))
 	}
 	return normalized
 }
@@ -643,4 +753,215 @@ func mergeStringMaps(parts ...map[string]string) map[string]string {
 		}
 	}
 	return merged
+}
+
+func validateEnvironmentOverlays(cfg *ProjectConfig) error {
+	for envName, overlay := range cfg.Environments {
+		name := strings.TrimSpace(envName)
+		if name == "" {
+			return errors.New("environments keys must be present")
+		}
+		if err := validateEnvironmentOverlay(name, overlay, cfg); err != nil {
+			return err
+		}
+		resolved, err := ResolveEnvironmentConfig(*cfg, name)
+		if err != nil {
+			return err
+		}
+		if err := validateResolvedProjectConfig(&resolved); err != nil {
+			return fmt.Errorf("environments.%s: %w", name, err)
+		}
+	}
+	return nil
+}
+
+func validateEnvironmentOverlay(envName string, overlay EnvironmentOverlay, cfg *ProjectConfig) error {
+	if overlay.Ingress != nil {
+		if overlay.Ingress.Service != nil && strings.TrimSpace(*overlay.Ingress.Service) == "" {
+			return fmt.Errorf("environments.%s.ingress.service must be present", envName)
+		}
+		if overlay.Ingress.TLS != nil {
+			for field, value := range map[string]*string{
+				"mode":             overlay.Ingress.TLS.Mode,
+				"email":            overlay.Ingress.TLS.Email,
+				"ca_directory_url": overlay.Ingress.TLS.CADirectoryURL,
+			} {
+				if value != nil && strings.TrimSpace(*value) == "" {
+					return fmt.Errorf("environments.%s.ingress.tls.%s must be present", envName, field)
+				}
+			}
+		}
+	}
+	for serviceName, service := range overlay.Services {
+		if _, ok := cfg.Services[serviceName]; !ok {
+			return fmt.Errorf("environments.%s.services.%s not found in services", envName, serviceName)
+		}
+		for field, value := range map[string]*string{
+			"kind":  service.Kind,
+			"image": service.Image,
+		} {
+			if value != nil && strings.TrimSpace(*value) == "" {
+				return fmt.Errorf("environments.%s.services.%s.%s must be present", envName, serviceName, field)
+			}
+		}
+		if service.Healthcheck != nil && service.Healthcheck.Port != nil && *service.Healthcheck.Port <= 0 {
+			return fmt.Errorf("environments.%s.services.%s.healthcheck.port must be a positive integer", envName, serviceName)
+		}
+	}
+	if overlay.Tasks != nil && overlay.Tasks.Release != nil {
+		release := overlay.Tasks.Release
+		if release.Service != nil && strings.TrimSpace(*release.Service) == "" {
+			return fmt.Errorf("environments.%s.tasks.release.service must be present", envName)
+		}
+	}
+	return nil
+}
+
+func cloneProjectConfig(cfg ProjectConfig) ProjectConfig {
+	cloned := cfg
+	cloned.Build.Platforms = append([]string(nil), cfg.Build.Platforms...)
+	cloned.Services = map[string]ServiceConfig{}
+	for name, service := range cfg.Services {
+		cloned.Services[name] = cloneServiceConfig(service)
+	}
+	if cfg.Tasks.Release != nil {
+		release := *cfg.Tasks.Release
+		release.Command = append([]string(nil), cfg.Tasks.Release.Command...)
+		release.Args = append([]string(nil), cfg.Tasks.Release.Args...)
+		release.Env = cloneStringMap(cfg.Tasks.Release.Env)
+		cloned.Tasks.Release = &release
+	}
+	if cfg.Ingress != nil {
+		ingress := *cfg.Ingress
+		ingress.Hosts = append([]string(nil), cfg.Ingress.Hosts...)
+		cloned.Ingress = &ingress
+	}
+	cloned.Environments = cfg.Environments
+	return cloned
+}
+
+func cloneServiceConfig(service ServiceConfig) ServiceConfig {
+	cloned := service
+	cloned.Command = append([]string(nil), service.Command...)
+	cloned.Args = append([]string(nil), service.Args...)
+	cloned.Env = cloneStringMap(service.Env)
+	cloned.SecretRefs = append([]SecretRef(nil), service.SecretRefs...)
+	cloned.Ports = append([]ServicePort(nil), service.Ports...)
+	cloned.Volumes = append([]Volume(nil), service.Volumes...)
+	if service.Healthcheck != nil {
+		healthcheck := *service.Healthcheck
+		cloned.Healthcheck = &healthcheck
+	}
+	return cloned
+}
+
+func mergeServiceConfig(base ServiceConfig, overlay ServiceConfigOverlay) ServiceConfig {
+	merged := cloneServiceConfig(base)
+	if overlay.Kind != nil {
+		merged.Kind = strings.TrimSpace(*overlay.Kind)
+	}
+	if overlay.Image != nil {
+		merged.Image = strings.TrimSpace(*overlay.Image)
+	}
+	if overlay.Command != nil {
+		merged.Command = append([]string(nil), overlay.Command...)
+	}
+	if overlay.Args != nil {
+		merged.Args = append([]string(nil), overlay.Args...)
+	}
+	if overlay.Env != nil {
+		merged.Env = mergeStringMaps(merged.Env, overlay.Env)
+	}
+	if overlay.SecretRefs != nil {
+		merged.SecretRefs = append([]SecretRef(nil), overlay.SecretRefs...)
+	}
+	if overlay.Ports != nil {
+		merged.Ports = append([]ServicePort(nil), overlay.Ports...)
+	}
+	if overlay.Volumes != nil {
+		merged.Volumes = append([]Volume(nil), overlay.Volumes...)
+	}
+	if overlay.Healthcheck != nil {
+		if merged.Healthcheck == nil {
+			merged.Healthcheck = &HTTPHealthcheck{}
+		}
+		if overlay.Healthcheck.Path != nil {
+			merged.Healthcheck.Path = strings.TrimSpace(*overlay.Healthcheck.Path)
+		}
+		if overlay.Healthcheck.Port != nil {
+			merged.Healthcheck.Port = *overlay.Healthcheck.Port
+		}
+	}
+	return merged
+}
+
+func mergeTasksConfig(base TasksConfig, overlay *TasksConfigOverlay) TasksConfig {
+	merged := base
+	if overlay == nil || overlay.Release == nil {
+		return merged
+	}
+	if merged.Release == nil {
+		merged.Release = &TaskConfig{}
+	}
+	if overlay.Release.Service != nil {
+		merged.Release.Service = strings.TrimSpace(*overlay.Release.Service)
+	}
+	if overlay.Release.Command != nil {
+		merged.Release.Command = append([]string(nil), overlay.Release.Command...)
+	}
+	if overlay.Release.Args != nil {
+		merged.Release.Args = append([]string(nil), overlay.Release.Args...)
+	}
+	if overlay.Release.Env != nil {
+		merged.Release.Env = mergeStringMaps(merged.Release.Env, overlay.Release.Env)
+	}
+	return merged
+}
+
+func mergeIngressConfig(base *IngressConfig, overlay *IngressConfigOverlay) *IngressConfig {
+	if overlay == nil {
+		if base == nil {
+			return nil
+		}
+		cloned := *base
+		cloned.Hosts = append([]string(nil), base.Hosts...)
+		return &cloned
+	}
+	merged := &IngressConfig{}
+	if base != nil {
+		*merged = *base
+		merged.Hosts = append([]string(nil), base.Hosts...)
+	}
+	if overlay.Hosts != nil {
+		merged.Hosts = append([]string(nil), overlay.Hosts...)
+	}
+	if overlay.Service != nil {
+		merged.Service = strings.TrimSpace(*overlay.Service)
+	}
+	if overlay.TLS != nil {
+		if overlay.TLS.Mode != nil {
+			merged.TLS.Mode = strings.TrimSpace(*overlay.TLS.Mode)
+		}
+		if overlay.TLS.Email != nil {
+			merged.TLS.Email = strings.TrimSpace(*overlay.TLS.Email)
+		}
+		if overlay.TLS.CADirectoryURL != nil {
+			merged.TLS.CADirectoryURL = strings.TrimSpace(*overlay.TLS.CADirectoryURL)
+		}
+	}
+	if overlay.RedirectHTTP != nil {
+		merged.RedirectHTTP = *overlay.RedirectHTTP
+	}
+	return merged
+}
+
+func cloneStringMap(values map[string]string) map[string]string {
+	if values == nil {
+		return nil
+	}
+	cloned := map[string]string{}
+	for key, value := range values {
+		cloned[key] = value
+	}
+	return cloned
 }

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -99,7 +99,7 @@ type IngressConfig struct {
 	Hosts        []string         `yaml:"hosts,omitempty" json:"hosts,omitempty"`
 	Service      string           `yaml:"service,omitempty" json:"service,omitempty"`
 	TLS          IngressTLSConfig `yaml:"tls,omitempty" json:"tls,omitempty"`
-	RedirectHTTP bool             `yaml:"redirect_http,omitempty" json:"redirect_http,omitempty"`
+	RedirectHTTP *bool            `yaml:"redirect_http,omitempty" json:"redirect_http,omitempty"`
 }
 
 type HTTPHealthcheckOverlay struct {
@@ -497,6 +497,9 @@ func applyDefaults(cfg *ProjectConfig) {
 		}
 		cfg.Ingress.TLS.Email = strings.TrimSpace(cfg.Ingress.TLS.Email)
 		cfg.Ingress.TLS.CADirectoryURL = strings.TrimSpace(cfg.Ingress.TLS.CADirectoryURL)
+		if cfg.Ingress.TLS.Mode == "auto" && cfg.Ingress.RedirectHTTP == nil {
+			cfg.Ingress.RedirectHTTP = boolPtr(true)
+		}
 	}
 }
 
@@ -834,6 +837,9 @@ func cloneProjectConfig(cfg ProjectConfig) ProjectConfig {
 	if cfg.Ingress != nil {
 		ingress := *cfg.Ingress
 		ingress.Hosts = append([]string(nil), cfg.Ingress.Hosts...)
+		if cfg.Ingress.RedirectHTTP != nil {
+			ingress.RedirectHTTP = boolPtr(*cfg.Ingress.RedirectHTTP)
+		}
 		cloned.Ingress = &ingress
 	}
 	cloned.Environments = cfg.Environments
@@ -931,6 +937,9 @@ func mergeIngressConfig(base *IngressConfig, overlay *IngressConfigOverlay) *Ing
 	if base != nil {
 		*merged = *base
 		merged.Hosts = append([]string(nil), base.Hosts...)
+		if base.RedirectHTTP != nil {
+			merged.RedirectHTTP = boolPtr(*base.RedirectHTTP)
+		}
 	}
 	if overlay.Hosts != nil {
 		merged.Hosts = append([]string(nil), overlay.Hosts...)
@@ -950,7 +959,7 @@ func mergeIngressConfig(base *IngressConfig, overlay *IngressConfigOverlay) *Ing
 		}
 	}
 	if overlay.RedirectHTTP != nil {
-		merged.RedirectHTTP = *overlay.RedirectHTTP
+		merged.RedirectHTTP = boolPtr(*overlay.RedirectHTTP)
 	}
 	return merged
 }
@@ -964,4 +973,8 @@ func cloneStringMap(values map[string]string) map[string]string {
 		cloned[key] = value
 	}
 	return cloned
+}
+
+func boolPtr(value bool) *bool {
+	return &value
 }

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -83,7 +83,7 @@ func TestLoadAppliesDefaultBuildPlatforms(t *testing.T) {
 	root := t.TempDir()
 	path := filepath.Join(root, FilePath)
 	content := strings.Join([]string{
-		"schema_version: 5",
+		"schema_version: 6",
 		"organization: acme",
 		"project: ShopApp",
 		"default_environment: production",
@@ -121,7 +121,7 @@ func TestLoadRejectsLegacyInitHook(t *testing.T) {
 	root := t.TempDir()
 	path := filepath.Join(root, FilePath)
 	content := strings.Join([]string{
-		"schema_version: 5",
+		"schema_version: 6",
 		"organization: acme",
 		"project: ShopApp",
 		"default_environment: production",
@@ -155,7 +155,7 @@ func TestLoadRejectsStringCommandSyntax(t *testing.T) {
 	root := t.TempDir()
 	path := filepath.Join(root, FilePath)
 	content := strings.Join([]string{
-		"schema_version: 5",
+		"schema_version: 6",
 		"organization: acme",
 		"project: ShopApp",
 		"default_environment: production",
@@ -207,7 +207,7 @@ func TestLoadRejectsLegacyDirectConfig(t *testing.T) {
 	root := t.TempDir()
 	path := filepath.Join(root, FilePath)
 	content := strings.Join([]string{
-		"schema_version: 5",
+		"schema_version: 6",
 		"organization: acme",
 		"project: ShopApp",
 		"default_environment: production",
@@ -244,7 +244,7 @@ func TestLoadRejectsLegacySoloConfigBlock(t *testing.T) {
 	root := t.TempDir()
 	path := filepath.Join(root, FilePath)
 	content := strings.Join([]string{
-		"schema_version: 5",
+		"schema_version: 6",
 		"organization: solo",
 		"project: ShopApp",
 		"default_environment: production",
@@ -352,4 +352,201 @@ func TestReadmeExampleConfigParses(t *testing.T) {
 	if cfg == nil {
 		t.Fatal("Load() returned nil config")
 	}
+}
+
+func TestResolveEnvironmentConfigMergesOverlay(t *testing.T) {
+	t.Parallel()
+
+	project := DefaultProjectConfig("acme", "ShopApp", "production")
+	project.Ingress = &IngressConfig{
+		Hosts:   []string{"app.example.test"},
+		Service: "web",
+		TLS:     IngressTLSConfig{Mode: "auto", Email: "ops@example.test"},
+	}
+	project.Services["web"] = Service{
+		Kind:       ServiceKindWeb,
+		Command:    []string{"bundle", "exec", "puma"},
+		Args:       []string{"-C", "config/puma.rb"},
+		Env:        map[string]string{"RAILS_ENV": "production", "BASE_ONLY": "1"},
+		SecretRefs: []SecretRef{{Name: "BASE_KEY", Secret: "gsm://base"}},
+		Ports:      []ServicePort{{Name: "http", Port: 3000}},
+		Healthcheck: &HTTPHealthcheck{
+			Path: "/up",
+			Port: 3000,
+		},
+		Volumes: []Volume{{Source: "storage", Target: "/rails/storage"}},
+	}
+	project.Tasks.Release = &TaskConfig{
+		Service: "web",
+		Command: []string{"bundle", "exec", "rails", "db:migrate"},
+		Env:     map[string]string{"RELEASE_ONLY": "base"},
+	}
+	redirectHTTP := false
+	stagingService := "web"
+	stagingPath := "/healthz"
+	stagingPort := 8080
+	project.Environments = map[string]EnvironmentOverlay{
+		"staging": {
+			Ingress: &IngressConfigOverlay{
+				Hosts:   []string{"staging.example.test", "alt-staging.example.test"},
+				Service: &stagingService,
+				TLS: &IngressTLSConfigOverlay{
+					Email: stringPtr("staging@example.test"),
+				},
+				RedirectHTTP: &redirectHTTP,
+			},
+			Services: map[string]ServiceConfigOverlay{
+				"web": {
+					Command:     []string{"./bin/staging-web"},
+					Env:         map[string]string{"RAILS_ENV": "staging", "STAGING_ONLY": "1"},
+					SecretRefs:  []SecretRef{{Name: "STAGING_KEY", Secret: "gsm://staging"}},
+					Ports:       []ServicePort{{Name: "http", Port: 8080}},
+					Volumes:     []Volume{{Source: "staging-storage", Target: "/rails/storage"}},
+					Healthcheck: &HTTPHealthcheckOverlay{Path: &stagingPath, Port: &stagingPort},
+				},
+			},
+			Tasks: &TasksConfigOverlay{
+				Release: &TaskConfigOverlay{
+					Env:     map[string]string{"RELEASE_ONLY": "staging", "MIGRATION_MODE": "online"},
+					Command: []string{"bundle", "exec", "rails", "db:prepare"},
+				},
+			},
+		},
+	}
+
+	resolved, err := ResolveEnvironmentConfig(project, "staging")
+	if err != nil {
+		t.Fatalf("ResolveEnvironmentConfig() error = %v", err)
+	}
+	if resolved.DefaultEnvironment != "staging" {
+		t.Fatalf("default_environment = %q, want staging", resolved.DefaultEnvironment)
+	}
+	if got := strings.Join(resolved.Ingress.Hosts, ","); got != "staging.example.test,alt-staging.example.test" {
+		t.Fatalf("ingress.hosts = %q", got)
+	}
+	if resolved.Ingress.TLS.Mode != "auto" || resolved.Ingress.TLS.Email != "staging@example.test" {
+		t.Fatalf("ingress tls = %#v", resolved.Ingress.TLS)
+	}
+	if resolved.Ingress.RedirectHTTP {
+		t.Fatalf("ingress.redirect_http = true, want false")
+	}
+	web := resolved.Services["web"]
+	if got := strings.Join(web.Command, " "); got != "./bin/staging-web" {
+		t.Fatalf("command = %q", got)
+	}
+	if web.Args[0] != "-C" {
+		t.Fatalf("args = %#v", web.Args)
+	}
+	if web.Env["RAILS_ENV"] != "staging" || web.Env["BASE_ONLY"] != "1" || web.Env["STAGING_ONLY"] != "1" {
+		t.Fatalf("env = %#v", web.Env)
+	}
+	if len(web.SecretRefs) != 1 || web.SecretRefs[0].Name != "STAGING_KEY" {
+		t.Fatalf("secret_refs = %#v", web.SecretRefs)
+	}
+	if web.Healthcheck == nil || web.Healthcheck.Path != "/healthz" || web.Healthcheck.Port != 8080 {
+		t.Fatalf("healthcheck = %#v", web.Healthcheck)
+	}
+	if resolved.Tasks.Release == nil {
+		t.Fatal("release task missing")
+	}
+	if got := strings.Join(resolved.Tasks.Release.Command, " "); got != "bundle exec rails db:prepare" {
+		t.Fatalf("release command = %q", got)
+	}
+	if resolved.Tasks.Release.Env["RELEASE_ONLY"] != "staging" || resolved.Tasks.Release.Env["MIGRATION_MODE"] != "online" {
+		t.Fatalf("release env = %#v", resolved.Tasks.Release.Env)
+	}
+}
+
+func TestResolveEnvironmentConfigReturnsBaseForMissingOverlay(t *testing.T) {
+	t.Parallel()
+
+	project := DefaultProjectConfig("acme", "ShopApp", "production")
+	resolved, err := ResolveEnvironmentConfig(project, "staging")
+	if err != nil {
+		t.Fatalf("ResolveEnvironmentConfig() error = %v", err)
+	}
+	if resolved.DefaultEnvironment != "staging" {
+		t.Fatalf("default_environment = %q, want staging", resolved.DefaultEnvironment)
+	}
+	if _, ok := resolved.Services["web"]; !ok {
+		t.Fatalf("resolved services = %#v", resolved.Services)
+	}
+}
+
+func TestLoadRejectsOverlayServiceNotInBase(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	path := filepath.Join(root, FilePath)
+	content := strings.Join([]string{
+		"schema_version: 6",
+		"organization: acme",
+		"project: ShopApp",
+		"default_environment: production",
+		"build:",
+		"  context: .",
+		"  dockerfile: Dockerfile",
+		"services:",
+		"  web:",
+		"    kind: web",
+		"    ports:",
+		"      - name: http",
+		"        port: 3000",
+		"    healthcheck:",
+		"      path: /up",
+		"environments:",
+		"  staging:",
+		"    services:",
+		"      jobs:",
+		"        command:",
+		"          - ./bin/jobs",
+	}, "\n") + "\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Load(path)
+	if err == nil || !strings.Contains(err.Error(), "environments.staging.services.jobs not found in services") {
+		t.Fatalf("expected missing service error, got %v", err)
+	}
+}
+
+func TestLoadRejectsUnknownOverlayKeys(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	path := filepath.Join(root, FilePath)
+	content := strings.Join([]string{
+		"schema_version: 6",
+		"organization: acme",
+		"project: ShopApp",
+		"default_environment: production",
+		"build:",
+		"  context: .",
+		"  dockerfile: Dockerfile",
+		"services:",
+		"  web:",
+		"    kind: web",
+		"    ports:",
+		"      - name: http",
+		"        port: 3000",
+		"    healthcheck:",
+		"      path: /up",
+		"environments:",
+		"  staging:",
+		"    build:",
+		"      context: .",
+	}, "\n") + "\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Load(path)
+	if err == nil || !strings.Contains(err.Error(), "field build not found") {
+		t.Fatalf("expected unknown overlay key error, got %v", err)
+	}
+}
+
+func stringPtr(value string) *string {
+	return &value
 }

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -427,8 +427,8 @@ func TestResolveEnvironmentConfigMergesOverlay(t *testing.T) {
 	if resolved.Ingress.TLS.Mode != "auto" || resolved.Ingress.TLS.Email != "staging@example.test" {
 		t.Fatalf("ingress tls = %#v", resolved.Ingress.TLS)
 	}
-	if resolved.Ingress.RedirectHTTP {
-		t.Fatalf("ingress.redirect_http = true, want false")
+	if resolved.Ingress.RedirectHTTP == nil || *resolved.Ingress.RedirectHTTP {
+		t.Fatalf("ingress.redirect_http = %#v, want false", resolved.Ingress.RedirectHTTP)
 	}
 	web := resolved.Services["web"]
 	if got := strings.Join(web.Command, " "); got != "./bin/staging-web" {

--- a/cli/internal/discovery/discovery_test.go
+++ b/cli/internal/discovery/discovery_test.go
@@ -77,7 +77,7 @@ func TestDiscoverFindsGenericWorkspaceFromConfig(t *testing.T) {
 	t.Parallel()
 
 	root := t.TempDir()
-	if err := os.WriteFile(filepath.Join(root, "devopsellence.yml"), []byte("schema_version: 5\norganization: acme\nproject: demo\ndefault_environment: production\nbuild:\n  context: .\n  dockerfile: Dockerfile\nservices:\n  web:\n    kind: web\n    ports:\n      - name: http\n        port: 8080\n    healthcheck:\n      path: /\n      port: 8080\n"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(root, "devopsellence.yml"), []byte("schema_version: 6\norganization: acme\nproject: demo\ndefault_environment: production\nbuild:\n  context: .\n  dockerfile: Dockerfile\nservices:\n  web:\n    kind: web\n    ports:\n      - name: http\n        port: 8080\n    healthcheck:\n      path: /\n      port: 8080\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	start := filepath.Join(root, "src", "api")

--- a/cli/internal/solo/desiredstate.go
+++ b/cli/internal/solo/desiredstate.go
@@ -312,9 +312,16 @@ func buildIngress(ingress *config.IngressConfig, environmentName string) *ingres
 			Email:          strings.TrimSpace(ingress.TLS.Email),
 			CADirectoryURL: strings.TrimSpace(ingress.TLS.CADirectoryURL),
 		},
-		RedirectHTTP: ingress.RedirectHTTP,
+		RedirectHTTP: ingressRedirectHTTPValue(ingress),
 		Routes:       routes,
 	}
+}
+
+func ingressRedirectHTTPValue(ingress *config.IngressConfig) bool {
+	if ingress == nil || ingress.RedirectHTTP == nil {
+		return true
+	}
+	return *ingress.RedirectHTTP
 }
 
 func mergeIngressForNode(labels []string, snapshots []DeploySnapshot, environmentNames map[string]string) (*ingressJSON, error) {

--- a/cli/internal/solo/desiredstate_test.go
+++ b/cli/internal/solo/desiredstate_test.go
@@ -10,6 +10,10 @@ import (
 	"github.com/devopsellence/cli/internal/config"
 )
 
+func boolPtr(value bool) *bool {
+	return &value
+}
+
 func baseProject() *config.ProjectConfig {
 	cfg := config.DefaultProjectConfig("solo", "myapp", config.DefaultEnvironment)
 	cfg.Services["web"] = config.Service{
@@ -194,7 +198,7 @@ func TestBuildDesiredStateForNodeIncludesIngressForIngressNode(t *testing.T) {
 			Email:          "ops@example.com",
 			CADirectoryURL: "https://acme-staging-v02.api.letsencrypt.org/directory",
 		},
-		RedirectHTTP: true,
+		RedirectHTTP: boolPtr(true),
 	}
 
 	data, err := BuildDesiredStateForNode(cfg, "myapp:def5678", "def5678", map[string]string{"DATABASE_URL": "postgres://localhost/mydb"}, []string{config.DefaultWebRole}, true, false, []NodePeer{{

--- a/cli/internal/workflow/app.go
+++ b/cli/internal/workflow/app.go
@@ -4099,7 +4099,9 @@ func ingressPayload(cfg config.ProjectConfig) map[string]any {
 	if len(cfg.Ingress.Hosts) > 0 {
 		payload["hosts"] = append([]string(nil), cfg.Ingress.Hosts...)
 	}
-	payload["redirect_http"] = cfg.Ingress.RedirectHTTP
+	if cfg.Ingress.RedirectHTTP != nil {
+		payload["redirect_http"] = *cfg.Ingress.RedirectHTTP
+	}
 	if tls := map[string]any{
 		"mode":             strings.TrimSpace(cfg.Ingress.TLS.Mode),
 		"email":            strings.TrimSpace(cfg.Ingress.TLS.Email),

--- a/cli/internal/workflow/app.go
+++ b/cli/internal/workflow/app.go
@@ -34,6 +34,7 @@ import (
 	"github.com/devopsellence/cli/internal/ui"
 
 	"golang.org/x/term"
+	"gopkg.in/yaml.v3"
 )
 
 const outputSchemaVersion = 1
@@ -131,6 +132,10 @@ type InitOptions struct {
 	ProjectName    string
 	Environment    string
 	NonInteractive bool
+}
+
+type ConfigResolveOptions struct {
+	Environment string
 }
 
 type DeployOptions struct {
@@ -659,6 +664,12 @@ func (a *App) Deploy(ctx context.Context, opts DeployOptions) error {
 			update("Loading config…")
 			cfg = *existing
 		}
+		selectedEnvironment := a.effectiveEnvironment(opts.Environment, &cfg)
+		resolvedCfg, err := config.ResolveEnvironmentConfig(cfg, selectedEnvironment)
+		if err != nil {
+			return ExitError{Code: 1, Err: err}
+		}
+		cfg = resolvedCfg
 		a.warnAboutPrebuiltImageConfig(opts, discovered, cfg)
 		a.API.BaseURL = firstNonEmpty(preflight.Tokens.APIBase, a.API.BaseURL)
 
@@ -692,7 +703,7 @@ func (a *App) Deploy(ctx context.Context, opts DeployOptions) error {
 			target, err := a.resolveDeployTarget(ctx, withAuth, resolveDeployTargetInput{
 				Organization:   firstNonEmpty(opts.Organization, cfg.Organization),
 				Project:        firstNonEmpty(opts.Project, cfg.Project),
-				Environment:    firstNonEmpty(opts.Environment, cfg.DefaultEnvironment),
+				Environment:    cfg.DefaultEnvironment,
 				Interactive:    !opts.NonInteractive,
 				NonInteractive: opts.NonInteractive,
 			}, update)
@@ -751,7 +762,7 @@ func (a *App) Deploy(ctx context.Context, opts DeployOptions) error {
 				ImageDigest:     digest,
 				Services:        servicePayloads(cfg.Services),
 				Tasks:           taskPayloads(cfg.Tasks),
-				IngressService:  ingressServicePayload(cfg),
+				Ingress:         ingressPayload(cfg),
 			})
 			return callErr
 		}); err != nil {
@@ -1282,6 +1293,7 @@ func (a *App) Doctor(ctx context.Context) error {
 	})
 
 	var cfg config.Project
+	var selectedEnvironment string
 	addCheck("config", func() (string, error) {
 		if discoveryErr != nil {
 			return "", discoveryErr
@@ -1291,7 +1303,13 @@ func (a *App) Doctor(ctx context.Context) error {
 			return "", err
 		}
 		cfg = loaded
-		return cfg.Organization + " / " + cfg.Project + " / " + cfg.DefaultEnvironment, nil
+		selectedEnvironment = a.effectiveEnvironment("", &cfg)
+		resolved, err := config.ResolveEnvironmentConfig(cfg, selectedEnvironment)
+		if err != nil {
+			return "", err
+		}
+		cfg = resolved
+		return cfg.Organization + " / " + cfg.Project + " / " + selectedEnvironment, nil
 	})
 
 	var tokens auth.Tokens
@@ -1334,7 +1352,7 @@ func (a *App) Doctor(ctx context.Context) error {
 		if err != nil {
 			return "", err
 		}
-		_, env, err := a.findProjectEnvironment(ctx, tokens.AccessToken, org.ID, cfg.Project, cfg.DefaultEnvironment)
+		_, env, err := a.findProjectEnvironment(ctx, tokens.AccessToken, org.ID, cfg.Project, selectedEnvironment)
 		if err != nil {
 			return "", err
 		}
@@ -1364,6 +1382,26 @@ func (a *App) Doctor(ctx context.Context) error {
 		}
 		a.Printer.Println(prefix, fmt.Sprintf("%v:", check["name"]), check["detail"])
 	}
+	return nil
+}
+
+func (a *App) ConfigResolve(opts ConfigResolveOptions) error {
+	_, resolved, selectedEnvironment, err := a.resolvedWorkspaceConfig(opts.Environment)
+	if err != nil {
+		return wrapError(err)
+	}
+	if a.Printer.JSON {
+		return a.Printer.PrintJSON(map[string]any{
+			"schema_version":       outputSchemaVersion,
+			"selected_environment": selectedEnvironment,
+			"config":               resolved,
+		})
+	}
+	data, err := yaml.Marshal(resolved)
+	if err != nil {
+		return ExitError{Code: 1, Err: err}
+	}
+	fmt.Fprint(a.Printer.Out, string(data))
 	return nil
 }
 
@@ -2347,7 +2385,7 @@ func (a *App) EnvironmentUse(ctx context.Context, opts EnvironmentUseOptions) er
 	if strings.TrimSpace(opts.Name) == "" {
 		return ExitError{Code: 2, Err: errors.New("environment name required: env use <name>")}
 	}
-	discovered, cfg, err := a.requiredWorkspaceConfig()
+	_, cfg, err := a.requiredWorkspaceConfig()
 	if err != nil {
 		return wrapError(err)
 	}
@@ -2363,21 +2401,19 @@ func (a *App) EnvironmentUse(ctx context.Context, opts EnvironmentUseOptions) er
 	if err != nil {
 		return wrapError(err)
 	}
-	cfg.Organization = organization.Name
-	cfg.Project = project.Name
-	cfg.DefaultEnvironment = environment.Name
-	if _, err := a.ConfigStore.Write(discovered.WorkspaceRoot, cfg); err != nil {
+	if err := a.SetEnvironment(environment.Name); err != nil {
 		return wrapError(err)
 	}
 	_ = a.rememberOrganization(organization.ID)
 	if a.Printer.JSON {
 		return a.Printer.PrintJSON(map[string]any{
-			"schema_version": outputSchemaVersion,
-			"ok":             true,
-			"organization":   organization,
-			"project":        project,
-			"environment":    environment,
-			"config_path":    a.ConfigStore.PathFor(discovered.WorkspaceRoot),
+			"schema_version":      outputSchemaVersion,
+			"ok":                  true,
+			"organization":        organization,
+			"project":             project,
+			"environment":         environment,
+			"workspace_key":       a.modeWorkspaceKey(),
+			"default_environment": cfg.DefaultEnvironment,
 		})
 	}
 	a.Printer.Println("Using environment", environment.Name+".")
@@ -3206,13 +3242,7 @@ func (a *App) resolveWorkspace(ctx context.Context, token, organizationInput, pr
 	if orgInput == "" && existing != nil {
 		orgInput = existing.Organization
 	}
-	resolvedEnvironmentName := strings.TrimSpace(environmentName)
-	if resolvedEnvironmentName == "" && existing != nil {
-		resolvedEnvironmentName = strings.TrimSpace(existing.DefaultEnvironment)
-	}
-	if resolvedEnvironmentName == "" {
-		resolvedEnvironmentName = config.DefaultEnvironment
-	}
+	resolvedEnvironmentName := a.effectiveEnvironment(environmentName, existing)
 
 	var organization api.Organization
 	if autoCreateDefault {
@@ -3307,7 +3337,7 @@ func (a *App) initializeWorkspace(ctx context.Context, callAuth authCall, opts I
 	}
 
 	projectName := firstNonEmpty(opts.ProjectName, safeConfigValue(existing, func(cfg *config.Project) string { return cfg.Project }), discovered.ProjectName)
-	environmentName := firstNonEmpty(opts.Environment, safeConfigValue(existing, func(cfg *config.Project) string { return cfg.DefaultEnvironment }), config.DefaultEnvironment)
+	environmentName := a.effectiveEnvironment(opts.Environment, existing)
 	orgInput := firstNonEmpty(opts.Organization, safeConfigValue(existing, func(cfg *config.Project) string { return cfg.Organization }))
 
 	update("Resolving deploy target…")
@@ -3572,6 +3602,22 @@ func (a *App) requiredWorkspaceConfig() (discovery.Result, config.Project, error
 		return discovery.Result{}, config.Project{}, errors.New("project not initialized. run `devopsellence setup` first")
 	}
 	return discovered, *loaded, nil
+}
+
+func (a *App) resolvedWorkspaceConfig(explicitEnvironment string) (discovery.Result, config.Project, string, error) {
+	discovered, loaded, err := a.optionalWorkspaceConfig()
+	if err != nil {
+		return discovery.Result{}, config.Project{}, "", err
+	}
+	if loaded == nil {
+		return discovery.Result{}, config.Project{}, "", errors.New("project not initialized. run `devopsellence setup` first")
+	}
+	selectedEnvironment := a.effectiveEnvironment(explicitEnvironment, loaded)
+	resolved, err := config.ResolveEnvironmentConfig(*loaded, selectedEnvironment)
+	if err != nil {
+		return discovery.Result{}, config.Project{}, "", err
+	}
+	return discovered, resolved, selectedEnvironment, nil
 }
 
 func (a *App) applyInferredHealthcheckConfig(workspaceRoot string, cfg config.ProjectConfig, initialized *initializedWorkspace, inferredPort int) (config.ProjectConfig, string, string, error) {
@@ -4033,15 +4079,35 @@ func taskPayloads(tasks config.TasksConfig) map[string]any {
 	return payloads
 }
 
-func ingressServicePayload(cfg config.ProjectConfig) string {
+func ingressPayload(cfg config.ProjectConfig) map[string]any {
+	serviceName := ""
 	if cfg.Ingress != nil && strings.TrimSpace(cfg.Ingress.Service) != "" {
-		return strings.TrimSpace(cfg.Ingress.Service)
+		serviceName = strings.TrimSpace(cfg.Ingress.Service)
+	} else if name, ok := cfg.PrimaryWebServiceName(); ok {
+		serviceName = name
 	}
-	name, ok := cfg.PrimaryWebServiceName()
-	if !ok {
-		return ""
+	if serviceName == "" {
+		return nil
 	}
-	return name
+
+	payload := map[string]any{
+		"service": serviceName,
+	}
+	if cfg.Ingress == nil {
+		return payload
+	}
+	if len(cfg.Ingress.Hosts) > 0 {
+		payload["hosts"] = append([]string(nil), cfg.Ingress.Hosts...)
+	}
+	payload["redirect_http"] = cfg.Ingress.RedirectHTTP
+	if tls := map[string]any{
+		"mode":             strings.TrimSpace(cfg.Ingress.TLS.Mode),
+		"email":            strings.TrimSpace(cfg.Ingress.TLS.Email),
+		"ca_directory_url": strings.TrimSpace(cfg.Ingress.TLS.CADirectoryURL),
+	}; tls["mode"] != "" || tls["email"] != "" || tls["ca_directory_url"] != "" {
+		payload["tls"] = tls
+	}
+	return payload
 }
 
 func cloneEnv(env map[string]string) map[string]string {

--- a/cli/internal/workflow/management_test.go
+++ b/cli/internal/workflow/management_test.go
@@ -184,6 +184,9 @@ func TestContextShowJSONIncludesWorkspaceContext(t *testing.T) {
 		"modes": map[string]any{
 			root: "shared",
 		},
+		"environments": map[string]any{
+			root: "production",
+		},
 	}); err != nil {
 		t.Fatalf("write workspace state: %v", err)
 	}
@@ -204,7 +207,10 @@ func TestContextShowJSONIncludesWorkspaceContext(t *testing.T) {
 	if payload["mode"] != "shared" {
 		t.Fatalf("mode = %v, want shared", payload["mode"])
 	}
-	if stringValueAny(payload["organization"]) != "default" || stringValueAny(payload["project"]) != "ShopApp" || stringValueAny(payload["environment"]) != "staging" {
+	if stringValueAny(payload["organization"]) != "default" || stringValueAny(payload["project"]) != "ShopApp" {
+		t.Fatalf("payload = %#v", payload)
+	}
+	if stringValueAny(payload["default_environment"]) != "staging" || stringValueAny(payload["selected_environment"]) != "production" || stringValueAny(payload["environment"]) != "production" {
 		t.Fatalf("payload = %#v", payload)
 	}
 }
@@ -279,7 +285,7 @@ func TestProjectUseUpdatesConfig(t *testing.T) {
 	}
 }
 
-func TestEnvironmentUseUpdatesConfig(t *testing.T) {
+func TestEnvironmentUseUpdatesWorkspaceStateNotConfig(t *testing.T) {
 	t.Parallel()
 
 	root := makeRailsRoot(t, "ShopApp")
@@ -312,8 +318,16 @@ func TestEnvironmentUseUpdatesConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadFromRoot() error = %v", err)
 	}
-	if loaded.DefaultEnvironment != "production" {
-		t.Fatalf("default_environment = %q, want production", loaded.DefaultEnvironment)
+	if loaded.DefaultEnvironment != "staging" {
+		t.Fatalf("default_environment = %q, want staging", loaded.DefaultEnvironment)
+	}
+	state, err := app.WorkspaceState.Read()
+	if err != nil {
+		t.Fatalf("Read() workspace state error = %v", err)
+	}
+	environments, _ := state["environments"].(map[string]any)
+	if stringValueAny(environments[root]) != "production" {
+		t.Fatalf("workspace environments = %#v", environments)
 	}
 }
 
@@ -357,6 +371,121 @@ func TestEnvironmentOpenUsesWorkspaceContext(t *testing.T) {
 	}
 	if opened != "https://shop.example.test" {
 		t.Fatalf("opened = %q, want https://shop.example.test", opened)
+	}
+}
+
+func TestConfigResolvePrintsResolvedEnvironmentConfig(t *testing.T) {
+	t.Parallel()
+
+	root := makeRailsRoot(t, "ShopApp")
+	project := config.DefaultProjectConfig("default", "ShopApp", "production")
+	project.Ingress = &config.IngressConfig{
+		Hosts:   []string{"app.example.test"},
+		Service: "web",
+	}
+	project.Environments = map[string]config.EnvironmentOverlay{
+		"staging": {
+			Ingress: &config.IngressConfigOverlay{
+				Hosts: []string{"staging.example.test"},
+			},
+			Services: map[string]config.ServiceConfigOverlay{
+				"web": {
+					Env: map[string]string{"RAILS_ENV": "staging"},
+				},
+			},
+		},
+	}
+	if _, err := config.Write(root, project); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	app := newTestApp(t, root, roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		return nil, nil
+	}))
+
+	var stdout bytes.Buffer
+	app.Printer.Out = &stdout
+	app.Printer.JSON = true
+	app.Printer.Interactive = false
+
+	if err := app.ConfigResolve(ConfigResolveOptions{Environment: "staging"}); err != nil {
+		t.Fatalf("ConfigResolve() error = %v", err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal config resolve output: %v", err)
+	}
+	if stringValueAny(payload["selected_environment"]) != "staging" {
+		t.Fatalf("selected_environment = %#v", payload["selected_environment"])
+	}
+	configPayload, _ := payload["config"].(map[string]any)
+	if stringValueAny(configPayload["default_environment"]) != "staging" {
+		t.Fatalf("config = %#v", configPayload)
+	}
+	ingress, _ := configPayload["ingress"].(map[string]any)
+	hosts, _ := ingress["hosts"].([]any)
+	if len(hosts) != 1 || stringValueAny(hosts[0]) != "staging.example.test" {
+		t.Fatalf("ingress hosts = %#v", ingress["hosts"])
+	}
+}
+
+func TestStatusUsesSavedWorkspaceEnvironment(t *testing.T) {
+	t.Parallel()
+
+	root := makeRailsRoot(t, "ShopApp")
+	if _, err := config.Write(root, config.DefaultProjectConfig("default", "ShopApp", "staging")); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	app := newTestApp(t, root, roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/cli/organizations":
+			return jsonResponse(t, map[string]any{"organizations": []map[string]any{{"id": 7, "name": "default", "role": "owner"}}}), nil
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/cli/projects":
+			return jsonResponse(t, map[string]any{"projects": []map[string]any{{"id": 11, "name": "ShopApp"}}}), nil
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/cli/projects/11/environments":
+			return jsonResponse(t, map[string]any{"environments": []map[string]any{
+				{"id": 44, "name": "staging"},
+				{"id": 45, "name": "production"},
+			}}), nil
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/cli/environments/45/status":
+			return jsonResponse(t, map[string]any{
+				"organization":   map[string]any{"id": 7, "name": "default"},
+				"project":        map[string]any{"id": 11, "name": "ShopApp"},
+				"environment":    map[string]any{"id": 45, "name": "production"},
+				"assigned_nodes": 0,
+			}), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+			return nil, nil
+		}
+	}))
+	if err := app.WorkspaceState.Write(map[string]any{
+		"environments": map[string]any{
+			root: "production",
+		},
+	}); err != nil {
+		t.Fatalf("write workspace state: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	app.Printer.Out = &stdout
+	app.Printer.JSON = true
+	app.Printer.Interactive = false
+
+	if err := app.Status(context.Background(), StatusOptions{}); err != nil {
+		t.Fatalf("Status() error = %v", err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal status output: %v", err)
+	}
+	environment, _ := payload["environment"].(map[string]any)
+	if stringValueAny(environment["name"]) != "production" {
+		t.Fatalf("environment = %#v", environment)
 	}
 }
 

--- a/cli/internal/workflow/mode.go
+++ b/cli/internal/workflow/mode.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -65,6 +66,22 @@ func (a *App) savedMode() (Mode, bool, error) {
 	return mode, true, nil
 }
 
+func (a *App) savedEnvironment() (string, bool, error) {
+	if a.WorkspaceState == nil {
+		return "", false, nil
+	}
+	current, err := a.WorkspaceState.Read()
+	if err != nil {
+		return "", false, err
+	}
+	environments, _ := current["environments"].(map[string]any)
+	value := stringFromAny(environments[a.modeWorkspaceKey()])
+	if strings.TrimSpace(value) == "" {
+		return "", false, nil
+	}
+	return strings.TrimSpace(value), true, nil
+}
+
 func (a *App) SetMode(mode Mode) error {
 	if a.WorkspaceState == nil {
 		return nil
@@ -78,6 +95,37 @@ func (a *App) SetMode(mode Mode) error {
 		current["modes"] = modes
 		return current, nil
 	})
+}
+
+func (a *App) SetEnvironment(name string) error {
+	if a.WorkspaceState == nil {
+		return nil
+	}
+	return a.WorkspaceState.Update(func(current map[string]any) (map[string]any, error) {
+		environments, _ := current["environments"].(map[string]any)
+		if environments == nil {
+			environments = map[string]any{}
+		}
+		environments[a.modeWorkspaceKey()] = strings.TrimSpace(name)
+		current["environments"] = environments
+		return current, nil
+	})
+}
+
+func (a *App) effectiveEnvironment(explicit string, cfg *config.Project) string {
+	if strings.TrimSpace(explicit) != "" {
+		return strings.TrimSpace(explicit)
+	}
+	if value := strings.TrimSpace(os.Getenv("DEVOPSELLENCE_ENVIRONMENT")); value != "" {
+		return value
+	}
+	if saved, ok, err := a.savedEnvironment(); err == nil && ok {
+		return saved
+	}
+	if cfg != nil && strings.TrimSpace(cfg.DefaultEnvironment) != "" {
+		return strings.TrimSpace(cfg.DefaultEnvironment)
+	}
+	return config.DefaultEnvironment
 }
 
 func (a *App) suggestedMode() Mode {
@@ -192,8 +240,11 @@ func (a *App) ContextShow() error {
 	if cfg != nil {
 		result["organization"] = cfg.Organization
 		result["project"] = cfg.Project
-		result["environment"] = cfg.DefaultEnvironment
+		result["default_environment"] = cfg.DefaultEnvironment
 	}
+	selectedEnvironment := a.effectiveEnvironment("", cfg)
+	result["environment"] = selectedEnvironment
+	result["selected_environment"] = selectedEnvironment
 	if a.Printer.JSON {
 		return a.Printer.PrintJSON(result)
 	}
@@ -202,7 +253,8 @@ func (a *App) ContextShow() error {
 		{Label: "Mode", Value: firstNonEmpty(string(mode), "not set")},
 		{Label: "Organization", Value: safeConfigValue(cfg, func(value *config.Project) string { return value.Organization })},
 		{Label: "Project", Value: safeConfigValue(cfg, func(value *config.Project) string { return value.Project })},
-		{Label: "Environment", Value: safeConfigValue(cfg, func(value *config.Project) string { return value.DefaultEnvironment })},
+		{Label: "Default Env", Value: safeConfigValue(cfg, func(value *config.Project) string { return value.DefaultEnvironment })},
+		{Label: "Selected Env", Value: selectedEnvironment},
 	}
 	a.Printer.Println(ui.RenderCard(ui.Card{Title: "Context", Rows: rows}))
 	if !ok {

--- a/cli/internal/workflow/root.go
+++ b/cli/internal/workflow/root.go
@@ -371,6 +371,22 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 	contextCommand.AddCommand(envCommand)
 	root.AddCommand(contextCommand)
 
+	var configResolveOpts ConfigResolveOptions
+	configCommand := &cobra.Command{
+		Use:   "config",
+		Short: "Inspect resolved workspace config",
+	}
+	configResolveCommand := &cobra.Command{
+		Use:   "resolve",
+		Short: "Print the resolved config for one environment",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return app.ConfigResolve(configResolveOpts)
+		},
+	}
+	configResolveCommand.Flags().StringVar(&configResolveOpts.Environment, "env", "", "Environment name override")
+	configCommand.AddCommand(configResolveCommand)
+	root.AddCommand(configCommand)
+
 	authCommand := &cobra.Command{Use: "auth", Short: "Manage sign-in and API tokens"}
 	authCommand.AddCommand(&cobra.Command{
 		Use:   "login",

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1733,7 +1733,7 @@ func (a *App) IngressSet(_ context.Context, opts IngressSetOptions) error {
 			Email:          strings.TrimSpace(opts.TLSEmail),
 			CADirectoryURL: strings.TrimSpace(opts.TLSCADirectoryURL),
 		},
-		RedirectHTTP: redirectHTTP,
+		RedirectHTTP: configBoolPtr(redirectHTTP),
 	}
 	written, err := a.ConfigStore.Write(discovered.WorkspaceRoot, *cfg)
 	if err != nil {
@@ -1910,6 +1910,10 @@ func soloDefaultProjectConfig(discovered discovery.Result) *config.ProjectConfig
 		}
 	}
 	return &cfg
+}
+
+func configBoolPtr(value bool) *bool {
+	return &value
 }
 
 type ingressDNSReportResult struct {

--- a/control-plane/app/controllers/api/v1/agent/ingress_certificates_controller.rb
+++ b/control-plane/app/controllers/api/v1/agent/ingress_certificates_controller.rb
@@ -16,7 +16,7 @@ module Api
 
           ingress = current_environment.environment_ingress
           return render_error("invalid_request", "environment ingress is not provisioned", status: :unprocessable_entity) unless ingress
-          return render_error("invalid_request", "hostname mismatch", status: :unprocessable_entity) unless ingress.hostname == hostname
+          return render_error("invalid_request", "hostname mismatch", status: :unprocessable_entity) unless ingress.hostname_matches?(hostname)
 
           result = nil
           ingress.with_lock do

--- a/control-plane/app/controllers/api/v1/cli/deployments_controller.rb
+++ b/control-plane/app/controllers/api/v1/cli/deployments_controller.rb
@@ -94,8 +94,10 @@ module Api
           return nil unless ingress
 
           {
-            hostname: ingress.hostname,
+            hostname: ingress.primary_hostname,
+            hosts: ingress.hosts,
             public_url: ingress.public_url,
+            public_urls: ingress.public_urls,
             status: ingress.status
           }
         end

--- a/control-plane/app/controllers/api/v1/cli/environment_statuses_controller.rb
+++ b/control-plane/app/controllers/api/v1/cli/environment_statuses_controller.rb
@@ -84,8 +84,10 @@ module Api
           return nil unless ingress
 
           {
-            hostname: ingress.hostname,
+            hostname: ingress.primary_hostname,
+            hosts: ingress.hosts,
             public_url: ingress.public_url,
+            public_urls: ingress.public_urls,
             status: ingress.status,
             last_error: ingress.last_error
           }

--- a/control-plane/app/controllers/api/v1/cli/releases_controller.rb
+++ b/control-plane/app/controllers/api/v1/cli/releases_controller.rb
@@ -61,8 +61,10 @@ module Api
             warning: assignment_warning_for(environment, assigned_nodes),
             trial_expires_at: environment.nodes.maximum(:lease_expires_at)&.utc&.iso8601,
             ingress_strategy: environment.ingress_strategy,
-            hostname: environment.environment_ingress&.hostname,
+            hostname: environment.environment_ingress&.primary_hostname,
+            hosts: environment.environment_ingress&.hosts || [],
             public_url: environment.environment_ingress&.public_url,
+            public_urls: environment.environment_ingress&.public_urls || [],
             ingress_status: environment.environment_ingress&.status,
             ingress: serialize_ingress(environment.environment_ingress)
           }, status: :created
@@ -111,7 +113,7 @@ module Api
               revision: params[:revision],
               services: params[:services],
               tasks: params[:tasks],
-              ingress_service: params[:ingress_service],
+              ingress: params[:ingress],
               healthcheck_interval_seconds: params[:healthcheck_interval_seconds],
               healthcheck_timeout_seconds: params[:healthcheck_timeout_seconds]
             }
@@ -122,8 +124,10 @@ module Api
           return nil unless ingress
 
           {
-            hostname: ingress.hostname,
+            hostname: ingress.primary_hostname,
+            hosts: ingress.hosts,
             public_url: ingress.public_url,
+            public_urls: ingress.public_urls,
             status: ingress.status,
             last_error: ingress.last_error
           }

--- a/control-plane/app/models/concerns/ingress_hostnames.rb
+++ b/control-plane/app/models/concerns/ingress_hostnames.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module IngressHostnames
+  module_function
+
+  def normalize(value)
+    value.to_s.strip.downcase
+  end
+
+  def normalize_all(values)
+    Array(values).map { |entry| normalize(entry) }.reject(&:blank?).uniq
+  end
+end

--- a/control-plane/app/models/environment_ingress.rb
+++ b/control-plane/app/models/environment_ingress.rb
@@ -91,7 +91,7 @@ class EnvironmentIngress < ApplicationRecord
     end
 
     def normalize_host(value)
-      value.to_s.strip.downcase
+      IngressHostnames.normalize(value)
     end
 
     def ensure_primary_host_record!

--- a/control-plane/app/models/environment_ingress.rb
+++ b/control-plane/app/models/environment_ingress.rb
@@ -14,15 +14,32 @@ class EnvironmentIngress < ApplicationRecord
   ].freeze
 
   belongs_to :environment
+  has_many :environment_ingress_hosts, -> { order(:position, :id) }, dependent: :destroy
 
   before_validation :assign_gcp_secret_name
+  after_commit :ensure_primary_host_record!, on: [ :create, :update ]
 
   validates :hostname, presence: true, uniqueness: true
   validates :gcp_secret_name, presence: true, uniqueness: true
   validates :status, inclusion: { in: STATUSES }
 
+  def hosts
+    persisted = environment_ingress_hosts.map { |entry| entry.hostname.to_s.strip }.reject(&:blank?)
+    return persisted if persisted.any?
+
+    hostname.to_s.strip.present? ? [ hostname.to_s.strip ] : []
+  end
+
+  def public_urls
+    hosts.map { |host| Devopsellence::IngressConfig.public_url(host) }.compact
+  end
+
+  def primary_hostname
+    hosts.first
+  end
+
   def public_url
-    Devopsellence::IngressConfig.public_url(hostname)
+    Devopsellence::IngressConfig.public_url(primary_hostname)
   end
 
   def tunnel_token_secret_ref
@@ -48,7 +65,36 @@ class EnvironmentIngress < ApplicationRecord
     status == STATUS_DEGRADED
   end
 
+  def hostname_matches?(candidate)
+    hosts.include?(candidate.to_s.strip)
+  end
+
+  def assign_hosts!(values)
+    normalized = normalize_hosts(values)
+    raise ArgumentError, "hosts must include at least one host" if normalized.empty?
+
+    transaction do
+      update!(hostname: normalized.first)
+      environment_ingress_hosts.destroy_all
+      normalized.each_with_index do |entry, index|
+        environment_ingress_hosts.create!(hostname: entry, position: index)
+      end
+    end
+    reload
+  end
+
   private
+    def normalize_hosts(values)
+      Array(values).map { |entry| entry.to_s.strip }.reject(&:blank?).uniq
+    end
+
+    def ensure_primary_host_record!
+      return unless hostname.to_s.strip.present?
+      return if environment_ingress_hosts.exists?(hostname: hostname)
+
+      assign_hosts!([ hostname ])
+    end
+
     def assign_gcp_secret_name
       return if gcp_secret_name.present? || environment.blank?
 

--- a/control-plane/app/models/environment_ingress.rb
+++ b/control-plane/app/models/environment_ingress.rb
@@ -17,6 +17,7 @@ class EnvironmentIngress < ApplicationRecord
   has_many :environment_ingress_hosts, -> { order(:position, :id) }, dependent: :destroy
 
   before_validation :assign_gcp_secret_name
+  before_validation :normalize_hostname!
   after_commit :ensure_primary_host_record!, on: [ :create, :update ]
 
   validates :hostname, presence: true, uniqueness: true
@@ -24,10 +25,11 @@ class EnvironmentIngress < ApplicationRecord
   validates :status, inclusion: { in: STATUSES }
 
   def hosts
-    persisted = environment_ingress_hosts.map { |entry| entry.hostname.to_s.strip }.reject(&:blank?)
+    persisted = environment_ingress_hosts.map { |entry| normalize_host(entry.hostname) }.reject(&:blank?)
     return persisted if persisted.any?
 
-    hostname.to_s.strip.present? ? [ hostname.to_s.strip ] : []
+    normalized_hostname = normalize_host(hostname)
+    normalized_hostname.present? ? [ normalized_hostname ] : []
   end
 
   def public_urls
@@ -66,7 +68,7 @@ class EnvironmentIngress < ApplicationRecord
   end
 
   def hostname_matches?(candidate)
-    hosts.include?(candidate.to_s.strip)
+    hosts.include?(normalize_host(candidate))
   end
 
   def assign_hosts!(values)
@@ -85,14 +87,23 @@ class EnvironmentIngress < ApplicationRecord
 
   private
     def normalize_hosts(values)
-      Array(values).map { |entry| entry.to_s.strip }.reject(&:blank?).uniq
+      Array(values).map { |entry| normalize_host(entry) }.reject(&:blank?).uniq
+    end
+
+    def normalize_host(value)
+      value.to_s.strip.downcase
     end
 
     def ensure_primary_host_record!
-      return unless hostname.to_s.strip.present?
-      return if environment_ingress_hosts.exists?(hostname: hostname)
+      normalized_hostname = normalize_host(hostname)
+      return if normalized_hostname.blank?
+      return if environment_ingress_hosts.exists?(hostname: normalized_hostname)
 
-      assign_hosts!([ hostname ])
+      assign_hosts!([ normalized_hostname ])
+    end
+
+    def normalize_hostname!
+      self.hostname = normalize_host(hostname)
     end
 
     def assign_gcp_secret_name

--- a/control-plane/app/models/environment_ingress_host.rb
+++ b/control-plane/app/models/environment_ingress_host.rb
@@ -3,6 +3,13 @@
 class EnvironmentIngressHost < ApplicationRecord
   belongs_to :environment_ingress
 
+  before_validation :normalize_hostname!
+
   validates :hostname, presence: true, uniqueness: true
   validates :position, numericality: { greater_than_or_equal_to: 0 }
+
+  private
+    def normalize_hostname!
+      self.hostname = hostname.to_s.strip.downcase
+    end
 end

--- a/control-plane/app/models/environment_ingress_host.rb
+++ b/control-plane/app/models/environment_ingress_host.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class EnvironmentIngressHost < ApplicationRecord
+  belongs_to :environment_ingress
+
+  validates :hostname, presence: true, uniqueness: true
+  validates :position, numericality: { greater_than_or_equal_to: 0 }
+end

--- a/control-plane/app/models/environment_ingress_host.rb
+++ b/control-plane/app/models/environment_ingress_host.rb
@@ -10,6 +10,6 @@ class EnvironmentIngressHost < ApplicationRecord
 
   private
     def normalize_hostname!
-      self.hostname = hostname.to_s.strip.downcase
+      self.hostname = IngressHostnames.normalize(hostname)
     end
 end

--- a/control-plane/app/models/release.rb
+++ b/control-plane/app/models/release.rb
@@ -66,12 +66,7 @@ class Release < ApplicationRecord
 
   def ingress_config
     ingress = runtime_payload["ingress"]
-    return ingress if ingress.is_a?(Hash)
-
-    legacy_service = runtime_payload["ingress_service"].to_s.strip
-    return nil if legacy_service.blank?
-
-    { "service" => legacy_service }
+    ingress.is_a?(Hash) ? ingress : nil
   end
 
   def has_release_task?
@@ -277,6 +272,11 @@ class Release < ApplicationRecord
   end
 
   def validate_ingress_config
+    if runtime_payload.key?("ingress") && !runtime_payload["ingress"].is_a?(Hash)
+      errors.add(:runtime_json, "ingress must decode to an object")
+      return
+    end
+
     ingress = ingress_config
     if ingress.nil?
       if web_service_names.length > 1

--- a/control-plane/app/models/release.rb
+++ b/control-plane/app/models/release.rb
@@ -289,7 +289,7 @@ class Release < ApplicationRecord
     unless hosts.nil? || string_array?(hosts)
       errors.add(:runtime_json, "ingress.hosts must be an array of strings")
     end
-    if string_array?(hosts) && hosts.uniq.length != hosts.length
+    if string_array?(hosts) && IngressHostnames.normalize_all(hosts).length != hosts.length
       errors.add(:runtime_json, "ingress.hosts must be unique")
     end
 

--- a/control-plane/app/models/release.rb
+++ b/control-plane/app/models/release.rb
@@ -64,6 +64,11 @@ class Release < ApplicationRecord
     task.is_a?(Hash) ? task : nil
   end
 
+  def ingress_config
+    ingress = runtime_payload["ingress"]
+    ingress.is_a?(Hash) ? ingress : nil
+  end
+
   def has_release_task?
     release_task_config.present?
   end
@@ -93,14 +98,7 @@ class Release < ApplicationRecord
   end
 
   def ingress_service_name
-    configured = runtime_payload["ingress_service"].to_s.strip
-    return configured if configured.present?
-
-    names = web_service_names
-    return "web" if names.include?("web")
-    return names.first if names.one?
-
-    nil
+    ingress_config&.dig("service").to_s.strip.presence
   end
 
   def scheduled_services_for(node:)
@@ -169,7 +167,7 @@ class Release < ApplicationRecord
     end
 
     validate_release_task
-    validate_ingress_service
+    validate_ingress_config
   end
 
   def validate_service_config(name, service)
@@ -273,21 +271,53 @@ class Release < ApplicationRecord
     end
   end
 
-  def validate_ingress_service
-    name = ingress_service_name
-    if name.blank? && web_service_names.length > 1
-      errors.add(:runtime_json, "ingress_service is required when multiple web services are defined")
+  def validate_ingress_config
+    ingress = ingress_config
+    if ingress.nil?
+      if web_service_names.length > 1
+        errors.add(:runtime_json, "ingress.service is required when multiple web services are defined")
+      end
       return
     end
-    return if name.blank?
+
+    hosts = ingress["hosts"]
+    unless hosts.nil? || string_array?(hosts)
+      errors.add(:runtime_json, "ingress.hosts must be an array of strings")
+    end
+    if string_array?(hosts) && hosts.uniq.length != hosts.length
+      errors.add(:runtime_json, "ingress.hosts must be unique")
+    end
+
+    name = ingress["service"].to_s.strip
+    if name.blank?
+      errors.add(:runtime_json, "ingress.service is required")
+      return
+    end
 
     service = services_config[name]
     if service.blank?
-      errors.add(:runtime_json, "ingress_service must reference an existing service")
+      errors.add(:runtime_json, "ingress.service must reference an existing service")
       return
     end
     if service_kind(service) != "web"
-      errors.add(:runtime_json, "ingress_service must reference a web service")
+      errors.add(:runtime_json, "ingress.service must reference a web service")
+    end
+
+    tls = ingress["tls"]
+    unless tls.nil? || tls.is_a?(Hash)
+      errors.add(:runtime_json, "ingress.tls must be an object")
+      return
+    end
+    if tls.is_a?(Hash)
+      mode = tls["mode"].to_s.strip
+      if mode.present? && ![ "auto", "off", "manual" ].include?(mode)
+        errors.add(:runtime_json, "ingress.tls.mode must be auto, off, or manual")
+      end
+    end
+
+    redirect_http = ingress["redirect_http"]
+    unless redirect_http.nil? || redirect_http == true || redirect_http == false
+      errors.add(:runtime_json, "ingress.redirect_http must be a boolean")
     end
   end
 
@@ -314,14 +344,21 @@ class Release < ApplicationRecord
       assert_supported_runtime_service!(name, service)
     end
 
-    return unless tasks_config.key?("release")
+    if tasks_config.key?("release")
+      task = tasks_config["release"]
+      raise InvalidRuntimeConfig, "tasks.release must decode to an object" unless task.is_a?(Hash)
 
-    task = tasks_config["release"]
-    raise InvalidRuntimeConfig, "tasks.release must decode to an object" unless task.is_a?(Hash)
+      assert_deprecated_runtime_key_absent!(task, deprecated_key: "entrypoint", field: "tasks.release.entrypoint")
+      assert_runtime_string_array!(task["command"], field: "tasks.release.command")
+      assert_runtime_string_array!(task["args"], field: "tasks.release.args")
+    end
 
-    assert_deprecated_runtime_key_absent!(task, deprecated_key: "entrypoint", field: "tasks.release.entrypoint")
-    assert_runtime_string_array!(task["command"], field: "tasks.release.command")
-    assert_runtime_string_array!(task["args"], field: "tasks.release.args")
+    return unless runtime_payload.key?("ingress")
+
+    ingress = runtime_payload["ingress"]
+    raise InvalidRuntimeConfig, "ingress must decode to an object" unless ingress.is_a?(Hash)
+
+    assert_runtime_string_array!(ingress["hosts"], field: "ingress.hosts")
   end
 
   def assert_supported_runtime_service!(name, service)

--- a/control-plane/app/models/release.rb
+++ b/control-plane/app/models/release.rb
@@ -66,7 +66,12 @@ class Release < ApplicationRecord
 
   def ingress_config
     ingress = runtime_payload["ingress"]
-    ingress.is_a?(Hash) ? ingress : nil
+    return ingress if ingress.is_a?(Hash)
+
+    legacy_service = runtime_payload["ingress_service"].to_s.strip
+    return nil if legacy_service.blank?
+
+    { "service" => legacy_service }
   end
 
   def has_release_task?

--- a/control-plane/app/services/cloudflare/environment_ingress_provisioner.rb
+++ b/control-plane/app/services/cloudflare/environment_ingress_provisioner.rb
@@ -5,13 +5,14 @@ require "securerandom"
 module Cloudflare
   class EnvironmentIngressProvisioner
     def initialize(environment:, client: RestClient.new, secret_manager: Gcp::EnvironmentSecretManager.new,
-      hostname_generator: nil, origin_service: Devopsellence::IngressConfig.envoy_origin, release: nil)
+      hostname_generator: nil, origin_service: Devopsellence::IngressConfig.envoy_origin, release: nil, stale_hosts: [])
       @environment = environment
       @client = client
       @secret_manager = secret_manager
       @hostname_generator = hostname_generator || -> { SecureRandom.alphanumeric(EnvironmentIngress::HOSTNAME_LENGTH).downcase }
       @origin_service = origin_service
       @release = release || environment.current_release
+      @stale_hosts = stale_hosts
     end
 
     def call
@@ -40,7 +41,7 @@ module Cloudflare
       end
 
       if ingress.primary_hostname.present? && ingress.cloudflare_tunnel_id.present?
-        ensure_managed_tunnel_routing!(ingress, stale_hosts: previous_hosts - ingress.hosts)
+        ensure_managed_tunnel_routing!(ingress, stale_hosts: removed_hosts(previous_hosts, ingress))
         mark_ingress_ready!(ingress)
         return ingress
       end
@@ -49,7 +50,7 @@ module Cloudflare
       tunnel_token = client.tunnel_token(tunnel_id: tunnel.fetch("id"))
 
       ingress.cloudflare_tunnel_id = tunnel.fetch("id")
-      ensure_managed_tunnel_routing!(ingress, stale_hosts: previous_hosts - ingress.hosts)
+      ensure_managed_tunnel_routing!(ingress, stale_hosts: removed_hosts(previous_hosts, ingress))
       mark_ingress_ready!(ingress, provisioned_at: Time.current)
       secret_manager.upsert_ingress_token!(environment_ingress: ingress, value: tunnel_token)
       ingress
@@ -65,7 +66,7 @@ module Cloudflare
 
     private
 
-    attr_reader :environment, :client, :secret_manager, :hostname_generator, :origin_service, :release
+    attr_reader :environment, :client, :secret_manager, :hostname_generator, :origin_service, :release, :stale_hosts
 
     def next_hostname!
       20.times do
@@ -121,6 +122,10 @@ module Cloudflare
       return [ environment.environment_bundle.hostname ] if environment.environment_bundle&.hostname.present?
 
       [ next_hostname! ]
+    end
+
+    def removed_hosts(previous_hosts, ingress)
+      ((previous_hosts - ingress.hosts) | stale_hosts).uniq
     end
   end
 end

--- a/control-plane/app/services/cloudflare/environment_ingress_provisioner.rb
+++ b/control-plane/app/services/cloudflare/environment_ingress_provisioner.rb
@@ -116,7 +116,7 @@ module Cloudflare
     end
 
     def desired_hosts_for(ingress)
-      configured = Array(release&.ingress_config&.dig("hosts")).map(&:to_s).map(&:strip).reject(&:blank?).uniq
+      configured = IngressHostnames.normalize_all(release&.ingress_config&.dig("hosts"))
       return configured if configured.any?
       return ingress.hosts if ingress.hosts.any?
       return [ environment.environment_bundle.hostname ] if environment.environment_bundle&.hostname.present?

--- a/control-plane/app/services/cloudflare/environment_ingress_provisioner.rb
+++ b/control-plane/app/services/cloudflare/environment_ingress_provisioner.rb
@@ -5,29 +5,30 @@ require "securerandom"
 module Cloudflare
   class EnvironmentIngressProvisioner
     def initialize(environment:, client: RestClient.new, secret_manager: Gcp::EnvironmentSecretManager.new,
-      hostname_generator: nil, origin_service: Devopsellence::IngressConfig.envoy_origin)
+      hostname_generator: nil, origin_service: Devopsellence::IngressConfig.envoy_origin, release: nil)
       @environment = environment
       @client = client
       @secret_manager = secret_manager
       @hostname_generator = hostname_generator || -> { SecureRandom.alphanumeric(EnvironmentIngress::HOSTNAME_LENGTH).downcase }
       @origin_service = origin_service
+      @release = release || environment.current_release
     end
 
     def call
       ingress = environment.environment_ingress || environment.build_environment_ingress(status: EnvironmentIngress::STATUS_PENDING)
+      previous_hosts = ingress.hosts
       if environment.environment_bundle&.hostname.present? && environment.environment_bundle&.cloudflare_tunnel_id.present?
-        ingress.hostname = environment.environment_bundle.hostname
         ingress.cloudflare_tunnel_id = environment.environment_bundle.cloudflare_tunnel_id
         ingress.gcp_secret_name = environment.environment_bundle.gcp_secret_name
         ingress.provisioned_at ||= environment.environment_bundle.provisioned_at || Time.current
-        ingress.save! if ingress.new_record? || ingress.changed?
       end
 
-      hostname = ingress.hostname.presence || next_hostname!
-      ingress.hostname = hostname
+      hosts = desired_hosts_for(ingress)
+      ingress.hostname = hosts.first
       ingress.gcp_secret_name ||= environment.environment_bundle&.gcp_secret_name || "env-#{environment.id}-ingress-cloudflare-tunnel-token"
       ingress.status = EnvironmentIngress::STATUS_PENDING
       ingress.save! if ingress.new_record? || ingress.changed?
+      ingress.assign_hosts!(hosts) if hosts != ingress.hosts
 
       if Devopsellence::IngressConfig.local?
         ingress.cloudflare_tunnel_id = ingress.cloudflare_tunnel_id.presence || "local-env-#{environment.id}"
@@ -38,17 +39,17 @@ module Cloudflare
         return ingress
       end
 
-      if ingress.hostname.present? && ingress.cloudflare_tunnel_id.present?
-        ensure_managed_tunnel_routing!(ingress)
+      if ingress.primary_hostname.present? && ingress.cloudflare_tunnel_id.present?
+        ensure_managed_tunnel_routing!(ingress, stale_hosts: previous_hosts - ingress.hosts)
         mark_ingress_ready!(ingress)
         return ingress
       end
 
-      tunnel = client.create_tunnel(name: tunnel_name(hostname))
+      tunnel = client.create_tunnel(name: tunnel_name(ingress.primary_hostname))
       tunnel_token = client.tunnel_token(tunnel_id: tunnel.fetch("id"))
 
       ingress.cloudflare_tunnel_id = tunnel.fetch("id")
-      ensure_managed_tunnel_routing!(ingress)
+      ensure_managed_tunnel_routing!(ingress, stale_hosts: previous_hosts - ingress.hosts)
       mark_ingress_ready!(ingress, provisioned_at: Time.current)
       secret_manager.upsert_ingress_token!(environment_ingress: ingress, value: tunnel_token)
       ingress
@@ -64,12 +65,12 @@ module Cloudflare
 
     private
 
-    attr_reader :environment, :client, :secret_manager, :hostname_generator, :origin_service
+    attr_reader :environment, :client, :secret_manager, :hostname_generator, :origin_service, :release
 
     def next_hostname!
       20.times do
         hostname = "#{hostname_generator.call}.#{zone_name}"
-        return hostname unless EnvironmentIngress.exists?(hostname: hostname)
+        return hostname unless EnvironmentIngressHost.exists?(hostname: hostname) || EnvironmentIngress.exists?(hostname: hostname)
       end
 
       raise "failed to allocate a unique ingress hostname"
@@ -87,15 +88,23 @@ module Cloudflare
       Devopsellence::IngressConfig.hostname_zone_name
     end
 
-    def ensure_managed_tunnel_routing!(ingress)
-      client.delete_dns_records(hostname: ingress.hostname, type: "A")
-      client.delete_dns_records(hostname: ingress.hostname, type: "CNAME")
+    def ensure_managed_tunnel_routing!(ingress, stale_hosts: [])
+      stale_hosts.each do |host|
+        client.delete_dns_records(hostname: host, type: "A")
+        client.delete_dns_records(hostname: host, type: "CNAME")
+      end
+      ingress.hosts.each do |host|
+        client.delete_dns_records(hostname: host, type: "A")
+        client.delete_dns_records(hostname: host, type: "CNAME")
+      end
       client.configure_tunnel(
         tunnel_id: ingress.cloudflare_tunnel_id,
-        hostname: ingress.hostname,
+        hostnames: ingress.hosts,
         service: origin_service
       )
-      client.create_dns_cname(hostname: ingress.hostname, target: "#{ingress.cloudflare_tunnel_id}.cfargotunnel.com")
+      ingress.hosts.each do |host|
+        client.create_dns_cname(hostname: host, target: "#{ingress.cloudflare_tunnel_id}.cfargotunnel.com")
+      end
     end
 
     def mark_ingress_ready!(ingress, provisioned_at: ingress.provisioned_at || Time.current)
@@ -103,6 +112,15 @@ module Cloudflare
       ingress.last_error = nil
       ingress.provisioned_at ||= provisioned_at
       ingress.save!
+    end
+
+    def desired_hosts_for(ingress)
+      configured = Array(release&.ingress_config&.dig("hosts")).map(&:to_s).map(&:strip).reject(&:blank?).uniq
+      return configured if configured.any?
+      return ingress.hosts if ingress.hosts.any?
+      return [ environment.environment_bundle.hostname ] if environment.environment_bundle&.hostname.present?
+
+      [ next_hostname! ]
     end
   end
 end

--- a/control-plane/app/services/cloudflare/rest_client.rb
+++ b/control-plane/app/services/cloudflare/rest_client.rb
@@ -40,13 +40,13 @@ module Cloudflare
       result.fetch("token")
     end
 
-    def configure_tunnel(tunnel_id:, hostname:, service:)
+    def configure_tunnel(tunnel_id:, service:, hostname: nil, hostnames: nil)
+      routes = Array(hostnames.presence || hostname).map do |entry|
+        { hostname: entry, service: service }
+      end
       request(:put, "/accounts/#{account_id}/cfd_tunnel/#{tunnel_id}/configurations", payload: {
         config: {
-          ingress: [
-            { hostname: hostname, service: service },
-            { service: "http_status:404" }
-          ]
+          ingress: routes + [ { service: "http_status:404" } ]
         }
       })
     end

--- a/control-plane/app/services/deployments/publisher.rb
+++ b/control-plane/app/services/deployments/publisher.rb
@@ -116,11 +116,17 @@ module Deployments
     end
 
     def ingress_ready?
-      environment.environment_ingress&.status == EnvironmentIngress::STATUS_READY
+      ingress = environment.environment_ingress
+      return false unless ingress&.status == EnvironmentIngress::STATUS_READY
+
+      desired_hosts = Array(release.ingress_config&.dig("hosts")).map(&:to_s).map(&:strip).reject(&:blank?).uniq
+      return true if desired_hosts.empty?
+
+      ingress.hosts == desired_hosts
     end
 
     def provision_ingress!
-      EnvironmentIngresses::Reconciler.new(environment: environment).call
+      EnvironmentIngresses::Reconciler.new(environment: environment, release: release).call
       environment.association(:environment_ingress).reset
     end
 

--- a/control-plane/app/services/deployments/publisher.rb
+++ b/control-plane/app/services/deployments/publisher.rb
@@ -119,7 +119,7 @@ module Deployments
       ingress = environment.environment_ingress
       return false unless ingress&.status == EnvironmentIngress::STATUS_READY
 
-      desired_hosts = Array(release.ingress_config&.dig("hosts")).map(&:to_s).map(&:strip).reject(&:blank?).uniq
+      desired_hosts = IngressHostnames.normalize_all(release.ingress_config&.dig("hosts"))
       return true if desired_hosts.empty?
 
       ingress.hosts == desired_hosts

--- a/control-plane/app/services/environment_bundles/claim.rb
+++ b/control-plane/app/services/environment_bundles/claim.rb
@@ -83,6 +83,7 @@ module EnvironmentBundles
         ingress.last_error = nil
         ingress.provisioned_at = bundle.provisioned_at || Time.current
         ingress.save!
+        ingress.assign_hosts!([ bundle.hostname ])
       end
     end
   end

--- a/control-plane/app/services/environment_bundles/provisioner.rb
+++ b/control-plane/app/services/environment_bundles/provisioner.rb
@@ -70,7 +70,9 @@ module EnvironmentBundles
       zone = hostname_zone_name
       20.times do
         candidate = "#{SecureRandom.alphanumeric(EnvironmentIngress::HOSTNAME_LENGTH).downcase}.#{zone}"
-        return candidate unless EnvironmentIngress.exists?(hostname: candidate) || EnvironmentBundle.exists?(hostname: candidate)
+        return candidate unless EnvironmentIngressHost.exists?(hostname: candidate) ||
+          EnvironmentIngress.exists?(hostname: candidate) ||
+          EnvironmentBundle.exists?(hostname: candidate)
       end
       raise "failed to allocate a unique bundle ingress hostname"
     end

--- a/control-plane/app/services/environment_ingresses/direct_dns_strategy.rb
+++ b/control-plane/app/services/environment_ingresses/direct_dns_strategy.rb
@@ -2,14 +2,15 @@
 
 module EnvironmentIngresses
   class DirectDnsStrategy
-    def initialize(environment:, ingress:, client: Cloudflare::RestClient.new)
+    def initialize(environment:, ingress:, client: Cloudflare::RestClient.new, stale_hosts: [])
       @environment = environment
       @ingress = ingress
       @client = client
+      @stale_hosts = stale_hosts
     end
 
     def call
-      raise "environment ingress hostname is required" if ingress.hostname.blank?
+      raise "environment ingress hosts are required" if ingress.hosts.empty?
 
       addresses = EligibleNodes.new(environment:).call.map(&:public_ip).uniq.sort
 
@@ -35,11 +36,17 @@ module EnvironmentIngresses
 
     private
 
-    attr_reader :environment, :ingress, :client
+    attr_reader :environment, :ingress, :client, :stale_hosts
 
     def cutover_to_direct_dns!(addresses)
-      client.delete_dns_records(hostname: ingress.hostname, type: "CNAME")
-      client.replace_dns_a_records(hostname: ingress.hostname, addresses:)
+      stale_hosts.each do |host|
+        client.delete_dns_records(hostname: host, type: "A")
+        client.delete_dns_records(hostname: host, type: "CNAME")
+      end
+      ingress.hosts.each do |host|
+        client.delete_dns_records(hostname: host, type: "CNAME")
+        client.replace_dns_a_records(hostname: host, addresses:)
+      end
     rescue StandardError
       restore_tunnel_routing!
       raise
@@ -48,11 +55,13 @@ module EnvironmentIngresses
     def restore_tunnel_routing!
       return if ingress.cloudflare_tunnel_id.to_s.strip.empty?
 
-      client.delete_dns_records(hostname: ingress.hostname, type: "A")
-      client.create_dns_cname(
-        hostname: ingress.hostname,
-        target: "#{ingress.cloudflare_tunnel_id}.cfargotunnel.com"
-      )
+      ingress.hosts.each do |host|
+        client.delete_dns_records(hostname: host, type: "A")
+        client.create_dns_cname(
+          hostname: host,
+          target: "#{ingress.cloudflare_tunnel_id}.cfargotunnel.com"
+        )
+      end
     rescue StandardError
       nil
     end

--- a/control-plane/app/services/environment_ingresses/reconciler.rb
+++ b/control-plane/app/services/environment_ingresses/reconciler.rb
@@ -2,42 +2,63 @@
 
 module EnvironmentIngresses
   class Reconciler
-    def initialize(environment:, client: Cloudflare::RestClient.new)
+    def initialize(environment:, client: Cloudflare::RestClient.new, release: nil)
       @environment = environment
       @client = client
+      @release = release || environment.current_release
     end
 
     def call
-      ingress = ensure_ingress!
+      ingress, stale_hosts = ensure_ingress!
       return nil unless ingress
 
       if environment.direct_dns_ingress?
-        DirectDnsStrategy.new(environment:, ingress:, client:).call
+        DirectDnsStrategy.new(environment:, ingress:, client:, stale_hosts:).call
       else
-        Cloudflare::EnvironmentIngressProvisioner.new(environment:, client:).call
+        Cloudflare::EnvironmentIngressProvisioner.new(environment:, client:, release:).call
       end
     end
 
     private
 
-    attr_reader :environment, :client
+    attr_reader :environment, :client, :release
 
     def ensure_ingress!
       ingress = environment.environment_ingress
-      return ingress if ingress
+      previous_hosts = ingress&.hosts || []
+      return [ sync_ingress_hosts!(ingress), previous_hosts - ingress.hosts ] if ingress
 
       bundle = environment.environment_bundle
       if bundle&.hostname.present?
-        return environment.create_environment_ingress!(
+        ingress = environment.create_environment_ingress!(
           hostname: bundle.hostname,
           cloudflare_tunnel_id: bundle.cloudflare_tunnel_id,
           gcp_secret_name: bundle.gcp_secret_name,
           status: environment.direct_dns_ingress? ? EnvironmentIngress::STATUS_PENDING : EnvironmentIngress::STATUS_READY,
           provisioned_at: bundle.provisioned_at || Time.current
         )
+        return [ sync_ingress_hosts!(ingress), [] ]
       end
 
-      Cloudflare::EnvironmentIngressProvisioner.new(environment:, client:).call
+      ingress = Cloudflare::EnvironmentIngressProvisioner.new(environment:, client:, release:).call
+      [ ingress, [] ]
+    end
+
+    def sync_ingress_hosts!(ingress)
+      return ingress unless ingress
+
+      desired_hosts = desired_hosts_for(ingress)
+      ingress.assign_hosts!(desired_hosts) if desired_hosts.any? && desired_hosts != ingress.hosts
+      ingress
+    end
+
+    def desired_hosts_for(ingress)
+      configured = Array(release&.ingress_config&.dig("hosts")).map(&:to_s).map(&:strip).reject(&:blank?).uniq
+      return configured if configured.any?
+      return ingress.hosts if ingress.hosts.any?
+      return [ ingress.hostname ] if ingress.hostname.present?
+
+      []
     end
   end
 end

--- a/control-plane/app/services/environment_ingresses/reconciler.rb
+++ b/control-plane/app/services/environment_ingresses/reconciler.rb
@@ -15,7 +15,7 @@ module EnvironmentIngresses
       if environment.direct_dns_ingress?
         DirectDnsStrategy.new(environment:, ingress:, client:, stale_hosts:).call
       else
-        Cloudflare::EnvironmentIngressProvisioner.new(environment:, client:, release:).call
+        Cloudflare::EnvironmentIngressProvisioner.new(environment:, client:, release:, stale_hosts:).call
       end
     end
 

--- a/control-plane/app/services/environment_ingresses/reconciler.rb
+++ b/control-plane/app/services/environment_ingresses/reconciler.rb
@@ -53,7 +53,7 @@ module EnvironmentIngresses
     end
 
     def desired_hosts_for(ingress)
-      configured = Array(release&.ingress_config&.dig("hosts")).map(&:to_s).map(&:strip).reject(&:blank?).uniq
+      configured = IngressHostnames.normalize_all(release&.ingress_config&.dig("hosts"))
       return configured if configured.any?
       return ingress.hosts if ingress.hosts.any?
       return [ ingress.hostname ] if ingress.hostname.present?

--- a/control-plane/app/services/node_desired_state/ingress_payload.rb
+++ b/control-plane/app/services/node_desired_state/ingress_payload.rb
@@ -3,43 +3,44 @@
 module NodeDesiredState
   class IngressPayload
     def self.build(node:, environment:, release:)
+      ingress_config = release.ingress_config
       ingress_service_name = release.ingress_service_name
       return nil if ingress_service_name.blank?
       return nil unless release.service_scheduled_on?(ingress_service_name, node)
       return nil unless Devopsellence::IngressConfig.managed?
 
       ingress = environment.environment_ingress
-      return nil unless ingress&.hostname.present?
+      hosts = ingress&.hosts || []
+      return nil if hosts.empty?
+
+      payload = {
+        hosts: hosts,
+        tls: normalize_tls(ingress_config&.dig("tls")),
+        redirectHttp: ingress_config&.key?("redirect_http") ? ingress_config["redirect_http"] : true,
+        routes: routes_for(environment:, hosts:, release:)
+      }.compact
 
       if environment.tunnel_ingress?
         return nil unless ingress.status == EnvironmentIngress::STATUS_READY
 
-        {
-          hosts: [ ingress.hostname ],
+        payload.merge(
           mode: Environment::INGRESS_STRATEGY_TUNNEL,
-          tunnelTokenSecretRef: ingress.tunnel_token_secret_ref,
-          routes: routes_for(environment:, ingress:, release:)
-        }
+          tunnelTokenSecretRef: ingress.tunnel_token_secret_ref
+        )
       else
         return nil unless node.supports_capability?(Node::CAPABILITY_DIRECT_DNS_INGRESS)
 
-        {
-          hosts: [ ingress.hostname ],
+        payload.merge(
           mode: "public",
-          tls: {
-            mode: "auto"
-          },
-          redirectHttp: true,
-          routes: routes_for(environment:, ingress:, release:)
-        }
+        )
       end
     end
 
-    def self.routes_for(environment:, ingress:, release:)
-      [
+    def self.routes_for(environment:, hosts:, release:)
+      hosts.map do |host|
         {
           match: {
-            hostname: ingress.hostname
+            hostname: host
           },
           target: {
             environment: environment.name,
@@ -47,7 +48,17 @@ module NodeDesiredState
             port: "http"
           }
         }
-      ]
+      end
+    end
+
+    def self.normalize_tls(tls)
+      return { mode: "auto" } unless tls.is_a?(Hash)
+
+      {
+        mode: tls["mode"].presence || "auto",
+        email: tls["email"],
+        caDirectoryUrl: tls["ca_directory_url"]
+      }.compact
     end
   end
 end

--- a/control-plane/app/services/releases/runtime_attributes.rb
+++ b/control-plane/app/services/releases/runtime_attributes.rb
@@ -133,8 +133,14 @@ module Releases
         end
 
       tls = ingress["tls"] || ingress[:tls]
+      hosts = optional_service_array(ingress["hosts"] || ingress[:hosts], field: :"ingress.hosts")
+      normalized_hosts = IngressHostnames.normalize_all(hosts)
+      if hosts.present? && normalized_hosts.length != hosts.length
+        raise InvalidPayload, "ingress.hosts must be unique"
+      end
+
       parsed = {
-        "hosts" => optional_service_array(ingress["hosts"] || ingress[:hosts], field: :"ingress.hosts"),
+        "hosts" => normalized_hosts.presence,
         "service" => optional_service_string(ingress["service"] || ingress[:service]),
         "redirect_http" => optional_boolean(redirect_http, field: :"ingress.redirect_http")
       }.compact

--- a/control-plane/app/services/releases/runtime_attributes.rb
+++ b/control-plane/app/services/releases/runtime_attributes.rb
@@ -24,7 +24,7 @@ module Releases
       runtime = {
         "services" => parse_services(params[:services]),
         "tasks" => parse_tasks(params[:tasks]),
-        "ingress_service" => optional_string(:ingress_service)
+        "ingress" => parse_ingress(params[:ingress])
       }.compact
 
       attrs.merge(runtime_json: JSON.generate(runtime))
@@ -121,6 +121,27 @@ module Releases
       }.compact
     end
 
+    def parse_ingress(value)
+      ingress = parse_hash(value, field: :ingress)
+      return nil if ingress.blank?
+
+      tls = ingress["tls"] || ingress[:tls]
+      parsed = {
+        "hosts" => optional_service_array(ingress["hosts"] || ingress[:hosts], field: :"ingress.hosts"),
+        "service" => optional_service_string(ingress["service"] || ingress[:service]),
+        "redirect_http" => optional_boolean(ingress["redirect_http"] || ingress[:redirect_http], field: :"ingress.redirect_http")
+      }.compact
+      if tls.present?
+        tls = parse_hash(tls, field: :"ingress.tls")
+        parsed["tls"] = {
+          "mode" => optional_service_string(tls["mode"] || tls[:mode]),
+          "email" => optional_service_string(tls["email"] || tls[:email]),
+          "ca_directory_url" => optional_service_string(tls["ca_directory_url"] || tls[:ca_directory_url])
+        }.compact
+      end
+      parsed
+    end
+
     def parse_ports(value, field:)
       parse_array(value, field:).map.with_index do |entry, index|
         port = parse_hash(entry, field: :"#{field}[#{index}]")
@@ -215,6 +236,13 @@ module Releases
       raise InvalidPayload, "#{field} is required" if integer.nil?
 
       integer
+    end
+
+    def optional_boolean(value, field:)
+      return nil if value.nil? || value == ""
+      return value if value == true || value == false
+
+      raise InvalidPayload, "#{field} must be a boolean"
     end
   end
 end

--- a/control-plane/app/services/releases/runtime_attributes.rb
+++ b/control-plane/app/services/releases/runtime_attributes.rb
@@ -125,11 +125,18 @@ module Releases
       ingress = parse_hash(value, field: :ingress)
       return nil if ingress.blank?
 
+      redirect_http =
+        if ingress.key?("redirect_http")
+          ingress["redirect_http"]
+        elsif ingress.key?(:redirect_http)
+          ingress[:redirect_http]
+        end
+
       tls = ingress["tls"] || ingress[:tls]
       parsed = {
         "hosts" => optional_service_array(ingress["hosts"] || ingress[:hosts], field: :"ingress.hosts"),
         "service" => optional_service_string(ingress["service"] || ingress[:service]),
-        "redirect_http" => optional_boolean(ingress["redirect_http"] || ingress[:redirect_http], field: :"ingress.redirect_http")
+        "redirect_http" => optional_boolean(redirect_http, field: :"ingress.redirect_http")
       }.compact
       if tls.present?
         tls = parse_hash(tls, field: :"ingress.tls")

--- a/control-plane/app/views/marketing/docs.html.erb
+++ b/control-plane/app/views/marketing/docs.html.erb
@@ -353,7 +353,7 @@
         <span class="terminal-bar-title">devopsellence.yml</span>
       </div>
       <div class="terminal-body">
-        <pre class="config-pre"><code>schema_version: 5
+        <pre class="config-pre"><code>schema_version: 6
 app:
   type: rails
 organization: solo
@@ -577,7 +577,7 @@ jobs:
         <span class="terminal-bar-title">devopsellence.yml</span>
       </div>
       <div class="terminal-body">
-        <pre class="config-pre"><code>schema_version: 5
+        <pre class="config-pre"><code>schema_version: 6
 
 app:
   type: rails

--- a/control-plane/db/migrate/20260423000100_create_environment_ingress_hosts.rb
+++ b/control-plane/db/migrate/20260423000100_create_environment_ingress_hosts.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class CreateEnvironmentIngressHosts < ActiveRecord::Migration[8.1]
+  class MigrationEnvironmentIngress < ApplicationRecord
+    self.table_name = "environment_ingresses"
+  end
+
+  def up
+    create_table :environment_ingress_hosts do |t|
+      t.references :environment_ingress, null: false, foreign_key: true
+      t.string :hostname, null: false
+      t.integer :position, null: false, default: 0
+      t.timestamps
+    end
+
+    add_index :environment_ingress_hosts, :hostname, unique: true
+    add_index :environment_ingress_hosts, [ :environment_ingress_id, :position ], unique: true, name: "index_env_ingress_hosts_on_ingress_and_position"
+
+    MigrationEnvironmentIngress.reset_column_information
+    MigrationEnvironmentIngress.find_each do |ingress|
+      hostname = ingress.hostname.to_s.strip
+      next if hostname.blank?
+
+      execute <<~SQL.squish
+        INSERT INTO environment_ingress_hosts (environment_ingress_id, hostname, position, created_at, updated_at)
+        VALUES (#{ingress.id}, #{connection.quote(hostname)}, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+      SQL
+    end
+  end
+
+  def down
+    drop_table :environment_ingress_hosts
+  end
+end

--- a/control-plane/db/migrate/20260423000100_create_environment_ingress_hosts.rb
+++ b/control-plane/db/migrate/20260423000100_create_environment_ingress_hosts.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 class CreateEnvironmentIngressHosts < ActiveRecord::Migration[8.1]
-  class MigrationEnvironmentIngress < ApplicationRecord
-    self.table_name = "environment_ingresses"
-  end
-
   def up
     create_table :environment_ingress_hosts do |t|
       t.references :environment_ingress, null: false, foreign_key: true
@@ -15,17 +11,6 @@ class CreateEnvironmentIngressHosts < ActiveRecord::Migration[8.1]
 
     add_index :environment_ingress_hosts, :hostname, unique: true
     add_index :environment_ingress_hosts, [ :environment_ingress_id, :position ], unique: true, name: "index_env_ingress_hosts_on_ingress_and_position"
-
-    MigrationEnvironmentIngress.reset_column_information
-    MigrationEnvironmentIngress.find_each do |ingress|
-      hostname = ingress.hostname.to_s.strip
-      next if hostname.blank?
-
-      execute <<~SQL.squish
-        INSERT INTO environment_ingress_hosts (environment_ingress_id, hostname, position, created_at, updated_at)
-        VALUES (#{ingress.id}, #{connection.quote(hostname)}, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
-      SQL
-    end
   end
 
   def down

--- a/control-plane/db/schema.rb
+++ b/control-plane/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_18_123100) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_23_000100) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -123,6 +123,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_18_123100) do
     t.index ["environment_id"], name: "index_environment_ingresses_on_environment_id", unique: true
     t.index ["gcp_secret_name"], name: "index_environment_ingresses_on_gcp_secret_name", unique: true
     t.index ["hostname"], name: "index_environment_ingresses_on_hostname", unique: true
+  end
+
+  create_table "environment_ingress_hosts", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "environment_ingress_id", null: false
+    t.string "hostname", null: false
+    t.integer "position", default: 0, null: false
+    t.datetime "updated_at", null: false
+    t.index ["environment_ingress_id", "position"], name: "index_env_ingress_hosts_on_ingress_and_position", unique: true
+    t.index ["environment_ingress_id"], name: "index_environment_ingress_hosts_on_environment_ingress_id"
+    t.index ["hostname"], name: "index_environment_ingress_hosts_on_hostname", unique: true
   end
 
   create_table "environment_secrets", force: :cascade do |t|
@@ -485,6 +496,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_18_123100) do
   add_foreign_key "environment_bundles", "environments", column: "claimed_by_environment_id"
   add_foreign_key "environment_bundles", "organization_bundles"
   add_foreign_key "environment_bundles", "runtime_projects"
+  add_foreign_key "environment_ingress_hosts", "environment_ingresses"
   add_foreign_key "environment_ingresses", "environments"
   add_foreign_key "environment_secrets", "environments"
   add_foreign_key "environments", "environment_bundles"

--- a/control-plane/test/integration/abuse_controls_test.rb
+++ b/control-plane/test/integration/abuse_controls_test.rb
@@ -298,7 +298,7 @@ class AbuseControlsTest < ActionDispatch::IntegrationTest
       services: {
         web: web_service_runtime(port: 80)
       },
-      ingress_service: "web"
+      ingress: { service: "web" }
     }
   end
 

--- a/control-plane/test/integration/api_agent_ingress_certificates_test.rb
+++ b/control-plane/test/integration/api_agent_ingress_certificates_test.rb
@@ -6,6 +6,62 @@ require "test_helper"
 class ApiAgentIngressCertificatesTest < ActionDispatch::IntegrationTest
   include ActiveSupport::Testing::TimeHelpers
 
+  test "accepts a secondary configured ingress hostname" do
+    organization = Organization.create!(name: "org-#{SecureRandom.hex(3)}")
+    project = organization.projects.create!(name: "ShopApp")
+    environment = project.environments.create!(
+      name: "production",
+      runtime_kind: Environment::RUNTIME_CUSTOMER_NODES,
+      ingress_strategy: Environment::INGRESS_STRATEGY_DIRECT_DNS,
+      gcp_project_id: "gcp-proj-a",
+      gcp_project_number: "123456789",
+      service_account_email: "svc-a@gcp-proj-a.iam.gserviceaccount.com",
+      workload_identity_pool: "pool-a",
+      workload_identity_provider: "provider-a"
+    )
+    primary_hostname = random_ingress_hostname
+    secondary_hostname = random_ingress_hostname
+    ingress = environment.create_environment_ingress!(
+      hostname: primary_hostname,
+      cloudflare_tunnel_id: "tunnel-1",
+      gcp_secret_name: "env-#{environment.id}-ingress-cloudflare-tunnel-token",
+      status: EnvironmentIngress::STATUS_PENDING,
+      provisioned_at: Time.current
+    )
+    ingress.assign_hosts!([ primary_hostname, secondary_hostname ])
+    release = project.releases.create!(
+      git_sha: "a" * 40,
+      revision: "rev-1",
+      image_repository: "shop-app",
+      image_digest: "sha256:#{'b' * 64}",
+      runtime_json: release_runtime_json,
+      status: Release::STATUS_PUBLISHED,
+      published_at: Time.current
+    )
+    environment.update!(current_release: release)
+    node, access_token, = issue_test_node!(organization: organization, name: "node-a")
+    node.update!(
+      environment: environment,
+      public_ip: "203.0.113.10",
+      capabilities_json: JSON.generate([Node::CAPABILITY_DIRECT_DNS_INGRESS])
+    )
+
+    issuer_result = Struct.new(:certificate_pem, :not_after).new("cert-pem", 30.days.from_now)
+    IngressCertificates::Issuer.any_instance.stubs(:call).returns(issuer_result)
+
+    post "/api/v1/agent/ingress_certificates",
+      params: { hostname: secondary_hostname, csr: "csr" },
+      headers: {
+        "Authorization" => "Bearer #{access_token}",
+        "devopsellence-agent-capabilities" => Node::CAPABILITY_DIRECT_DNS_INGRESS
+      },
+      as: :json
+
+    assert_response :created
+    payload = JSON.parse(response.body)
+    assert_equal secondary_hostname, payload.fetch("hostname")
+  end
+
   test "returns retry-after when certificate issuance is rate limited" do
     organization = Organization.create!(name: "org-#{SecureRandom.hex(3)}")
     project = organization.projects.create!(name: "ShopApp")

--- a/control-plane/test/integration/api_cli_mvp_test.rb
+++ b/control-plane/test/integration/api_cli_mvp_test.rb
@@ -1427,7 +1427,7 @@ class ApiCliMvpTest < ActionDispatch::IntegrationTest
             ]
           )
         },
-        ingress_service: "web"
+        ingress: { service: "web" }
       },
       headers: auth_headers_for(user),
       as: :json
@@ -1455,7 +1455,7 @@ class ApiCliMvpTest < ActionDispatch::IntegrationTest
           image_repository: "shop-app",
           image_digest: "sha256:#{'b' * 64}",
           services: { web: web_service_runtime(port: 80) },
-          ingress_service: "web"
+          ingress: { service: "web" }
         },
         headers: auth_headers_for(user),
         as: :json
@@ -1519,7 +1519,7 @@ class ApiCliMvpTest < ActionDispatch::IntegrationTest
             volumes: [{ source: "app_storage", target: "/rails/storage" }]
           )
         },
-        ingress_service: "web"
+        ingress: { service: "web" }
       },
       headers: auth_headers_for(user),
       as: :json
@@ -1546,7 +1546,7 @@ class ApiCliMvpTest < ActionDispatch::IntegrationTest
         services: {
           web: web_service_runtime(port: 80, env: { "RAILS_ENV" => "production" })
         },
-        ingress_service: "web"
+        ingress: { service: "web" }
       },
       headers: auth_headers_for(user),
       as: :json

--- a/control-plane/test/models/deployments_publisher_test.rb
+++ b/control-plane/test/models/deployments_publisher_test.rb
@@ -134,6 +134,58 @@ class DeploymentsPublisherTest < ActiveSupport::TestCase
     assert_equal 3, service.dig("healthcheck", "retries")
   end
 
+  test "publishes desired state ingress routes for every configured host" do
+    organization = Organization.create!(name: "org-#{SecureRandom.hex(3)}")
+    ensure_test_organization_runtime!(organization)
+    project = organization.projects.create!(name: "Project A")
+    environment = project.environments.create!(
+      name: "Production",
+      gcp_project_id: "gcp-proj-a",
+      gcp_project_number: "123456789",
+      service_account_email: "svc-a@gcp-proj-a.iam.gserviceaccount.com",
+      workload_identity_pool: "pool-a",
+      workload_identity_provider: "provider-a",
+      runtime_kind: Environment::RUNTIME_CUSTOMER_NODES
+    )
+    release = project.releases.create!(
+      git_sha: "abcd1234",
+      image_digest: "sha256:abc",
+      image_repository: "api",
+      runtime_json: release_runtime_json(ingress: {
+        "service" => "web",
+        "hosts" => [ "app.example.test", "www.example.test" ],
+        "tls" => { "mode" => "manual" },
+        "redirect_http" => false
+      }),
+      revision: "rel-1"
+    )
+    node, _access, _refresh = issue_test_node!(organization: organization, name: "node-a")
+    node.update!(environment: environment)
+    store = FakeObjectStore.new
+    ingress = environment.create_environment_ingress!(
+      hostname: "app.example.test",
+      cloudflare_tunnel_id: "tunnel-1",
+      gcp_secret_name: "env-#{environment.id}-ingress-cloudflare-tunnel-token",
+      status: EnvironmentIngress::STATUS_READY,
+      provisioned_at: Time.current
+    )
+    ingress.assign_hosts!([ "app.example.test", "www.example.test" ])
+
+    Gcp::EnvironmentRuntimeProvisioner.any_instance.stubs(:call).returns(
+      Gcp::EnvironmentRuntimeProvisioner::Result.new(status: :ready, message: nil)
+    )
+    EnvironmentIngresses::Reconciler.any_instance.stubs(:call).returns(environment.environment_ingress)
+    Gcp::EnvironmentSecretManager.any_instance.stubs(:ensure_ingress_access!).returns(true)
+
+    Deployments::Publisher.new(environment: environment, release: release, store: store).call
+
+    desired_state = store.desired_state_payload(bucket: organization.gcs_bucket_name, object_path: node.desired_state_object_path)
+    assert_equal [ "app.example.test", "www.example.test" ], desired_state.dig("ingress", "hosts")
+    assert_equal [ "app.example.test", "www.example.test" ], desired_state.dig("ingress", "routes").map { |route| route.dig("match", "hostname") }
+    assert_equal false, desired_state.dig("ingress", "redirectHttp")
+    assert_equal "manual", desired_state.dig("ingress", "tls", "mode")
+  end
+
   test "publishes immutable desired state object plus pointer and direct desired state path" do
     organization = Organization.create!(name: "org-#{SecureRandom.hex(3)}")
     ensure_test_organization_runtime!(organization)

--- a/control-plane/test/models/deployments_publisher_test.rb
+++ b/control-plane/test/models/deployments_publisher_test.rb
@@ -186,6 +186,56 @@ class DeploymentsPublisherTest < ActiveSupport::TestCase
     assert_equal "manual", desired_state.dig("ingress", "tls", "mode")
   end
 
+  test "skips ingress reprovision when stored ingress hosts only differ by case" do
+    organization = Organization.create!(name: "org-#{SecureRandom.hex(3)}")
+    ensure_test_organization_runtime!(organization)
+    project = organization.projects.create!(name: "Project A")
+    environment = project.environments.create!(
+      name: "Production",
+      gcp_project_id: "gcp-proj-a",
+      gcp_project_number: "123456789",
+      service_account_email: "svc-a@gcp-proj-a.iam.gserviceaccount.com",
+      workload_identity_pool: "pool-a",
+      workload_identity_provider: "provider-a",
+      runtime_kind: Environment::RUNTIME_CUSTOMER_NODES
+    )
+    release = project.releases.create!(
+      git_sha: "abcd1234",
+      image_digest: "sha256:abc",
+      image_repository: "api",
+      runtime_json: JSON.generate(
+        {
+          "services" => { "web" => web_service_runtime },
+          "tasks" => {},
+          "ingress" => {
+            "service" => "web",
+            "hosts" => ["App.Example.Test", "WWW.Example.Test"]
+          }
+        }
+      ),
+      revision: "rel-1"
+    )
+    node, _access, _refresh = issue_test_node!(organization: organization, name: "node-a")
+    node.update!(environment: environment)
+    store = FakeObjectStore.new
+    ingress = environment.create_environment_ingress!(
+      hostname: "app.example.test",
+      cloudflare_tunnel_id: "tunnel-1",
+      gcp_secret_name: "env-#{environment.id}-ingress-cloudflare-tunnel-token",
+      status: EnvironmentIngress::STATUS_READY,
+      provisioned_at: Time.current
+    )
+    ingress.assign_hosts!(["app.example.test", "www.example.test"])
+
+    Gcp::EnvironmentRuntimeProvisioner.any_instance.stubs(:call).returns(
+      Gcp::EnvironmentRuntimeProvisioner::Result.new(status: :ready, message: nil)
+    )
+    EnvironmentIngresses::Reconciler.any_instance.expects(:call).never
+    Gcp::EnvironmentSecretManager.any_instance.stubs(:ensure_ingress_access!).returns(true)
+
+    Deployments::Publisher.new(environment: environment, release: release, store: store).call
+  end
+
   test "publishes immutable desired state object plus pointer and direct desired state path" do
     organization = Organization.create!(name: "org-#{SecureRandom.hex(3)}")
     ensure_test_organization_runtime!(organization)

--- a/control-plane/test/models/environment_ingress_test.rb
+++ b/control-plane/test/models/environment_ingress_test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "securerandom"
+require "test_helper"
+
+class EnvironmentIngressTest < ActiveSupport::TestCase
+  test "normalizes and de-duplicates hosts case-insensitively" do
+    organization = Organization.create!(name: "org-#{SecureRandom.hex(3)}")
+    ensure_test_organization_runtime!(organization)
+    project = organization.projects.create!(name: "Project A")
+    environment = project.environments.create!(
+      name: "production",
+      gcp_project_id: organization.gcp_project_id,
+      gcp_project_number: organization.gcp_project_number,
+      workload_identity_pool: organization.workload_identity_pool,
+      workload_identity_provider: organization.workload_identity_provider,
+      service_account_email: "env@#{organization.gcp_project_id}.iam.gserviceaccount.com"
+    )
+
+    ingress = environment.create_environment_ingress!(
+      hostname: "APP.Example.Test",
+      cloudflare_tunnel_id: "tunnel-1",
+      gcp_secret_name: "env-#{environment.id}-ingress-cloudflare-tunnel-token",
+      status: EnvironmentIngress::STATUS_READY,
+      provisioned_at: Time.current
+    )
+
+    ingress.assign_hosts!([ "WWW.Example.Test", "www.example.test", "Api.Example.Test" ])
+
+    assert_equal [ "www.example.test", "api.example.test" ], ingress.reload.hosts
+    assert_equal "www.example.test", ingress.hostname
+    assert ingress.hostname_matches?("API.EXAMPLE.TEST")
+  end
+end

--- a/control-plane/test/models/release_test.rb
+++ b/control-plane/test/models/release_test.rb
@@ -51,22 +51,6 @@ class ReleaseTest < ActiveSupport::TestCase
     assert_includes release.errors[:runtime_json], "tasks.release.args must be an array of strings"
   end
 
-  test "legacy ingress_service remains readable for existing releases" do
-    release = build_release(
-      runtime_json: JSON.generate(
-        {
-          "services" => { "web" => web_service_runtime },
-          "tasks" => {},
-          "ingress_service" => "web"
-        }
-      )
-    )
-
-    assert_predicate release, :valid?
-    assert_equal "web", release.ingress_service_name
-    assert_equal({ "service" => "web" }, release.ingress_config)
-  end
-
   test "ingress hosts must be unique case-insensitively" do
     release = build_release(
       runtime_json: release_runtime_json(
@@ -79,6 +63,21 @@ class ReleaseTest < ActiveSupport::TestCase
 
     assert_not release.valid?
     assert_includes release.errors[:runtime_json], "ingress.hosts must be unique"
+  end
+
+  test "ingress must decode to an object when present" do
+    release = build_release(
+      runtime_json: JSON.generate(
+        {
+          "services" => { "web" => web_service_runtime },
+          "tasks" => {},
+          "ingress" => "web"
+        }
+      )
+    )
+
+    assert_not release.valid?
+    assert_includes release.errors[:runtime_json], "ingress must decode to an object"
   end
 
   test "blank kind does not contribute required labels and reports one kind error" do

--- a/control-plane/test/models/release_test.rb
+++ b/control-plane/test/models/release_test.rb
@@ -67,6 +67,20 @@ class ReleaseTest < ActiveSupport::TestCase
     assert_equal({ "service" => "web" }, release.ingress_config)
   end
 
+  test "ingress hosts must be unique case-insensitively" do
+    release = build_release(
+      runtime_json: release_runtime_json(
+        ingress: {
+          "service" => "web",
+          "hosts" => ["App.Example.Test", "app.example.test"]
+        }
+      )
+    )
+
+    assert_not release.valid?
+    assert_includes release.errors[:runtime_json], "ingress.hosts must be unique"
+  end
+
   test "blank kind does not contribute required labels and reports one kind error" do
     release = build_release(
       runtime_json: release_runtime_json(

--- a/control-plane/test/models/release_test.rb
+++ b/control-plane/test/models/release_test.rb
@@ -51,6 +51,22 @@ class ReleaseTest < ActiveSupport::TestCase
     assert_includes release.errors[:runtime_json], "tasks.release.args must be an array of strings"
   end
 
+  test "legacy ingress_service remains readable for existing releases" do
+    release = build_release(
+      runtime_json: JSON.generate(
+        {
+          "services" => { "web" => web_service_runtime },
+          "tasks" => {},
+          "ingress_service" => "web"
+        }
+      )
+    )
+
+    assert_predicate release, :valid?
+    assert_equal "web", release.ingress_service_name
+    assert_equal({ "service" => "web" }, release.ingress_config)
+  end
+
   test "blank kind does not contribute required labels and reports one kind error" do
     release = build_release(
       runtime_json: release_runtime_json(

--- a/control-plane/test/models/release_test.rb
+++ b/control-plane/test/models/release_test.rb
@@ -10,27 +10,27 @@ class ReleaseTest < ActiveSupport::TestCase
           "admin" => web_service_runtime,
           "public" => web_service_runtime
         },
-        ingress_service: nil
+        ingress: nil
       )
     )
 
     assert_not release.valid?
-    assert_includes release.errors[:runtime_json], "ingress_service is required when multiple web services are defined"
+    assert_includes release.errors[:runtime_json], "ingress.service is required when multiple web services are defined"
   end
 
-  test "uses canonical web service as inferred ingress service when present" do
+  test "requires explicit ingress service even when a canonical web service exists" do
     release = build_release(
       runtime_json: release_runtime_json(
         services: {
           "admin" => web_service_runtime,
           "web" => web_service_runtime
         },
-        ingress_service: nil
+        ingress: nil
       )
     )
 
-    assert_predicate release, :valid?
-    assert_equal "web", release.ingress_service_name
+    assert_not release.valid?
+    assert_includes release.errors[:runtime_json], "ingress.service is required when multiple web services are defined"
   end
 
   test "release task command and args must be arrays" do

--- a/control-plane/test/services/cloudflare/environment_ingress_provisioner_test.rb
+++ b/control-plane/test/services/cloudflare/environment_ingress_provisioner_test.rb
@@ -197,6 +197,55 @@ module Cloudflare
       ], client.deleted_dns_records
     end
 
+    test "normalizes stored mixed-case release hosts before updating routing" do
+      organization = Organization.create!(name: "org-#{SecureRandom.hex(3)}")
+      ensure_test_organization_runtime!(organization)
+      project = organization.projects.create!(name: "Project A")
+      environment = project.environments.create!(
+        name: "production",
+        gcp_project_id: organization.gcp_project_id,
+        gcp_project_number: organization.gcp_project_number,
+        workload_identity_pool: organization.workload_identity_pool,
+        workload_identity_provider: organization.workload_identity_provider,
+        service_account_email: "env@#{organization.gcp_project_id}.iam.gserviceaccount.com"
+      )
+      release = project.releases.create!(
+        git_sha: "a" * 40,
+        revision: "rel-1",
+        image_repository: "shop-app",
+        image_digest: "sha256:#{"b" * 64}",
+        runtime_json: JSON.generate(
+          {
+            "services" => { "web" => web_service_runtime },
+            "tasks" => {},
+            "ingress" => {
+              "service" => "web",
+              "hosts" => ["App.Example.Test", "WWW.Example.Test"]
+            }
+          }
+        )
+      )
+      environment.update!(current_release: release)
+      environment.create_environment_ingress!(
+        hostname: "app.example.test",
+        cloudflare_tunnel_id: "tunnel-1",
+        gcp_secret_name: "env-#{environment.id}-ingress-cloudflare-tunnel-token",
+        status: EnvironmentIngress::STATUS_READY,
+        provisioned_at: Time.current
+      )
+      client = FakeClient.new
+
+      ingress = EnvironmentIngressProvisioner.new(
+        environment: environment,
+        client: client,
+        secret_manager: FakeSecretManager.new,
+        release: release
+      ).call
+
+      assert_equal ["app.example.test", "www.example.test"], ingress.hosts
+      assert_equal ["app.example.test", "www.example.test"], client.configured_tunnels.first[:hostnames]
+    end
+
     test "restores tunnel routing from environment bundle data" do
       organization = Organization.create!(name: "org-#{SecureRandom.hex(3)}")
       ensure_test_organization_runtime!(organization)

--- a/control-plane/test/services/cloudflare/environment_ingress_provisioner_test.rb
+++ b/control-plane/test/services/cloudflare/environment_ingress_provisioner_test.rb
@@ -159,6 +159,44 @@ module Cloudflare
       ], client.dns_records
     end
 
+    test "removes stale hosts supplied by the reconciler" do
+      organization = Organization.create!(name: "org-#{SecureRandom.hex(3)}")
+      ensure_test_organization_runtime!(organization)
+      project = organization.projects.create!(name: "Project A")
+      environment = project.environments.create!(
+        name: "production",
+        gcp_project_id: organization.gcp_project_id,
+        gcp_project_number: organization.gcp_project_number,
+        workload_identity_pool: organization.workload_identity_pool,
+        workload_identity_provider: organization.workload_identity_provider,
+        service_account_email: "env@#{organization.gcp_project_id}.iam.gserviceaccount.com"
+      )
+      current_host = "#{SecureRandom.alphanumeric(6).downcase}.devopsellence.io"
+      stale_host = "#{SecureRandom.alphanumeric(6).downcase}.devopsellence.io"
+      environment.create_environment_ingress!(
+        hostname: current_host,
+        cloudflare_tunnel_id: "tunnel-1",
+        gcp_secret_name: "env-#{environment.id}-ingress-cloudflare-tunnel-token",
+        status: EnvironmentIngress::STATUS_READY,
+        provisioned_at: Time.current
+      )
+      client = FakeClient.new
+
+      EnvironmentIngressProvisioner.new(
+        environment: environment,
+        client: client,
+        secret_manager: FakeSecretManager.new,
+        stale_hosts: [ stale_host ]
+      ).call
+
+      assert_equal [
+        { hostname: stale_host, type: "A" },
+        { hostname: stale_host, type: "CNAME" },
+        { hostname: current_host, type: "A" },
+        { hostname: current_host, type: "CNAME" }
+      ], client.deleted_dns_records
+    end
+
     test "restores tunnel routing from environment bundle data" do
       organization = Organization.create!(name: "org-#{SecureRandom.hex(3)}")
       ensure_test_organization_runtime!(organization)

--- a/control-plane/test/services/cloudflare/environment_ingress_provisioner_test.rb
+++ b/control-plane/test/services/cloudflare/environment_ingress_provisioner_test.rb
@@ -28,10 +28,10 @@ module Cloudflare
         "token-#{token_requests.size}"
       end
 
-      def configure_tunnel(tunnel_id:, hostname:, service:)
+      def configure_tunnel(tunnel_id:, service:, hostname: nil, hostnames: nil)
         @configured_tunnels << {
           tunnel_id: tunnel_id,
-          hostname: hostname,
+          hostnames: Array(hostnames.presence || hostname),
           service: service
         }
       end
@@ -106,6 +106,7 @@ module Cloudflare
       assert_equal [ "tunnel-1" ], client.token_requests
       assert_equal [ "env-#{environment.id}-#{slug}" ], client.created_tunnels
       assert_equal "http://devopsellence-envoy:8000", client.configured_tunnels.first[:service]
+      assert_equal [ "#{slug}.devopsellence.io" ], client.configured_tunnels.first[:hostnames]
       assert_equal "tunnel-1.cfargotunnel.com", client.dns_records.first[:target]
     end
 
@@ -142,7 +143,7 @@ module Cloudflare
       assert_equal [
         {
           tunnel_id: "tunnel-1",
-          hostname: "#{slug}.devopsellence.io",
+          hostnames: [ "#{slug}.devopsellence.io" ],
           service: "http://devopsellence-envoy:8000"
         }
       ], client.configured_tunnels
@@ -195,7 +196,7 @@ module Cloudflare
       assert_equal [
         {
           tunnel_id: bundle.cloudflare_tunnel_id,
-          hostname: bundle.hostname,
+          hostnames: [ bundle.hostname ],
           service: "http://devopsellence-envoy:8000"
         }
       ], client.configured_tunnels

--- a/control-plane/test/services/environment_bundles/provisioner_test.rb
+++ b/control-plane/test/services/environment_bundles/provisioner_test.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "securerandom"
+require "test_helper"
+
+module EnvironmentBundles
+  class ProvisionerTest < ActiveSupport::TestCase
+    ReadyResult = Struct.new(:status, :message, keyword_init: true)
+
+    class FakeBroker
+      def provision_environment_bundle!(bundle:)
+        ReadyResult.new(status: :ready, message: nil)
+      end
+
+      def upsert_environment_bundle_tunnel_secret!(bundle:, tunnel_token:)
+        ReadyResult.new(status: :ready, message: nil)
+      end
+    end
+
+    test "bundle hostname allocation skips secondary ingress hosts" do
+      organization = Organization.create!(name: "org-#{SecureRandom.hex(3)}")
+      runtime = RuntimeProject.default!
+      organization_bundle = ensure_test_organization_bundle!(organization, runtime:, status: OrganizationBundle::STATUS_CLAIMED)
+      project = organization.projects.create!(name: "Project A")
+      environment = project.environments.create!(
+        name: "production",
+        gcp_project_id: organization.gcp_project_id,
+        gcp_project_number: organization.gcp_project_number,
+        workload_identity_pool: organization.workload_identity_pool,
+        workload_identity_provider: organization.workload_identity_provider,
+        service_account_email: "env@#{organization.gcp_project_id}.iam.gserviceaccount.com"
+      )
+      ingress = environment.create_environment_ingress!(
+        hostname: "primary.local.devopsellence.test",
+        cloudflare_tunnel_id: "tunnel-1",
+        gcp_secret_name: "env-#{environment.id}-ingress-cloudflare-tunnel-token",
+        status: EnvironmentIngress::STATUS_READY,
+        provisioned_at: Time.current
+      )
+      ingress.assign_hosts!(["primary.local.devopsellence.test", "taken.local.devopsellence.test"])
+
+      SecureRandom.stubs(:alphanumeric).returns("taken", "fresh")
+
+      with_runtime_config(
+        ingress_backend: "local",
+        local_ingress_public_url: "http://127.0.0.1:18080",
+        local_ingress_hostname_suffix: "local.devopsellence.test"
+      ) do
+        bundle = Provisioner.new(
+          organization_bundle: organization_bundle,
+          broker: FakeBroker.new
+        ).call
+
+        assert_equal "fresh.local.devopsellence.test", bundle.hostname
+      end
+    end
+  end
+end

--- a/control-plane/test/services/environment_ingresses/reconciler_test.rb
+++ b/control-plane/test/services/environment_ingresses/reconciler_test.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "securerandom"
+require "test_helper"
+
+module EnvironmentIngresses
+  class ReconcilerTest < ActiveSupport::TestCase
+    test "passes stale hosts to the cloudflare provisioner after syncing ingress hosts" do
+      organization = Organization.create!(name: "org-#{SecureRandom.hex(3)}")
+      ensure_test_organization_runtime!(organization)
+      project = organization.projects.create!(name: "Project A")
+      environment = project.environments.create!(
+        name: "production",
+        gcp_project_id: organization.gcp_project_id,
+        gcp_project_number: organization.gcp_project_number,
+        workload_identity_pool: organization.workload_identity_pool,
+        workload_identity_provider: organization.workload_identity_provider,
+        service_account_email: "env@#{organization.gcp_project_id}.iam.gserviceaccount.com"
+      )
+      previous_host = "#{SecureRandom.alphanumeric(6).downcase}.devopsellence.io"
+      desired_host = "#{SecureRandom.alphanumeric(6).downcase}.devopsellence.io"
+      release = project.releases.create!(
+        git_sha: "a" * 40,
+        revision: "rel-1",
+        image_repository: "shop-app",
+        image_digest: "sha256:#{"b" * 64}",
+        runtime_json: release_runtime_json(ingress: {
+          "service" => "web",
+          "hosts" => [ desired_host ]
+        })
+      )
+      environment.update!(current_release: release)
+      ingress = environment.create_environment_ingress!(
+        hostname: previous_host,
+        cloudflare_tunnel_id: "tunnel-1",
+        gcp_secret_name: "env-#{environment.id}-ingress-cloudflare-tunnel-token",
+        status: EnvironmentIngress::STATUS_READY,
+        provisioned_at: Time.current
+      )
+      client = Object.new
+      provisioner = mock("provisioner")
+
+      Cloudflare::EnvironmentIngressProvisioner.expects(:new).with(
+        environment: environment,
+        client: client,
+        release: release,
+        stale_hosts: [ previous_host ]
+      ).returns(provisioner)
+      provisioner.expects(:call).returns(ingress)
+
+      Reconciler.new(environment: environment, client: client, release: release).call
+
+      assert_equal [ desired_host ], ingress.reload.hosts
+    end
+  end
+end

--- a/control-plane/test/services/releases/runtime_attributes_test.rb
+++ b/control-plane/test/services/releases/runtime_attributes_test.rb
@@ -146,5 +146,29 @@ module Releases
 
       assert_equal "ingress.redirect_http must be a boolean", error.message
     end
+
+    test "preserves explicit false ingress redirect_http" do
+      attrs = RuntimeAttributes.new(
+        params: {
+          git_sha: "a" * 40,
+          image_repository: "api",
+          image_digest: "sha256:#{"b" * 64}",
+          services: {
+            web: {
+              kind: "web",
+              ports: [{ name: "http", port: 3000 }],
+              healthcheck: { path: "/up", port: 3000 }
+            }
+          },
+          ingress: {
+            service: "web",
+            redirect_http: false
+          }
+        }
+      ).to_h
+
+      runtime = JSON.parse(attrs.fetch(:runtime_json))
+      assert_equal false, runtime.dig("ingress", "redirect_http")
+    end
   end
 end

--- a/control-plane/test/services/releases/runtime_attributes_test.rb
+++ b/control-plane/test/services/releases/runtime_attributes_test.rb
@@ -102,6 +102,13 @@ module Releases
               service: "web",
               args: ["release"]
             }
+          },
+          ingress: {
+            service: "web",
+            hosts: ["app.example.test", "www.example.test"],
+            tls: {
+              mode: "manual"
+            }
           }
         }
       ).to_h
@@ -110,6 +117,34 @@ module Releases
       assert_equal ["/app"], runtime.dig("services", "web", "command")
       assert_equal ["web"], runtime.dig("services", "web", "args")
       assert_equal ["release"], runtime.dig("tasks", "release", "args")
+      assert_equal ["app.example.test", "www.example.test"], runtime.dig("ingress", "hosts")
+      assert_equal "web", runtime.dig("ingress", "service")
+      assert_equal "manual", runtime.dig("ingress", "tls", "mode")
+    end
+
+    test "rejects non-boolean ingress redirect_http" do
+      error = assert_raises(RuntimeAttributes::InvalidPayload) do
+        RuntimeAttributes.new(
+          params: {
+            git_sha: "a" * 40,
+            image_repository: "api",
+            image_digest: "sha256:#{"b" * 64}",
+            services: {
+              web: {
+                kind: "web",
+                ports: [{ name: "http", port: 3000 }],
+                healthcheck: { path: "/up", port: 3000 }
+              }
+            },
+            ingress: {
+              service: "web",
+              redirect_http: "yes"
+            }
+          }
+        ).to_h
+      end
+
+      assert_equal "ingress.redirect_http must be a boolean", error.message
     end
   end
 end

--- a/control-plane/test/services/releases/runtime_attributes_test.rb
+++ b/control-plane/test/services/releases/runtime_attributes_test.rb
@@ -170,5 +170,52 @@ module Releases
       runtime = JSON.parse(attrs.fetch(:runtime_json))
       assert_equal false, runtime.dig("ingress", "redirect_http")
     end
+
+    test "normalizes ingress hosts and rejects case-insensitive duplicates" do
+      error = assert_raises(RuntimeAttributes::InvalidPayload) do
+        RuntimeAttributes.new(
+          params: {
+            git_sha: "a" * 40,
+            image_repository: "api",
+            image_digest: "sha256:#{"b" * 64}",
+            services: {
+              web: {
+                kind: "web",
+                ports: [{ name: "http", port: 3000 }],
+                healthcheck: { path: "/up", port: 3000 }
+              }
+            },
+            ingress: {
+              service: "web",
+              hosts: ["App.Example.Test", "app.example.test"]
+            }
+          }
+        ).to_h
+      end
+
+      assert_equal "ingress.hosts must be unique", error.message
+
+      attrs = RuntimeAttributes.new(
+        params: {
+          git_sha: "a" * 40,
+          image_repository: "api",
+          image_digest: "sha256:#{"b" * 64}",
+          services: {
+            web: {
+              kind: "web",
+              ports: [{ name: "http", port: 3000 }],
+              healthcheck: { path: "/up", port: 3000 }
+            }
+          },
+          ingress: {
+            service: "web",
+            hosts: ["App.Example.Test", "WWW.Example.Test"]
+          }
+        }
+      ).to_h
+
+      runtime = JSON.parse(attrs.fetch(:runtime_json))
+      assert_equal ["app.example.test", "www.example.test"], runtime.dig("ingress", "hosts")
+    end
   end
 end

--- a/control-plane/test/test_helper.rb
+++ b/control-plane/test/test_helper.rb
@@ -198,13 +198,14 @@ module ActiveSupport
       }.compact
     end
 
-    def release_runtime_json(services: nil, tasks: {}, ingress_service: "web")
+    def release_runtime_json(services: nil, tasks: {}, ingress: :__default__)
       services ||= { "web" => web_service_runtime }
+      ingress = { "service" => "web" } if ingress == :__default__
       ::JSON.generate(
         {
           "services" => services,
           "tasks" => tasks,
-          "ingress_service" => ingress_service
+          "ingress" => ingress
         }.compact
       )
     end

--- a/test/e2e/solo_e2e.rb
+++ b/test/e2e/solo_e2e.rb
@@ -449,9 +449,10 @@ PY
 
   def write_devopsellence_yml!
     config = {
-      "schema_version" => 5,
+      "schema_version" => 6,
       "organization" => "solo",
       "project" => @project_name,
+      "default_environment" => "production",
       "build" => {
         "context" => ".",
         "dockerfile" => "Dockerfile",


### PR DESCRIPTION
## Summary
- add `schema_version: 6` environment overlays and CLI environment resolution with sticky workspace selection
- switch shared release/runtime ingress to structured `ingress` payloads and preserve compatibility `hostname`/`public_url` fields
- persist and reconcile full shared ingress host sets with new `environment_ingress_hosts` records plus multi-host tests/docs

## Why
Shared mode needed full multi-host ingress end to end, and local environment selection needed to stop mutating `devopsellence.yml`. This refactor makes environment-specific config resolution explicit and moves shared ingress onto a structured runtime contract.

## Impact
- `devopsellence.yml` now supports base config plus per-environment overlays under `environments:`
- `devopsellence context env use` writes workspace state instead of rewriting repo config
- shared releases/status payloads expose `hosts` and `public_urls` while keeping primary `hostname` / `public_url`
- shared ingress reconciliation now applies every configured host for tunnel and direct DNS flows

## Validation
- `mise run test:cli`
- `cd control-plane && mise run test -- test/models/release_test.rb test/services/releases/runtime_attributes_test.rb test/services/cloudflare/environment_ingress_provisioner_test.rb test/models/deployments_publisher_test.rb test/integration/api_agent_ingress_certificates_test.rb`
- `cd control-plane && mise run test -- test/services/environment_ingresses/direct_dns_strategy_test.rb test/integration/api_cli_mvp_test.rb test/integration/api_deployment_progress_test.rb`