### PR TITLE
fix: default solo setup wizard to hetzner

### DIFF
--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1554,7 +1554,7 @@ func (a *App) SoloSetup(ctx context.Context, _ SoloSetupOptions) error {
 	if !a.Printer.Interactive {
 		return fmt.Errorf("solo setup requires an interactive terminal; use `devopsellence node create`, or add a node to %s and run `devopsellence node attach`", solo.DefaultStatePath())
 	}
-	mode, err := a.promptLine("Node source (existing/hetzner)", "existing")
+	mode, err := a.promptLine("Node source (existing/hetzner)", "hetzner")
 	if err != nil {
 		return err
 	}

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -1045,7 +1045,7 @@ func TestEnsureGeneratedWorkspaceSSHKeyRejectsMismatchedPublicKey(t *testing.T) 
 	}
 }
 
-func TestSoloSetupHetznerDefaultsToGeneratedWorkspaceKey(t *testing.T) {
+func TestSoloSetupDefaultsToHetznerAndGeneratedWorkspaceKey(t *testing.T) {
 	stateDir := t.TempDir()
 	t.Setenv("XDG_STATE_HOME", stateDir)
 
@@ -1056,7 +1056,7 @@ func TestSoloSetupHetznerDefaultsToGeneratedWorkspaceKey(t *testing.T) {
 	var stdout bytes.Buffer
 	var created SoloNodeCreateOptions
 	app := &App{
-		In:          strings.NewReader("hetzner\nprod-1\nweb\nash\ncpx11\n\n"),
+		In:          strings.NewReader("\nprod-1\nweb\nash\ncpx11\n\n"),
 		Printer:     output.New(&stdout, io.Discard, false),
 		ConfigStore: config.NewStore(),
 		Cwd:         workspaceRoot,
@@ -1071,6 +1071,9 @@ func TestSoloSetupHetznerDefaultsToGeneratedWorkspaceKey(t *testing.T) {
 
 	if err := app.SoloSetup(context.Background(), SoloSetupOptions{}); err != nil {
 		t.Fatal(err)
+	}
+	if created.Provider != "hetzner" {
+		t.Fatalf("provider = %q, want hetzner", created.Provider)
 	}
 	if created.SSHPublicKey == "" {
 		t.Fatal("generated SSH public key path empty")


### PR DESCRIPTION
## Summary
- default the interactive solo setup node source prompt to `hetzner`
- update the setup test to accept the default blank answer and assert the Hetzner provider is used

## Test Plan
- mise exec -- go test ./internal/workflow -run 'TestSoloSetupDefaultsToHetznerAndGeneratedWorkspaceKey|TestSoloSetupHetznerExistingUsesPromptedPublicKeyPath' -count=1
- mise exec -- go test ./internal/workflow -count=1