### PR TITLE
feat: bootstrap explicit ingress defaults

### DIFF
--- a/cli/internal/api/client.go
+++ b/cli/internal/api/client.go
@@ -48,9 +48,10 @@ type Project struct {
 }
 
 type Environment struct {
-	ID              int    `json:"id"`
-	Name            string `json:"name"`
-	IngressStrategy string `json:"ingress_strategy,omitempty"`
+	ID              int      `json:"id"`
+	Name            string   `json:"name"`
+	IngressStrategy string   `json:"ingress_strategy,omitempty"`
+	IngressHosts    []string `json:"ingress_hosts,omitempty"`
 }
 
 type DeployTargetResponse struct {

--- a/cli/internal/workflow/app.go
+++ b/cli/internal/workflow/app.go
@@ -3360,6 +3360,9 @@ func (a *App) initializeWorkspace(ctx context.Context, callAuth authCall, opts I
 	if existing == nil && discovered.InferredWebPort > 0 {
 		projectConfig = setPrimaryWebServicePort(projectConfig, discovered.InferredWebPort)
 	}
+	if existing == nil {
+		projectConfig = applySharedBootstrapIngress(projectConfig, target.Environment.IngressHosts)
+	}
 	if existing != nil {
 		projectConfig.Build = existing.Build
 		projectConfig.Services = existing.Services
@@ -3715,6 +3718,46 @@ func setPrimaryWebServicePort(cfg config.ProjectConfig, port int) config.Project
 		}
 	}
 	cfg.Services[name] = service
+	return cfg
+}
+
+func applyBootstrapIngress(cfg config.ProjectConfig, hosts []string) config.ProjectConfig {
+	serviceName, ok := cfg.PrimaryWebServiceName()
+	if !ok {
+		return cfg
+	}
+	resolvedHosts := normalizeIngressHosts(hosts)
+	if len(resolvedHosts) == 0 {
+		resolvedHosts = []string{"*"}
+	}
+	cfg.Ingress = &config.IngressConfig{
+		Hosts:   resolvedHosts,
+		Service: serviceName,
+		TLS: config.IngressTLSConfig{
+			Mode: "off",
+		},
+		RedirectHTTP: configBoolPtr(false),
+	}
+	return cfg
+}
+
+func applySharedBootstrapIngress(cfg config.ProjectConfig, hosts []string) config.ProjectConfig {
+	serviceName, ok := cfg.PrimaryWebServiceName()
+	if !ok {
+		return cfg
+	}
+	resolvedHosts := normalizeIngressHostsKeepOrder(hosts)
+	if len(resolvedHosts) == 0 {
+		return cfg
+	}
+	cfg.Ingress = &config.IngressConfig{
+		Hosts:   resolvedHosts,
+		Service: serviceName,
+		TLS: config.IngressTLSConfig{
+			Mode: "off",
+		},
+		RedirectHTTP: configBoolPtr(false),
+	}
 	return cfg
 }
 

--- a/cli/internal/workflow/management_test.go
+++ b/cli/internal/workflow/management_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strings"
 	"sync"
@@ -165,6 +166,103 @@ func TestInitWritesGenericConfigAtRepoRoot(t *testing.T) {
 	web := webService(t, loaded)
 	if web.Healthcheck == nil || web.Healthcheck.Path != "/" {
 		t.Fatalf("generic healthcheck path = %#v, want /", web.Healthcheck)
+	}
+}
+
+func TestInitBootstrapsSharedIngressFromCanonicalDomain(t *testing.T) {
+	t.Parallel()
+
+	root := makeRailsRoot(t, "ShopApp")
+	app := newTestAppWithDeployTarget(t, root, roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/cli/deploy_target":
+			return jsonResponseWithStatus(t, http.StatusCreated, map[string]any{
+				"organization":         map[string]any{"id": 7, "name": "default"},
+				"organization_created": false,
+				"project":              map[string]any{"id": 11, "name": "ShopApp", "organization_id": 7},
+				"project_created":      false,
+				"environment": map[string]any{
+					"id":            44,
+					"name":          "production",
+					"project_id":    11,
+					"runtime_kind":  "managed",
+					"ingress_hosts": []string{"www.prod-abc.devopsellence.io", "prod-abc.devopsellence.io"},
+				},
+				"environment_created": true,
+			}), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+			return nil, nil
+		}
+	}))
+
+	if err := app.Init(context.Background(), InitOptions{NonInteractive: true}); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+
+	loaded, err := config.LoadFromRoot(root)
+	if err != nil {
+		t.Fatalf("LoadFromRoot() error = %v", err)
+	}
+	if loaded == nil || loaded.Ingress == nil {
+		t.Fatalf("expected bootstrapped ingress, got %#v", loaded)
+	}
+	if got, want := loaded.Ingress.Service, config.DefaultWebServiceName; got != want {
+		t.Fatalf("ingress.service = %q, want %q", got, want)
+	}
+	if got, want := loaded.Ingress.Hosts, []string{"www.prod-abc.devopsellence.io", "prod-abc.devopsellence.io"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("ingress.hosts = %#v, want %#v", got, want)
+	}
+	if got, want := loaded.Ingress.TLS.Mode, "off"; got != want {
+		t.Fatalf("ingress.tls.mode = %q, want %q", got, want)
+	}
+	if loaded.Ingress.RedirectHTTP == nil {
+		t.Fatal("expected explicit ingress.redirect_http=false")
+	}
+	if *loaded.Ingress.RedirectHTTP {
+		t.Fatal("ingress.redirect_http = true, want false")
+	}
+}
+
+func TestInitLeavesSharedIngressUnsetUntilCanonicalDomainExists(t *testing.T) {
+	t.Parallel()
+
+	root := makeRailsRoot(t, "ShopApp")
+	app := newTestAppWithDeployTarget(t, root, roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/cli/deploy_target":
+			return jsonResponseWithStatus(t, http.StatusCreated, map[string]any{
+				"organization":         map[string]any{"id": 7, "name": "default"},
+				"organization_created": false,
+				"project":              map[string]any{"id": 11, "name": "ShopApp", "organization_id": 7},
+				"project_created":      false,
+				"environment": map[string]any{
+					"id":           44,
+					"name":         "production",
+					"project_id":   11,
+					"runtime_kind": "managed",
+				},
+				"environment_created": true,
+			}), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+			return nil, nil
+		}
+	}))
+
+	if err := app.Init(context.Background(), InitOptions{NonInteractive: true}); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+
+	loaded, err := config.LoadFromRoot(root)
+	if err != nil {
+		t.Fatalf("LoadFromRoot() error = %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("expected config to load")
+	}
+	if loaded.Ingress != nil {
+		t.Fatalf("expected shared ingress to stay unset without canonical host, got %#v", loaded.Ingress)
 	}
 }
 

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1909,6 +1909,7 @@ func soloDefaultProjectConfig(discovered discovery.Result) *config.ProjectConfig
 			cfg.Services[serviceName] = service
 		}
 	}
+	cfg = applyBootstrapIngress(cfg, nil)
 	return &cfg
 }
 
@@ -2042,6 +2043,22 @@ func normalizeIngressHosts(values []string) []string {
 		}
 	}
 	sort.Strings(normalized)
+	return normalized
+}
+
+func normalizeIngressHostsKeepOrder(values []string) []string {
+	seen := map[string]bool{}
+	normalized := []string{}
+	for _, value := range values {
+		for _, part := range strings.Split(value, ",") {
+			part = strings.TrimSpace(part)
+			if part == "" || seen[part] {
+				continue
+			}
+			seen[part] = true
+			normalized = append(normalized, part)
+		}
+	}
 	return normalized
 }
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -48,6 +48,39 @@ func TestDockerBuildArgsRejectsMultiplePlatforms(t *testing.T) {
 	}
 }
 
+func TestSoloDefaultProjectConfigBootstrapsExplicitCatchAllIngress(t *testing.T) {
+	t.Parallel()
+
+	cfg := soloDefaultProjectConfig(discovery.Result{
+		ProjectName:     "shop-app",
+		AppType:         config.AppTypeRails,
+		InferredWebPort: 3001,
+	})
+
+	if cfg.Ingress == nil {
+		t.Fatal("expected bootstrapped ingress")
+	}
+	if got, want := cfg.Ingress.Service, config.DefaultWebServiceName; got != want {
+		t.Fatalf("ingress.service = %q, want %q", got, want)
+	}
+	if got, want := cfg.Ingress.Hosts, []string{"*"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("ingress.hosts = %#v, want %#v", got, want)
+	}
+	if got, want := cfg.Ingress.TLS.Mode, "off"; got != want {
+		t.Fatalf("ingress.tls.mode = %q, want %q", got, want)
+	}
+	if cfg.Ingress.RedirectHTTP == nil {
+		t.Fatal("expected explicit ingress.redirect_http=false")
+	}
+	if *cfg.Ingress.RedirectHTTP {
+		t.Fatal("ingress.redirect_http = true, want false")
+	}
+	web := cfg.Services[config.DefaultWebServiceName]
+	if got, want := web.HTTPPort(0), 3001; got != want {
+		t.Fatalf("web http port = %d, want %d", got, want)
+	}
+}
+
 func TestValidateSoloNodeScheduleSelectsReleaseNode(t *testing.T) {
 	cfg := &config.ProjectConfig{
 		Services: map[string]config.ServiceConfig{

--- a/control-plane/app/controllers/api/v1/cli/deploy_targets_controller.rb
+++ b/control-plane/app/controllers/api/v1/cli/deploy_targets_controller.rb
@@ -183,8 +183,19 @@ module Api
             name: environment.name,
             project_id: environment.project_id,
             identity_version: environment.identity_version,
-            runtime_kind: environment.runtime_kind
+            runtime_kind: environment.runtime_kind,
+            ingress_hosts: environment_ingress_hosts(environment)
           }
+        end
+
+        def environment_ingress_hosts(environment)
+          ingress_hosts = environment.environment_ingress&.hosts
+          return ingress_hosts if ingress_hosts.present?
+
+          bundle_hostname = environment.environment_bundle&.hostname.to_s.strip
+          return [ bundle_hostname ] if bundle_hostname.present?
+
+          []
         end
 
         def integer_string?(value)

--- a/control-plane/test/integration/api_cli_mvp_test.rb
+++ b/control-plane/test/integration/api_cli_mvp_test.rb
@@ -208,6 +208,41 @@ class ApiCliMvpTest < ActionDispatch::IntegrationTest
     assert_equal "managed", json_body.dig("environment", "runtime_kind")
   end
 
+  test "deploy target includes canonical ingress hosts for existing environment" do
+    user = User.create!(email: "owner-#{SecureRandom.hex(4)}@example.com", confirmed_at: Time.current)
+    organization = Organization.create!(name: "acme")
+    ensure_test_organization_runtime!(organization)
+    OrganizationMembership.create!(organization: organization, user: user, role: OrganizationMembership::ROLE_OWNER)
+    project = organization.projects.create!(name: "ShopApp")
+    environment = project.environments.create!(
+      name: "production",
+      gcp_project_id: organization.gcp_project_id,
+      gcp_project_number: organization.gcp_project_number,
+      workload_identity_pool: organization.workload_identity_pool,
+      workload_identity_provider: organization.workload_identity_provider,
+      runtime_kind: Environment::RUNTIME_MANAGED
+    )
+    ingress = environment.create_environment_ingress!(
+      hostname: "prod-abc.devopsellence.io",
+      gcp_secret_name: "env-#{SecureRandom.hex(4)}-ingress-cloudflare-tunnel-token",
+      status: EnvironmentIngress::STATUS_READY,
+      provisioned_at: Time.current
+    )
+    ingress.assign_hosts!([ "prod-abc.devopsellence.io", "www.prod-abc.devopsellence.io" ])
+
+    post "/api/v1/cli/deploy_target",
+      params: {
+        organization: "acme",
+        project: "ShopApp",
+        environment: "production"
+      },
+      headers: auth_headers_for(user),
+      as: :json
+
+    assert_response :success
+    assert_equal [ "prod-abc.devopsellence.io", "www.prod-abc.devopsellence.io" ], json_body.dig("environment", "ingress_hosts")
+  end
+
   test "deploy target resolves existing organization by preferred id when organization is omitted" do
     user = User.create!(email: "owner-#{SecureRandom.hex(4)}@example.com", confirmed_at: Time.current)
     alpha = Organization.create!(name: "alpha")


### PR DESCRIPTION
## Summary
- bootstrap explicit solo ingress as a catch-all route with TLS off and redirect disabled
- bootstrap explicit shared ingress from canonical environment hosts when available, and leave ingress unset until the host exists
- expose environment ingress hosts in the deploy-target response so shared init can write the canonical domain into config

## Test Plan
- `cd cli && mise x go@1.25.8 -- go test ./...`
- Independent code review via Hermes subagent
- Control-plane tests not run locally in this environment because Ruby/Bundler are unavailable on PATH
