### PR TITLE
[codex] add north-star doc

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,25 @@
 
 Always write "devopsellence" in all lowercase.
 
+## Product Direction
+
+Read [`docs/vision.md`](docs/vision.md) and [`docs/north-star.md`](docs/north-star.md) for product and architecture intent.
+
+Critical defaults:
+
+- devopsellence targets containerized apps on VMs; do not introduce PaaS/Kubernetes-lite abstractions.
+- Desired state is the stable control surface; agent reconciliation is the core loop.
+- Solo/shared are management topologies, not separate deployment systems.
+- Prefer one common Go deployment core for config interpretation, validation, planning, desired-state generation, ingress, placement, and status interpretation.
+- CLI should call the common core in-process for solo; Rails should eventually call it through service/RPC for shared.
+- Rails owns product state: accounts, authz, billing, hosted persistence, API surfaces.
+- Agent runtime should stay mode-agnostic; wire concrete adapters for desired-state source, secret resolver, status sink, registry auth, etc.
+- Placement is policy, not runtime schema. Shared may require one environment per node; solo may allow multiple environments per node.
+- Provider-specific integration belongs behind infrastructure adapters; do not leak cloud/provider concepts into the core runtime model.
+- Desired-state/status payloads backed by protobuf use protobuf JSON casing; Rails-owned JSON/API payloads use snake_case.
+- Product intent: one shared stable release version. Use `DEVOPSELLENCE_STABLE_VERSION`; do not add per-component stable version env vars or defaults.
+- Keep ordinary-tool escape hatches: SSH, Docker, files, logs, JSON, cloud CLIs.
+
 ## Layout
 
 | Path | Stack | Purpose |
@@ -18,9 +37,7 @@ Each component has its own toolchain, tests, and CI. No shared build system.
 
 Use `mise`.
 
-From repo root:
-
-```
+```sh
 mise run test:agent
 mise run test:cli
 mise run test:cp
@@ -34,7 +51,7 @@ mise run fmt:agent
 
 Per component:
 
-```
+```sh
 cd agent && mise run build && mise run test && mise run fmt
 cd agent && mise run protoc
 cd cli && mise run build && mise run test
@@ -44,11 +61,20 @@ cd control-plane && bin/dev
 
 Control-plane tests start Postgres via mise. Single file:
 
-```
+```sh
 cd control-plane && mise run test -- test/path/file_test.rb
 ```
 
-## Structure
+## Code Conventions
+
+- Go: `gofmt`; no extra linter config.
+- For `agent/` and `cli/` API/doc inspection, prefer `go doc` and `gopls` before ad-hoc text searches.
+- Rails: `.rubocop.yml`; prefer Rails 8 solid stack, no-build CSS/JS, Tailwind, sqlite where appropriate.
+- Rails migrations are append-only. Once committed/pushed, do not edit; add a new migration.
+- Never test static pages with no business logic.
+- Keep local override files and machine-specific templates out of this repo.
+
+## Key Paths
 
 - `agent/cmd/devopsellence/`: agent entrypoint.
 - `agent/internal/`: engine, reconcile, envoy, gcp, auth, cloudflared, etc.
@@ -59,34 +85,11 @@ cd control-plane && mise run test -- test/path/file_test.rb
 - `control-plane/script/`: local operational scripts only.
 - `.github/workflows/`: public CI/release workflows with path filters.
 
-## Conventions
-
-- Go: `gofmt`; no extra linter config.
-- For `agent/` and `cli/` API and documentation inspection, prefer `go doc` and `gopls` (for example, workspace symbol/definition lookups) before ad-hoc text searches.
-- Rails: `.rubocop.yml`.
-- Prefer Rails 8 solid stack, no-build CSS/JS, Tailwind, sqlite where appropriate.
-- Rails migrations: append-only. Once a migration is committed/pushed, do not edit it; add a new migration.
-- Never test static pages with no business logic.
-- Keep local override files and machine-specific templates out of this repo.
-
 ## Review Handling
 
 - Explicit user product direction overrides reviewer suggestions.
 - If user says no legacy / no backward compat / clean slate, do not add backfills, shims, or compat code just to satisfy review comments; leave the thread open and note the rationale.
 - Right after each PR is opened or updated with pushed fixes, request a fresh Copilot review with `gh pr edit <pr-number> --add-reviewer copilot-pull-request-reviewer`.
-
-## Architecture
-
-- Solo/shared deploy semantics should match. Differences: user/org/project management, ownership, persistence, transport, policy.
-- Product intent: one shared stable release version for devopsellence. Use `DEVOPSELLENCE_STABLE_VERSION`; do not add per-component stable version env vars or defaults.
-- Shared core owns config interpretation, validation, planning, desired-state generation, ingress, placement constraints, status interpretation.
-- Prefer Go for reusable deployment core logic. CLI calls it in-process for solo; Rails should eventually call it through service/RPC.
-- Rails owns product state: accounts, authz, billing, hosted persistence, API surfaces.
-- Placement is policy, not schema. Shared may require one environment per node; solo may allow multiple environments per node.
-- Desired state is mode-independent node runtime state. A node may carry multiple environment instances; an environment may have multiple named services/workers.
-- JSON casing: protobuf-backed desired-state/status payloads follow protobuf JSON casing; Rails-owned JSON/API payloads follow snake_case.
-- Agent runtime must not know product modes like solo/shared. Wire concrete adapters for desired-state source, secret resolver, status sink, registry auth, etc.
-- Core: solid, explicit. Edges: more malleable.
 
 ## Public Boundary
 

--- a/docs/north-star.md
+++ b/docs/north-star.md
@@ -75,11 +75,11 @@ Persistence should sit behind explicit state adapters.
 
 Differences in tenancy, locking, jobs, and coordination should live in adapters, not in separate deploy semantics.
 
-### 4. broker adapters
+### 4. infrastructure adapters
 
-Infrastructure integration should sit behind broker adapters that understand primitives, not product semantics.
+Infrastructure integration should sit behind adapters that understand provider primitives, not product semantics.
 
-Broker responsibilities include:
+Infrastructure adapter responsibilities include:
 
 - container registries;
 - desired-state storage;
@@ -89,7 +89,7 @@ Broker responsibilities include:
 - DNS, certificates, and cloud-owned ingress helpers;
 - lifecycle cleanup and diagnostics.
 
-Broker adapters should be cloud-specific when that produces a better result. The goal is not a weak lowest-common-denominator abstraction. The goal is a clean seam between deploy semantics and infrastructure execution.
+Infrastructure adapters should be cloud-specific when that produces a better result. The goal is not a weak lowest-common-denominator abstraction. The goal is a clean seam between deploy semantics and infrastructure execution.
 
 ### 5. product surfaces
 
@@ -107,10 +107,10 @@ The intended shape is:
 
 ```text
 solo:
-  cli -> deployment core -> state adapter + broker adapter -> agent
+  cli -> deployment core -> state adapter + infrastructure adapter -> agent
 
 shared:
-  control plane -> core api/rpc -> deployment core -> state adapter + broker adapter -> agent
+  control plane -> core api/rpc -> deployment core -> state adapter + infrastructure adapter -> agent
 ```
 
 The agent should stay mode-agnostic. It should know how to fetch desired state, resolve secrets, pull images, reconcile containers and Envoy, and publish status through concrete adapters. It should not branch on solo or shared as product concepts.

--- a/docs/north-star.md
+++ b/docs/north-star.md
@@ -19,7 +19,7 @@ The same deploy model should work in solo and shared mode. Solo and shared are d
 
 ## Design priorities
 
-- one shared deployment core;
+- one common deployment core;
 - the agent as the only mandatory runtime component;
 - desired state as the stable control surface;
 - mode-independent runtime semantics;
@@ -51,7 +51,7 @@ This layer should define what is valid, what can transition, and what data must 
 
 ### 2. deployment core
 
-One shared deployment core should own deploy semantics:
+One common deployment core should own deploy semantics:
 
 - config interpretation;
 - validation;
@@ -95,7 +95,7 @@ Broker adapters should be cloud-specific when that produces a better result. The
 
 The CLI and control plane should stay thin relative to the core.
 
-- the CLI should run the shared core in-process for solo workflows;
+- the CLI should run the common core in-process for solo workflows;
 - the control plane should call the same core through APIs or RPC for shared workflows;
 - auth, orgs, billing, quotas, support tooling, and UI can live outside the deployment core.
 

--- a/docs/north-star.md
+++ b/docs/north-star.md
@@ -1,0 +1,252 @@
+# devopsellence north star
+
+This document turns [vision.md](vision.md) into a more concrete target. The vision explains what devopsellence believes. This document describes the system shape, architectural boundaries, and core features the product should converge on.
+
+## North-star statement
+
+devopsellence should be the simplest serious system for running a small-to-medium containerized application on VMs you control.
+
+Its core job is narrow:
+
+- interpret application config;
+- validate and plan a release;
+- decide what should run on which nodes;
+- publish desired state;
+- let the agent reconcile that state;
+- report enough status and diagnostics to explain reality.
+
+The same deploy model should work in solo and shared mode. Solo and shared are different management topologies, not different deployment systems.
+
+## Design priorities
+
+- one shared deployment core;
+- the agent as the only mandatory runtime component;
+- desired state as the stable control surface;
+- mode-independent runtime semantics;
+- placement as policy, not schema;
+- provider primitives instead of devopsellence-owned replacements;
+- thin product surfaces around a strong core;
+- ordinary tools still useful for debugging and operations.
+
+## Target architecture
+
+The long-term architecture should separate five concerns cleanly.
+
+### 1. domain model
+
+One domain model should define the core entities and invariants:
+
+- workspace or application scope;
+- environments;
+- services and one-shot tasks;
+- nodes and node labels;
+- environment-to-node attachments;
+- releases or deploy snapshots;
+- desired-state publications;
+- runtime status snapshots;
+- ingress intent;
+- secret references.
+
+This layer should define what is valid, what can transition, and what data must exist for deploy behavior to be deterministic.
+
+### 2. deployment core
+
+One shared deployment core should own deploy semantics:
+
+- config interpretation;
+- validation;
+- planning;
+- placement evaluation;
+- desired-state generation;
+- release selection;
+- republish rules;
+- ingress modeling;
+- status interpretation.
+
+This core should live in Go and be usable both in-process and over an RPC boundary. If a behavior changes deploy correctness in solo and shared, it belongs here.
+
+### 3. state adapters
+
+Persistence should sit behind explicit state adapters.
+
+- solo can use sqlite or local state files;
+- shared can use postgres;
+- both should preserve the same logical model wherever practical.
+
+Differences in tenancy, locking, jobs, and coordination should live in adapters, not in separate deploy semantics.
+
+### 4. broker adapters
+
+Infrastructure integration should sit behind broker adapters that understand primitives, not product semantics.
+
+Broker responsibilities include:
+
+- container registries;
+- desired-state storage;
+- secret storage and resolution;
+- identities and registry auth;
+- compute or node provisioning where applicable;
+- DNS, certificates, and cloud-owned ingress helpers;
+- lifecycle cleanup and diagnostics.
+
+Broker adapters should be cloud-specific when that produces a better result. The goal is not a weak lowest-common-denominator abstraction. The goal is a clean seam between deploy semantics and infrastructure execution.
+
+### 5. product surfaces
+
+The CLI and control plane should stay thin relative to the core.
+
+- the CLI should run the shared core in-process for solo workflows;
+- the control plane should call the same core through APIs or RPC for shared workflows;
+- auth, orgs, billing, quotas, support tooling, and UI can live outside the deployment core.
+
+Product surfaces matter, but they should not redefine the deploy model.
+
+## System shape
+
+The intended shape is:
+
+```text
+solo:
+  cli -> deployment core -> state adapter + broker adapter -> agent
+
+shared:
+  control plane -> core api/rpc -> deployment core -> state adapter + broker adapter -> agent
+```
+
+The agent should stay mode-agnostic. It should know how to fetch desired state, resolve secrets, pull images, reconcile containers and Envoy, and publish status through concrete adapters. It should not branch on solo or shared as product concepts.
+
+## Core runtime model
+
+The runtime model should stay small and explicit.
+
+- A deployment is made of named environments, services, and tasks.
+- A service is an explicit runtime unit; do not hard-code the world into one `web` and one `worker`.
+- A node may carry one or more environment instances. Whether shared allows one environment per node is a policy choice, not a runtime-model constraint.
+- A release should be an immutable deploy snapshot derived from config, build inputs, ingress intent, and secret references.
+- Desired-state publication should be the per-node materialization of that release.
+- Status should be an observed-state report tied to a release or publication revision.
+- Ingress intent should live in desired state, not in a separate hidden control path.
+- Secret values should live in secret stores or local operator-controlled sources; the core should mainly track references, wiring, and delivery semantics.
+
+## Core features
+
+These are the foundational features the system should be excellent at before it grows outward.
+
+### Config to release
+
+devopsellence should take `devopsellence.yml`, validate it, normalize it, and produce an auditable release snapshot with minimal ambiguity.
+
+### Multi-service application model
+
+The product should handle real applications with:
+
+- multiple named web and worker services;
+- release or migration tasks;
+- per-environment overrides;
+- health checks, ports, and runtime env;
+- explicit service identity.
+
+### Placement and attachments
+
+The system should make node targeting explicit.
+
+- environments attach to nodes through clear records and policies;
+- placement constraints should be understandable and explain failures;
+- solo and shared should use the same conceptual model even when policy differs.
+
+### Desired-state publication
+
+Publishing desired state should be durable, auditable, and mode-independent.
+
+- solo should be able to publish through local artifacts;
+- shared should be able to publish through object storage and service APIs;
+- the agent-facing document shape should remain stable.
+
+### Reconciliation
+
+The agent should continuously reconcile the node toward desired state:
+
+- image pull and auth;
+- secret resolution;
+- container lifecycle;
+- Envoy config and reload;
+- drift correction;
+- status reporting.
+
+This loop is the heart of devopsellence.
+
+### Secrets
+
+Secrets should feel consistent even when the backing store changes.
+
+- solo should support local operator-controlled secrets;
+- shared should support secret-manager-backed references;
+- application config should not need a different mental model per mode.
+
+### Ingress and TLS
+
+Ingress should be first-class and mode-independent.
+
+- hostnames;
+- public service selection;
+- Envoy-managed routing;
+- node-owned certificate material;
+- optional DNS or cloud ingress assistance where useful.
+
+### Status and diagnostics
+
+Operators should be able to answer:
+
+- what release is intended?
+- what publication reached each node?
+- what is actually running?
+- what failed?
+- what should I inspect next?
+
+That requires durable release metadata, per-node status, and plain diagnostic surfaces rather than hidden orchestration state.
+
+### Escape hatches
+
+devopsellence should remain operable with ordinary tools.
+
+- local override remains possible;
+- SSH, Docker, files, logs, JSON, and cloud CLIs remain valid debugging tools;
+- the official control plane should not be the only way to recover or understand a deployment.
+
+## What should stay out of the core
+
+These may matter to the product, but they are not the north star of the system itself:
+
+- billing and monetization;
+- account and org management;
+- support and admin surfaces;
+- proprietary replacements for databases, caches, queues, logs, or analytics;
+- hidden schedulers or cluster abstractions;
+- cross-cloud lowest-common-denominator abstractions;
+- features that only make sense through the hosted control plane.
+
+Those concerns can exist at the edge. They should not distort the deployment core.
+
+## Sequencing bias
+
+When tradeoffs appear, bias toward this order:
+
+1. strengthen the shared deploy model;
+2. make solo and shared semantics converge;
+3. stabilize the desired-state contract and agent adapter seams;
+4. keep product shells thin;
+5. add provider-specific capabilities through adapters;
+6. only then expand outward into richer workflow and product layers.
+
+## Success test
+
+This north star is being met if the following become true:
+
+- the same app model works in solo and shared without semantic drift;
+- moving from local to hosted changes adapters more than it changes concepts;
+- the release, publication, reconcile, and status path is understandable end to end;
+- provider-specific integrations do not leak into the core runtime model;
+- the agent remains small, explicit, and mode-agnostic;
+- operators can debug the system without learning a devopsellence-only universe.
+
+The shortest version is this: devopsellence should become a clear, durable deployment core for containerized applications on VMs, with thin control surfaces around it and no unnecessary new abstraction layer.


### PR DESCRIPTION
## What changed
- add `docs/north-star.md`
- translate `docs/vision.md` into a more concrete target document
- define the target system shape, architectural seams, runtime model, core features, and non-goals

## Why
`docs/vision.md` captures philosophy, but there was not yet a companion doc that states the nearer-term architectural target and the foundational features the system should converge on.

## Impact
- gives the repo a concrete architecture/reference doc for foundational system design
- clarifies the intended boundaries between domain model, deployment core, state adapters, broker adapters, agent, and product surfaces
- keeps focus on core deploy semantics rather than hosted-product edges

## Validation
- reviewed against `docs/vision.md`
- reviewed against `../managed-devopsellence/docs/broker-architecture.md`
- `git diff --cached --check`

## Notes
- docs-only change
- no tests run