### PR TITLE
feat: replace service kinds with explicit ingress rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,6 @@ build:
     - linux/amd64
 services:
   web:
-    kind: web
     ports:
       - name: http
         port: 3000
@@ -130,9 +129,15 @@ tasks:
       - bin/rails
       - db:migrate
 ingress:
-  service: web
   hosts:
     - app.example.com
+  rules:
+    - match:
+        host: app.example.com
+        path_prefix: /
+      target:
+        service: web
+        port: http
   tls:
     mode: auto
     email: ops@example.com

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ The product layering is deliberate:
 
 When you outgrow solo, `devopsellence mode use shared` switches to control-plane workflows. Same config, same agent, same deploy verbs.
 
-The design rationale lives in [`docs/vision.md`](docs/vision.md).
+The design rationale lives in [`docs/vision.md`](docs/vision.md). The explicit ingress-rules + generic-services schema change is documented in [`docs/specs/2026-04-24-explicit-ingress-rules-and-generic-services.md`](docs/specs/2026-04-24-explicit-ingress-rules-and-generic-services.md).
 
 ## Monorepo layout
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,13 @@ environments:
     ingress:
       hosts:
         - staging.example.com
+      rules:
+        - match:
+            host: staging.example.com
+            path_prefix: /
+          target:
+            service: web
+            port: http
   production:
     services:
       web:
@@ -154,20 +161,18 @@ environments:
           RAILS_ENV: production
 ```
 
-### Example: run cloudflared as an accessory service
+### Example: run cloudflared as a normal service
 
-`kind: accessory` is already supported for non-web sidecars/helpers. That means Cloudflare Tunnel can live in normal app config instead of as special agent-managed behavior:
+Cloudflare Tunnel can live in normal app config instead of as special agent-managed behavior:
 
 ```yaml
 services:
   web:
-    kind: web
     ports:
       - name: http
         port: 3000
 
   cloudflared:
-    kind: accessory
     image: docker.io/cloudflare/cloudflared:latest
     command: ["cloudflared"]
     args: ["tunnel", "run"]

--- a/agent/internal/desiredstate/validate.go
+++ b/agent/internal/desiredstate/validate.go
@@ -246,15 +246,9 @@ func validateIngressRoutes(state *desiredstatepb.DesiredState) error {
 		if service == nil {
 			return fmt.Errorf("ingress.routes[%d].target references missing service %s/%s", i, env, serviceName)
 		}
-		if ServiceKind(service) != ServiceKindWeb {
-			return fmt.Errorf("ingress.routes[%d].target service %s/%s must be kind web", i, env, serviceName)
-		}
 		portName := strings.TrimSpace(route.Target.Port)
 		if portName == "" {
-			portName = DefaultHTTPPortName
-		}
-		if portName != DefaultHTTPPortName {
-			return fmt.Errorf("ingress.routes[%d].target port must be %q", i, DefaultHTTPPortName)
+			return fmt.Errorf("ingress.routes[%d].target.port required", i)
 		}
 		if !serviceHasPort(service, portName) {
 			return fmt.Errorf("ingress.routes[%d].target references missing port %s/%s:%s", i, env, serviceName, portName)

--- a/agent/internal/desiredstate/validate.go
+++ b/agent/internal/desiredstate/validate.go
@@ -248,7 +248,7 @@ func validateIngressRoutes(state *desiredstatepb.DesiredState) error {
 		}
 		portName := strings.TrimSpace(route.Target.Port)
 		if portName == "" {
-			return fmt.Errorf("ingress.routes[%d].target.port required", i)
+			return fmt.Errorf("ingress.routes[%d].target.port is required", i)
 		}
 		if !serviceHasPort(service, portName) {
 			return fmt.Errorf("ingress.routes[%d].target references missing port %s/%s:%s", i, env, serviceName, portName)

--- a/agent/internal/desiredstate/validate_test.go
+++ b/agent/internal/desiredstate/validate_test.go
@@ -212,7 +212,7 @@ func TestValidateIngressRouteTarget(t *testing.T) {
 	}
 }
 
-func TestValidateIngressRouteTargetRequiresWebService(t *testing.T) {
+func TestValidateIngressRouteTargetAllowsNonWebService(t *testing.T) {
 	state := desiredState(&desiredstatepb.Service{
 		Name:  "worker",
 		Kind:  "worker",
@@ -247,7 +247,7 @@ func TestValidateIngressRouteTargetAllowsGenericServiceAndNamedPort(t *testing.T
 	}
 }
 
-func TestValidateIngressRouteTargetRequiresHTTPPort(t *testing.T) {
+func TestValidateIngressRouteTargetAllowsNonHTTPNamedPort(t *testing.T) {
 	service := webService()
 	service.Ports = append(service.Ports, &desiredstatepb.ServicePort{Name: "metrics", Port: 9090})
 	state := desiredState(service)
@@ -258,6 +258,18 @@ func TestValidateIngressRouteTargetRequiresHTTPPort(t *testing.T) {
 	}
 	if err := Validate(state); err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateIngressRouteTargetRequiresNamedPort(t *testing.T) {
+	state := desiredState(webService())
+	state.Ingress = &desiredstatepb.Ingress{
+		Mode:   "public",
+		Hosts:  []string{"app.example.com"},
+		Routes: []*desiredstatepb.IngressRoute{route("app.example.com", "production", "web", "")},
+	}
+	if err := Validate(state); err == nil {
+		t.Fatal("expected error")
 	}
 }
 

--- a/agent/internal/desiredstate/validate_test.go
+++ b/agent/internal/desiredstate/validate_test.go
@@ -268,8 +268,12 @@ func TestValidateIngressRouteTargetRequiresNamedPort(t *testing.T) {
 		Hosts:  []string{"app.example.com"},
 		Routes: []*desiredstatepb.IngressRoute{route("app.example.com", "production", "web", "")},
 	}
-	if err := Validate(state); err == nil {
+	err := Validate(state)
+	if err == nil {
 		t.Fatal("expected error")
+	}
+	if got, want := err.Error(), "ingress.routes[0].target.port is required"; got != want {
+		t.Fatalf("error = %q, want %q", got, want)
 	}
 }
 

--- a/agent/internal/desiredstate/validate_test.go
+++ b/agent/internal/desiredstate/validate_test.go
@@ -224,8 +224,26 @@ func TestValidateIngressRouteTargetRequiresWebService(t *testing.T) {
 		Hosts:  []string{"app.example.com"},
 		Routes: []*desiredstatepb.IngressRoute{route("app.example.com", "production", "worker", "http")},
 	}
-	if err := Validate(state); err == nil {
-		t.Fatal("expected error")
+	if err := Validate(state); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateIngressRouteTargetAllowsGenericServiceAndNamedPort(t *testing.T) {
+	service := &desiredstatepb.Service{
+		Name:  "api",
+		Kind:  "worker",
+		Image: "busybox",
+		Ports: []*desiredstatepb.ServicePort{{Name: "metrics", Port: 9090}},
+	}
+	state := desiredState(service)
+	state.Ingress = &desiredstatepb.Ingress{
+		Mode:   "public",
+		Hosts:  []string{"app.example.com"},
+		Routes: []*desiredstatepb.IngressRoute{route("app.example.com", "production", "api", "metrics")},
+	}
+	if err := Validate(state); err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
@@ -238,8 +256,8 @@ func TestValidateIngressRouteTargetRequiresHTTPPort(t *testing.T) {
 		Hosts:  []string{"app.example.com"},
 		Routes: []*desiredstatepb.IngressRoute{route("app.example.com", "production", "web", "metrics")},
 	}
-	if err := Validate(state); err == nil {
-		t.Fatal("expected error")
+	if err := Validate(state); err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -485,9 +485,9 @@ func applyDefaults(cfg *ProjectConfig) {
 		cfg.Tasks.Release.Env = mergeStringMaps(cfg.Tasks.Release.Env)
 	}
 	if cfg.Ingress != nil {
-		cfg.Ingress.Hosts = normalizeStringList(cfg.Ingress.Hosts)
+		cfg.Ingress.Hosts = normalizeIngressHostList(cfg.Ingress.Hosts)
 		for i, rule := range cfg.Ingress.Rules {
-			rule.Match.Host = strings.TrimSpace(rule.Match.Host)
+			rule.Match.Host = normalizedIngressHost(rule.Match.Host)
 			rule.Match.PathPrefix = strings.TrimSpace(rule.Match.PathPrefix)
 			if rule.Match.PathPrefix == "" {
 				rule.Match.PathPrefix = "/"
@@ -567,6 +567,20 @@ func normalizeStringList(values []string) []string {
 	normalized := make([]string, 0, len(values))
 	for _, value := range values {
 		value = strings.TrimSpace(value)
+		if value == "" || seen[value] {
+			continue
+		}
+		seen[value] = true
+		normalized = append(normalized, value)
+	}
+	return normalized
+}
+
+func normalizeIngressHostList(values []string) []string {
+	seen := make(map[string]bool, len(values))
+	normalized := make([]string, 0, len(values))
+	for _, value := range values {
+		value = normalizedIngressHost(value)
 		if value == "" || seen[value] {
 			continue
 		}

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -99,7 +99,7 @@ type IngressConfig struct {
 	Hosts        []string             `yaml:"hosts,omitempty" json:"hosts,omitempty"`
 	Rules        []IngressRuleConfig  `yaml:"rules,omitempty" json:"rules,omitempty"`
 	TLS          IngressTLSConfig     `yaml:"tls,omitempty" json:"tls,omitempty"`
-	RedirectHTTP bool                 `yaml:"redirect_http,omitempty" json:"redirect_http,omitempty"`
+	RedirectHTTP *bool                `yaml:"redirect_http,omitempty" json:"redirect_http,omitempty"`
 }
 
 type IngressRuleConfig struct {
@@ -117,6 +117,52 @@ type IngressTargetConfig struct {
 	Port    string `yaml:"port" json:"port"`
 }
 
+type HTTPHealthcheckOverlay struct {
+	Path *string `yaml:"path,omitempty" json:"path,omitempty"`
+	Port *int    `yaml:"port,omitempty" json:"port,omitempty"`
+}
+
+type ServiceConfigOverlay struct {
+	Image       *string                 `yaml:"image,omitempty" json:"image,omitempty"`
+	Command     []string                `yaml:"command,omitempty" json:"command,omitempty"`
+	Args        []string                `yaml:"args,omitempty" json:"args,omitempty"`
+	Env         map[string]string       `yaml:"env,omitempty" json:"env,omitempty"`
+	SecretRefs  []SecretRef             `yaml:"secret_refs,omitempty" json:"secret_refs,omitempty"`
+	Ports       []ServicePort           `yaml:"ports,omitempty" json:"ports,omitempty"`
+	Healthcheck *HTTPHealthcheckOverlay `yaml:"healthcheck,omitempty" json:"healthcheck,omitempty"`
+	Volumes     []Volume                `yaml:"volumes,omitempty" json:"volumes,omitempty"`
+}
+
+type TaskConfigOverlay struct {
+	Service *string           `yaml:"service,omitempty" json:"service,omitempty"`
+	Command []string          `yaml:"command,omitempty" json:"command,omitempty"`
+	Args    []string          `yaml:"args,omitempty" json:"args,omitempty"`
+	Env     map[string]string `yaml:"env,omitempty" json:"env,omitempty"`
+}
+
+type TasksConfigOverlay struct {
+	Release *TaskConfigOverlay `yaml:"release,omitempty" json:"release,omitempty"`
+}
+
+type IngressTLSConfigOverlay struct {
+	Mode           *string `yaml:"mode,omitempty" json:"mode,omitempty"`
+	Email          *string `yaml:"email,omitempty" json:"email,omitempty"`
+	CADirectoryURL *string `yaml:"ca_directory_url,omitempty" json:"ca_directory_url,omitempty"`
+}
+
+type IngressConfigOverlay struct {
+	Hosts        []string                 `yaml:"hosts,omitempty" json:"hosts,omitempty"`
+	Rules        []IngressRuleConfig      `yaml:"rules,omitempty" json:"rules,omitempty"`
+	TLS          *IngressTLSConfigOverlay `yaml:"tls,omitempty" json:"tls,omitempty"`
+	RedirectHTTP *bool                    `yaml:"redirect_http,omitempty" json:"redirect_http,omitempty"`
+}
+
+type EnvironmentOverlay struct {
+	Ingress  *IngressConfigOverlay           `yaml:"ingress,omitempty" json:"ingress,omitempty"`
+	Services map[string]ServiceConfigOverlay `yaml:"services,omitempty" json:"services,omitempty"`
+	Tasks    *TasksConfigOverlay             `yaml:"tasks,omitempty" json:"tasks,omitempty"`
+}
+
 type SoloNode struct {
 	Host             string   `yaml:"host" json:"host"`
 	User             string   `yaml:"user" json:"user"`
@@ -132,15 +178,16 @@ type SoloNode struct {
 }
 
 type ProjectConfig struct {
-	SchemaVersion      int                      `yaml:"schema_version" json:"schema_version"`
-	App                AppConfig                `yaml:"app,omitempty" json:"app,omitempty"`
-	Organization       string                   `yaml:"organization" json:"organization"`
-	Project            string                   `yaml:"project" json:"project"`
-	DefaultEnvironment string                   `yaml:"default_environment" json:"default_environment"`
-	Build              BuildConfig              `yaml:"build" json:"build"`
-	Services           map[string]ServiceConfig `yaml:"services" json:"services"`
-	Tasks              TasksConfig              `yaml:"tasks,omitempty" json:"tasks,omitempty"`
-	Ingress            *IngressConfig           `yaml:"ingress,omitempty" json:"ingress,omitempty"`
+	SchemaVersion      int                           `yaml:"schema_version" json:"schema_version"`
+	App                AppConfig                     `yaml:"app,omitempty" json:"app,omitempty"`
+	Organization       string                        `yaml:"organization" json:"organization"`
+	Project            string                        `yaml:"project" json:"project"`
+	DefaultEnvironment string                        `yaml:"default_environment" json:"default_environment"`
+	Build              BuildConfig                   `yaml:"build" json:"build"`
+	Services           map[string]ServiceConfig      `yaml:"services" json:"services"`
+	Tasks              TasksConfig                   `yaml:"tasks,omitempty" json:"tasks,omitempty"`
+	Ingress            *IngressConfig                `yaml:"ingress,omitempty" json:"ingress,omitempty"`
+	Environments       map[string]EnvironmentOverlay `yaml:"environments,omitempty" json:"environments,omitempty"`
 }
 
 type Project = ProjectConfig
@@ -277,6 +324,7 @@ func DefaultProjectConfigForType(organization, project, environment, appType str
 		},
 		Services: map[string]ServiceConfig{
 			DefaultWebServiceName: {
+				Kind:       ServiceKindWeb,
 				Env:        map[string]string{},
 				SecretRefs: []SecretRef{},
 				Volumes:    []Volume{},
@@ -314,6 +362,17 @@ func Validate(cfg *ProjectConfig) error {
 	if strings.TrimSpace(cfg.DefaultEnvironment) == "" {
 		return errors.New("default_environment is required")
 	}
+	if err := validateEnvironmentOverlays(cfg); err != nil {
+		return err
+	}
+	resolved, err := ResolveEnvironmentConfig(*cfg, cfg.DefaultEnvironment)
+	if err != nil {
+		return err
+	}
+	return validateResolvedProjectConfig(&resolved)
+}
+
+func validateResolvedProjectConfig(cfg *ProjectConfig) error {
 	if strings.TrimSpace(cfg.Build.Context) == "" {
 		return errors.New("build.context is required")
 	}
@@ -392,6 +451,9 @@ func applyDefaults(cfg *ProjectConfig) {
 	if cfg.Services == nil {
 		cfg.Services = map[string]ServiceConfig{}
 	}
+	if cfg.Environments == nil {
+		cfg.Environments = map[string]EnvironmentOverlay{}
+	}
 	for name, service := range cfg.Services {
 		if service.Env == nil {
 			service.Env = map[string]string{}
@@ -405,7 +467,7 @@ func applyDefaults(cfg *ProjectConfig) {
 		service.Ports = normalizeServicePorts(service.Ports)
 		if service.Healthcheck != nil {
 			service.Healthcheck.Path = strings.TrimSpace(service.Healthcheck.Path)
-			if service.Healthcheck.Path == "" {
+			if strings.TrimSpace(service.Healthcheck.Path) == "" {
 				if cfg.App.Type == AppTypeGeneric {
 					service.Healthcheck.Path = "/"
 				} else {
@@ -420,6 +482,9 @@ func applyDefaults(cfg *ProjectConfig) {
 		cfg.Services[name] = service
 	}
 	if cfg.Tasks.Release != nil {
+		cfg.Tasks.Release.Service = strings.TrimSpace(cfg.Tasks.Release.Service)
+		cfg.Tasks.Release.Command = normalizeStringListKeepOrder(cfg.Tasks.Release.Command)
+		cfg.Tasks.Release.Args = normalizeStringListKeepOrder(cfg.Tasks.Release.Args)
 		cfg.Tasks.Release.Env = mergeStringMaps(cfg.Tasks.Release.Env)
 	}
 	if cfg.Ingress != nil {
@@ -440,10 +505,47 @@ func applyDefaults(cfg *ProjectConfig) {
 		}
 		cfg.Ingress.TLS.Email = strings.TrimSpace(cfg.Ingress.TLS.Email)
 		cfg.Ingress.TLS.CADirectoryURL = strings.TrimSpace(cfg.Ingress.TLS.CADirectoryURL)
-		if cfg.Ingress.TLS.Mode == "auto" {
-			cfg.Ingress.RedirectHTTP = true
+		if cfg.Ingress.TLS.Mode == "auto" && cfg.Ingress.RedirectHTTP == nil {
+			cfg.Ingress.RedirectHTTP = boolPtr(true)
 		}
 	}
+}
+
+func ResolveEnvironmentConfig(base ProjectConfig, selectedEnv string) (ProjectConfig, error) {
+	resolved := cloneProjectConfig(base)
+	envName := strings.TrimSpace(selectedEnv)
+	if envName == "" {
+		envName = strings.TrimSpace(base.DefaultEnvironment)
+	}
+	if envName == "" {
+		envName = DefaultEnvironment
+	}
+	resolved.DefaultEnvironment = envName
+
+	overlay, ok := base.Environments[envName]
+	if !ok {
+		applyDefaults(&resolved)
+		return resolved, nil
+	}
+
+	if overlay.Ingress != nil {
+		resolved.Ingress = mergeIngressConfig(resolved.Ingress, overlay.Ingress)
+	}
+	if len(overlay.Services) > 0 {
+		if resolved.Services == nil {
+			resolved.Services = map[string]ServiceConfig{}
+		}
+		for name, entry := range overlay.Services {
+			baseService := resolved.Services[name]
+			resolved.Services[name] = mergeServiceConfig(baseService, entry)
+		}
+	}
+	if overlay.Tasks != nil {
+		resolved.Tasks = mergeTasksConfig(resolved.Tasks, overlay.Tasks)
+	}
+
+	applyDefaults(&resolved)
+	return resolved, nil
 }
 
 func normalizeNodeLabels(labels []string) []string {
@@ -473,6 +575,17 @@ func normalizeStringList(values []string) []string {
 		}
 		seen[value] = true
 		normalized = append(normalized, value)
+	}
+	return normalized
+}
+
+func normalizeStringListKeepOrder(values []string) []string {
+	if values == nil {
+		return nil
+	}
+	normalized := make([]string, 0, len(values))
+	for _, value := range values {
+		normalized = append(normalized, strings.TrimSpace(value))
 	}
 	return normalized
 }
@@ -531,70 +644,31 @@ func validateService(name string, service ServiceConfig) error {
 	}
 	seenPorts := map[string]bool{}
 	for _, port := range service.Ports {
-		portName := strings.TrimSpace(port.Name)
-		if portName == "" {
+		if strings.TrimSpace(port.Name) == "" {
 			return fmt.Errorf("services.%s.ports[].name is required", name)
 		}
 		if port.Port <= 0 {
 			return fmt.Errorf("services.%s.ports[%s].port must be a positive integer", name, port.Name)
 		}
-		if seenPorts[portName] {
-			return fmt.Errorf("services.%s.ports contains duplicate port %q", name, portName)
+		if seenPorts[port.Name] {
+			return fmt.Errorf("services.%s.ports contains duplicate port %q", name, port.Name)
 		}
-		seenPorts[portName] = true
+		seenPorts[port.Name] = true
 	}
-	if service.Healthcheck != nil {
+	serviceKind := inferredServiceKind(name, service)
+	if serviceKind == ServiceKindWeb {
+		if service.HTTPPort(0) <= 0 {
+			return fmt.Errorf("services.%s must expose an http port", name)
+		}
+		if service.Healthcheck == nil {
+			return fmt.Errorf("services.%s.healthcheck is required", name)
+		}
 		if strings.TrimSpace(service.Healthcheck.Path) == "" {
 			return fmt.Errorf("services.%s.healthcheck.path is required", name)
 		}
 		if service.Healthcheck.Port <= 0 {
 			return fmt.Errorf("services.%s.healthcheck.port must be a positive integer", name)
 		}
-	}
-	return nil
-}
-
-func validateIngressRules(cfg *ProjectConfig) error {
-	knownHosts := map[string]struct{}{}
-	for _, host := range cfg.Ingress.Hosts {
-		knownHosts[host] = struct{}{}
-	}
-	seen := map[string]struct{}{}
-	for i, rule := range cfg.Ingress.Rules {
-		host := strings.TrimSpace(rule.Match.Host)
-		if host == "" {
-			return fmt.Errorf("ingress.rules[%d].match.host is required", i)
-		}
-		if _, ok := knownHosts[host]; !ok {
-			return fmt.Errorf("ingress.rules[%d].match.host %q missing from ingress.hosts", i, host)
-		}
-		pathPrefix := strings.TrimSpace(rule.Match.PathPrefix)
-		if pathPrefix == "" {
-			pathPrefix = "/"
-		}
-		if !strings.HasPrefix(pathPrefix, "/") {
-			return fmt.Errorf("ingress.rules[%d].match.path_prefix must start with /", i)
-		}
-		serviceName := strings.TrimSpace(rule.Target.Service)
-		if serviceName == "" {
-			return fmt.Errorf("ingress.rules[%d].target.service is required", i)
-		}
-		service, ok := cfg.Services[serviceName]
-		if !ok {
-			return fmt.Errorf("ingress.rules[%d].target.service %q not found in services", i, serviceName)
-		}
-		portName := strings.TrimSpace(rule.Target.Port)
-		if portName == "" {
-			return fmt.Errorf("ingress.rules[%d].target.port is required", i)
-		}
-		if !service.HasPortNamed(portName) {
-			return fmt.Errorf("ingress.rules[%d].target.port %q not found on service %q", i, portName, serviceName)
-		}
-		key := host + "\x00" + pathPrefix
-		if _, ok := seen[key]; ok {
-			return fmt.Errorf("ingress.rules[%d]: duplicate route for %s%s", i, host, pathPrefix)
-		}
-		seen[key] = struct{}{}
 	}
 	return nil
 }
@@ -632,6 +706,54 @@ func validateTasks(cfg *ProjectConfig) error {
 	return nil
 }
 
+func validateIngressRules(cfg *ProjectConfig) error {
+	if cfg == nil || cfg.Ingress == nil {
+		return nil
+	}
+	hostSet := map[string]bool{}
+	for _, host := range cfg.Ingress.Hosts {
+		hostSet[strings.TrimSpace(host)] = true
+	}
+	seenRoutes := map[string]bool{}
+	for i, rule := range cfg.Ingress.Rules {
+		host := strings.TrimSpace(rule.Match.Host)
+		pathPrefix := strings.TrimSpace(rule.Match.PathPrefix)
+		if pathPrefix == "" {
+			pathPrefix = "/"
+		}
+		serviceName := strings.TrimSpace(rule.Target.Service)
+		portName := strings.TrimSpace(rule.Target.Port)
+		if host == "" {
+			return fmt.Errorf("ingress.rules[%d].match.host is required", i)
+		}
+		if !hostSet[host] {
+			return fmt.Errorf("ingress.rules[%d].match.host must exist in ingress.hosts", i)
+		}
+		if !strings.HasPrefix(pathPrefix, "/") {
+			return fmt.Errorf("ingress.rules[%d].match.path_prefix must start with /", i)
+		}
+		if serviceName == "" {
+			return fmt.Errorf("ingress.rules[%d].target.service is required", i)
+		}
+		service, ok := cfg.Services[serviceName]
+		if !ok {
+			return fmt.Errorf("ingress.rules[%d].target.service %q not found in services", i, serviceName)
+		}
+		if portName == "" {
+			return fmt.Errorf("ingress.rules[%d].target.port is required", i)
+		}
+		if !service.HasPortNamed(portName) {
+			return fmt.Errorf("ingress.rules[%d].target.port %q not found on service %q", i, portName, serviceName)
+		}
+		key := host + "\n" + pathPrefix
+		if seenRoutes[key] {
+			return fmt.Errorf("ingress.rules contains duplicate route for host %q and path_prefix %q", host, pathPrefix)
+		}
+		seenRoutes[key] = true
+	}
+	return nil
+}
+
 func (cfg ProjectConfig) ServiceNames() []string {
 	names := make([]string, 0, len(cfg.Services))
 	for name := range cfg.Services {
@@ -652,23 +774,6 @@ func (cfg ProjectConfig) ServicesByKind(kind string) []string {
 }
 
 func (cfg ProjectConfig) PrimaryWebServiceName() (string, bool) {
-	targeted := map[string]struct{}{}
-	if cfg.Ingress != nil {
-		for _, rule := range cfg.Ingress.Rules {
-			serviceName := strings.TrimSpace(rule.Target.Service)
-			if serviceName != "" {
-				targeted[serviceName] = struct{}{}
-			}
-		}
-	}
-	if len(targeted) == 1 {
-		for serviceName := range targeted {
-			return serviceName, true
-		}
-	}
-	if _, ok := targeted[DefaultWebServiceName]; ok {
-		return DefaultWebServiceName, true
-	}
 	services := cfg.ServicesByKind(ServiceKindWeb)
 	if len(services) == 0 {
 		return "", false
@@ -696,6 +801,7 @@ func (service ServiceConfig) HTTPPort(fallback int) int {
 }
 
 func (service ServiceConfig) HasPortNamed(name string) bool {
+	name = strings.TrimSpace(name)
 	for _, port := range service.Ports {
 		if strings.TrimSpace(port.Name) == name && port.Port > 0 {
 			return true
@@ -719,4 +825,221 @@ func mergeStringMaps(parts ...map[string]string) map[string]string {
 		}
 	}
 	return merged
+}
+
+func validateEnvironmentOverlays(cfg *ProjectConfig) error {
+	for envName, overlay := range cfg.Environments {
+		name := strings.TrimSpace(envName)
+		if name == "" {
+			return errors.New("environments keys must be present")
+		}
+		if err := validateEnvironmentOverlay(name, overlay, cfg); err != nil {
+			return err
+		}
+		resolved, err := ResolveEnvironmentConfig(*cfg, name)
+		if err != nil {
+			return err
+		}
+		if err := validateResolvedProjectConfig(&resolved); err != nil {
+			return fmt.Errorf("environments.%s: %w", name, err)
+		}
+	}
+	return nil
+}
+
+func validateEnvironmentOverlay(envName string, overlay EnvironmentOverlay, cfg *ProjectConfig) error {
+	if overlay.Ingress != nil {
+		if overlay.Ingress.TLS != nil {
+			for field, value := range map[string]*string{
+				"mode":             overlay.Ingress.TLS.Mode,
+				"email":            overlay.Ingress.TLS.Email,
+				"ca_directory_url": overlay.Ingress.TLS.CADirectoryURL,
+			} {
+				if value != nil && strings.TrimSpace(*value) == "" {
+					return fmt.Errorf("environments.%s.ingress.tls.%s must be present", envName, field)
+				}
+			}
+		}
+	}
+	for serviceName, service := range overlay.Services {
+		if _, ok := cfg.Services[serviceName]; !ok {
+			return fmt.Errorf("environments.%s.services.%s not found in services", envName, serviceName)
+		}
+		for field, value := range map[string]*string{
+			"image": service.Image,
+		} {
+			if value != nil && strings.TrimSpace(*value) == "" {
+				return fmt.Errorf("environments.%s.services.%s.%s must be present", envName, serviceName, field)
+			}
+		}
+		if service.Healthcheck != nil && service.Healthcheck.Port != nil && *service.Healthcheck.Port <= 0 {
+			return fmt.Errorf("environments.%s.services.%s.healthcheck.port must be a positive integer", envName, serviceName)
+		}
+	}
+	if overlay.Tasks != nil && overlay.Tasks.Release != nil {
+		release := overlay.Tasks.Release
+		if release.Service != nil && strings.TrimSpace(*release.Service) == "" {
+			return fmt.Errorf("environments.%s.tasks.release.service must be present", envName)
+		}
+	}
+	return nil
+}
+
+func cloneProjectConfig(cfg ProjectConfig) ProjectConfig {
+	cloned := cfg
+	cloned.Build.Platforms = append([]string(nil), cfg.Build.Platforms...)
+	cloned.Services = map[string]ServiceConfig{}
+	for name, service := range cfg.Services {
+		cloned.Services[name] = cloneServiceConfig(service)
+	}
+	if cfg.Tasks.Release != nil {
+		release := *cfg.Tasks.Release
+		release.Command = append([]string(nil), cfg.Tasks.Release.Command...)
+		release.Args = append([]string(nil), cfg.Tasks.Release.Args...)
+		release.Env = cloneStringMap(cfg.Tasks.Release.Env)
+		cloned.Tasks.Release = &release
+	}
+	if cfg.Ingress != nil {
+		ingress := *cfg.Ingress
+		ingress.Hosts = append([]string(nil), cfg.Ingress.Hosts...)
+		ingress.Rules = append([]IngressRuleConfig(nil), cfg.Ingress.Rules...)
+		if cfg.Ingress.RedirectHTTP != nil {
+			ingress.RedirectHTTP = boolPtr(*cfg.Ingress.RedirectHTTP)
+		}
+		cloned.Ingress = &ingress
+	}
+	cloned.Environments = cfg.Environments
+	return cloned
+}
+
+func cloneServiceConfig(service ServiceConfig) ServiceConfig {
+	cloned := service
+	cloned.Command = append([]string(nil), service.Command...)
+	cloned.Args = append([]string(nil), service.Args...)
+	cloned.Env = cloneStringMap(service.Env)
+	cloned.SecretRefs = append([]SecretRef(nil), service.SecretRefs...)
+	cloned.Ports = append([]ServicePort(nil), service.Ports...)
+	cloned.Volumes = append([]Volume(nil), service.Volumes...)
+	if service.Healthcheck != nil {
+		healthcheck := *service.Healthcheck
+		cloned.Healthcheck = &healthcheck
+	}
+	return cloned
+}
+
+func mergeServiceConfig(base ServiceConfig, overlay ServiceConfigOverlay) ServiceConfig {
+	merged := cloneServiceConfig(base)
+	if overlay.Image != nil {
+		merged.Image = strings.TrimSpace(*overlay.Image)
+	}
+	if overlay.Command != nil {
+		merged.Command = append([]string(nil), overlay.Command...)
+	}
+	if overlay.Args != nil {
+		merged.Args = append([]string(nil), overlay.Args...)
+	}
+	if overlay.Env != nil {
+		merged.Env = mergeStringMaps(merged.Env, overlay.Env)
+	}
+	if overlay.SecretRefs != nil {
+		merged.SecretRefs = append([]SecretRef(nil), overlay.SecretRefs...)
+	}
+	if overlay.Ports != nil {
+		merged.Ports = append([]ServicePort(nil), overlay.Ports...)
+	}
+	if overlay.Volumes != nil {
+		merged.Volumes = append([]Volume(nil), overlay.Volumes...)
+	}
+	if overlay.Healthcheck != nil {
+		if merged.Healthcheck == nil {
+			merged.Healthcheck = &HTTPHealthcheck{}
+		}
+		if overlay.Healthcheck.Path != nil {
+			merged.Healthcheck.Path = strings.TrimSpace(*overlay.Healthcheck.Path)
+		}
+		if overlay.Healthcheck.Port != nil {
+			merged.Healthcheck.Port = *overlay.Healthcheck.Port
+		}
+	}
+	return merged
+}
+
+func mergeTasksConfig(base TasksConfig, overlay *TasksConfigOverlay) TasksConfig {
+	merged := base
+	if overlay == nil || overlay.Release == nil {
+		return merged
+	}
+	if merged.Release == nil {
+		merged.Release = &TaskConfig{}
+	}
+	if overlay.Release.Service != nil {
+		merged.Release.Service = strings.TrimSpace(*overlay.Release.Service)
+	}
+	if overlay.Release.Command != nil {
+		merged.Release.Command = append([]string(nil), overlay.Release.Command...)
+	}
+	if overlay.Release.Args != nil {
+		merged.Release.Args = append([]string(nil), overlay.Release.Args...)
+	}
+	if overlay.Release.Env != nil {
+		merged.Release.Env = mergeStringMaps(merged.Release.Env, overlay.Release.Env)
+	}
+	return merged
+}
+
+func mergeIngressConfig(base *IngressConfig, overlay *IngressConfigOverlay) *IngressConfig {
+	if overlay == nil {
+		if base == nil {
+			return nil
+		}
+		cloned := *base
+		cloned.Hosts = append([]string(nil), base.Hosts...)
+		cloned.Rules = append([]IngressRuleConfig(nil), base.Rules...)
+		return &cloned
+	}
+	merged := &IngressConfig{}
+	if base != nil {
+		*merged = *base
+		merged.Hosts = append([]string(nil), base.Hosts...)
+		merged.Rules = append([]IngressRuleConfig(nil), base.Rules...)
+		if base.RedirectHTTP != nil {
+			merged.RedirectHTTP = boolPtr(*base.RedirectHTTP)
+		}
+	}
+	if overlay.Hosts != nil {
+		merged.Hosts = append([]string(nil), overlay.Hosts...)
+	}
+	if overlay.Rules != nil {
+		merged.Rules = append([]IngressRuleConfig(nil), overlay.Rules...)
+	}
+	if overlay.TLS != nil {
+		if overlay.TLS.Mode != nil {
+			merged.TLS.Mode = strings.TrimSpace(*overlay.TLS.Mode)
+		}
+		if overlay.TLS.Email != nil {
+			merged.TLS.Email = strings.TrimSpace(*overlay.TLS.Email)
+		}
+		if overlay.TLS.CADirectoryURL != nil {
+			merged.TLS.CADirectoryURL = strings.TrimSpace(*overlay.TLS.CADirectoryURL)
+		}
+	}
+	if overlay.RedirectHTTP != nil {
+		merged.RedirectHTTP = boolPtr(*overlay.RedirectHTTP)
+	}
+	return merged
+}
+
+func cloneStringMap(values map[string]string) map[string]string {
+	if values == nil {
+		return nil
+	}
+	cloned := map[string]string{}
+	for key, value := range values {
+		cloned[key] = value
+	}
+	return cloned
+}
+
+func boolPtr(value bool) *bool {
+	return &value
 }

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -55,6 +55,8 @@ type ServicePort struct {
 }
 
 type ServiceConfig struct {
+	// Kind is inferred after load/defaulting for internal scheduling and placement logic.
+	// It is not part of the repo config schema and is never serialized back to YAML/JSON.
 	Kind        string            `yaml:"-" json:"-"`
 	Image       string            `yaml:"image,omitempty" json:"image,omitempty"`
 	Command     []string          `yaml:"command,omitempty" json:"command,omitempty"`

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -577,14 +577,12 @@ func normalizeStringList(values []string) []string {
 }
 
 func normalizeIngressHostList(values []string) []string {
-	seen := make(map[string]bool, len(values))
 	normalized := make([]string, 0, len(values))
 	for _, value := range values {
 		value = normalizedIngressHost(value)
-		if value == "" || seen[value] {
+		if value == "" {
 			continue
 		}
-		seen[value] = true
 		normalized = append(normalized, value)
 	}
 	return normalized

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -96,10 +96,10 @@ type IngressTLSConfig struct {
 }
 
 type IngressConfig struct {
-	Hosts        []string             `yaml:"hosts,omitempty" json:"hosts,omitempty"`
-	Rules        []IngressRuleConfig  `yaml:"rules,omitempty" json:"rules,omitempty"`
-	TLS          IngressTLSConfig     `yaml:"tls,omitempty" json:"tls,omitempty"`
-	RedirectHTTP *bool                `yaml:"redirect_http,omitempty" json:"redirect_http,omitempty"`
+	Hosts        []string            `yaml:"hosts,omitempty" json:"hosts,omitempty"`
+	Rules        []IngressRuleConfig `yaml:"rules,omitempty" json:"rules,omitempty"`
+	TLS          IngressTLSConfig    `yaml:"tls,omitempty" json:"tls,omitempty"`
+	RedirectHTTP *bool               `yaml:"redirect_http,omitempty" json:"redirect_http,omitempty"`
 }
 
 type IngressRuleConfig struct {
@@ -712,11 +712,11 @@ func validateIngressRules(cfg *ProjectConfig) error {
 	}
 	hostSet := map[string]bool{}
 	for _, host := range cfg.Ingress.Hosts {
-		hostSet[strings.TrimSpace(host)] = true
+		hostSet[normalizedIngressHost(host)] = true
 	}
 	seenRoutes := map[string]bool{}
 	for i, rule := range cfg.Ingress.Rules {
-		host := strings.TrimSpace(rule.Match.Host)
+		host := normalizedIngressHost(rule.Match.Host)
 		pathPrefix := strings.TrimSpace(rule.Match.PathPrefix)
 		if pathPrefix == "" {
 			pathPrefix = "/"
@@ -815,6 +815,10 @@ func inferredServiceKind(name string, service ServiceConfig) string {
 		return ServiceKindWeb
 	}
 	return ServiceKindWorker
+}
+
+func normalizedIngressHost(host string) string {
+	return strings.ToLower(strings.TrimSpace(host))
 }
 
 func mergeStringMaps(parts ...map[string]string) map[string]string {

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -55,7 +55,7 @@ type ServicePort struct {
 }
 
 type ServiceConfig struct {
-	Kind        string            `yaml:"kind" json:"kind"`
+	Kind        string            `yaml:"-" json:"-"`
 	Image       string            `yaml:"image,omitempty" json:"image,omitempty"`
 	Command     []string          `yaml:"command,omitempty" json:"command,omitempty"`
 	Args        []string          `yaml:"args,omitempty" json:"args,omitempty"`
@@ -96,57 +96,25 @@ type IngressTLSConfig struct {
 }
 
 type IngressConfig struct {
-	Hosts        []string         `yaml:"hosts,omitempty" json:"hosts,omitempty"`
-	Service      string           `yaml:"service,omitempty" json:"service,omitempty"`
-	TLS          IngressTLSConfig `yaml:"tls,omitempty" json:"tls,omitempty"`
-	RedirectHTTP *bool            `yaml:"redirect_http,omitempty" json:"redirect_http,omitempty"`
+	Hosts        []string             `yaml:"hosts,omitempty" json:"hosts,omitempty"`
+	Rules        []IngressRuleConfig  `yaml:"rules,omitempty" json:"rules,omitempty"`
+	TLS          IngressTLSConfig     `yaml:"tls,omitempty" json:"tls,omitempty"`
+	RedirectHTTP bool                 `yaml:"redirect_http,omitempty" json:"redirect_http,omitempty"`
 }
 
-type HTTPHealthcheckOverlay struct {
-	Path *string `yaml:"path,omitempty" json:"path,omitempty"`
-	Port *int    `yaml:"port,omitempty" json:"port,omitempty"`
+type IngressRuleConfig struct {
+	Match  IngressMatchConfig  `yaml:"match" json:"match"`
+	Target IngressTargetConfig `yaml:"target" json:"target"`
 }
 
-type ServiceConfigOverlay struct {
-	Kind        *string                 `yaml:"kind,omitempty" json:"kind,omitempty"`
-	Image       *string                 `yaml:"image,omitempty" json:"image,omitempty"`
-	Command     []string                `yaml:"command,omitempty" json:"command,omitempty"`
-	Args        []string                `yaml:"args,omitempty" json:"args,omitempty"`
-	Env         map[string]string       `yaml:"env,omitempty" json:"env,omitempty"`
-	SecretRefs  []SecretRef             `yaml:"secret_refs,omitempty" json:"secret_refs,omitempty"`
-	Ports       []ServicePort           `yaml:"ports,omitempty" json:"ports,omitempty"`
-	Healthcheck *HTTPHealthcheckOverlay `yaml:"healthcheck,omitempty" json:"healthcheck,omitempty"`
-	Volumes     []Volume                `yaml:"volumes,omitempty" json:"volumes,omitempty"`
+type IngressMatchConfig struct {
+	Host       string `yaml:"host" json:"host"`
+	PathPrefix string `yaml:"path_prefix,omitempty" json:"path_prefix,omitempty"`
 }
 
-type TaskConfigOverlay struct {
-	Service *string           `yaml:"service,omitempty" json:"service,omitempty"`
-	Command []string          `yaml:"command,omitempty" json:"command,omitempty"`
-	Args    []string          `yaml:"args,omitempty" json:"args,omitempty"`
-	Env     map[string]string `yaml:"env,omitempty" json:"env,omitempty"`
-}
-
-type TasksConfigOverlay struct {
-	Release *TaskConfigOverlay `yaml:"release,omitempty" json:"release,omitempty"`
-}
-
-type IngressTLSConfigOverlay struct {
-	Mode           *string `yaml:"mode,omitempty" json:"mode,omitempty"`
-	Email          *string `yaml:"email,omitempty" json:"email,omitempty"`
-	CADirectoryURL *string `yaml:"ca_directory_url,omitempty" json:"ca_directory_url,omitempty"`
-}
-
-type IngressConfigOverlay struct {
-	Hosts        []string                 `yaml:"hosts,omitempty" json:"hosts,omitempty"`
-	Service      *string                  `yaml:"service,omitempty" json:"service,omitempty"`
-	TLS          *IngressTLSConfigOverlay `yaml:"tls,omitempty" json:"tls,omitempty"`
-	RedirectHTTP *bool                    `yaml:"redirect_http,omitempty" json:"redirect_http,omitempty"`
-}
-
-type EnvironmentOverlay struct {
-	Ingress  *IngressConfigOverlay           `yaml:"ingress,omitempty" json:"ingress,omitempty"`
-	Services map[string]ServiceConfigOverlay `yaml:"services,omitempty" json:"services,omitempty"`
-	Tasks    *TasksConfigOverlay             `yaml:"tasks,omitempty" json:"tasks,omitempty"`
+type IngressTargetConfig struct {
+	Service string `yaml:"service" json:"service"`
+	Port    string `yaml:"port" json:"port"`
 }
 
 type SoloNode struct {
@@ -164,16 +132,15 @@ type SoloNode struct {
 }
 
 type ProjectConfig struct {
-	SchemaVersion      int                           `yaml:"schema_version" json:"schema_version"`
-	App                AppConfig                     `yaml:"app,omitempty" json:"app,omitempty"`
-	Organization       string                        `yaml:"organization" json:"organization"`
-	Project            string                        `yaml:"project" json:"project"`
-	DefaultEnvironment string                        `yaml:"default_environment" json:"default_environment"`
-	Build              BuildConfig                   `yaml:"build" json:"build"`
-	Services           map[string]ServiceConfig      `yaml:"services" json:"services"`
-	Tasks              TasksConfig                   `yaml:"tasks,omitempty" json:"tasks,omitempty"`
-	Ingress            *IngressConfig                `yaml:"ingress,omitempty" json:"ingress,omitempty"`
-	Environments       map[string]EnvironmentOverlay `yaml:"environments,omitempty" json:"environments,omitempty"`
+	SchemaVersion      int                      `yaml:"schema_version" json:"schema_version"`
+	App                AppConfig                `yaml:"app,omitempty" json:"app,omitempty"`
+	Organization       string                   `yaml:"organization" json:"organization"`
+	Project            string                   `yaml:"project" json:"project"`
+	DefaultEnvironment string                   `yaml:"default_environment" json:"default_environment"`
+	Build              BuildConfig              `yaml:"build" json:"build"`
+	Services           map[string]ServiceConfig `yaml:"services" json:"services"`
+	Tasks              TasksConfig              `yaml:"tasks,omitempty" json:"tasks,omitempty"`
+	Ingress            *IngressConfig           `yaml:"ingress,omitempty" json:"ingress,omitempty"`
 }
 
 type Project = ProjectConfig
@@ -310,7 +277,6 @@ func DefaultProjectConfigForType(organization, project, environment, appType str
 		},
 		Services: map[string]ServiceConfig{
 			DefaultWebServiceName: {
-				Kind:       ServiceKindWeb,
 				Env:        map[string]string{},
 				SecretRefs: []SecretRef{},
 				Volumes:    []Volume{},
@@ -348,17 +314,6 @@ func Validate(cfg *ProjectConfig) error {
 	if strings.TrimSpace(cfg.DefaultEnvironment) == "" {
 		return errors.New("default_environment is required")
 	}
-	if err := validateEnvironmentOverlays(cfg); err != nil {
-		return err
-	}
-	resolved, err := ResolveEnvironmentConfig(*cfg, cfg.DefaultEnvironment)
-	if err != nil {
-		return err
-	}
-	return validateResolvedProjectConfig(&resolved)
-}
-
-func validateResolvedProjectConfig(cfg *ProjectConfig) error {
 	if strings.TrimSpace(cfg.Build.Context) == "" {
 		return errors.New("build.context is required")
 	}
@@ -376,18 +331,11 @@ func validateResolvedProjectConfig(cfg *ProjectConfig) error {
 	if len(cfg.Services) == 0 {
 		return errors.New("services must include at least one service")
 	}
-	webServices := 0
 	for _, name := range cfg.ServiceNames() {
 		service := cfg.Services[name]
 		if err := validateService(name, service); err != nil {
 			return err
 		}
-		if service.Kind == ServiceKindWeb {
-			webServices++
-		}
-	}
-	if webServices == 0 {
-		return errors.New("services must include at least one web service")
 	}
 	if err := validateTasks(cfg); err != nil {
 		return err
@@ -407,15 +355,11 @@ func validateResolvedProjectConfig(cfg *ProjectConfig) error {
 			}
 			seenHosts[host] = true
 		}
-		if strings.TrimSpace(cfg.Ingress.Service) == "" {
-			return errors.New("ingress.service is required")
+		if len(cfg.Ingress.Rules) == 0 {
+			return errors.New("ingress.rules is required")
 		}
-		service, ok := cfg.Services[cfg.Ingress.Service]
-		if !ok {
-			return fmt.Errorf("ingress.service %q not found in services", cfg.Ingress.Service)
-		}
-		if service.Kind != ServiceKindWeb {
-			return fmt.Errorf("ingress.service %q must be kind %q", cfg.Ingress.Service, ServiceKindWeb)
+		if err := validateIngressRules(cfg); err != nil {
+			return err
 		}
 		switch strings.TrimSpace(cfg.Ingress.TLS.Mode) {
 		case "", "auto", "off", "manual":
@@ -448,9 +392,6 @@ func applyDefaults(cfg *ProjectConfig) {
 	if cfg.Services == nil {
 		cfg.Services = map[string]ServiceConfig{}
 	}
-	if cfg.Environments == nil {
-		cfg.Environments = map[string]EnvironmentOverlay{}
-	}
 	for name, service := range cfg.Services {
 		if service.Env == nil {
 			service.Env = map[string]string{}
@@ -462,14 +403,9 @@ func applyDefaults(cfg *ProjectConfig) {
 			service.Volumes = []Volume{}
 		}
 		service.Ports = normalizeServicePorts(service.Ports)
-		if service.Kind == ServiceKindWeb {
-			if len(service.Ports) == 0 {
-				service.Ports = []ServicePort{{Name: "http", Port: DefaultWebPort}}
-			}
-			if service.Healthcheck == nil {
-				service.Healthcheck = &HTTPHealthcheck{}
-			}
-			if strings.TrimSpace(service.Healthcheck.Path) == "" {
+		if service.Healthcheck != nil {
+			service.Healthcheck.Path = strings.TrimSpace(service.Healthcheck.Path)
+			if service.Healthcheck.Path == "" {
 				if cfg.App.Type == AppTypeGeneric {
 					service.Healthcheck.Path = "/"
 				} else {
@@ -480,64 +416,34 @@ func applyDefaults(cfg *ProjectConfig) {
 				service.Healthcheck.Port = service.HTTPPort(DefaultWebPort)
 			}
 		}
+		service.Kind = inferredServiceKind(name, service)
 		cfg.Services[name] = service
 	}
 	if cfg.Tasks.Release != nil {
-		cfg.Tasks.Release.Service = strings.TrimSpace(cfg.Tasks.Release.Service)
-		cfg.Tasks.Release.Command = normalizeStringListKeepOrder(cfg.Tasks.Release.Command)
-		cfg.Tasks.Release.Args = normalizeStringListKeepOrder(cfg.Tasks.Release.Args)
 		cfg.Tasks.Release.Env = mergeStringMaps(cfg.Tasks.Release.Env)
 	}
 	if cfg.Ingress != nil {
 		cfg.Ingress.Hosts = normalizeStringList(cfg.Ingress.Hosts)
-		cfg.Ingress.Service = strings.TrimSpace(cfg.Ingress.Service)
+		for i, rule := range cfg.Ingress.Rules {
+			rule.Match.Host = strings.TrimSpace(rule.Match.Host)
+			rule.Match.PathPrefix = strings.TrimSpace(rule.Match.PathPrefix)
+			if rule.Match.PathPrefix == "" {
+				rule.Match.PathPrefix = "/"
+			}
+			rule.Target.Service = strings.TrimSpace(rule.Target.Service)
+			rule.Target.Port = strings.TrimSpace(rule.Target.Port)
+			cfg.Ingress.Rules[i] = rule
+		}
 		cfg.Ingress.TLS.Mode = strings.TrimSpace(cfg.Ingress.TLS.Mode)
 		if cfg.Ingress.TLS.Mode == "" {
 			cfg.Ingress.TLS.Mode = "auto"
 		}
 		cfg.Ingress.TLS.Email = strings.TrimSpace(cfg.Ingress.TLS.Email)
 		cfg.Ingress.TLS.CADirectoryURL = strings.TrimSpace(cfg.Ingress.TLS.CADirectoryURL)
-		if cfg.Ingress.TLS.Mode == "auto" && cfg.Ingress.RedirectHTTP == nil {
-			cfg.Ingress.RedirectHTTP = boolPtr(true)
+		if cfg.Ingress.TLS.Mode == "auto" {
+			cfg.Ingress.RedirectHTTP = true
 		}
 	}
-}
-
-func ResolveEnvironmentConfig(base ProjectConfig, selectedEnv string) (ProjectConfig, error) {
-	resolved := cloneProjectConfig(base)
-	envName := strings.TrimSpace(selectedEnv)
-	if envName == "" {
-		envName = strings.TrimSpace(base.DefaultEnvironment)
-	}
-	if envName == "" {
-		envName = DefaultEnvironment
-	}
-	resolved.DefaultEnvironment = envName
-
-	overlay, ok := base.Environments[envName]
-	if !ok {
-		applyDefaults(&resolved)
-		return resolved, nil
-	}
-
-	if overlay.Ingress != nil {
-		resolved.Ingress = mergeIngressConfig(resolved.Ingress, overlay.Ingress)
-	}
-	if len(overlay.Services) > 0 {
-		if resolved.Services == nil {
-			resolved.Services = map[string]ServiceConfig{}
-		}
-		for name, entry := range overlay.Services {
-			baseService := resolved.Services[name]
-			resolved.Services[name] = mergeServiceConfig(baseService, entry)
-		}
-	}
-	if overlay.Tasks != nil {
-		resolved.Tasks = mergeTasksConfig(resolved.Tasks, overlay.Tasks)
-	}
-
-	applyDefaults(&resolved)
-	return resolved, nil
 }
 
 func normalizeNodeLabels(labels []string) []string {
@@ -571,17 +477,6 @@ func normalizeStringList(values []string) []string {
 	return normalized
 }
 
-func normalizeStringListKeepOrder(values []string) []string {
-	if values == nil {
-		return nil
-	}
-	normalized := make([]string, 0, len(values))
-	for _, value := range values {
-		normalized = append(normalized, strings.TrimSpace(value))
-	}
-	return normalized
-}
-
 func normalizeServicePorts(ports []ServicePort) []ServicePort {
 	if ports == nil {
 		return nil
@@ -600,11 +495,6 @@ func normalizeServicePorts(ports []ServicePort) []ServicePort {
 }
 
 func validateService(name string, service ServiceConfig) error {
-	switch service.Kind {
-	case ServiceKindWeb, ServiceKindWorker, ServiceKindAccessory:
-	default:
-		return fmt.Errorf("services.%s.kind must be one of %q, %q, or %q", name, ServiceKindWeb, ServiceKindWorker, ServiceKindAccessory)
-	}
 	for _, arg := range service.Command {
 		if strings.TrimSpace(arg) == "" {
 			return fmt.Errorf("services.%s.command entries must be present", name)
@@ -641,30 +531,70 @@ func validateService(name string, service ServiceConfig) error {
 	}
 	seenPorts := map[string]bool{}
 	for _, port := range service.Ports {
-		if strings.TrimSpace(port.Name) == "" {
+		portName := strings.TrimSpace(port.Name)
+		if portName == "" {
 			return fmt.Errorf("services.%s.ports[].name is required", name)
 		}
 		if port.Port <= 0 {
 			return fmt.Errorf("services.%s.ports[%s].port must be a positive integer", name, port.Name)
 		}
-		if seenPorts[port.Name] {
-			return fmt.Errorf("services.%s.ports contains duplicate port %q", name, port.Name)
+		if seenPorts[portName] {
+			return fmt.Errorf("services.%s.ports contains duplicate port %q", name, portName)
 		}
-		seenPorts[port.Name] = true
+		seenPorts[portName] = true
 	}
-	if service.Kind == ServiceKindWeb {
-		if service.HTTPPort(0) <= 0 {
-			return fmt.Errorf("services.%s must expose an http port", name)
-		}
-		if service.Healthcheck == nil {
-			return fmt.Errorf("services.%s.healthcheck is required", name)
-		}
+	if service.Healthcheck != nil {
 		if strings.TrimSpace(service.Healthcheck.Path) == "" {
 			return fmt.Errorf("services.%s.healthcheck.path is required", name)
 		}
 		if service.Healthcheck.Port <= 0 {
 			return fmt.Errorf("services.%s.healthcheck.port must be a positive integer", name)
 		}
+	}
+	return nil
+}
+
+func validateIngressRules(cfg *ProjectConfig) error {
+	knownHosts := map[string]struct{}{}
+	for _, host := range cfg.Ingress.Hosts {
+		knownHosts[host] = struct{}{}
+	}
+	seen := map[string]struct{}{}
+	for i, rule := range cfg.Ingress.Rules {
+		host := strings.TrimSpace(rule.Match.Host)
+		if host == "" {
+			return fmt.Errorf("ingress.rules[%d].match.host is required", i)
+		}
+		if _, ok := knownHosts[host]; !ok {
+			return fmt.Errorf("ingress.rules[%d].match.host %q missing from ingress.hosts", i, host)
+		}
+		pathPrefix := strings.TrimSpace(rule.Match.PathPrefix)
+		if pathPrefix == "" {
+			pathPrefix = "/"
+		}
+		if !strings.HasPrefix(pathPrefix, "/") {
+			return fmt.Errorf("ingress.rules[%d].match.path_prefix must start with /", i)
+		}
+		serviceName := strings.TrimSpace(rule.Target.Service)
+		if serviceName == "" {
+			return fmt.Errorf("ingress.rules[%d].target.service is required", i)
+		}
+		service, ok := cfg.Services[serviceName]
+		if !ok {
+			return fmt.Errorf("ingress.rules[%d].target.service %q not found in services", i, serviceName)
+		}
+		portName := strings.TrimSpace(rule.Target.Port)
+		if portName == "" {
+			return fmt.Errorf("ingress.rules[%d].target.port is required", i)
+		}
+		if !service.HasPortNamed(portName) {
+			return fmt.Errorf("ingress.rules[%d].target.port %q not found on service %q", i, portName, serviceName)
+		}
+		key := host + "\x00" + pathPrefix
+		if _, ok := seen[key]; ok {
+			return fmt.Errorf("ingress.rules[%d]: duplicate route for %s%s", i, host, pathPrefix)
+		}
+		seen[key] = struct{}{}
 	}
 	return nil
 }
@@ -722,6 +652,23 @@ func (cfg ProjectConfig) ServicesByKind(kind string) []string {
 }
 
 func (cfg ProjectConfig) PrimaryWebServiceName() (string, bool) {
+	targeted := map[string]struct{}{}
+	if cfg.Ingress != nil {
+		for _, rule := range cfg.Ingress.Rules {
+			serviceName := strings.TrimSpace(rule.Target.Service)
+			if serviceName != "" {
+				targeted[serviceName] = struct{}{}
+			}
+		}
+	}
+	if len(targeted) == 1 {
+		for serviceName := range targeted {
+			return serviceName, true
+		}
+	}
+	if _, ok := targeted[DefaultWebServiceName]; ok {
+		return DefaultWebServiceName, true
+	}
 	services := cfg.ServicesByKind(ServiceKindWeb)
 	if len(services) == 0 {
 		return "", false
@@ -748,6 +695,22 @@ func (service ServiceConfig) HTTPPort(fallback int) int {
 	return fallback
 }
 
+func (service ServiceConfig) HasPortNamed(name string) bool {
+	for _, port := range service.Ports {
+		if strings.TrimSpace(port.Name) == name && port.Port > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func inferredServiceKind(name string, service ServiceConfig) string {
+	if service.HasPortNamed("http") || service.Healthcheck != nil || strings.TrimSpace(name) == DefaultWebServiceName {
+		return ServiceKindWeb
+	}
+	return ServiceKindWorker
+}
+
 func mergeStringMaps(parts ...map[string]string) map[string]string {
 	merged := map[string]string{}
 	for _, part := range parts {
@@ -756,225 +719,4 @@ func mergeStringMaps(parts ...map[string]string) map[string]string {
 		}
 	}
 	return merged
-}
-
-func validateEnvironmentOverlays(cfg *ProjectConfig) error {
-	for envName, overlay := range cfg.Environments {
-		name := strings.TrimSpace(envName)
-		if name == "" {
-			return errors.New("environments keys must be present")
-		}
-		if err := validateEnvironmentOverlay(name, overlay, cfg); err != nil {
-			return err
-		}
-		resolved, err := ResolveEnvironmentConfig(*cfg, name)
-		if err != nil {
-			return err
-		}
-		if err := validateResolvedProjectConfig(&resolved); err != nil {
-			return fmt.Errorf("environments.%s: %w", name, err)
-		}
-	}
-	return nil
-}
-
-func validateEnvironmentOverlay(envName string, overlay EnvironmentOverlay, cfg *ProjectConfig) error {
-	if overlay.Ingress != nil {
-		if overlay.Ingress.Service != nil && strings.TrimSpace(*overlay.Ingress.Service) == "" {
-			return fmt.Errorf("environments.%s.ingress.service must be present", envName)
-		}
-		if overlay.Ingress.TLS != nil {
-			for field, value := range map[string]*string{
-				"mode":             overlay.Ingress.TLS.Mode,
-				"email":            overlay.Ingress.TLS.Email,
-				"ca_directory_url": overlay.Ingress.TLS.CADirectoryURL,
-			} {
-				if value != nil && strings.TrimSpace(*value) == "" {
-					return fmt.Errorf("environments.%s.ingress.tls.%s must be present", envName, field)
-				}
-			}
-		}
-	}
-	for serviceName, service := range overlay.Services {
-		if _, ok := cfg.Services[serviceName]; !ok {
-			return fmt.Errorf("environments.%s.services.%s not found in services", envName, serviceName)
-		}
-		for field, value := range map[string]*string{
-			"kind":  service.Kind,
-			"image": service.Image,
-		} {
-			if value != nil && strings.TrimSpace(*value) == "" {
-				return fmt.Errorf("environments.%s.services.%s.%s must be present", envName, serviceName, field)
-			}
-		}
-		if service.Healthcheck != nil && service.Healthcheck.Port != nil && *service.Healthcheck.Port <= 0 {
-			return fmt.Errorf("environments.%s.services.%s.healthcheck.port must be a positive integer", envName, serviceName)
-		}
-	}
-	if overlay.Tasks != nil && overlay.Tasks.Release != nil {
-		release := overlay.Tasks.Release
-		if release.Service != nil && strings.TrimSpace(*release.Service) == "" {
-			return fmt.Errorf("environments.%s.tasks.release.service must be present", envName)
-		}
-	}
-	return nil
-}
-
-func cloneProjectConfig(cfg ProjectConfig) ProjectConfig {
-	cloned := cfg
-	cloned.Build.Platforms = append([]string(nil), cfg.Build.Platforms...)
-	cloned.Services = map[string]ServiceConfig{}
-	for name, service := range cfg.Services {
-		cloned.Services[name] = cloneServiceConfig(service)
-	}
-	if cfg.Tasks.Release != nil {
-		release := *cfg.Tasks.Release
-		release.Command = append([]string(nil), cfg.Tasks.Release.Command...)
-		release.Args = append([]string(nil), cfg.Tasks.Release.Args...)
-		release.Env = cloneStringMap(cfg.Tasks.Release.Env)
-		cloned.Tasks.Release = &release
-	}
-	if cfg.Ingress != nil {
-		ingress := *cfg.Ingress
-		ingress.Hosts = append([]string(nil), cfg.Ingress.Hosts...)
-		if cfg.Ingress.RedirectHTTP != nil {
-			ingress.RedirectHTTP = boolPtr(*cfg.Ingress.RedirectHTTP)
-		}
-		cloned.Ingress = &ingress
-	}
-	cloned.Environments = cfg.Environments
-	return cloned
-}
-
-func cloneServiceConfig(service ServiceConfig) ServiceConfig {
-	cloned := service
-	cloned.Command = append([]string(nil), service.Command...)
-	cloned.Args = append([]string(nil), service.Args...)
-	cloned.Env = cloneStringMap(service.Env)
-	cloned.SecretRefs = append([]SecretRef(nil), service.SecretRefs...)
-	cloned.Ports = append([]ServicePort(nil), service.Ports...)
-	cloned.Volumes = append([]Volume(nil), service.Volumes...)
-	if service.Healthcheck != nil {
-		healthcheck := *service.Healthcheck
-		cloned.Healthcheck = &healthcheck
-	}
-	return cloned
-}
-
-func mergeServiceConfig(base ServiceConfig, overlay ServiceConfigOverlay) ServiceConfig {
-	merged := cloneServiceConfig(base)
-	if overlay.Kind != nil {
-		merged.Kind = strings.TrimSpace(*overlay.Kind)
-	}
-	if overlay.Image != nil {
-		merged.Image = strings.TrimSpace(*overlay.Image)
-	}
-	if overlay.Command != nil {
-		merged.Command = append([]string(nil), overlay.Command...)
-	}
-	if overlay.Args != nil {
-		merged.Args = append([]string(nil), overlay.Args...)
-	}
-	if overlay.Env != nil {
-		merged.Env = mergeStringMaps(merged.Env, overlay.Env)
-	}
-	if overlay.SecretRefs != nil {
-		merged.SecretRefs = append([]SecretRef(nil), overlay.SecretRefs...)
-	}
-	if overlay.Ports != nil {
-		merged.Ports = append([]ServicePort(nil), overlay.Ports...)
-	}
-	if overlay.Volumes != nil {
-		merged.Volumes = append([]Volume(nil), overlay.Volumes...)
-	}
-	if overlay.Healthcheck != nil {
-		if merged.Healthcheck == nil {
-			merged.Healthcheck = &HTTPHealthcheck{}
-		}
-		if overlay.Healthcheck.Path != nil {
-			merged.Healthcheck.Path = strings.TrimSpace(*overlay.Healthcheck.Path)
-		}
-		if overlay.Healthcheck.Port != nil {
-			merged.Healthcheck.Port = *overlay.Healthcheck.Port
-		}
-	}
-	return merged
-}
-
-func mergeTasksConfig(base TasksConfig, overlay *TasksConfigOverlay) TasksConfig {
-	merged := base
-	if overlay == nil || overlay.Release == nil {
-		return merged
-	}
-	if merged.Release == nil {
-		merged.Release = &TaskConfig{}
-	}
-	if overlay.Release.Service != nil {
-		merged.Release.Service = strings.TrimSpace(*overlay.Release.Service)
-	}
-	if overlay.Release.Command != nil {
-		merged.Release.Command = append([]string(nil), overlay.Release.Command...)
-	}
-	if overlay.Release.Args != nil {
-		merged.Release.Args = append([]string(nil), overlay.Release.Args...)
-	}
-	if overlay.Release.Env != nil {
-		merged.Release.Env = mergeStringMaps(merged.Release.Env, overlay.Release.Env)
-	}
-	return merged
-}
-
-func mergeIngressConfig(base *IngressConfig, overlay *IngressConfigOverlay) *IngressConfig {
-	if overlay == nil {
-		if base == nil {
-			return nil
-		}
-		cloned := *base
-		cloned.Hosts = append([]string(nil), base.Hosts...)
-		return &cloned
-	}
-	merged := &IngressConfig{}
-	if base != nil {
-		*merged = *base
-		merged.Hosts = append([]string(nil), base.Hosts...)
-		if base.RedirectHTTP != nil {
-			merged.RedirectHTTP = boolPtr(*base.RedirectHTTP)
-		}
-	}
-	if overlay.Hosts != nil {
-		merged.Hosts = append([]string(nil), overlay.Hosts...)
-	}
-	if overlay.Service != nil {
-		merged.Service = strings.TrimSpace(*overlay.Service)
-	}
-	if overlay.TLS != nil {
-		if overlay.TLS.Mode != nil {
-			merged.TLS.Mode = strings.TrimSpace(*overlay.TLS.Mode)
-		}
-		if overlay.TLS.Email != nil {
-			merged.TLS.Email = strings.TrimSpace(*overlay.TLS.Email)
-		}
-		if overlay.TLS.CADirectoryURL != nil {
-			merged.TLS.CADirectoryURL = strings.TrimSpace(*overlay.TLS.CADirectoryURL)
-		}
-	}
-	if overlay.RedirectHTTP != nil {
-		merged.RedirectHTTP = boolPtr(*overlay.RedirectHTTP)
-	}
-	return merged
-}
-
-func cloneStringMap(values map[string]string) map[string]string {
-	if values == nil {
-		return nil
-	}
-	cloned := map[string]string{}
-	for key, value := range values {
-		cloned[key] = value
-	}
-	return cloned
-}
-
-func boolPtr(value bool) *bool {
-	return &value
 }

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -55,9 +55,6 @@ type ServicePort struct {
 }
 
 type ServiceConfig struct {
-	// Kind is inferred after load/defaulting for internal scheduling and placement logic.
-	// It is not part of the repo config schema and is never serialized back to YAML/JSON.
-	Kind        string            `yaml:"-" json:"-"`
 	Image       string            `yaml:"image,omitempty" json:"image,omitempty"`
 	Command     []string          `yaml:"command,omitempty" json:"command,omitempty"`
 	Args        []string          `yaml:"args,omitempty" json:"args,omitempty"`
@@ -326,7 +323,6 @@ func DefaultProjectConfigForType(organization, project, environment, appType str
 		},
 		Services: map[string]ServiceConfig{
 			DefaultWebServiceName: {
-				Kind:       ServiceKindWeb,
 				Env:        map[string]string{},
 				SecretRefs: []SecretRef{},
 				Volumes:    []Volume{},
@@ -480,7 +476,6 @@ func applyDefaults(cfg *ProjectConfig) {
 				service.Healthcheck.Port = service.HTTPPort(DefaultWebPort)
 			}
 		}
-		service.Kind = inferredServiceKind(name, service)
 		cfg.Services[name] = service
 	}
 	if cfg.Tasks.Release != nil {
@@ -657,7 +652,7 @@ func validateService(name string, service ServiceConfig) error {
 		}
 		seenPorts[port.Name] = true
 	}
-	serviceKind := inferredServiceKind(name, service)
+	serviceKind := InferredServiceKind(name, service)
 	if serviceKind == ServiceKindWeb {
 		if service.HTTPPort(0) <= 0 {
 			return fmt.Errorf("services.%s must expose an http port", name)
@@ -765,25 +760,20 @@ func (cfg ProjectConfig) ServiceNames() []string {
 	return names
 }
 
-func (cfg ProjectConfig) ServicesByKind(kind string) []string {
-	names := []string{}
+func (cfg ProjectConfig) PrimaryWebServiceName() (string, bool) {
+	services := []string{}
 	for _, name := range cfg.ServiceNames() {
-		if cfg.Services[name].Kind == kind {
-			names = append(names, name)
+		if InferredServiceKind(name, cfg.Services[name]) == ServiceKindWeb {
+			services = append(services, name)
 		}
 	}
-	return names
-}
-
-func (cfg ProjectConfig) PrimaryWebServiceName() (string, bool) {
-	services := cfg.ServicesByKind(ServiceKindWeb)
 	if len(services) == 0 {
 		return "", false
 	}
 	if len(services) == 1 {
 		return services[0], true
 	}
-	if _, ok := cfg.Services[DefaultWebServiceName]; ok && cfg.Services[DefaultWebServiceName].Kind == ServiceKindWeb {
+	if service, ok := cfg.Services[DefaultWebServiceName]; ok && InferredServiceKind(DefaultWebServiceName, service) == ServiceKindWeb {
 		return DefaultWebServiceName, true
 	}
 	return "", false
@@ -812,7 +802,7 @@ func (service ServiceConfig) HasPortNamed(name string) bool {
 	return false
 }
 
-func inferredServiceKind(name string, service ServiceConfig) string {
+func InferredServiceKind(name string, service ServiceConfig) string {
 	if service.HasPortNamed("http") || service.Healthcheck != nil || strings.TrimSpace(name) == DefaultWebServiceName {
 		return ServiceKindWeb
 	}

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -16,7 +16,6 @@ func TestWriteAndLoadFromRoot(t *testing.T) {
 	root := t.TempDir()
 	project := DefaultProjectConfig("acme", "ShopApp", "staging")
 	project.Services["jobs"] = Service{
-		Kind:       ServiceKindWorker,
 		Command:    []string{"./bin/jobs"},
 		Env:        map[string]string{"QUEUE": "default"},
 		SecretRefs: []SecretRef{{Name: "API_KEY", Secret: "gsm://projects/test/secrets/api-key"}},
@@ -188,7 +187,6 @@ func TestValidateAcceptsWorkerWithoutExtraPlacementFields(t *testing.T) {
 
 	project := DefaultProjectConfig("acme", "ShopApp", "production")
 	project.Services["jobs"] = Service{
-		Kind:    ServiceKindWorker,
 		Command: []string{"./bin/jobs"},
 	}
 
@@ -400,7 +398,6 @@ func TestResolveEnvironmentConfigMergesOverlay(t *testing.T) {
 		TLS: IngressTLSConfig{Mode: "auto", Email: "ops@example.test"},
 	}
 	project.Services["web"] = Service{
-		Kind:       ServiceKindWeb,
 		Command:    []string{"bundle", "exec", "puma"},
 		Args:       []string{"-C", "config/puma.rb"},
 		Env:        map[string]string{"RAILS_ENV": "production", "BASE_ONLY": "1"},

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -92,7 +92,6 @@ func TestLoadAppliesDefaultBuildPlatforms(t *testing.T) {
 		"  dockerfile: Dockerfile",
 		"services:",
 		"  web:",
-		"    kind: web",
 		"    ports:",
 		"      - name: http",
 		"        port: 3000",
@@ -130,7 +129,6 @@ func TestLoadRejectsLegacyInitHook(t *testing.T) {
 		"  dockerfile: Dockerfile",
 		"services:",
 		"  web:",
-		"    kind: web",
 		"    ports:",
 		"      - name: http",
 		"        port: 3000",
@@ -164,7 +162,6 @@ func TestLoadRejectsStringCommandSyntax(t *testing.T) {
 		"  dockerfile: Dockerfile",
 		"services:",
 		"  web:",
-		"    kind: web",
 		"    command: ./bin/server",
 		"    ports:",
 		"      - name: http",
@@ -201,6 +198,18 @@ func TestValidateAcceptsWorkerWithoutExtraPlacementFields(t *testing.T) {
 	}
 }
 
+func TestInferredServiceKindTreatsNonHTTPPortOnlyServiceAsWorker(t *testing.T) {
+	t.Parallel()
+
+	service := ServiceConfig{
+		Ports: []ServicePort{{Name: "metrics", Port: 9090}},
+	}
+
+	if got := inferredServiceKind("api", service); got != ServiceKindWorker {
+		t.Fatalf("inferredServiceKind() = %q, want %q", got, ServiceKindWorker)
+	}
+}
+
 func TestLoadRejectsLegacyDirectConfig(t *testing.T) {
 	t.Parallel()
 
@@ -216,7 +225,6 @@ func TestLoadRejectsLegacyDirectConfig(t *testing.T) {
 		"  dockerfile: Dockerfile",
 		"services:",
 		"  web:",
-		"    kind: web",
 		"    ports:",
 		"      - name: http",
 		"        port: 3000",
@@ -253,7 +261,6 @@ func TestLoadRejectsLegacySoloConfigBlock(t *testing.T) {
 		"  dockerfile: Dockerfile",
 		"services:",
 		"  web:",
-		"    kind: web",
 		"    ports:",
 		"      - name: http",
 		"        port: 3000",
@@ -354,199 +361,69 @@ func TestReadmeExampleConfigParses(t *testing.T) {
 	}
 }
 
-func TestResolveEnvironmentConfigMergesOverlay(t *testing.T) {
+func TestValidateAcceptsGenericServicesAndExplicitIngressRules(t *testing.T) {
 	t.Parallel()
 
 	project := DefaultProjectConfig("acme", "ShopApp", "production")
+	project.SchemaVersion = 6
+	project.Services = map[string]Service{
+		"app": {
+			Command: []string{"./bin/web"},
+			Ports:   []ServicePort{{Name: "http", Port: 3000}},
+			Healthcheck: &HTTPHealthcheck{
+				Path: "/up",
+				Port: 3000,
+			},
+		},
+		"api": {
+			Command: []string{"./bin/api"},
+			Ports:   []ServicePort{{Name: "http", Port: 4000}},
+		},
+		"worker": {
+			Command: []string{"./bin/worker"},
+		},
+	}
 	project.Ingress = &IngressConfig{
-		Hosts:   []string{"app.example.test"},
-		Service: "web",
-		TLS:     IngressTLSConfig{Mode: "auto", Email: "ops@example.test"},
-	}
-	project.Services["web"] = Service{
-		Kind:       ServiceKindWeb,
-		Command:    []string{"bundle", "exec", "puma"},
-		Args:       []string{"-C", "config/puma.rb"},
-		Env:        map[string]string{"RAILS_ENV": "production", "BASE_ONLY": "1"},
-		SecretRefs: []SecretRef{{Name: "BASE_KEY", Secret: "gsm://base"}},
-		Ports:      []ServicePort{{Name: "http", Port: 3000}},
-		Healthcheck: &HTTPHealthcheck{
-			Path: "/up",
-			Port: 3000,
-		},
-		Volumes: []Volume{{Source: "storage", Target: "/rails/storage"}},
-	}
-	project.Tasks.Release = &TaskConfig{
-		Service: "web",
-		Command: []string{"bundle", "exec", "rails", "db:migrate"},
-		Env:     map[string]string{"RELEASE_ONLY": "base"},
-	}
-	redirectHTTP := false
-	stagingService := "web"
-	stagingPath := "/healthz"
-	stagingPort := 8080
-	project.Environments = map[string]EnvironmentOverlay{
-		"staging": {
-			Ingress: &IngressConfigOverlay{
-				Hosts:   []string{"staging.example.test", "alt-staging.example.test"},
-				Service: &stagingService,
-				TLS: &IngressTLSConfigOverlay{
-					Email: stringPtr("staging@example.test"),
-				},
-				RedirectHTTP: &redirectHTTP,
+		Hosts: []string{"app.example.com"},
+		Rules: []IngressRuleConfig{
+			{
+				Match:  IngressMatchConfig{Host: "app.example.com", PathPrefix: "/api"},
+				Target: IngressTargetConfig{Service: "api", Port: "http"},
 			},
-			Services: map[string]ServiceConfigOverlay{
-				"web": {
-					Command:     []string{"./bin/staging-web"},
-					Env:         map[string]string{"RAILS_ENV": "staging", "STAGING_ONLY": "1"},
-					SecretRefs:  []SecretRef{{Name: "STAGING_KEY", Secret: "gsm://staging"}},
-					Ports:       []ServicePort{{Name: "http", Port: 8080}},
-					Volumes:     []Volume{{Source: "staging-storage", Target: "/rails/storage"}},
-					Healthcheck: &HTTPHealthcheckOverlay{Path: &stagingPath, Port: &stagingPort},
-				},
-			},
-			Tasks: &TasksConfigOverlay{
-				Release: &TaskConfigOverlay{
-					Env:     map[string]string{"RELEASE_ONLY": "staging", "MIGRATION_MODE": "online"},
-					Command: []string{"bundle", "exec", "rails", "db:prepare"},
-				},
+			{
+				Match:  IngressMatchConfig{Host: "app.example.com", PathPrefix: "/"},
+				Target: IngressTargetConfig{Service: "app", Port: "http"},
 			},
 		},
 	}
 
-	resolved, err := ResolveEnvironmentConfig(project, "staging")
-	if err != nil {
-		t.Fatalf("ResolveEnvironmentConfig() error = %v", err)
-	}
-	if resolved.DefaultEnvironment != "staging" {
-		t.Fatalf("default_environment = %q, want staging", resolved.DefaultEnvironment)
-	}
-	if got := strings.Join(resolved.Ingress.Hosts, ","); got != "staging.example.test,alt-staging.example.test" {
-		t.Fatalf("ingress.hosts = %q", got)
-	}
-	if resolved.Ingress.TLS.Mode != "auto" || resolved.Ingress.TLS.Email != "staging@example.test" {
-		t.Fatalf("ingress tls = %#v", resolved.Ingress.TLS)
-	}
-	if resolved.Ingress.RedirectHTTP == nil || *resolved.Ingress.RedirectHTTP {
-		t.Fatalf("ingress.redirect_http = %#v, want false", resolved.Ingress.RedirectHTTP)
-	}
-	web := resolved.Services["web"]
-	if got := strings.Join(web.Command, " "); got != "./bin/staging-web" {
-		t.Fatalf("command = %q", got)
-	}
-	if web.Args[0] != "-C" {
-		t.Fatalf("args = %#v", web.Args)
-	}
-	if web.Env["RAILS_ENV"] != "staging" || web.Env["BASE_ONLY"] != "1" || web.Env["STAGING_ONLY"] != "1" {
-		t.Fatalf("env = %#v", web.Env)
-	}
-	if len(web.SecretRefs) != 1 || web.SecretRefs[0].Name != "STAGING_KEY" {
-		t.Fatalf("secret_refs = %#v", web.SecretRefs)
-	}
-	if web.Healthcheck == nil || web.Healthcheck.Path != "/healthz" || web.Healthcheck.Port != 8080 {
-		t.Fatalf("healthcheck = %#v", web.Healthcheck)
-	}
-	if resolved.Tasks.Release == nil {
-		t.Fatal("release task missing")
-	}
-	if got := strings.Join(resolved.Tasks.Release.Command, " "); got != "bundle exec rails db:prepare" {
-		t.Fatalf("release command = %q", got)
-	}
-	if resolved.Tasks.Release.Env["RELEASE_ONLY"] != "staging" || resolved.Tasks.Release.Env["MIGRATION_MODE"] != "online" {
-		t.Fatalf("release env = %#v", resolved.Tasks.Release.Env)
+	if err := Validate(&project); err != nil {
+		t.Fatalf("Validate() error = %v", err)
 	}
 }
 
-func TestResolveEnvironmentConfigReturnsBaseForMissingOverlay(t *testing.T) {
+func TestValidateRejectsIngressRuleTargetingMissingNamedPort(t *testing.T) {
 	t.Parallel()
 
 	project := DefaultProjectConfig("acme", "ShopApp", "production")
-	resolved, err := ResolveEnvironmentConfig(project, "staging")
-	if err != nil {
-		t.Fatalf("ResolveEnvironmentConfig() error = %v", err)
+	project.SchemaVersion = 6
+	project.Services = map[string]Service{
+		"app": {
+			Command: []string{"./bin/web"},
+			Ports:   []ServicePort{{Name: "http", Port: 3000}},
+			Healthcheck: &HTTPHealthcheck{Path: "/up", Port: 3000},
+		},
 	}
-	if resolved.DefaultEnvironment != "staging" {
-		t.Fatalf("default_environment = %q, want staging", resolved.DefaultEnvironment)
-	}
-	if _, ok := resolved.Services["web"]; !ok {
-		t.Fatalf("resolved services = %#v", resolved.Services)
-	}
-}
-
-func TestLoadRejectsOverlayServiceNotInBase(t *testing.T) {
-	t.Parallel()
-
-	root := t.TempDir()
-	path := filepath.Join(root, FilePath)
-	content := strings.Join([]string{
-		"schema_version: 6",
-		"organization: acme",
-		"project: ShopApp",
-		"default_environment: production",
-		"build:",
-		"  context: .",
-		"  dockerfile: Dockerfile",
-		"services:",
-		"  web:",
-		"    kind: web",
-		"    ports:",
-		"      - name: http",
-		"        port: 3000",
-		"    healthcheck:",
-		"      path: /up",
-		"environments:",
-		"  staging:",
-		"    services:",
-		"      jobs:",
-		"        command:",
-		"          - ./bin/jobs",
-	}, "\n") + "\n"
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
-		t.Fatal(err)
+	project.Ingress = &IngressConfig{
+		Hosts: []string{"app.example.com"},
+		Rules: []IngressRuleConfig{{
+			Match:  IngressMatchConfig{Host: "app.example.com", PathPrefix: "/"},
+			Target: IngressTargetConfig{Service: "app", Port: "metrics"},
+		}},
 	}
 
-	_, err := Load(path)
-	if err == nil || !strings.Contains(err.Error(), "environments.staging.services.jobs not found in services") {
-		t.Fatalf("expected missing service error, got %v", err)
+	err := Validate(&project)
+	if err == nil || !strings.Contains(err.Error(), "ingress.rules[0].target.port") {
+		t.Fatalf("expected ingress rule target port validation error, got %v", err)
 	}
-}
-
-func TestLoadRejectsUnknownOverlayKeys(t *testing.T) {
-	t.Parallel()
-
-	root := t.TempDir()
-	path := filepath.Join(root, FilePath)
-	content := strings.Join([]string{
-		"schema_version: 6",
-		"organization: acme",
-		"project: ShopApp",
-		"default_environment: production",
-		"build:",
-		"  context: .",
-		"  dockerfile: Dockerfile",
-		"services:",
-		"  web:",
-		"    kind: web",
-		"    ports:",
-		"      - name: http",
-		"        port: 3000",
-		"    healthcheck:",
-		"      path: /up",
-		"environments:",
-		"  staging:",
-		"    build:",
-		"      context: .",
-	}, "\n") + "\n"
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	_, err := Load(path)
-	if err == nil || !strings.Contains(err.Error(), "field build not found") {
-		t.Fatalf("expected unknown overlay key error, got %v", err)
-	}
-}
-
-func stringPtr(value string) *string {
-	return &value
 }

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -198,18 +198,6 @@ func TestValidateAcceptsWorkerWithoutExtraPlacementFields(t *testing.T) {
 	}
 }
 
-func TestInferredServiceKindTreatsNonHTTPPortOnlyServiceAsWorker(t *testing.T) {
-	t.Parallel()
-
-	service := ServiceConfig{
-		Ports: []ServicePort{{Name: "metrics", Port: 9090}},
-	}
-
-	if got := inferredServiceKind("api", service); got != ServiceKindWorker {
-		t.Fatalf("inferredServiceKind() = %q, want %q", got, ServiceKindWorker)
-	}
-}
-
 func TestLoadRejectsLegacyDirectConfig(t *testing.T) {
 	t.Parallel()
 
@@ -361,69 +349,205 @@ func TestReadmeExampleConfigParses(t *testing.T) {
 	}
 }
 
-func TestValidateAcceptsGenericServicesAndExplicitIngressRules(t *testing.T) {
+func TestResolveEnvironmentConfigMergesOverlay(t *testing.T) {
 	t.Parallel()
 
 	project := DefaultProjectConfig("acme", "ShopApp", "production")
-	project.SchemaVersion = 6
-	project.Services = map[string]Service{
-		"app": {
-			Command: []string{"./bin/web"},
-			Ports:   []ServicePort{{Name: "http", Port: 3000}},
-			Healthcheck: &HTTPHealthcheck{
-				Path: "/up",
-				Port: 3000,
-			},
-		},
-		"api": {
-			Command: []string{"./bin/api"},
-			Ports:   []ServicePort{{Name: "http", Port: 4000}},
-		},
-		"worker": {
-			Command: []string{"./bin/worker"},
-		},
-	}
 	project.Ingress = &IngressConfig{
-		Hosts: []string{"app.example.com"},
-		Rules: []IngressRuleConfig{
-			{
-				Match:  IngressMatchConfig{Host: "app.example.com", PathPrefix: "/api"},
-				Target: IngressTargetConfig{Service: "api", Port: "http"},
+		Hosts: []string{"app.example.test"},
+		Rules: []IngressRuleConfig{{
+			Match:  IngressMatchConfig{Host: "app.example.test", PathPrefix: "/"},
+			Target: IngressTargetConfig{Service: "web", Port: "http"},
+		}},
+		TLS: IngressTLSConfig{Mode: "auto", Email: "ops@example.test"},
+	}
+	project.Services["web"] = Service{
+		Kind:       ServiceKindWeb,
+		Command:    []string{"bundle", "exec", "puma"},
+		Args:       []string{"-C", "config/puma.rb"},
+		Env:        map[string]string{"RAILS_ENV": "production", "BASE_ONLY": "1"},
+		SecretRefs: []SecretRef{{Name: "BASE_KEY", Secret: "gsm://base"}},
+		Ports:      []ServicePort{{Name: "http", Port: 3000}},
+		Healthcheck: &HTTPHealthcheck{
+			Path: "/up",
+			Port: 3000,
+		},
+		Volumes: []Volume{{Source: "storage", Target: "/rails/storage"}},
+	}
+	project.Tasks.Release = &TaskConfig{
+		Service: "web",
+		Command: []string{"bundle", "exec", "rails", "db:migrate"},
+		Env:     map[string]string{"RELEASE_ONLY": "base"},
+	}
+	redirectHTTP := false
+	stagingPath := "/healthz"
+	stagingPort := 8080
+	project.Environments = map[string]EnvironmentOverlay{
+		"staging": {
+			Ingress: &IngressConfigOverlay{
+				Hosts: []string{"staging.example.test", "alt-staging.example.test"},
+				Rules: []IngressRuleConfig{{
+					Match:  IngressMatchConfig{Host: "staging.example.test", PathPrefix: "/"},
+					Target: IngressTargetConfig{Service: "web", Port: "http"},
+				}, {
+					Match:  IngressMatchConfig{Host: "alt-staging.example.test", PathPrefix: "/"},
+					Target: IngressTargetConfig{Service: "web", Port: "http"},
+				}},
+				TLS: &IngressTLSConfigOverlay{
+					Email: stringPtr("staging@example.test"),
+				},
+				RedirectHTTP: &redirectHTTP,
 			},
-			{
-				Match:  IngressMatchConfig{Host: "app.example.com", PathPrefix: "/"},
-				Target: IngressTargetConfig{Service: "app", Port: "http"},
+			Services: map[string]ServiceConfigOverlay{
+				"web": {
+					Command:     []string{"./bin/staging-web"},
+					Env:         map[string]string{"RAILS_ENV": "staging", "STAGING_ONLY": "1"},
+					SecretRefs:  []SecretRef{{Name: "STAGING_KEY", Secret: "gsm://staging"}},
+					Ports:       []ServicePort{{Name: "http", Port: 8080}},
+					Volumes:     []Volume{{Source: "staging-storage", Target: "/rails/storage"}},
+					Healthcheck: &HTTPHealthcheckOverlay{Path: &stagingPath, Port: &stagingPort},
+				},
+			},
+			Tasks: &TasksConfigOverlay{
+				Release: &TaskConfigOverlay{
+					Env:     map[string]string{"RELEASE_ONLY": "staging", "MIGRATION_MODE": "online"},
+					Command: []string{"bundle", "exec", "rails", "db:prepare"},
+				},
 			},
 		},
 	}
 
-	if err := Validate(&project); err != nil {
-		t.Fatalf("Validate() error = %v", err)
+	resolved, err := ResolveEnvironmentConfig(project, "staging")
+	if err != nil {
+		t.Fatalf("ResolveEnvironmentConfig() error = %v", err)
+	}
+	if resolved.DefaultEnvironment != "staging" {
+		t.Fatalf("default_environment = %q, want staging", resolved.DefaultEnvironment)
+	}
+	if got := strings.Join(resolved.Ingress.Hosts, ","); got != "staging.example.test,alt-staging.example.test" {
+		t.Fatalf("ingress.hosts = %q", got)
+	}
+	if resolved.Ingress.TLS.Mode != "auto" || resolved.Ingress.TLS.Email != "staging@example.test" {
+		t.Fatalf("ingress tls = %#v", resolved.Ingress.TLS)
+	}
+	if resolved.Ingress.RedirectHTTP == nil || *resolved.Ingress.RedirectHTTP {
+		t.Fatalf("ingress.redirect_http = %#v, want false", resolved.Ingress.RedirectHTTP)
+	}
+	web := resolved.Services["web"]
+	if got := strings.Join(web.Command, " "); got != "./bin/staging-web" {
+		t.Fatalf("command = %q", got)
+	}
+	if web.Args[0] != "-C" {
+		t.Fatalf("args = %#v", web.Args)
+	}
+	if web.Env["RAILS_ENV"] != "staging" || web.Env["BASE_ONLY"] != "1" || web.Env["STAGING_ONLY"] != "1" {
+		t.Fatalf("env = %#v", web.Env)
+	}
+	if len(web.SecretRefs) != 1 || web.SecretRefs[0].Name != "STAGING_KEY" {
+		t.Fatalf("secret_refs = %#v", web.SecretRefs)
+	}
+	if web.Healthcheck == nil || web.Healthcheck.Path != "/healthz" || web.Healthcheck.Port != 8080 {
+		t.Fatalf("healthcheck = %#v", web.Healthcheck)
+	}
+	if resolved.Tasks.Release == nil {
+		t.Fatal("release task missing")
+	}
+	if got := strings.Join(resolved.Tasks.Release.Command, " "); got != "bundle exec rails db:prepare" {
+		t.Fatalf("release command = %q", got)
+	}
+	if resolved.Tasks.Release.Env["RELEASE_ONLY"] != "staging" || resolved.Tasks.Release.Env["MIGRATION_MODE"] != "online" {
+		t.Fatalf("release env = %#v", resolved.Tasks.Release.Env)
 	}
 }
 
-func TestValidateRejectsIngressRuleTargetingMissingNamedPort(t *testing.T) {
+func TestResolveEnvironmentConfigReturnsBaseForMissingOverlay(t *testing.T) {
 	t.Parallel()
 
 	project := DefaultProjectConfig("acme", "ShopApp", "production")
-	project.SchemaVersion = 6
-	project.Services = map[string]Service{
-		"app": {
-			Command: []string{"./bin/web"},
-			Ports:   []ServicePort{{Name: "http", Port: 3000}},
-			Healthcheck: &HTTPHealthcheck{Path: "/up", Port: 3000},
-		},
+	resolved, err := ResolveEnvironmentConfig(project, "staging")
+	if err != nil {
+		t.Fatalf("ResolveEnvironmentConfig() error = %v", err)
 	}
-	project.Ingress = &IngressConfig{
-		Hosts: []string{"app.example.com"},
-		Rules: []IngressRuleConfig{{
-			Match:  IngressMatchConfig{Host: "app.example.com", PathPrefix: "/"},
-			Target: IngressTargetConfig{Service: "app", Port: "metrics"},
-		}},
+	if resolved.DefaultEnvironment != "staging" {
+		t.Fatalf("default_environment = %q, want staging", resolved.DefaultEnvironment)
+	}
+	if _, ok := resolved.Services["web"]; !ok {
+		t.Fatalf("resolved services = %#v", resolved.Services)
+	}
+}
+
+func TestLoadRejectsOverlayServiceNotInBase(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	path := filepath.Join(root, FilePath)
+	content := strings.Join([]string{
+		"schema_version: 6",
+		"organization: acme",
+		"project: ShopApp",
+		"default_environment: production",
+		"build:",
+		"  context: .",
+		"  dockerfile: Dockerfile",
+		"services:",
+		"  web:",
+		"    ports:",
+		"      - name: http",
+		"        port: 3000",
+		"    healthcheck:",
+		"      path: /up",
+		"environments:",
+		"  staging:",
+		"    services:",
+		"      jobs:",
+		"        command:",
+		"          - ./bin/jobs",
+	}, "\n") + "\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
 	}
 
-	err := Validate(&project)
-	if err == nil || !strings.Contains(err.Error(), "ingress.rules[0].target.port") {
-		t.Fatalf("expected ingress rule target port validation error, got %v", err)
+	_, err := Load(path)
+	if err == nil || !strings.Contains(err.Error(), "environments.staging.services.jobs not found in services") {
+		t.Fatalf("expected missing service error, got %v", err)
 	}
+}
+
+func TestLoadRejectsUnknownOverlayKeys(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	path := filepath.Join(root, FilePath)
+	content := strings.Join([]string{
+		"schema_version: 6",
+		"organization: acme",
+		"project: ShopApp",
+		"default_environment: production",
+		"build:",
+		"  context: .",
+		"  dockerfile: Dockerfile",
+		"services:",
+		"  web:",
+		"    ports:",
+		"      - name: http",
+		"        port: 3000",
+		"    healthcheck:",
+		"      path: /up",
+		"environments:",
+		"  staging:",
+		"    build:",
+		"      context: .",
+	}, "\n") + "\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Load(path)
+	if err == nil || !strings.Contains(err.Error(), "field build not found") {
+		t.Fatalf("expected unknown overlay key error, got %v", err)
+	}
+}
+
+func stringPtr(value string) *string {
+	return &value
 }

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -282,6 +282,44 @@ func TestValidateRejectsBlankBuildPlatform(t *testing.T) {
 	}
 }
 
+func TestValidateIngressRulesTreatHostsCaseInsensitively(t *testing.T) {
+	t.Parallel()
+
+	project := DefaultProjectConfig("acme", "ShopApp", "production")
+	project.Ingress = &IngressConfig{
+		Hosts: []string{"App.Example.com"},
+		Rules: []IngressRuleConfig{{
+			Match:  IngressMatchConfig{Host: "app.example.COM", PathPrefix: "/"},
+			Target: IngressTargetConfig{Service: "web", Port: "http"},
+		}},
+	}
+
+	if err := Validate(&project); err != nil {
+		t.Fatalf("expected ingress host matching to be case-insensitive, got %v", err)
+	}
+}
+
+func TestValidateIngressRulesRejectsCaseInsensitiveDuplicateRoutes(t *testing.T) {
+	t.Parallel()
+
+	project := DefaultProjectConfig("acme", "ShopApp", "production")
+	project.Ingress = &IngressConfig{
+		Hosts: []string{"App.Example.com"},
+		Rules: []IngressRuleConfig{{
+			Match:  IngressMatchConfig{Host: "App.Example.com", PathPrefix: "/"},
+			Target: IngressTargetConfig{Service: "web", Port: "http"},
+		}, {
+			Match:  IngressMatchConfig{Host: "app.example.COM", PathPrefix: "/"},
+			Target: IngressTargetConfig{Service: "web", Port: "http"},
+		}},
+	}
+
+	err := Validate(&project)
+	if err == nil || !strings.Contains(err.Error(), "duplicate route") {
+		t.Fatalf("expected duplicate route error, got %v", err)
+	}
+}
+
 func TestWriteGenericConfigUsesRepoRootPath(t *testing.T) {
 	t.Parallel()
 

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -327,6 +327,48 @@ func TestLoadNormalizesIngressHostsAndRuleHosts(t *testing.T) {
 	}
 }
 
+func TestLoadRejectsDuplicateIngressHostsAfterNormalization(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	path := filepath.Join(root, FilePath)
+	content := strings.Join([]string{
+		"schema_version: 6",
+		"organization: acme",
+		"project: ShopApp",
+		"default_environment: production",
+		"build:",
+		"  context: .",
+		"  dockerfile: Dockerfile",
+		"services:",
+		"  web:",
+		"    ports:",
+		"      - name: http",
+		"        port: 3000",
+		"    healthcheck:",
+		"      path: /up",
+		"ingress:",
+		"  hosts:",
+		"    - App.Example.com",
+		"    - app.example.COM",
+		"  rules:",
+		"    - match:",
+		"        host: app.example.com",
+		"        path_prefix: /",
+		"      target:",
+		"        service: web",
+		"        port: http",
+	}, "\n") + "\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Load(path)
+	if err == nil || !strings.Contains(err.Error(), "ingress.hosts contains duplicate host") {
+		t.Fatalf("expected duplicate ingress host error, got %v", err)
+	}
+}
+
 func TestValidateIngressRulesTreatHostsCaseInsensitively(t *testing.T) {
 	t.Parallel()
 

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -280,6 +280,53 @@ func TestValidateRejectsBlankBuildPlatform(t *testing.T) {
 	}
 }
 
+func TestLoadNormalizesIngressHostsAndRuleHosts(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	path := filepath.Join(root, FilePath)
+	content := strings.Join([]string{
+		"schema_version: 6",
+		"organization: acme",
+		"project: ShopApp",
+		"default_environment: production",
+		"build:",
+		"  context: .",
+		"  dockerfile: Dockerfile",
+		"services:",
+		"  web:",
+		"    ports:",
+		"      - name: http",
+		"        port: 3000",
+		"    healthcheck:",
+		"      path: /up",
+		"ingress:",
+		"  hosts:",
+		"    - App.Example.com",
+		"  rules:",
+		"    - match:",
+		"        host: APP.EXAMPLE.COM",
+		"        path_prefix: /",
+		"      target:",
+		"        service: web",
+		"        port: http",
+	}, "\n") + "\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if got := strings.Join(cfg.Ingress.Hosts, ","); got != "app.example.com" {
+		t.Fatalf("ingress.hosts = %q, want normalized host", got)
+	}
+	if got := cfg.Ingress.Rules[0].Match.Host; got != "app.example.com" {
+		t.Fatalf("rule match host = %q, want normalized host", got)
+	}
+}
+
 func TestValidateIngressRulesTreatHostsCaseInsensitively(t *testing.T) {
 	t.Parallel()
 

--- a/cli/internal/discovery/discovery_test.go
+++ b/cli/internal/discovery/discovery_test.go
@@ -77,7 +77,7 @@ func TestDiscoverFindsGenericWorkspaceFromConfig(t *testing.T) {
 	t.Parallel()
 
 	root := t.TempDir()
-	if err := os.WriteFile(filepath.Join(root, "devopsellence.yml"), []byte("schema_version: 6\norganization: acme\nproject: demo\ndefault_environment: production\nbuild:\n  context: .\n  dockerfile: Dockerfile\nservices:\n  web:\n    kind: web\n    ports:\n      - name: http\n        port: 8080\n    healthcheck:\n      path: /\n      port: 8080\n"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(root, "devopsellence.yml"), []byte("schema_version: 6\norganization: acme\nproject: demo\ndefault_environment: production\nbuild:\n  context: .\n  dockerfile: Dockerfile\nservices:\n  web:\n    ports:\n      - name: http\n        port: 8080\n    healthcheck:\n      path: /\n      port: 8080\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	start := filepath.Join(root, "src", "api")

--- a/cli/internal/solo/desiredstate.go
+++ b/cli/internal/solo/desiredstate.go
@@ -311,7 +311,7 @@ func buildIngress(ingress *config.IngressConfig, environmentName string) *ingres
 			},
 		})
 	}
-	redirectHTTP := false
+	redirectHTTP := true
 	if ingress.RedirectHTTP != nil {
 		redirectHTTP = *ingress.RedirectHTTP
 	}

--- a/cli/internal/solo/desiredstate.go
+++ b/cli/internal/solo/desiredstate.go
@@ -146,9 +146,11 @@ func BuildDesiredStateForNode(cfg *config.ProjectConfig, imageTag, revision stri
 
 	for _, serviceName := range cfg.ServiceNames() {
 		service := cfg.Services[serviceName]
-		if !shouldScheduleService(labels, service.Kind) {
+		serviceKind := effectiveServiceKind(serviceName, service)
+		if !shouldScheduleService(labels, serviceKind) {
 			continue
 		}
+		service.Kind = serviceKind
 		rendered, err := buildService(serviceName, service, imageTag, secrets)
 		if err != nil {
 			return nil, fmt.Errorf("build service %s: %w", serviceName, err)
@@ -284,43 +286,42 @@ func normalizeEnvironmentNameToken(value string) string {
 }
 
 func buildIngress(ingress *config.IngressConfig, environmentName string) *ingressJSON {
-	if ingress == nil || len(ingress.Hosts) == 0 {
+	if ingress == nil || len(ingress.Hosts) == 0 || len(ingress.Rules) == 0 {
 		return nil
 	}
 	mode := strings.TrimSpace(ingress.TLS.Mode)
 	if mode == "" {
 		mode = "auto"
 	}
-	routes := make([]ingressRouteJSON, 0, len(ingress.Hosts))
-	for _, host := range ingress.Hosts {
+	routes := make([]ingressRouteJSON, 0, len(ingress.Rules))
+	for _, rule := range ingress.Rules {
+		pathPrefix := strings.TrimSpace(rule.Match.PathPrefix)
+		if pathPrefix == "" {
+			pathPrefix = "/"
+		}
 		routes = append(routes, ingressRouteJSON{
 			Match: ingressMatchJSON{
-				Hostname: host,
+				Hostname:   strings.TrimSpace(rule.Match.Host),
+				PathPrefix: pathPrefix,
 			},
 			Target: ingressTargetJSON{
 				Environment: environmentName,
-				Service:     ingress.Service,
-				Port:        "http",
+				Service:     strings.TrimSpace(rule.Target.Service),
+				Port:        strings.TrimSpace(rule.Target.Port),
 			},
 		})
 	}
 	return &ingressJSON{
 		Hosts: append([]string(nil), ingress.Hosts...),
+		Mode:  "public",
 		TLS: ingressTLSJSON{
 			Mode:           mode,
 			Email:          strings.TrimSpace(ingress.TLS.Email),
 			CADirectoryURL: strings.TrimSpace(ingress.TLS.CADirectoryURL),
 		},
-		RedirectHTTP: ingressRedirectHTTPValue(ingress),
+		RedirectHTTP: ingress.RedirectHTTP,
 		Routes:       routes,
 	}
-}
-
-func ingressRedirectHTTPValue(ingress *config.IngressConfig) bool {
-	if ingress == nil || ingress.RedirectHTTP == nil {
-		return true
-	}
-	return *ingress.RedirectHTTP
 }
 
 func mergeIngressForNode(labels []string, snapshots []DeploySnapshot, environmentNames map[string]string) (*ingressJSON, error) {
@@ -329,21 +330,21 @@ func mergeIngressForNode(labels []string, snapshots []DeploySnapshot, environmen
 	routeSet := map[string]bool{}
 
 	for _, snapshot := range snapshots {
-		if snapshot.Ingress == nil || !shouldScheduleService(labels, snapshot.IngressServiceKind) {
+		if snapshot.Ingress == nil || !snapshotShouldScheduleIngress(labels, snapshot) {
 			continue
 		}
 		if merged == nil {
 			merged = &ingressJSON{
-				Mode:         normalizedMergedIngressMode(snapshot.Ingress.Mode),
+				Mode:         snapshot.Ingress.Mode,
 				TLS:          snapshot.Ingress.TLS,
 				RedirectHTTP: snapshot.Ingress.RedirectHTTP,
 			}
-		} else if merged.TLS != snapshot.Ingress.TLS || merged.RedirectHTTP != snapshot.Ingress.RedirectHTTP || merged.Mode != normalizedMergedIngressMode(snapshot.Ingress.Mode) {
+		} else if merged.TLS != snapshot.Ingress.TLS || merged.RedirectHTTP != snapshot.Ingress.RedirectHTTP || merged.Mode != snapshot.Ingress.Mode {
 			differingSettings := []string{}
 			if merged.TLS != snapshot.Ingress.TLS {
 				differingSettings = append(differingSettings, "TLS")
 			}
-			if merged.Mode != normalizedMergedIngressMode(snapshot.Ingress.Mode) {
+			if merged.Mode != snapshot.Ingress.Mode {
 				differingSettings = append(differingSettings, "mode")
 			}
 			if merged.RedirectHTTP != snapshot.Ingress.RedirectHTTP {
@@ -395,11 +396,58 @@ func mergeIngressForNode(labels []string, snapshots []DeploySnapshot, environmen
 	return merged, nil
 }
 
-func normalizedMergedIngressMode(mode string) string {
-	if strings.TrimSpace(mode) == "public" {
-		return ""
+func snapshotShouldScheduleIngress(labels []string, snapshot DeploySnapshot) bool {
+	serviceKinds := map[string]string{}
+	for _, service := range snapshot.Services {
+		serviceKinds[strings.TrimSpace(service.Name)] = strings.TrimSpace(service.Kind)
 	}
-	return strings.TrimSpace(mode)
+	serviceNames := ingressTargetServiceNamesFromRoutes(snapshot.Ingress)
+	if len(serviceNames) == 0 {
+		return false
+	}
+	for _, serviceName := range serviceNames {
+		kind, ok := serviceKinds[serviceName]
+		if !ok || !shouldScheduleService(labels, kind) {
+			return false
+		}
+	}
+	return true
+}
+
+func ingressTargetServiceNames(ingress *config.IngressConfig) []string {
+	serviceSet := map[string]bool{}
+	serviceNames := []string{}
+	if ingress == nil {
+		return serviceNames
+	}
+	for _, rule := range ingress.Rules {
+		serviceName := strings.TrimSpace(rule.Target.Service)
+		if serviceName == "" || serviceSet[serviceName] {
+			continue
+		}
+		serviceSet[serviceName] = true
+		serviceNames = append(serviceNames, serviceName)
+	}
+	sort.Strings(serviceNames)
+	return serviceNames
+}
+
+func ingressTargetServiceNamesFromRoutes(ingress *ingressJSON) []string {
+	serviceSet := map[string]bool{}
+	serviceNames := []string{}
+	if ingress == nil {
+		return serviceNames
+	}
+	for _, route := range ingress.Routes {
+		serviceName := strings.TrimSpace(route.Target.Service)
+		if serviceName == "" || serviceSet[serviceName] {
+			continue
+		}
+		serviceSet[serviceName] = true
+		serviceNames = append(serviceNames, serviceName)
+	}
+	sort.Strings(serviceNames)
+	return serviceNames
 }
 
 func syntheticRevision(ds desiredStateJSON) (string, error) {
@@ -460,11 +508,20 @@ func shouldScheduleIngress(labels []string, cfg *config.ProjectConfig) bool {
 	if cfg == nil || cfg.Ingress == nil {
 		return false
 	}
-	service, ok := cfg.Services[cfg.Ingress.Service]
-	if !ok {
+	serviceNames := ingressTargetServiceNames(cfg.Ingress)
+	if len(serviceNames) == 0 {
 		return false
 	}
-	return shouldScheduleService(labels, service.Kind)
+	for _, serviceName := range serviceNames {
+		service, ok := cfg.Services[serviceName]
+		if !ok {
+			return false
+		}
+		if !shouldScheduleService(labels, effectiveServiceKind(serviceName, service)) {
+			return false
+		}
+	}
+	return true
 }
 
 func shouldScheduleReleaseTask(labels []string, cfg *config.ProjectConfig) bool {
@@ -487,6 +544,17 @@ func hasLabel(labels []string, want string) bool {
 		}
 	}
 	return false
+}
+
+func effectiveServiceKind(name string, svc config.ServiceConfig) string {
+	kind := strings.TrimSpace(svc.Kind)
+	if kind != "" {
+		return kind
+	}
+	if svc.HasPortNamed("http") || svc.Healthcheck != nil || strings.TrimSpace(name) == config.DefaultWebServiceName {
+		return config.ServiceKindWeb
+	}
+	return config.ServiceKindWorker
 }
 
 func buildService(serviceName string, svc config.ServiceConfig, imageTag string, secrets map[string]string) (serviceJSON, error) {

--- a/cli/internal/solo/desiredstate.go
+++ b/cli/internal/solo/desiredstate.go
@@ -311,6 +311,10 @@ func buildIngress(ingress *config.IngressConfig, environmentName string) *ingres
 			},
 		})
 	}
+	redirectHTTP := false
+	if ingress.RedirectHTTP != nil {
+		redirectHTTP = *ingress.RedirectHTTP
+	}
 	return &ingressJSON{
 		Hosts: append([]string(nil), ingress.Hosts...),
 		Mode:  "public",
@@ -319,7 +323,7 @@ func buildIngress(ingress *config.IngressConfig, environmentName string) *ingres
 			Email:          strings.TrimSpace(ingress.TLS.Email),
 			CADirectoryURL: strings.TrimSpace(ingress.TLS.CADirectoryURL),
 		},
-		RedirectHTTP: ingress.RedirectHTTP,
+		RedirectHTTP: redirectHTTP,
 		Routes:       routes,
 	}
 }
@@ -339,12 +343,12 @@ func mergeIngressForNode(labels []string, snapshots []DeploySnapshot, environmen
 				TLS:          snapshot.Ingress.TLS,
 				RedirectHTTP: snapshot.Ingress.RedirectHTTP,
 			}
-		} else if merged.TLS != snapshot.Ingress.TLS || merged.RedirectHTTP != snapshot.Ingress.RedirectHTTP || merged.Mode != snapshot.Ingress.Mode {
+		} else if merged.TLS != snapshot.Ingress.TLS || merged.RedirectHTTP != snapshot.Ingress.RedirectHTTP || normalizedIngressMode(merged.Mode) != normalizedIngressMode(snapshot.Ingress.Mode) {
 			differingSettings := []string{}
 			if merged.TLS != snapshot.Ingress.TLS {
 				differingSettings = append(differingSettings, "TLS")
 			}
-			if merged.Mode != snapshot.Ingress.Mode {
+			if normalizedIngressMode(merged.Mode) != normalizedIngressMode(snapshot.Ingress.Mode) {
 				differingSettings = append(differingSettings, "mode")
 			}
 			if merged.RedirectHTTP != snapshot.Ingress.RedirectHTTP {
@@ -394,6 +398,14 @@ func mergeIngressForNode(labels []string, snapshots []DeploySnapshot, environmen
 		return left.Target.Port < right.Target.Port
 	})
 	return merged, nil
+}
+
+func normalizedIngressMode(mode string) string {
+	mode = strings.TrimSpace(mode)
+	if mode == "" {
+		return "public"
+	}
+	return mode
 }
 
 func snapshotShouldScheduleIngress(labels []string, snapshot DeploySnapshot) bool {

--- a/cli/internal/solo/desiredstate.go
+++ b/cli/internal/solo/desiredstate.go
@@ -150,7 +150,6 @@ func BuildDesiredStateForNode(cfg *config.ProjectConfig, imageTag, revision stri
 		if !shouldScheduleService(labels, serviceKind) {
 			continue
 		}
-		service.Kind = serviceKind
 		rendered, err := buildService(serviceName, service, imageTag, secrets)
 		if err != nil {
 			return nil, fmt.Errorf("build service %s: %w", serviceName, err)
@@ -545,7 +544,7 @@ func shouldScheduleReleaseTask(labels []string, cfg *config.ProjectConfig) bool 
 	if !ok {
 		return false
 	}
-	return shouldScheduleService(labels, service.Kind)
+	return shouldScheduleService(labels, effectiveServiceKind(release.Service, service))
 }
 
 func hasLabel(labels []string, want string) bool {
@@ -559,14 +558,7 @@ func hasLabel(labels []string, want string) bool {
 }
 
 func effectiveServiceKind(name string, svc config.ServiceConfig) string {
-	kind := strings.TrimSpace(svc.Kind)
-	if kind != "" {
-		return kind
-	}
-	if svc.HasPortNamed("http") || svc.Healthcheck != nil || strings.TrimSpace(name) == config.DefaultWebServiceName {
-		return config.ServiceKindWeb
-	}
-	return config.ServiceKindWorker
+	return config.InferredServiceKind(name, svc)
 }
 
 func buildService(serviceName string, svc config.ServiceConfig, imageTag string, secrets map[string]string) (serviceJSON, error) {
@@ -580,7 +572,7 @@ func buildService(serviceName string, svc config.ServiceConfig, imageTag string,
 	}
 	c := serviceJSON{
 		Name:  serviceName,
-		Kind:  svc.Kind,
+		Kind:  effectiveServiceKind(serviceName, svc),
 		Image: image,
 		Env:   env,
 	}

--- a/cli/internal/solo/desiredstate_test.go
+++ b/cli/internal/solo/desiredstate_test.go
@@ -191,10 +191,19 @@ func TestBuildDesiredStateForLabelsIncludesReleaseWhenSelected(t *testing.T) {
 func TestBuildDesiredStateForNodeIncludesIngressForIngressNode(t *testing.T) {
 	cfg := baseProject()
 	cfg.Ingress = &config.IngressConfig{
-		Hosts:   []string{"app.example.com", "www.example.com"},
-		Service: "web",
+		Hosts: []string{"app.example.com", "www.example.com"},
+		Rules: []config.IngressRuleConfig{
+			{
+				Match:  config.IngressMatchConfig{Host: "app.example.com", PathPrefix: "/"},
+				Target: config.IngressTargetConfig{Service: "web", Port: "http"},
+			},
+			{
+				Match:  config.IngressMatchConfig{Host: "www.example.com", PathPrefix: "/"},
+				Target: config.IngressTargetConfig{Service: "web", Port: "http"},
+			},
+		},
 		TLS: config.IngressTLSConfig{
-			Mode:           "auto",
+			Mode:           "manual",
 			Email:          "ops@example.com",
 			CADirectoryURL: "https://acme-staging-v02.api.letsencrypt.org/directory",
 		},
@@ -236,7 +245,13 @@ func TestBuildDesiredStateForNodeOmitsIngressForNonIngressNode(t *testing.T) {
 		Kind:    config.ServiceKindWorker,
 		Command: []string{"sidekiq"},
 	}
-	cfg.Ingress = &config.IngressConfig{Hosts: []string{"app.example.com"}, Service: "web"}
+	cfg.Ingress = &config.IngressConfig{
+		Hosts: []string{"app.example.com"},
+		Rules: []config.IngressRuleConfig{{
+			Match:  config.IngressMatchConfig{Host: "app.example.com", PathPrefix: "/"},
+			Target: config.IngressTargetConfig{Service: "web", Port: "http"},
+		}},
+	}
 
 	data, err := BuildDesiredStateForNode(cfg, "myapp:def5678", "def5678", map[string]string{"DATABASE_URL": "postgres://localhost/mydb"}, []string{config.DefaultWorkerRole}, true, false)
 	if err != nil {
@@ -248,6 +263,66 @@ func TestBuildDesiredStateForNodeOmitsIngressForNonIngressNode(t *testing.T) {
 	}
 	if ds.Ingress != nil {
 		t.Fatalf("ingress = %#v, want nil", ds.Ingress)
+	}
+}
+
+func TestBuildDesiredStateForNodeSerializesExplicitIngressRules(t *testing.T) {
+	cfg := baseProject()
+	cfg.SchemaVersion = 6
+	cfg.Services = map[string]config.Service{
+		"app": {
+			Command: []string{"./bin/web"},
+			Ports:   []config.ServicePort{{Name: "http", Port: 3000}},
+			Healthcheck: &config.HTTPHealthcheck{
+				Path: "/up",
+				Port: 3000,
+			},
+		},
+		"api": {
+			Command: []string{"./bin/api"},
+			Ports:   []config.ServicePort{{Name: "http", Port: 4000}, {Name: "metrics", Port: 9090}},
+			Healthcheck: &config.HTTPHealthcheck{
+				Path: "/up",
+				Port: 4000,
+			},
+		},
+	}
+	cfg.Ingress = &config.IngressConfig{
+		Hosts: []string{"app.example.com"},
+		Rules: []config.IngressRuleConfig{
+			{
+				Match:  config.IngressMatchConfig{Host: "app.example.com", PathPrefix: "/api"},
+				Target: config.IngressTargetConfig{Service: "api", Port: "metrics"},
+			},
+			{
+				Match:  config.IngressMatchConfig{Host: "app.example.com", PathPrefix: "/"},
+				Target: config.IngressTargetConfig{Service: "app", Port: "http"},
+			},
+		},
+	}
+
+	data, err := BuildDesiredStateForNode(cfg, "myapp:def5678", "def5678", map[string]string{}, []string{config.DefaultWebRole}, true, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var ds desiredStateJSON
+	if err := json.Unmarshal(data, &ds); err != nil {
+		t.Fatal(err)
+	}
+	if ds.Ingress == nil {
+		t.Fatal("expected ingress")
+	}
+	if len(ds.Ingress.Routes) != 2 {
+		t.Fatalf("routes = %#v", ds.Ingress.Routes)
+	}
+	if ds.Ingress.Routes[0].Match.Hostname != "app.example.com" || ds.Ingress.Routes[0].Match.PathPrefix != "/api" {
+		t.Fatalf("first route match = %#v", ds.Ingress.Routes[0].Match)
+	}
+	if ds.Ingress.Routes[0].Target.Service != "api" || ds.Ingress.Routes[0].Target.Port != "metrics" {
+		t.Fatalf("first route target = %#v", ds.Ingress.Routes[0].Target)
+	}
+	if ds.Ingress.Routes[1].Target.Service != "app" || ds.Ingress.Routes[1].Target.Port != "http" {
+		t.Fatalf("second route target = %#v", ds.Ingress.Routes[1].Target)
 	}
 }
 
@@ -360,6 +435,7 @@ func TestMergeIngressForNodeSortsRoutesByPortWhenMatchFieldsTie(t *testing.T) {
 
 	snapshots := []DeploySnapshot{
 		{
+			Services: []serviceJSON{{Name: "web", Kind: config.ServiceKindWeb, Image: "demo:web"}},
 			Ingress: &ingressJSON{
 				Mode: "public",
 				TLS:  ingressTLSJSON{Mode: "auto"},
@@ -372,6 +448,7 @@ func TestMergeIngressForNodeSortsRoutesByPortWhenMatchFieldsTie(t *testing.T) {
 			IngressServiceKind: config.ServiceKindWeb,
 		},
 		{
+			Services: []serviceJSON{{Name: "web", Kind: config.ServiceKindWeb, Image: "demo:web"}},
 			Ingress: &ingressJSON{
 				Mode: "public",
 				TLS:  ingressTLSJSON{Mode: "auto"},

--- a/cli/internal/solo/desiredstate_test.go
+++ b/cli/internal/solo/desiredstate_test.go
@@ -17,7 +17,6 @@ func boolPtr(value bool) *bool {
 func baseProject() *config.ProjectConfig {
 	cfg := config.DefaultProjectConfig("solo", "myapp", config.DefaultEnvironment)
 	cfg.Services["web"] = config.Service{
-		Kind:    config.ServiceKindWeb,
 		Command: []string{"rails", "server"},
 		Env:     map[string]string{"RAILS_ENV": "production"},
 		SecretRefs: []config.SecretRef{
@@ -75,7 +74,6 @@ func TestBuildDesiredState_WebOnly(t *testing.T) {
 func TestBuildDesiredState_WithNamedWorkerAndReleaseTask(t *testing.T) {
 	cfg := baseProject()
 	cfg.Services["jobs"] = config.Service{
-		Kind:    config.ServiceKindWorker,
 		Command: []string{"sidekiq"},
 		Env:     map[string]string{"QUEUE": "default"},
 	}
@@ -110,7 +108,6 @@ func TestBuildDesiredState_WithNamedWorkerAndReleaseTask(t *testing.T) {
 func TestBuildDesiredState_MapsArgsToContainerCommand(t *testing.T) {
 	cfg := baseProject()
 	cfg.Services["web"] = config.Service{
-		Kind:        config.ServiceKindWeb,
 		Command:     []string{"/app"},
 		Args:        []string{"web", "--port", "3000"},
 		Ports:       []config.ServicePort{{Name: "http", Port: 3000}},
@@ -145,7 +142,6 @@ func TestBuildDesiredState_MapsArgsToContainerCommand(t *testing.T) {
 func TestBuildDesiredStateForLabelsFiltersServicesByKindLabel(t *testing.T) {
 	cfg := baseProject()
 	cfg.Services["jobs"] = config.Service{
-		Kind:    config.ServiceKindWorker,
 		Command: []string{"sidekiq"},
 	}
 	cfg.Tasks.Release = &config.TaskConfig{Service: "web", Command: []string{"rails", "db:migrate"}}
@@ -239,7 +235,6 @@ func TestBuildDesiredStateForNodeIncludesIngressForIngressNode(t *testing.T) {
 func TestBuildDesiredStateForNodeOmitsIngressForNonIngressNode(t *testing.T) {
 	cfg := baseProject()
 	cfg.Services["jobs"] = config.Service{
-		Kind:    config.ServiceKindWorker,
 		Command: []string{"sidekiq"},
 	}
 	cfg.Ingress = &config.IngressConfig{

--- a/cli/internal/solo/desiredstate_test.go
+++ b/cli/internal/solo/desiredstate_test.go
@@ -263,6 +263,32 @@ func TestBuildDesiredStateForNodeOmitsIngressForNonIngressNode(t *testing.T) {
 	}
 }
 
+func TestBuildDesiredStateForNodeDefaultsIngressRedirectHTTPToTrue(t *testing.T) {
+	cfg := baseProject()
+	cfg.Ingress = &config.IngressConfig{
+		Hosts: []string{"app.example.com"},
+		Rules: []config.IngressRuleConfig{{
+			Match:  config.IngressMatchConfig{Host: "app.example.com", PathPrefix: "/"},
+			Target: config.IngressTargetConfig{Service: "web", Port: "http"},
+		}},
+	}
+
+	data, err := BuildDesiredStateForNode(cfg, "myapp:def5678", "def5678", map[string]string{"DATABASE_URL": "postgres://localhost/mydb"}, []string{config.DefaultWebRole}, true, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var ds desiredStateJSON
+	if err := json.Unmarshal(data, &ds); err != nil {
+		t.Fatal(err)
+	}
+	if ds.Ingress == nil {
+		t.Fatal("expected ingress")
+	}
+	if !ds.Ingress.RedirectHTTP {
+		t.Fatalf("redirect_http = %v, want true", ds.Ingress.RedirectHTTP)
+	}
+}
+
 func TestBuildDesiredState_MissingSecretErrors(t *testing.T) {
 	cfg := baseProject()
 	_, err := BuildDesiredState(cfg, "myapp:abc1234", "abc1234", map[string]string{})

--- a/cli/internal/solo/desiredstate_test.go
+++ b/cli/internal/solo/desiredstate_test.go
@@ -192,18 +192,15 @@ func TestBuildDesiredStateForNodeIncludesIngressForIngressNode(t *testing.T) {
 	cfg := baseProject()
 	cfg.Ingress = &config.IngressConfig{
 		Hosts: []string{"app.example.com", "www.example.com"},
-		Rules: []config.IngressRuleConfig{
-			{
-				Match:  config.IngressMatchConfig{Host: "app.example.com", PathPrefix: "/"},
-				Target: config.IngressTargetConfig{Service: "web", Port: "http"},
-			},
-			{
-				Match:  config.IngressMatchConfig{Host: "www.example.com", PathPrefix: "/"},
-				Target: config.IngressTargetConfig{Service: "web", Port: "http"},
-			},
-		},
+		Rules: []config.IngressRuleConfig{{
+			Match:  config.IngressMatchConfig{Host: "app.example.com", PathPrefix: "/"},
+			Target: config.IngressTargetConfig{Service: "web", Port: "http"},
+		}, {
+			Match:  config.IngressMatchConfig{Host: "www.example.com", PathPrefix: "/"},
+			Target: config.IngressTargetConfig{Service: "web", Port: "http"},
+		}},
 		TLS: config.IngressTLSConfig{
-			Mode:           "manual",
+			Mode:           "auto",
 			Email:          "ops@example.com",
 			CADirectoryURL: "https://acme-staging-v02.api.letsencrypt.org/directory",
 		},
@@ -225,8 +222,8 @@ func TestBuildDesiredStateForNodeIncludesIngressForIngressNode(t *testing.T) {
 	if ds.Ingress == nil {
 		t.Fatal("expected ingress")
 	}
-	if ds.Ingress.Mode != "" {
-		t.Fatalf("mode = %q, want empty", ds.Ingress.Mode)
+	if ds.Ingress.Mode != "public" {
+		t.Fatalf("mode = %q, want public", ds.Ingress.Mode)
 	}
 	if strings.Join(ds.Ingress.Hosts, ",") != "app.example.com,www.example.com" {
 		t.Fatalf("hosts = %#v", ds.Ingress.Hosts)
@@ -263,66 +260,6 @@ func TestBuildDesiredStateForNodeOmitsIngressForNonIngressNode(t *testing.T) {
 	}
 	if ds.Ingress != nil {
 		t.Fatalf("ingress = %#v, want nil", ds.Ingress)
-	}
-}
-
-func TestBuildDesiredStateForNodeSerializesExplicitIngressRules(t *testing.T) {
-	cfg := baseProject()
-	cfg.SchemaVersion = 6
-	cfg.Services = map[string]config.Service{
-		"app": {
-			Command: []string{"./bin/web"},
-			Ports:   []config.ServicePort{{Name: "http", Port: 3000}},
-			Healthcheck: &config.HTTPHealthcheck{
-				Path: "/up",
-				Port: 3000,
-			},
-		},
-		"api": {
-			Command: []string{"./bin/api"},
-			Ports:   []config.ServicePort{{Name: "http", Port: 4000}, {Name: "metrics", Port: 9090}},
-			Healthcheck: &config.HTTPHealthcheck{
-				Path: "/up",
-				Port: 4000,
-			},
-		},
-	}
-	cfg.Ingress = &config.IngressConfig{
-		Hosts: []string{"app.example.com"},
-		Rules: []config.IngressRuleConfig{
-			{
-				Match:  config.IngressMatchConfig{Host: "app.example.com", PathPrefix: "/api"},
-				Target: config.IngressTargetConfig{Service: "api", Port: "metrics"},
-			},
-			{
-				Match:  config.IngressMatchConfig{Host: "app.example.com", PathPrefix: "/"},
-				Target: config.IngressTargetConfig{Service: "app", Port: "http"},
-			},
-		},
-	}
-
-	data, err := BuildDesiredStateForNode(cfg, "myapp:def5678", "def5678", map[string]string{}, []string{config.DefaultWebRole}, true, false)
-	if err != nil {
-		t.Fatal(err)
-	}
-	var ds desiredStateJSON
-	if err := json.Unmarshal(data, &ds); err != nil {
-		t.Fatal(err)
-	}
-	if ds.Ingress == nil {
-		t.Fatal("expected ingress")
-	}
-	if len(ds.Ingress.Routes) != 2 {
-		t.Fatalf("routes = %#v", ds.Ingress.Routes)
-	}
-	if ds.Ingress.Routes[0].Match.Hostname != "app.example.com" || ds.Ingress.Routes[0].Match.PathPrefix != "/api" {
-		t.Fatalf("first route match = %#v", ds.Ingress.Routes[0].Match)
-	}
-	if ds.Ingress.Routes[0].Target.Service != "api" || ds.Ingress.Routes[0].Target.Port != "metrics" {
-		t.Fatalf("first route target = %#v", ds.Ingress.Routes[0].Target)
-	}
-	if ds.Ingress.Routes[1].Target.Service != "app" || ds.Ingress.Routes[1].Target.Port != "http" {
-		t.Fatalf("second route target = %#v", ds.Ingress.Routes[1].Target)
 	}
 }
 
@@ -435,10 +372,11 @@ func TestMergeIngressForNodeSortsRoutesByPortWhenMatchFieldsTie(t *testing.T) {
 
 	snapshots := []DeploySnapshot{
 		{
-			Services: []serviceJSON{{Name: "web", Kind: config.ServiceKindWeb, Image: "demo:web"}},
+			Services: []serviceJSON{{Name: "web", Kind: config.ServiceKindWeb}},
 			Ingress: &ingressJSON{
 				Mode: "public",
 				TLS:  ingressTLSJSON{Mode: "auto"},
+				Hosts: []string{"app.example.com"},
 				Routes: []ingressRouteJSON{{
 					Match:  ingressMatchJSON{Hostname: "app.example.com"},
 					Target: ingressTargetJSON{Environment: "production", Service: "web", Port: "metrics"},
@@ -448,10 +386,11 @@ func TestMergeIngressForNodeSortsRoutesByPortWhenMatchFieldsTie(t *testing.T) {
 			IngressServiceKind: config.ServiceKindWeb,
 		},
 		{
-			Services: []serviceJSON{{Name: "web", Kind: config.ServiceKindWeb, Image: "demo:web"}},
+			Services: []serviceJSON{{Name: "web", Kind: config.ServiceKindWeb}},
 			Ingress: &ingressJSON{
 				Mode: "public",
 				TLS:  ingressTLSJSON{Mode: "auto"},
+				Hosts: []string{"app.example.com"},
 				Routes: []ingressRouteJSON{{
 					Match:  ingressMatchJSON{Hostname: "app.example.com"},
 					Target: ingressTargetJSON{Environment: "production", Service: "web", Port: "http"},
@@ -479,6 +418,7 @@ func TestMergeIngressForNodeTreatsBlankAndPublicModeAsEquivalent(t *testing.T) {
 
 	snapshots := []DeploySnapshot{
 		{
+			Services: []serviceJSON{{Name: "web", Kind: config.ServiceKindWeb}},
 			Ingress: &ingressJSON{
 				TLS:   ingressTLSJSON{Mode: "auto"},
 				Hosts: []string{"a.example.com"},
@@ -491,6 +431,7 @@ func TestMergeIngressForNodeTreatsBlankAndPublicModeAsEquivalent(t *testing.T) {
 			IngressServiceKind: config.ServiceKindWeb,
 		},
 		{
+			Services: []serviceJSON{{Name: "web", Kind: config.ServiceKindWeb}},
 			Ingress: &ingressJSON{
 				Mode:  "public",
 				TLS:   ingressTLSJSON{Mode: "auto"},

--- a/cli/internal/solo/state.go
+++ b/cli/internal/solo/state.go
@@ -208,9 +208,11 @@ func BuildDeploySnapshot(cfg *config.ProjectConfig, workspaceRoot, configPath, i
 	}
 	if cfg.Ingress != nil {
 		snapshot.Ingress = buildIngress(cfg.Ingress, environmentName)
-		snapshot.IngressService = cfg.Ingress.Service
-		if service, ok := cfg.Services[cfg.Ingress.Service]; ok {
-			snapshot.IngressServiceKind = service.Kind
+		if serviceName, ok := cfg.PrimaryWebServiceName(); ok {
+			snapshot.IngressService = serviceName
+			if service, ok := cfg.Services[serviceName]; ok {
+				snapshot.IngressServiceKind = service.Kind
+			}
 		}
 	}
 	return snapshot, nil

--- a/cli/internal/solo/state.go
+++ b/cli/internal/solo/state.go
@@ -208,7 +208,7 @@ func BuildDeploySnapshot(cfg *config.ProjectConfig, workspaceRoot, configPath, i
 	}
 	if cfg.Ingress != nil {
 		snapshot.Ingress = buildIngress(cfg.Ingress, environmentName)
-		if serviceName, ok := cfg.PrimaryWebServiceName(); ok {
+		if serviceName, ok := ingressSnapshotService(cfg); ok {
 			snapshot.IngressService = serviceName
 			if service, ok := cfg.Services[serviceName]; ok {
 				snapshot.IngressServiceKind = config.InferredServiceKind(serviceName, service)
@@ -216,6 +216,27 @@ func BuildDeploySnapshot(cfg *config.ProjectConfig, workspaceRoot, configPath, i
 		}
 	}
 	return snapshot, nil
+}
+
+func ingressSnapshotService(cfg *config.ProjectConfig) (string, bool) {
+	if cfg == nil || cfg.Ingress == nil {
+		return "", false
+	}
+	serviceNames := map[string]struct{}{}
+	for _, rule := range cfg.Ingress.Rules {
+		serviceName := strings.TrimSpace(rule.Target.Service)
+		if serviceName == "" {
+			continue
+		}
+		serviceNames[serviceName] = struct{}{}
+	}
+	if len(serviceNames) != 1 {
+		return "", false
+	}
+	for serviceName := range serviceNames {
+		return serviceName, true
+	}
+	return "", false
 }
 
 func RedactDeploySnapshotSecrets(snapshot DeploySnapshot, cfg *config.ProjectConfig) DeploySnapshot {

--- a/cli/internal/solo/state.go
+++ b/cli/internal/solo/state.go
@@ -203,7 +203,7 @@ func BuildDeploySnapshot(cfg *config.ProjectConfig, workspaceRoot, configPath, i
 		snapshot.ReleaseTask = &releaseTask
 		snapshot.ReleaseService = cfg.ReleaseTask().Service
 		if service, ok := cfg.Services[cfg.ReleaseTask().Service]; ok {
-			snapshot.ReleaseServiceKind = service.Kind
+			snapshot.ReleaseServiceKind = config.InferredServiceKind(cfg.ReleaseTask().Service, service)
 		}
 	}
 	if cfg.Ingress != nil {
@@ -211,7 +211,7 @@ func BuildDeploySnapshot(cfg *config.ProjectConfig, workspaceRoot, configPath, i
 		if serviceName, ok := cfg.PrimaryWebServiceName(); ok {
 			snapshot.IngressService = serviceName
 			if service, ok := cfg.Services[serviceName]; ok {
-				snapshot.IngressServiceKind = service.Kind
+				snapshot.IngressServiceKind = config.InferredServiceKind(serviceName, service)
 			}
 		}
 	}

--- a/cli/internal/solo/state_test.go
+++ b/cli/internal/solo/state_test.go
@@ -348,6 +348,66 @@ func TestRedactDeploySnapshotSecretsRemovesSecretValues(t *testing.T) {
 	}
 }
 
+func TestBuildDeploySnapshotDerivesIngressServiceFromIngressRules(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	cfg.Services["api"] = config.ServiceConfig{
+		Ports: []config.ServicePort{{Name: "metrics", Port: 9090}},
+	}
+	cfg.Ingress = &config.IngressConfig{
+		Hosts: []string{"app.example.com"},
+		Rules: []config.IngressRuleConfig{{
+			Match:  config.IngressMatchConfig{Host: "app.example.com", PathPrefix: "/api"},
+			Target: config.IngressTargetConfig{Service: "api", Port: "metrics"},
+		}},
+	}
+
+	snapshot, err := BuildDeploySnapshot(&cfg, "/workspace/demo", "/workspace/demo/devopsellence.yml", "demo:abc1234", "abc1234", map[string]string{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := snapshot.IngressService; got != "api" {
+		t.Fatalf("ingress service = %q, want api", got)
+	}
+	if got := snapshot.IngressServiceKind; got != config.ServiceKindWorker {
+		t.Fatalf("ingress service kind = %q, want %q", got, config.ServiceKindWorker)
+	}
+}
+
+func TestBuildDeploySnapshotLeavesIngressServiceBlankForMultipleTargets(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	cfg.Services["api"] = config.ServiceConfig{
+		Ports: []config.ServicePort{{Name: "metrics", Port: 9090}},
+	}
+	cfg.Ingress = &config.IngressConfig{
+		Hosts: []string{"app.example.com"},
+		Rules: []config.IngressRuleConfig{
+			{
+				Match:  config.IngressMatchConfig{Host: "app.example.com", PathPrefix: "/"},
+				Target: config.IngressTargetConfig{Service: config.DefaultWebServiceName, Port: "http"},
+			},
+			{
+				Match:  config.IngressMatchConfig{Host: "app.example.com", PathPrefix: "/api"},
+				Target: config.IngressTargetConfig{Service: "api", Port: "metrics"},
+			},
+		},
+	}
+
+	snapshot, err := BuildDeploySnapshot(&cfg, "/workspace/demo", "/workspace/demo/devopsellence.yml", "demo:abc1234", "abc1234", map[string]string{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapshot.IngressService != "" {
+		t.Fatalf("ingress service = %q, want blank", snapshot.IngressService)
+	}
+	if snapshot.IngressServiceKind != "" {
+		t.Fatalf("ingress service kind = %q, want blank", snapshot.IngressServiceKind)
+	}
+}
+
 func TestDetachNodeDoesNotMutatePreviouslyReturnedAttachments(t *testing.T) {
 	t.Parallel()
 

--- a/cli/internal/solo/state_test.go
+++ b/cli/internal/solo/state_test.go
@@ -317,7 +317,6 @@ func TestRedactDeploySnapshotSecretsRemovesSecretValues(t *testing.T) {
 
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")
 	cfg.Services["web"] = config.ServiceConfig{
-		Kind: config.ServiceKindWeb,
 		Env:  map[string]string{"PLAIN": "value"},
 		SecretRefs: []config.SecretRef{
 			{Name: "DATABASE_URL"},

--- a/cli/internal/workflow/app.go
+++ b/cli/internal/workflow/app.go
@@ -34,7 +34,6 @@ import (
 	"github.com/devopsellence/cli/internal/ui"
 
 	"golang.org/x/term"
-	"gopkg.in/yaml.v3"
 )
 
 const outputSchemaVersion = 1
@@ -132,10 +131,6 @@ type InitOptions struct {
 	ProjectName    string
 	Environment    string
 	NonInteractive bool
-}
-
-type ConfigResolveOptions struct {
-	Environment string
 }
 
 type DeployOptions struct {
@@ -664,12 +659,6 @@ func (a *App) Deploy(ctx context.Context, opts DeployOptions) error {
 			update("Loading config…")
 			cfg = *existing
 		}
-		selectedEnvironment := a.effectiveEnvironment(opts.Environment, &cfg)
-		resolvedCfg, err := config.ResolveEnvironmentConfig(cfg, selectedEnvironment)
-		if err != nil {
-			return ExitError{Code: 1, Err: err}
-		}
-		cfg = resolvedCfg
 		a.warnAboutPrebuiltImageConfig(opts, discovered, cfg)
 		a.API.BaseURL = firstNonEmpty(preflight.Tokens.APIBase, a.API.BaseURL)
 
@@ -703,7 +692,7 @@ func (a *App) Deploy(ctx context.Context, opts DeployOptions) error {
 			target, err := a.resolveDeployTarget(ctx, withAuth, resolveDeployTargetInput{
 				Organization:   firstNonEmpty(opts.Organization, cfg.Organization),
 				Project:        firstNonEmpty(opts.Project, cfg.Project),
-				Environment:    cfg.DefaultEnvironment,
+				Environment:    firstNonEmpty(opts.Environment, cfg.DefaultEnvironment),
 				Interactive:    !opts.NonInteractive,
 				NonInteractive: opts.NonInteractive,
 			}, update)
@@ -1293,7 +1282,6 @@ func (a *App) Doctor(ctx context.Context) error {
 	})
 
 	var cfg config.Project
-	var selectedEnvironment string
 	addCheck("config", func() (string, error) {
 		if discoveryErr != nil {
 			return "", discoveryErr
@@ -1303,13 +1291,7 @@ func (a *App) Doctor(ctx context.Context) error {
 			return "", err
 		}
 		cfg = loaded
-		selectedEnvironment = a.effectiveEnvironment("", &cfg)
-		resolved, err := config.ResolveEnvironmentConfig(cfg, selectedEnvironment)
-		if err != nil {
-			return "", err
-		}
-		cfg = resolved
-		return cfg.Organization + " / " + cfg.Project + " / " + selectedEnvironment, nil
+		return cfg.Organization + " / " + cfg.Project + " / " + cfg.DefaultEnvironment, nil
 	})
 
 	var tokens auth.Tokens
@@ -1352,7 +1334,7 @@ func (a *App) Doctor(ctx context.Context) error {
 		if err != nil {
 			return "", err
 		}
-		_, env, err := a.findProjectEnvironment(ctx, tokens.AccessToken, org.ID, cfg.Project, selectedEnvironment)
+		_, env, err := a.findProjectEnvironment(ctx, tokens.AccessToken, org.ID, cfg.Project, cfg.DefaultEnvironment)
 		if err != nil {
 			return "", err
 		}
@@ -1382,26 +1364,6 @@ func (a *App) Doctor(ctx context.Context) error {
 		}
 		a.Printer.Println(prefix, fmt.Sprintf("%v:", check["name"]), check["detail"])
 	}
-	return nil
-}
-
-func (a *App) ConfigResolve(opts ConfigResolveOptions) error {
-	_, resolved, selectedEnvironment, err := a.resolvedWorkspaceConfig(opts.Environment)
-	if err != nil {
-		return wrapError(err)
-	}
-	if a.Printer.JSON {
-		return a.Printer.PrintJSON(map[string]any{
-			"schema_version":       outputSchemaVersion,
-			"selected_environment": selectedEnvironment,
-			"config":               resolved,
-		})
-	}
-	data, err := yaml.Marshal(resolved)
-	if err != nil {
-		return ExitError{Code: 1, Err: err}
-	}
-	fmt.Fprint(a.Printer.Out, string(data))
 	return nil
 }
 
@@ -2385,7 +2347,7 @@ func (a *App) EnvironmentUse(ctx context.Context, opts EnvironmentUseOptions) er
 	if strings.TrimSpace(opts.Name) == "" {
 		return ExitError{Code: 2, Err: errors.New("environment name required: env use <name>")}
 	}
-	_, cfg, err := a.requiredWorkspaceConfig()
+	discovered, cfg, err := a.requiredWorkspaceConfig()
 	if err != nil {
 		return wrapError(err)
 	}
@@ -2401,19 +2363,21 @@ func (a *App) EnvironmentUse(ctx context.Context, opts EnvironmentUseOptions) er
 	if err != nil {
 		return wrapError(err)
 	}
-	if err := a.SetEnvironment(environment.Name); err != nil {
+	cfg.Organization = organization.Name
+	cfg.Project = project.Name
+	cfg.DefaultEnvironment = environment.Name
+	if _, err := a.ConfigStore.Write(discovered.WorkspaceRoot, cfg); err != nil {
 		return wrapError(err)
 	}
 	_ = a.rememberOrganization(organization.ID)
 	if a.Printer.JSON {
 		return a.Printer.PrintJSON(map[string]any{
-			"schema_version":      outputSchemaVersion,
-			"ok":                  true,
-			"organization":        organization,
-			"project":             project,
-			"environment":         environment,
-			"workspace_key":       a.modeWorkspaceKey(),
-			"default_environment": cfg.DefaultEnvironment,
+			"schema_version": outputSchemaVersion,
+			"ok":             true,
+			"organization":   organization,
+			"project":        project,
+			"environment":    environment,
+			"config_path":    a.ConfigStore.PathFor(discovered.WorkspaceRoot),
 		})
 	}
 	a.Printer.Println("Using environment", environment.Name+".")
@@ -3242,7 +3206,13 @@ func (a *App) resolveWorkspace(ctx context.Context, token, organizationInput, pr
 	if orgInput == "" && existing != nil {
 		orgInput = existing.Organization
 	}
-	resolvedEnvironmentName := a.effectiveEnvironment(environmentName, existing)
+	resolvedEnvironmentName := strings.TrimSpace(environmentName)
+	if resolvedEnvironmentName == "" && existing != nil {
+		resolvedEnvironmentName = strings.TrimSpace(existing.DefaultEnvironment)
+	}
+	if resolvedEnvironmentName == "" {
+		resolvedEnvironmentName = config.DefaultEnvironment
+	}
 
 	var organization api.Organization
 	if autoCreateDefault {
@@ -3337,7 +3307,7 @@ func (a *App) initializeWorkspace(ctx context.Context, callAuth authCall, opts I
 	}
 
 	projectName := firstNonEmpty(opts.ProjectName, safeConfigValue(existing, func(cfg *config.Project) string { return cfg.Project }), discovered.ProjectName)
-	environmentName := a.effectiveEnvironment(opts.Environment, existing)
+	environmentName := firstNonEmpty(opts.Environment, safeConfigValue(existing, func(cfg *config.Project) string { return cfg.DefaultEnvironment }), config.DefaultEnvironment)
 	orgInput := firstNonEmpty(opts.Organization, safeConfigValue(existing, func(cfg *config.Project) string { return cfg.Organization }))
 
 	update("Resolving deploy target…")
@@ -3359,9 +3329,6 @@ func (a *App) initializeWorkspace(ctx context.Context, callAuth authCall, opts I
 	projectConfig := config.DefaultProjectConfigForType(org.Name, project.Name, environment.Name, discovered.AppType)
 	if existing == nil && discovered.InferredWebPort > 0 {
 		projectConfig = setPrimaryWebServicePort(projectConfig, discovered.InferredWebPort)
-	}
-	if existing == nil {
-		projectConfig = applySharedBootstrapIngress(projectConfig, target.Environment.IngressHosts)
 	}
 	if existing != nil {
 		projectConfig.Build = existing.Build
@@ -3607,22 +3574,6 @@ func (a *App) requiredWorkspaceConfig() (discovery.Result, config.Project, error
 	return discovered, *loaded, nil
 }
 
-func (a *App) resolvedWorkspaceConfig(explicitEnvironment string) (discovery.Result, config.Project, string, error) {
-	discovered, loaded, err := a.optionalWorkspaceConfig()
-	if err != nil {
-		return discovery.Result{}, config.Project{}, "", err
-	}
-	if loaded == nil {
-		return discovery.Result{}, config.Project{}, "", errors.New("project not initialized. run `devopsellence setup` first")
-	}
-	selectedEnvironment := a.effectiveEnvironment(explicitEnvironment, loaded)
-	resolved, err := config.ResolveEnvironmentConfig(*loaded, selectedEnvironment)
-	if err != nil {
-		return discovery.Result{}, config.Project{}, "", err
-	}
-	return discovered, resolved, selectedEnvironment, nil
-}
-
 func (a *App) applyInferredHealthcheckConfig(workspaceRoot string, cfg config.ProjectConfig, initialized *initializedWorkspace, inferredPort int) (config.ProjectConfig, string, string, error) {
 	if initialized == nil || !initialized.CreatedConfig || inferredPort <= 0 {
 		return cfg, "", "", nil
@@ -3718,46 +3669,6 @@ func setPrimaryWebServicePort(cfg config.ProjectConfig, port int) config.Project
 		}
 	}
 	cfg.Services[name] = service
-	return cfg
-}
-
-func applyBootstrapIngress(cfg config.ProjectConfig, hosts []string) config.ProjectConfig {
-	serviceName, ok := cfg.PrimaryWebServiceName()
-	if !ok {
-		return cfg
-	}
-	resolvedHosts := normalizeIngressHosts(hosts)
-	if len(resolvedHosts) == 0 {
-		resolvedHosts = []string{"*"}
-	}
-	cfg.Ingress = &config.IngressConfig{
-		Hosts:   resolvedHosts,
-		Service: serviceName,
-		TLS: config.IngressTLSConfig{
-			Mode: "off",
-		},
-		RedirectHTTP: configBoolPtr(false),
-	}
-	return cfg
-}
-
-func applySharedBootstrapIngress(cfg config.ProjectConfig, hosts []string) config.ProjectConfig {
-	serviceName, ok := cfg.PrimaryWebServiceName()
-	if !ok {
-		return cfg
-	}
-	resolvedHosts := normalizeIngressHostsKeepOrder(hosts)
-	if len(resolvedHosts) == 0 {
-		return cfg
-	}
-	cfg.Ingress = &config.IngressConfig{
-		Hosts:   resolvedHosts,
-		Service: serviceName,
-		TLS: config.IngressTLSConfig{
-			Mode: "off",
-		},
-		RedirectHTTP: configBoolPtr(false),
-	}
 	return cfg
 }
 
@@ -4123,34 +4034,39 @@ func taskPayloads(tasks config.TasksConfig) map[string]any {
 }
 
 func ingressPayload(cfg config.ProjectConfig) map[string]any {
-	serviceName := ""
-	if cfg.Ingress != nil && strings.TrimSpace(cfg.Ingress.Service) != "" {
-		serviceName = strings.TrimSpace(cfg.Ingress.Service)
-	} else if name, ok := cfg.PrimaryWebServiceName(); ok {
-		serviceName = name
-	}
-	if serviceName == "" {
+	if cfg.Ingress == nil || len(cfg.Ingress.Hosts) == 0 || len(cfg.Ingress.Rules) == 0 {
 		return nil
 	}
-
 	payload := map[string]any{
-		"service": serviceName,
+		"hosts": append([]string(nil), cfg.Ingress.Hosts...),
 	}
-	if cfg.Ingress == nil {
-		return payload
+	rules := make([]map[string]any, 0, len(cfg.Ingress.Rules))
+	for _, rule := range cfg.Ingress.Rules {
+		pathPrefix := strings.TrimSpace(rule.Match.PathPrefix)
+		if pathPrefix == "" {
+			pathPrefix = "/"
+		}
+		rules = append(rules, map[string]any{
+			"match": map[string]any{
+				"host":        strings.TrimSpace(rule.Match.Host),
+				"path_prefix": pathPrefix,
+			},
+			"target": map[string]any{
+				"service": strings.TrimSpace(rule.Target.Service),
+				"port":    strings.TrimSpace(rule.Target.Port),
+			},
+		})
 	}
-	if len(cfg.Ingress.Hosts) > 0 {
-		payload["hosts"] = append([]string(nil), cfg.Ingress.Hosts...)
+	payload["rules"] = rules
+	if strings.TrimSpace(cfg.Ingress.TLS.Mode) != "" || strings.TrimSpace(cfg.Ingress.TLS.Email) != "" || strings.TrimSpace(cfg.Ingress.TLS.CADirectoryURL) != "" {
+		payload["tls"] = map[string]any{
+			"mode":             strings.TrimSpace(cfg.Ingress.TLS.Mode),
+			"email":            strings.TrimSpace(cfg.Ingress.TLS.Email),
+			"ca_directory_url": strings.TrimSpace(cfg.Ingress.TLS.CADirectoryURL),
+		}
 	}
-	if cfg.Ingress.RedirectHTTP != nil {
-		payload["redirect_http"] = *cfg.Ingress.RedirectHTTP
-	}
-	if tls := map[string]any{
-		"mode":             strings.TrimSpace(cfg.Ingress.TLS.Mode),
-		"email":            strings.TrimSpace(cfg.Ingress.TLS.Email),
-		"ca_directory_url": strings.TrimSpace(cfg.Ingress.TLS.CADirectoryURL),
-	}; tls["mode"] != "" || tls["email"] != "" || tls["ca_directory_url"] != "" {
-		payload["tls"] = tls
+	if cfg.Ingress.RedirectHTTP {
+		payload["redirect_http"] = true
 	}
 	return payload
 }

--- a/cli/internal/workflow/app.go
+++ b/cli/internal/workflow/app.go
@@ -2645,13 +2645,28 @@ func (a *App) currentEnvironmentSecrets(ctx context.Context, callAuth authCall, 
 func railsRuntimeServices(cfg config.ProjectConfig) []string {
 	services := []string{}
 	for _, name := range cfg.ServiceNames() {
-		service := cfg.Services[name]
-		if strings.TrimSpace(service.Image) != "" {
+		if looksLikeCloudflaredService(name, cfg.Services[name]) {
 			continue
 		}
 		services = append(services, name)
 	}
 	return services
+}
+
+func looksLikeCloudflaredService(name string, service config.ServiceConfig) bool {
+	if strings.EqualFold(strings.TrimSpace(name), "cloudflared") {
+		return true
+	}
+	image := strings.ToLower(strings.TrimSpace(service.Image))
+	if strings.Contains(image, "cloudflare/cloudflared") {
+		return true
+	}
+	for _, value := range append(append([]string{}, service.Command...), service.Args...) {
+		if strings.EqualFold(strings.TrimSpace(value), "cloudflared") {
+			return true
+		}
+	}
+	return false
 }
 
 func runtimeServices(cfg config.ProjectConfig) []string {

--- a/cli/internal/workflow/app.go
+++ b/cli/internal/workflow/app.go
@@ -2643,7 +2643,15 @@ func (a *App) currentEnvironmentSecrets(ctx context.Context, callAuth authCall, 
 }
 
 func railsRuntimeServices(cfg config.ProjectConfig) []string {
-	return cfg.ServiceNames()
+	services := []string{}
+	for _, name := range cfg.ServiceNames() {
+		service := cfg.Services[name]
+		if strings.TrimSpace(service.Image) != "" {
+			continue
+		}
+		services = append(services, name)
+	}
+	return services
 }
 
 func runtimeServices(cfg config.ProjectConfig) []string {

--- a/cli/internal/workflow/app.go
+++ b/cli/internal/workflow/app.go
@@ -2643,14 +2643,7 @@ func (a *App) currentEnvironmentSecrets(ctx context.Context, callAuth authCall, 
 }
 
 func railsRuntimeServices(cfg config.ProjectConfig) []string {
-	services := []string{}
-	for _, name := range cfg.ServiceNames() {
-		if cfg.Services[name].Kind == config.ServiceKindAccessory {
-			continue
-		}
-		services = append(services, name)
-	}
-	return services
+	return cfg.ServiceNames()
 }
 
 func runtimeServices(cfg config.ProjectConfig) []string {
@@ -4074,12 +4067,11 @@ func findEnvironment(environments []api.Environment, name string) (api.Environme
 	return api.Environment{}, false
 }
 
-func servicePayload(service *config.Service) map[string]any {
+func servicePayload(_ string, service *config.Service) map[string]any {
 	if service == nil {
 		return nil
 	}
 	payload := map[string]any{
-		"kind":        service.Kind,
 		"image":       strings.TrimSpace(service.Image),
 		"env":         cloneEnv(service.Env),
 		"secret_refs": service.SecretRefs,
@@ -4110,7 +4102,7 @@ func servicePayloads(services map[string]config.ServiceConfig) map[string]any {
 	sort.Strings(names)
 	for _, name := range names {
 		service := services[name]
-		payloads[name] = servicePayload(&service)
+		payloads[name] = servicePayload(name, &service)
 	}
 	return payloads
 }

--- a/cli/internal/workflow/app.go
+++ b/cli/internal/workflow/app.go
@@ -34,6 +34,7 @@ import (
 	"github.com/devopsellence/cli/internal/ui"
 
 	"golang.org/x/term"
+	"gopkg.in/yaml.v3"
 )
 
 const outputSchemaVersion = 1
@@ -131,6 +132,10 @@ type InitOptions struct {
 	ProjectName    string
 	Environment    string
 	NonInteractive bool
+}
+
+type ConfigResolveOptions struct {
+	Environment string
 }
 
 type DeployOptions struct {
@@ -659,6 +664,12 @@ func (a *App) Deploy(ctx context.Context, opts DeployOptions) error {
 			update("Loading config…")
 			cfg = *existing
 		}
+		selectedEnvironment := a.effectiveEnvironment(opts.Environment, &cfg)
+		resolvedCfg, err := config.ResolveEnvironmentConfig(cfg, selectedEnvironment)
+		if err != nil {
+			return ExitError{Code: 1, Err: err}
+		}
+		cfg = resolvedCfg
 		a.warnAboutPrebuiltImageConfig(opts, discovered, cfg)
 		a.API.BaseURL = firstNonEmpty(preflight.Tokens.APIBase, a.API.BaseURL)
 
@@ -692,7 +703,7 @@ func (a *App) Deploy(ctx context.Context, opts DeployOptions) error {
 			target, err := a.resolveDeployTarget(ctx, withAuth, resolveDeployTargetInput{
 				Organization:   firstNonEmpty(opts.Organization, cfg.Organization),
 				Project:        firstNonEmpty(opts.Project, cfg.Project),
-				Environment:    firstNonEmpty(opts.Environment, cfg.DefaultEnvironment),
+				Environment:    cfg.DefaultEnvironment,
 				Interactive:    !opts.NonInteractive,
 				NonInteractive: opts.NonInteractive,
 			}, update)
@@ -1282,6 +1293,7 @@ func (a *App) Doctor(ctx context.Context) error {
 	})
 
 	var cfg config.Project
+	var selectedEnvironment string
 	addCheck("config", func() (string, error) {
 		if discoveryErr != nil {
 			return "", discoveryErr
@@ -1291,7 +1303,13 @@ func (a *App) Doctor(ctx context.Context) error {
 			return "", err
 		}
 		cfg = loaded
-		return cfg.Organization + " / " + cfg.Project + " / " + cfg.DefaultEnvironment, nil
+		selectedEnvironment = a.effectiveEnvironment("", &cfg)
+		resolved, err := config.ResolveEnvironmentConfig(cfg, selectedEnvironment)
+		if err != nil {
+			return "", err
+		}
+		cfg = resolved
+		return cfg.Organization + " / " + cfg.Project + " / " + selectedEnvironment, nil
 	})
 
 	var tokens auth.Tokens
@@ -1334,7 +1352,7 @@ func (a *App) Doctor(ctx context.Context) error {
 		if err != nil {
 			return "", err
 		}
-		_, env, err := a.findProjectEnvironment(ctx, tokens.AccessToken, org.ID, cfg.Project, cfg.DefaultEnvironment)
+		_, env, err := a.findProjectEnvironment(ctx, tokens.AccessToken, org.ID, cfg.Project, selectedEnvironment)
 		if err != nil {
 			return "", err
 		}
@@ -1364,6 +1382,26 @@ func (a *App) Doctor(ctx context.Context) error {
 		}
 		a.Printer.Println(prefix, fmt.Sprintf("%v:", check["name"]), check["detail"])
 	}
+	return nil
+}
+
+func (a *App) ConfigResolve(opts ConfigResolveOptions) error {
+	_, resolved, selectedEnvironment, err := a.resolvedWorkspaceConfig(opts.Environment)
+	if err != nil {
+		return wrapError(err)
+	}
+	if a.Printer.JSON {
+		return a.Printer.PrintJSON(map[string]any{
+			"schema_version":       outputSchemaVersion,
+			"selected_environment": selectedEnvironment,
+			"config":               resolved,
+		})
+	}
+	data, err := yaml.Marshal(resolved)
+	if err != nil {
+		return ExitError{Code: 1, Err: err}
+	}
+	fmt.Fprint(a.Printer.Out, string(data))
 	return nil
 }
 
@@ -2347,7 +2385,7 @@ func (a *App) EnvironmentUse(ctx context.Context, opts EnvironmentUseOptions) er
 	if strings.TrimSpace(opts.Name) == "" {
 		return ExitError{Code: 2, Err: errors.New("environment name required: env use <name>")}
 	}
-	discovered, cfg, err := a.requiredWorkspaceConfig()
+	_, cfg, err := a.requiredWorkspaceConfig()
 	if err != nil {
 		return wrapError(err)
 	}
@@ -2363,21 +2401,19 @@ func (a *App) EnvironmentUse(ctx context.Context, opts EnvironmentUseOptions) er
 	if err != nil {
 		return wrapError(err)
 	}
-	cfg.Organization = organization.Name
-	cfg.Project = project.Name
-	cfg.DefaultEnvironment = environment.Name
-	if _, err := a.ConfigStore.Write(discovered.WorkspaceRoot, cfg); err != nil {
+	if err := a.SetEnvironment(environment.Name); err != nil {
 		return wrapError(err)
 	}
 	_ = a.rememberOrganization(organization.ID)
 	if a.Printer.JSON {
 		return a.Printer.PrintJSON(map[string]any{
-			"schema_version": outputSchemaVersion,
-			"ok":             true,
-			"organization":   organization,
-			"project":        project,
-			"environment":    environment,
-			"config_path":    a.ConfigStore.PathFor(discovered.WorkspaceRoot),
+			"schema_version":      outputSchemaVersion,
+			"ok":                  true,
+			"organization":        organization,
+			"project":             project,
+			"environment":         environment,
+			"workspace_key":       a.modeWorkspaceKey(),
+			"default_environment": cfg.DefaultEnvironment,
 		})
 	}
 	a.Printer.Println("Using environment", environment.Name+".")
@@ -3206,13 +3242,7 @@ func (a *App) resolveWorkspace(ctx context.Context, token, organizationInput, pr
 	if orgInput == "" && existing != nil {
 		orgInput = existing.Organization
 	}
-	resolvedEnvironmentName := strings.TrimSpace(environmentName)
-	if resolvedEnvironmentName == "" && existing != nil {
-		resolvedEnvironmentName = strings.TrimSpace(existing.DefaultEnvironment)
-	}
-	if resolvedEnvironmentName == "" {
-		resolvedEnvironmentName = config.DefaultEnvironment
-	}
+	resolvedEnvironmentName := a.effectiveEnvironment(environmentName, existing)
 
 	var organization api.Organization
 	if autoCreateDefault {
@@ -3307,7 +3337,7 @@ func (a *App) initializeWorkspace(ctx context.Context, callAuth authCall, opts I
 	}
 
 	projectName := firstNonEmpty(opts.ProjectName, safeConfigValue(existing, func(cfg *config.Project) string { return cfg.Project }), discovered.ProjectName)
-	environmentName := firstNonEmpty(opts.Environment, safeConfigValue(existing, func(cfg *config.Project) string { return cfg.DefaultEnvironment }), config.DefaultEnvironment)
+	environmentName := a.effectiveEnvironment(opts.Environment, existing)
 	orgInput := firstNonEmpty(opts.Organization, safeConfigValue(existing, func(cfg *config.Project) string { return cfg.Organization }))
 
 	update("Resolving deploy target…")
@@ -3329,6 +3359,9 @@ func (a *App) initializeWorkspace(ctx context.Context, callAuth authCall, opts I
 	projectConfig := config.DefaultProjectConfigForType(org.Name, project.Name, environment.Name, discovered.AppType)
 	if existing == nil && discovered.InferredWebPort > 0 {
 		projectConfig = setPrimaryWebServicePort(projectConfig, discovered.InferredWebPort)
+	}
+	if existing == nil {
+		projectConfig = applySharedBootstrapIngress(projectConfig, target.Environment.IngressHosts)
 	}
 	if existing != nil {
 		projectConfig.Build = existing.Build
@@ -3574,6 +3607,22 @@ func (a *App) requiredWorkspaceConfig() (discovery.Result, config.Project, error
 	return discovered, *loaded, nil
 }
 
+func (a *App) resolvedWorkspaceConfig(explicitEnvironment string) (discovery.Result, config.Project, string, error) {
+	discovered, loaded, err := a.optionalWorkspaceConfig()
+	if err != nil {
+		return discovery.Result{}, config.Project{}, "", err
+	}
+	if loaded == nil {
+		return discovery.Result{}, config.Project{}, "", errors.New("project not initialized. run `devopsellence setup` first")
+	}
+	selectedEnvironment := a.effectiveEnvironment(explicitEnvironment, loaded)
+	resolved, err := config.ResolveEnvironmentConfig(*loaded, selectedEnvironment)
+	if err != nil {
+		return discovery.Result{}, config.Project{}, "", err
+	}
+	return discovered, resolved, selectedEnvironment, nil
+}
+
 func (a *App) applyInferredHealthcheckConfig(workspaceRoot string, cfg config.ProjectConfig, initialized *initializedWorkspace, inferredPort int) (config.ProjectConfig, string, string, error) {
 	if initialized == nil || !initialized.CreatedConfig || inferredPort <= 0 {
 		return cfg, "", "", nil
@@ -3669,6 +3718,60 @@ func setPrimaryWebServicePort(cfg config.ProjectConfig, port int) config.Project
 		}
 	}
 	cfg.Services[name] = service
+	return cfg
+}
+
+func applyBootstrapIngress(cfg config.ProjectConfig, hosts []string) config.ProjectConfig {
+	serviceName, ok := cfg.PrimaryWebServiceName()
+	if !ok {
+		return cfg
+	}
+	resolvedHosts := normalizeIngressHosts(hosts)
+	if len(resolvedHosts) == 0 {
+		resolvedHosts = []string{"*"}
+	}
+	rules := make([]config.IngressRuleConfig, 0, len(resolvedHosts))
+	for _, host := range resolvedHosts {
+		rules = append(rules, config.IngressRuleConfig{
+			Match:  config.IngressMatchConfig{Host: host, PathPrefix: "/"},
+			Target: config.IngressTargetConfig{Service: serviceName, Port: "http"},
+		})
+	}
+	cfg.Ingress = &config.IngressConfig{
+		Hosts: resolvedHosts,
+		Rules: rules,
+		TLS: config.IngressTLSConfig{
+			Mode: "off",
+		},
+		RedirectHTTP: configBoolPtr(false),
+	}
+	return cfg
+}
+
+func applySharedBootstrapIngress(cfg config.ProjectConfig, hosts []string) config.ProjectConfig {
+	serviceName, ok := cfg.PrimaryWebServiceName()
+	if !ok {
+		return cfg
+	}
+	resolvedHosts := normalizeIngressHostsKeepOrder(hosts)
+	if len(resolvedHosts) == 0 {
+		return cfg
+	}
+	rules := make([]config.IngressRuleConfig, 0, len(resolvedHosts))
+	for _, host := range resolvedHosts {
+		rules = append(rules, config.IngressRuleConfig{
+			Match:  config.IngressMatchConfig{Host: host, PathPrefix: "/"},
+			Target: config.IngressTargetConfig{Service: serviceName, Port: "http"},
+		})
+	}
+	cfg.Ingress = &config.IngressConfig{
+		Hosts: resolvedHosts,
+		Rules: rules,
+		TLS: config.IngressTLSConfig{
+			Mode: "off",
+		},
+		RedirectHTTP: configBoolPtr(false),
+	}
 	return cfg
 }
 
@@ -4058,15 +4161,15 @@ func ingressPayload(cfg config.ProjectConfig) map[string]any {
 		})
 	}
 	payload["rules"] = rules
-	if strings.TrimSpace(cfg.Ingress.TLS.Mode) != "" || strings.TrimSpace(cfg.Ingress.TLS.Email) != "" || strings.TrimSpace(cfg.Ingress.TLS.CADirectoryURL) != "" {
-		payload["tls"] = map[string]any{
-			"mode":             strings.TrimSpace(cfg.Ingress.TLS.Mode),
-			"email":            strings.TrimSpace(cfg.Ingress.TLS.Email),
-			"ca_directory_url": strings.TrimSpace(cfg.Ingress.TLS.CADirectoryURL),
-		}
+	if cfg.Ingress.RedirectHTTP != nil {
+		payload["redirect_http"] = *cfg.Ingress.RedirectHTTP
 	}
-	if cfg.Ingress.RedirectHTTP {
-		payload["redirect_http"] = true
+	if tls := map[string]any{
+		"mode":             strings.TrimSpace(cfg.Ingress.TLS.Mode),
+		"email":            strings.TrimSpace(cfg.Ingress.TLS.Email),
+		"ca_directory_url": strings.TrimSpace(cfg.Ingress.TLS.CADirectoryURL),
+	}; tls["mode"] != "" || tls["email"] != "" || tls["ca_directory_url"] != "" {
+		payload["tls"] = tls
 	}
 	return payload
 }

--- a/cli/internal/workflow/management_test.go
+++ b/cli/internal/workflow/management_test.go
@@ -207,8 +207,20 @@ func TestInitBootstrapsSharedIngressFromCanonicalDomain(t *testing.T) {
 	if loaded == nil || loaded.Ingress == nil {
 		t.Fatalf("expected bootstrapped ingress, got %#v", loaded)
 	}
-	if got, want := loaded.Ingress.Service, config.DefaultWebServiceName; got != want {
-		t.Fatalf("ingress.service = %q, want %q", got, want)
+	if len(loaded.Ingress.Rules) != 2 {
+		t.Fatalf("ingress.rules = %#v, want two host rules", loaded.Ingress.Rules)
+	}
+	if got, want := loaded.Ingress.Rules[0].Target.Service, config.DefaultWebServiceName; got != want {
+		t.Fatalf("ingress.rules[0].target.service = %q, want %q", got, want)
+	}
+	if got, want := loaded.Ingress.Rules[0].Target.Port, "http"; got != want {
+		t.Fatalf("ingress.rules[0].target.port = %q, want %q", got, want)
+	}
+	if got, want := loaded.Ingress.Rules[0].Match.Host, "www.prod-abc.devopsellence.io"; got != want {
+		t.Fatalf("ingress.rules[0].match.host = %q, want %q", got, want)
+	}
+	if got, want := loaded.Ingress.Rules[1].Match.Host, "prod-abc.devopsellence.io"; got != want {
+		t.Fatalf("ingress.rules[1].match.host = %q, want %q", got, want)
 	}
 	if got, want := loaded.Ingress.Hosts, []string{"www.prod-abc.devopsellence.io", "prod-abc.devopsellence.io"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("ingress.hosts = %#v, want %#v", got, want)
@@ -478,13 +490,20 @@ func TestConfigResolvePrintsResolvedEnvironmentConfig(t *testing.T) {
 	root := makeRailsRoot(t, "ShopApp")
 	project := config.DefaultProjectConfig("default", "ShopApp", "production")
 	project.Ingress = &config.IngressConfig{
-		Hosts:   []string{"app.example.test"},
-		Service: "web",
+		Hosts: []string{"app.example.test"},
+		Rules: []config.IngressRuleConfig{{
+			Match:  config.IngressMatchConfig{Host: "app.example.test", PathPrefix: "/"},
+			Target: config.IngressTargetConfig{Service: "web", Port: "http"},
+		}},
 	}
 	project.Environments = map[string]config.EnvironmentOverlay{
 		"staging": {
 			Ingress: &config.IngressConfigOverlay{
 				Hosts: []string{"staging.example.test"},
+				Rules: []config.IngressRuleConfig{{
+					Match:  config.IngressMatchConfig{Host: "staging.example.test", PathPrefix: "/"},
+					Target: config.IngressTargetConfig{Service: "web", Port: "http"},
+				}},
 			},
 			Services: map[string]config.ServiceConfigOverlay{
 				"web": {

--- a/cli/internal/workflow/management_test.go
+++ b/cli/internal/workflow/management_test.go
@@ -1427,6 +1427,13 @@ func TestDeployUsesResolveDeployTargetWhenAvailable(t *testing.T) {
 
 	root := makeGitGenericRoot(t)
 	project := config.DefaultProjectConfigForType("default", filepath.Base(root), "production", config.AppTypeGeneric)
+	project.Ingress = &config.IngressConfig{
+		Hosts: []string{"app.example.com"},
+		Rules: []config.IngressRuleConfig{{
+			Match:  config.IngressMatchConfig{Host: "app.example.com", PathPrefix: "/"},
+			Target: config.IngressTargetConfig{Service: config.DefaultWebServiceName, Port: "http"},
+		}},
+	}
 	if _, err := config.Write(root, project); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
@@ -1501,6 +1508,12 @@ func TestDeployUsesResolveDeployTargetWhenAvailable(t *testing.T) {
 	}
 	if releaseCaptured.ImageRepository != "docker.io/mccutchen/go-httpbin" {
 		t.Fatalf("image repository = %q, want docker.io/mccutchen/go-httpbin", releaseCaptured.ImageRepository)
+	}
+	if got := stringValueAny(releaseCaptured.Ingress["hosts"].([]any)[0]); got != "app.example.com" {
+		t.Fatalf("ingress host = %q, want app.example.com", got)
+	}
+	if got := stringValueAny(releaseCaptured.Ingress["rules"].([]any)[0].(map[string]any)["target"].(map[string]any)["service"]); got != config.DefaultWebServiceName {
+		t.Fatalf("ingress target service = %q, want %q", got, config.DefaultWebServiceName)
 	}
 }
 

--- a/cli/internal/workflow/management_test.go
+++ b/cli/internal/workflow/management_test.go
@@ -2342,6 +2342,9 @@ func TestDeployRailsDoesNotSyncMasterKeyToHelperServices(t *testing.T) {
 	root := makeGitRailsRoot(t, "ShopApp")
 	project := config.DefaultProjectConfig("default", "ShopApp", "production")
 	project.Services["worker"] = config.ServiceConfig{}
+	web := project.Services["web"]
+	web.Image = "ghcr.io/acme/shop:latest"
+	project.Services["web"] = web
 	project.Services["cloudflared"] = config.ServiceConfig{
 		Image:   "docker.io/cloudflare/cloudflared:latest",
 		Command: []string{"cloudflared"},

--- a/cli/internal/workflow/management_test.go
+++ b/cli/internal/workflow/management_test.go
@@ -2336,6 +2336,102 @@ func TestDeployRailsCanSkipMasterKeySync(t *testing.T) {
 	}
 }
 
+func TestDeployRailsDoesNotSyncMasterKeyToHelperServices(t *testing.T) {
+	t.Parallel()
+
+	root := makeGitRailsRoot(t, "ShopApp")
+	project := config.DefaultProjectConfig("default", "ShopApp", "production")
+	project.Services["worker"] = config.ServiceConfig{}
+	project.Services["cloudflared"] = config.ServiceConfig{
+		Image:   "docker.io/cloudflare/cloudflared:latest",
+		Command: []string{"cloudflared"},
+		Args:    []string{"tunnel", "run"},
+	}
+	if _, err := config.Write(root, project); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "config", "master.key"), []byte("master-key-value\n"), 0o600); err != nil {
+		t.Fatalf("write master.key: %v", err)
+	}
+	commitAll(t, root, "configure deploy state")
+
+	var stdout bytes.Buffer
+	secretValues := map[string]string{}
+	var secretValuesMu sync.Mutex
+	app := newTestApp(t, root, roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/cli/organizations":
+			return jsonResponse(t, map[string]any{"organizations": []map[string]any{{"id": 7, "name": "default", "role": "owner"}}}), nil
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/cli/projects":
+			return jsonResponse(t, map[string]any{"projects": []map[string]any{{"id": 11, "name": "ShopApp"}}}), nil
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/cli/projects/11/environments":
+			return jsonResponse(t, map[string]any{"environments": []map[string]any{{"id": 44, "name": "production"}}}), nil
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/cli/environments/44/secrets":
+			return jsonResponse(t, map[string]any{"secrets": []map[string]any{}}), nil
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/cli/environments/44/secrets":
+			var payload map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode secret request: %v", err)
+			}
+			secretValuesMu.Lock()
+			secretValues[stringValueAny(payload["service_name"])] = stringValueAny(payload["value"])
+			secretValuesMu.Unlock()
+			return jsonResponse(t, map[string]any{"name": stringValueAny(payload["name"]), "service_name": stringValueAny(payload["service_name"]), "secret_ref": "gsm://projects/test/secrets/abc/versions/latest"}), nil
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/cli/projects/11/releases":
+			return jsonResponseWithStatus(t, http.StatusCreated, map[string]any{"id": 22}), nil
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/cli/releases/22/publish":
+			return jsonResponseWithStatus(t, http.StatusCreated, map[string]any{
+				"deployment_id":  77,
+				"assigned_nodes": 1,
+				"public_url":     "https://shop.example.test",
+			}), nil
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/cli/deployments/77":
+			return jsonResponse(t, map[string]any{
+				"id":          77,
+				"sequence":    1,
+				"status":      "published",
+				"environment": map[string]any{"id": 44, "name": "production"},
+				"release":     map[string]any{"id": 22, "revision": "rel-1"},
+				"summary": map[string]any{
+					"assigned_nodes": 1,
+					"pending":        0,
+					"reconciling":    0,
+					"settled":        1,
+					"error":          0,
+					"active":         false,
+					"complete":       true,
+					"failed":         false,
+				},
+				"nodes": []map[string]any{{"id": 1, "name": "node-a", "phase": "settled", "message": "revision healthy"}},
+			}), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+			return nil, nil
+		}
+	}))
+	app.Printer = output.New(&stdout, io.Discard, false)
+	app.DeployPollInterval = 5 * time.Millisecond
+	app.DeployTimeout = 500 * time.Millisecond
+
+	if err := app.Deploy(context.Background(), DeployOptions{Image: "example.com/shop@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}); err != nil {
+		t.Fatalf("Deploy() error = %v", err)
+	}
+	secretValuesMu.Lock()
+	defer secretValuesMu.Unlock()
+	if got := secretValues["web"]; got != "master-key-value" {
+		t.Fatalf("web secret value = %q, want master-key-value", got)
+	}
+	if got := secretValues["worker"]; got != "master-key-value" {
+		t.Fatalf("worker secret value = %q, want master-key-value", got)
+	}
+	if _, ok := secretValues["cloudflared"]; ok {
+		t.Fatalf("cloudflared unexpectedly received Rails master key: %#v", secretValues)
+	}
+	if !strings.Contains(stdout.String(), "Rails: syncing RAILS_MASTER_KEY from config/master.key for web, worker.") {
+		t.Fatalf("Deploy() output = %q, want Rails sync notice limited to app services", stdout.String())
+	}
+}
+
 func TestDeployRailsSkipsNoOpMasterKeyUpsertWhenDigestMatches(t *testing.T) {
 	t.Parallel()
 

--- a/cli/internal/workflow/management_test.go
+++ b/cli/internal/workflow/management_test.go
@@ -1543,7 +1543,6 @@ func TestDeployAppliesGitHubActionRuntimeOverrides(t *testing.T) {
 	web.Env = map[string]string{"FROM_CONFIG": "1"}
 	project.Services[config.DefaultWebServiceName] = web
 	project.Services["worker"] = config.Service{
-		Kind:    config.ServiceKindWorker,
 		Command: []string{"./bin/jobs"},
 		Env:     map[string]string{"WORKER_FROM_CONFIG": "1"},
 	}
@@ -1628,6 +1627,12 @@ func TestDeployAppliesGitHubActionRuntimeOverrides(t *testing.T) {
 
 	webPayload := releaseServicePayload(t, releaseCaptured, config.DefaultWebServiceName)
 	workerPayload := releaseServicePayload(t, releaseCaptured, "worker")
+	if _, ok := webPayload["kind"]; ok {
+		t.Fatalf("web payload unexpectedly includes kind: %#v", webPayload)
+	}
+	if _, ok := workerPayload["kind"]; ok {
+		t.Fatalf("worker payload unexpectedly includes kind: %#v", workerPayload)
+	}
 	if got, want := webPayload["env"], map[string]any{"FROM_CONFIG": "1", "RAILS_ENV": "production", "WEB_ONLY": "true"}; !equalJSONMap(got, want) {
 		t.Fatalf("web env = %#v, want %#v", got, want)
 	}
@@ -2162,7 +2167,7 @@ func TestDeployRailsSyncsMasterKeySecret(t *testing.T) {
 
 	root := makeGitRailsRoot(t, "ShopApp")
 	project := config.DefaultProjectConfig("default", "ShopApp", "production")
-	project.Services["worker"] = config.ServiceConfig{Kind: config.ServiceKindWorker, Command: []string{"bin/jobs"}}
+	project.Services["worker"] = config.ServiceConfig{Command: []string{"bin/jobs"}}
 	if _, err := config.Write(root, project); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
@@ -3351,7 +3356,7 @@ func TestDeployRailsSecretSyncRunsConcurrently(t *testing.T) {
 
 	root := makeGitRailsRoot(t, "ShopApp")
 	project := config.DefaultProjectConfig("default", "ShopApp", "production")
-	project.Services["worker"] = config.ServiceConfig{Kind: config.ServiceKindWorker, Command: []string{"bin/jobs"}}
+	project.Services["worker"] = config.ServiceConfig{Command: []string{"bin/jobs"}}
 	if _, err := config.Write(root, project); err != nil {
 		t.Fatalf("write config: %v", err)
 	}

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -362,11 +362,30 @@ func soloNodeCanRunIngress(node config.SoloNode, cfg *config.ProjectConfig) bool
 	if cfg == nil || cfg.Ingress == nil {
 		return false
 	}
-	service, ok := cfg.Services[cfg.Ingress.Service]
-	if !ok {
-		return false
+	serviceNames := map[string]bool{}
+	for _, rule := range cfg.Ingress.Rules {
+		serviceName := strings.TrimSpace(rule.Target.Service)
+		if serviceName == "" || serviceNames[serviceName] {
+			continue
+		}
+		serviceNames[serviceName] = true
+		service, ok := cfg.Services[serviceName]
+		if !ok {
+			return false
+		}
+		kind := strings.TrimSpace(service.Kind)
+		if kind == "" {
+			if service.HasPortNamed("http") || service.Healthcheck != nil || serviceName == config.DefaultWebServiceName {
+				kind = config.ServiceKindWeb
+			} else {
+				kind = config.ServiceKindWorker
+			}
+		}
+		if !soloNodeCanRunKind(node, kind) {
+			return false
+		}
 	}
-	return soloNodeCanRunKind(node, service.Kind)
+	return len(serviceNames) > 0
 }
 
 func sortedSoloNodeNames(nodes map[string]config.SoloNode) []string {
@@ -1702,8 +1721,8 @@ func (a *App) IngressSet(_ context.Context, opts IngressSetOptions) error {
 		return fmt.Errorf("ingress set requires at least one --host")
 	}
 	serviceName := strings.TrimSpace(opts.Service)
-	if serviceName == "" && cfg.Ingress != nil {
-		serviceName = strings.TrimSpace(cfg.Ingress.Service)
+	if serviceName == "" && cfg.Ingress != nil && len(cfg.Ingress.Rules) > 0 {
+		serviceName = strings.TrimSpace(cfg.Ingress.Rules[0].Target.Service)
 	}
 	if serviceName == "" {
 		var ok bool
@@ -1711,6 +1730,13 @@ func (a *App) IngressSet(_ context.Context, opts IngressSetOptions) error {
 		if !ok {
 			return fmt.Errorf("ingress set requires --service when the primary web service cannot be inferred")
 		}
+	}
+	rules := make([]config.IngressRuleConfig, 0, len(hosts))
+	for _, host := range hosts {
+		rules = append(rules, config.IngressRuleConfig{
+			Match:  config.IngressMatchConfig{Host: host, PathPrefix: "/"},
+			Target: config.IngressTargetConfig{Service: serviceName, Port: "http"},
+		})
 	}
 	tlsMode := strings.TrimSpace(opts.TLSMode)
 	if tlsMode == "" {
@@ -1726,8 +1752,8 @@ func (a *App) IngressSet(_ context.Context, opts IngressSetOptions) error {
 		redirectHTTP = opts.RedirectHTTP
 	}
 	cfg.Ingress = &config.IngressConfig{
-		Hosts:   hosts,
-		Service: serviceName,
+		Hosts: hosts,
+		Rules: rules,
 		TLS: config.IngressTLSConfig{
 			Mode:           tlsMode,
 			Email:          strings.TrimSpace(opts.TLSEmail),

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -323,15 +323,16 @@ func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 func validateSoloNodeSchedule(cfg *config.ProjectConfig, nodes map[string]config.SoloNode) (string, error) {
 	for _, serviceName := range cfg.ServiceNames() {
 		service := cfg.Services[serviceName]
+		serviceKind := config.InferredServiceKind(serviceName, service)
 		scheduled := false
 		for _, nodeName := range sortedSoloNodeNames(nodes) {
-			if soloNodeCanRunKind(nodes[nodeName], service.Kind) {
+			if soloNodeCanRunKind(nodes[nodeName], serviceKind) {
 				scheduled = true
 				break
 			}
 		}
 		if !scheduled {
-			return "", fmt.Errorf("solo deploy requires at least one selected node labeled %q for service %q", service.Kind, serviceName)
+			return "", fmt.Errorf("solo deploy requires at least one selected node labeled %q for service %q", serviceKind, serviceName)
 		}
 	}
 	release := cfg.ReleaseTask()
@@ -339,7 +340,7 @@ func validateSoloNodeSchedule(cfg *config.ProjectConfig, nodes map[string]config
 		return "", nil
 	}
 	for _, nodeName := range sortedSoloNodeNames(nodes) {
-		if soloNodeCanRunKind(nodes[nodeName], cfg.Services[release.Service].Kind) {
+		if soloNodeCanRunKind(nodes[nodeName], config.InferredServiceKind(release.Service, cfg.Services[release.Service])) {
 			return nodeName, nil
 		}
 	}
@@ -373,14 +374,7 @@ func soloNodeCanRunIngress(node config.SoloNode, cfg *config.ProjectConfig) bool
 		if !ok {
 			return false
 		}
-		kind := strings.TrimSpace(service.Kind)
-		if kind == "" {
-			if service.HasPortNamed("http") || service.Healthcheck != nil || serviceName == config.DefaultWebServiceName {
-				kind = config.ServiceKindWeb
-			} else {
-				kind = config.ServiceKindWorker
-			}
-		}
+		kind := config.InferredServiceKind(serviceName, service)
 		if !soloNodeCanRunKind(node, kind) {
 			return false
 		}
@@ -2171,9 +2165,6 @@ func applySoloRailsMasterKey(workspaceRoot string, cfg *config.ProjectConfig, se
 	services := []string{}
 	for _, serviceName := range cfg.ServiceNames() {
 		service := cfg.Services[serviceName]
-		if service.Kind == config.ServiceKindAccessory {
-			continue
-		}
 		if addServiceSecretRef(&service, railsMasterKeySecretName) {
 			cfg.Services[serviceName] = service
 			services = append(services, serviceName)

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -60,8 +60,20 @@ func TestSoloDefaultProjectConfigBootstrapsExplicitCatchAllIngress(t *testing.T)
 	if cfg.Ingress == nil {
 		t.Fatal("expected bootstrapped ingress")
 	}
-	if got, want := cfg.Ingress.Service, config.DefaultWebServiceName; got != want {
-		t.Fatalf("ingress.service = %q, want %q", got, want)
+	if len(cfg.Ingress.Rules) != 1 {
+		t.Fatalf("ingress.rules = %#v, want single root rule", cfg.Ingress.Rules)
+	}
+	if got, want := cfg.Ingress.Rules[0].Target.Service, config.DefaultWebServiceName; got != want {
+		t.Fatalf("ingress.rules[0].target.service = %q, want %q", got, want)
+	}
+	if got, want := cfg.Ingress.Rules[0].Target.Port, "http"; got != want {
+		t.Fatalf("ingress.rules[0].target.port = %q, want %q", got, want)
+	}
+	if got, want := cfg.Ingress.Rules[0].Match.Host, "*"; got != want {
+		t.Fatalf("ingress.rules[0].match.host = %q, want %q", got, want)
+	}
+	if got, want := cfg.Ingress.Rules[0].Match.PathPrefix, "/"; got != want {
+		t.Fatalf("ingress.rules[0].match.path_prefix = %q, want %q", got, want)
 	}
 	if got, want := cfg.Ingress.Hosts, []string{"*"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("ingress.hosts = %#v, want %#v", got, want)

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -97,7 +97,6 @@ func TestValidateSoloNodeScheduleSelectsReleaseNode(t *testing.T) {
 	cfg := &config.ProjectConfig{
 		Services: map[string]config.ServiceConfig{
 			config.DefaultWebServiceName: {
-				Kind:  config.ServiceKindWeb,
 				Ports: []config.ServicePort{{Name: "http", Port: 3000}},
 				Healthcheck: &config.HTTPHealthcheck{
 					Path: "/up",
@@ -105,7 +104,6 @@ func TestValidateSoloNodeScheduleSelectsReleaseNode(t *testing.T) {
 				},
 			},
 			"worker": {
-				Kind:    config.ServiceKindWorker,
 				Command: []string{"sidekiq"},
 			},
 		},
@@ -134,7 +132,6 @@ func TestValidateSoloNodeScheduleRejectsMissingWorker(t *testing.T) {
 	cfg := &config.ProjectConfig{
 		Services: map[string]config.ServiceConfig{
 			config.DefaultWebServiceName: {
-				Kind:  config.ServiceKindWeb,
 				Ports: []config.ServicePort{{Name: "http", Port: 3000}},
 				Healthcheck: &config.HTTPHealthcheck{
 					Path: "/up",
@@ -142,7 +139,6 @@ func TestValidateSoloNodeScheduleRejectsMissingWorker(t *testing.T) {
 				},
 			},
 			"worker": {
-				Kind:    config.ServiceKindWorker,
 				Command: []string{"sidekiq"},
 			},
 		},
@@ -152,6 +148,41 @@ func TestValidateSoloNodeScheduleRejectsMissingWorker(t *testing.T) {
 	})
 	if err == nil || !strings.Contains(err.Error(), "worker") {
 		t.Fatalf("expected missing worker error, got %v", err)
+	}
+}
+
+func TestValidateSoloNodeScheduleInfersKindsWithoutStoredConfigKind(t *testing.T) {
+	cfg := &config.ProjectConfig{
+		Services: map[string]config.ServiceConfig{
+			config.DefaultWebServiceName: {
+				Ports: []config.ServicePort{{Name: "http", Port: 3000}},
+				Healthcheck: &config.HTTPHealthcheck{
+					Path: "/up",
+					Port: 3000,
+				},
+			},
+			"worker": {
+				Command: []string{"sidekiq"},
+			},
+		},
+		Tasks: config.TasksConfig{
+			Release: &config.TaskConfig{
+				Service: config.DefaultWebServiceName,
+				Command: []string{"rails", "db:migrate"},
+			},
+		},
+	}
+	nodes := map[string]config.SoloNode{
+		"worker-a": {Labels: []string{config.DefaultWorkerRole}},
+		"web-a":    {Labels: []string{config.DefaultWebRole}},
+	}
+
+	got, err := validateSoloNodeSchedule(cfg, nodes)
+	if err != nil {
+		t.Fatalf("validateSoloNodeSchedule() error = %v", err)
+	}
+	if got != "web-a" {
+		t.Fatalf("release node = %q, want web-a", got)
 	}
 }
 
@@ -166,11 +197,9 @@ func TestSoloNodeCanRunIngressRequiresAllIngressTargetServices(t *testing.T) {
 	cfg := &config.ProjectConfig{
 		Services: map[string]config.ServiceConfig{
 			"web": {
-				Kind:  config.ServiceKindWeb,
 				Ports: []config.ServicePort{{Name: "http", Port: 3000}},
 			},
 			"api": {
-				Kind:  config.ServiceKindWorker,
 				Ports: []config.ServicePort{{Name: "metrics", Port: 9090}},
 			},
 		},
@@ -899,13 +928,11 @@ func TestApplySoloRailsMasterKeyUsesConfigMasterKey(t *testing.T) {
 		App: config.AppConfig{Type: config.AppTypeRails},
 		Services: map[string]config.ServiceConfig{
 			config.DefaultWebServiceName: {
-				Kind:        config.ServiceKindWeb,
 				Env:         map[string]string{},
 				Ports:       []config.ServicePort{{Name: "http", Port: 3000}},
 				Healthcheck: &config.HTTPHealthcheck{Path: "/up", Port: 3000},
 			},
 			"worker": {
-				Kind: config.ServiceKindWorker,
 				Env:  map[string]string{},
 			},
 		},
@@ -942,7 +969,6 @@ func TestApplySoloRailsMasterKeyLetsEnvOverrideMasterKey(t *testing.T) {
 		App: config.AppConfig{Type: config.AppTypeRails},
 		Services: map[string]config.ServiceConfig{
 			config.DefaultWebServiceName: {
-				Kind:        config.ServiceKindWeb,
 				Env:         map[string]string{},
 				Ports:       []config.ServicePort{{Name: "http", Port: 3000}},
 				Healthcheck: &config.HTTPHealthcheck{Path: "/up", Port: 3000},

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -596,7 +596,7 @@ func TestSoloDeployWaitsForSettledStatusBeforeSuccess(t *testing.T) {
 		Git:                git.Client{},
 		Cwd:                workspaceRoot,
 		DeployPollInterval: 5 * time.Millisecond,
-		DeployTimeout:      200 * time.Millisecond,
+		DeployTimeout:      time.Second,
 	}
 
 	if err := app.SoloDeploy(context.Background(), SoloDeployOptions{}); err != nil {
@@ -623,7 +623,7 @@ func TestWaitForSoloRolloutIgnoresMissingAndStaleStatusUntilExpectedRevisionSett
 	app := &App{
 		Printer:            output.New(io.Discard, io.Discard, false),
 		DeployPollInterval: 5 * time.Millisecond,
-		DeployTimeout:      200 * time.Millisecond,
+		DeployTimeout:      time.Second,
 	}
 
 	err := app.waitForSoloRollout(context.Background(), map[string]config.SoloNode{
@@ -933,7 +933,7 @@ func TestApplySoloRailsMasterKeyUsesConfigMasterKey(t *testing.T) {
 				Healthcheck: &config.HTTPHealthcheck{Path: "/up", Port: 3000},
 			},
 			"worker": {
-				Env:  map[string]string{},
+				Env: map[string]string{},
 			},
 		},
 	}

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -150,6 +150,32 @@ func TestSoloNodeCanRunUnlabeledNode(t *testing.T) {
 	}
 }
 
+func TestSoloNodeCanRunIngressRequiresAllIngressTargetServices(t *testing.T) {
+	cfg := &config.ProjectConfig{
+		Services: map[string]config.ServiceConfig{
+			"web": {
+				Kind:  config.ServiceKindWeb,
+				Ports: []config.ServicePort{{Name: "http", Port: 3000}},
+			},
+			"api": {
+				Kind:  config.ServiceKindWorker,
+				Ports: []config.ServicePort{{Name: "metrics", Port: 9090}},
+			},
+		},
+		Ingress: &config.IngressConfig{Rules: []config.IngressRuleConfig{
+			{Target: config.IngressTargetConfig{Service: "web", Port: "http"}},
+			{Target: config.IngressTargetConfig{Service: "api", Port: "metrics"}},
+		}},
+	}
+
+	if soloNodeCanRunIngress(config.SoloNode{Labels: []string{config.DefaultWebRole}}, cfg) {
+		t.Fatal("web-only node should not run ingress for mixed web/worker targets")
+	}
+	if !soloNodeCanRunIngress(config.SoloNode{Labels: []string{config.DefaultWebRole, config.DefaultWorkerRole}}, cfg) {
+		t.Fatal("web+worker node should run ingress when it hosts all targets")
+	}
+}
+
 func TestParseSoloLabels(t *testing.T) {
 	got, err := parseSoloLabels("web,worker web")
 	if err != nil {
@@ -1235,8 +1261,11 @@ func TestIngressSetInfersPrimaryWebService(t *testing.T) {
 	if written.Ingress == nil {
 		t.Fatal("ingress = nil, want populated ingress config")
 	}
-	if written.Ingress.Service != config.DefaultWebServiceName {
-		t.Fatalf("ingress.service = %q, want %q", written.Ingress.Service, config.DefaultWebServiceName)
+	if len(written.Ingress.Rules) != 1 {
+		t.Fatalf("ingress.rules = %#v, want one rule", written.Ingress.Rules)
+	}
+	if written.Ingress.Rules[0].Target.Service != config.DefaultWebServiceName {
+		t.Fatalf("ingress.rules[0].target.service = %q, want %q", written.Ingress.Rules[0].Target.Service, config.DefaultWebServiceName)
 	}
 }
 
@@ -1380,10 +1409,13 @@ func TestIngressSetPreservesExistingServiceWhenFlagOmitted(t *testing.T) {
 	cfg.Services["frontend"] = cfg.Services[config.DefaultWebServiceName]
 	delete(cfg.Services, config.DefaultWebServiceName)
 	cfg.Ingress = &config.IngressConfig{
-		Service: "frontend",
-		Hosts:   []string{"old.devopsellence.io"},
-		TLS:     config.IngressTLSConfig{Mode: "manual"},
+		Hosts: []string{"old.devopsellence.io"},
+		Rules: []config.IngressRuleConfig{{
+			Match:  config.IngressMatchConfig{Host: "old.devopsellence.io", PathPrefix: "/"},
+			Target: config.IngressTargetConfig{Service: "frontend", Port: "http"},
+		}},
 	}
+
 	if _, err := config.Write(dir, cfg); err != nil {
 		t.Fatal(err)
 	}
@@ -1407,8 +1439,11 @@ func TestIngressSetPreservesExistingServiceWhenFlagOmitted(t *testing.T) {
 	if written.Ingress == nil {
 		t.Fatal("ingress = nil, want populated ingress config")
 	}
-	if written.Ingress.Service != "frontend" {
-		t.Fatalf("ingress.service = %q, want frontend", written.Ingress.Service)
+	if len(written.Ingress.Rules) != 1 {
+		t.Fatalf("ingress.rules = %#v, want one rule", written.Ingress.Rules)
+	}
+	if written.Ingress.Rules[0].Target.Service != "frontend" {
+		t.Fatalf("ingress.rules[0].target.service = %q, want frontend", written.Ingress.Rules[0].Target.Service)
 	}
 }
 

--- a/control-plane/app/controllers/api/v1/agent/ingress_certificates_controller.rb
+++ b/control-plane/app/controllers/api/v1/agent/ingress_certificates_controller.rb
@@ -10,8 +10,8 @@ module Api
 
         def create
           return render_error("forbidden", "direct_dns ingress is disabled for this environment", status: :forbidden) unless current_environment&.direct_dns_ingress?
-          ingress_service_name = current_environment&.current_release&.ingress_service_name
-          return render_error("forbidden", "node is not eligible for ingress", status: :forbidden) unless ingress_service_name.present? && current_environment.current_release.service_scheduled_on?(ingress_service_name, current_node)
+          ingress_service_names = current_environment&.current_release&.ingress_target_service_names.to_a
+          return render_error("forbidden", "node is not eligible for ingress", status: :forbidden) unless ingress_service_names.any? && current_environment.current_release.ingress_scheduled_on?(current_node)
           return render_error("forbidden", "node capability missing", status: :forbidden) unless current_node.supports_capability?(Node::CAPABILITY_DIRECT_DNS_INGRESS)
 
           ingress = current_environment.environment_ingress

--- a/control-plane/app/controllers/api/v1/cli/assignments_controller.rb
+++ b/control-plane/app/controllers/api/v1/cli/assignments_controller.rb
@@ -39,8 +39,8 @@ module Api
             on_progress: on_progress
           ).call
 
-          ingress_service_name = environment.current_release&.ingress_service_name
-          if ingress_service_name.present? && environment.current_release.service_scheduled_on?(ingress_service_name, node)
+          ingress_service_names = environment.current_release&.ingress_target_service_names.to_a
+          if ingress_service_names.any? && environment.current_release.ingress_scheduled_on?(node)
             sse.write({ message: "Configuring Cloudflare ingress..." }, event: "progress")
             Cloudflare::EnvironmentIngressProvisioner.new(environment: environment).call
           end

--- a/control-plane/app/models/environment.rb
+++ b/control-plane/app/models/environment.rb
@@ -73,14 +73,15 @@ class Environment < ApplicationRecord
   end
 
   def assigned_ingress_nodes_missing_direct_dns_capability
-    service_name = current_release&.ingress_service_name
-    return [] if service_name.blank?
+    service_names = current_release&.ingress_target_service_names.to_a
+    return [] if service_names.empty?
 
     nodes.select do |node|
-      current_release.service_scheduled_on?(service_name, node) &&
+      current_release.ingress_scheduled_on?(node) &&
         !node.supports_capability?(Node::CAPABILITY_DIRECT_DNS_INGRESS)
     end
   end
+
 
   def active_runtime_project
     runtime_project || project&.organization&.runtime_project || RuntimeProject.default!

--- a/control-plane/app/models/release.rb
+++ b/control-plane/app/models/release.rb
@@ -289,7 +289,22 @@ class Release < ApplicationRecord
     ingress = ingress_config
     return if ingress.blank?
 
-    hosts = Array(ingress["hosts"])
+    hosts = ingress["hosts"]
+    hosts_valid = true
+    unless hosts.is_a?(Array)
+      errors.add(:runtime_json, "ingress.hosts must be an array")
+      hosts_valid = false
+    end
+
+    rules = ingress["rules"]
+    rules_valid = true
+    unless rules.is_a?(Array)
+      errors.add(:runtime_json, "ingress.rules must be an array")
+      rules_valid = false
+    end
+
+    return unless hosts_valid && rules_valid
+
     if hosts.blank?
       errors.add(:runtime_json, "ingress.hosts must include at least one host")
       return
@@ -303,7 +318,7 @@ class Release < ApplicationRecord
       errors.add(:runtime_json, "ingress.hosts must be unique")
     end
 
-    rules = Array(ingress["rules"])
+    rules = ingress["rules"]
     if rules.blank?
       errors.add(:runtime_json, "ingress.rules must include at least one rule")
       return

--- a/control-plane/app/models/release.rb
+++ b/control-plane/app/models/release.rb
@@ -7,7 +7,6 @@ class Release < ApplicationRecord
   STATUS_DRAFT = "draft"
   STATUS_PUBLISHED = "published"
   STATUSES = [ STATUS_DRAFT, STATUS_PUBLISHED ].freeze
-  SERVICE_KINDS = [ "web", "worker", "accessory" ].freeze
 
   belongs_to :project
 
@@ -191,9 +190,8 @@ class Release < ApplicationRecord
       return
     end
 
-    kind = service_kind(service)
-    if kind.present? && !SERVICE_KINDS.include?(kind)
-      errors.add(:runtime_json, "services.#{name}.kind must be one of #{SERVICE_KINDS.join(', ')}")
+    if service.key?("kind")
+      errors.add(:runtime_json, "services.#{name}.kind is no longer supported")
     end
 
     validate_string_array(service, name:, field: "command")
@@ -400,6 +398,7 @@ class Release < ApplicationRecord
   def assert_supported_runtime_service!(name, service)
     raise InvalidRuntimeConfig, "services.#{name} must decode to an object" unless service.is_a?(Hash)
 
+    assert_unsupported_runtime_key_absent!(service, deprecated_key: "kind", field: "services.#{name}.kind")
     assert_deprecated_runtime_key_absent!(service, deprecated_key: "entrypoint", field: "services.#{name}.entrypoint")
     assert_runtime_string_array!(service["command"], field: "services.#{name}.command")
     assert_runtime_string_array!(service["args"], field: "services.#{name}.args")
@@ -409,6 +408,12 @@ class Release < ApplicationRecord
     return unless hash.key?(deprecated_key)
 
     raise InvalidRuntimeConfig, "#{field} is no longer supported; use command or args"
+  end
+
+  def assert_unsupported_runtime_key_absent!(hash, deprecated_key:, field:)
+    return unless hash.key?(deprecated_key)
+
+    raise InvalidRuntimeConfig, "#{field} is no longer supported"
   end
 
   def assert_runtime_string_array!(value, field:)
@@ -502,13 +507,7 @@ class Release < ApplicationRecord
     end
   end
 
-  def service_kind(service)
-    service["kind"].to_s.strip
-  end
-
   def inferred_service_kind(name, service)
-    explicit = service_kind(service)
-    return explicit if explicit.present?
     return "web" if name.to_s.strip == "web"
     return "web" if http_port(service).to_i.positive?
     return "web" if service["healthcheck"].is_a?(Hash)

--- a/control-plane/app/models/release.rb
+++ b/control-plane/app/models/release.rb
@@ -289,6 +289,10 @@ class Release < ApplicationRecord
     ingress = ingress_config
     return if ingress.blank?
 
+    if ingress.key?("service")
+      errors.add(:runtime_json, "ingress.service is no longer supported")
+    end
+
     hosts = ingress["hosts"]
     hosts_valid = true
     unless hosts.is_a?(Array)

--- a/control-plane/app/models/release.rb
+++ b/control-plane/app/models/release.rb
@@ -404,8 +404,6 @@ class Release < ApplicationRecord
       assert_supported_runtime_service!(name, service)
     end
 
-    assert_supported_runtime_ingress!
-
     return unless tasks_config.key?("release")
 
     task = tasks_config["release"]
@@ -423,21 +421,6 @@ class Release < ApplicationRecord
     assert_deprecated_runtime_key_absent!(service, deprecated_key: "entrypoint", field: "services.#{name}.entrypoint")
     assert_runtime_string_array!(service["command"], field: "services.#{name}.command")
     assert_runtime_string_array!(service["args"], field: "services.#{name}.args")
-  end
-
-  def assert_supported_runtime_ingress!
-    return unless runtime_payload.key?("ingress")
-
-    ingress = runtime_payload["ingress"]
-    raise InvalidRuntimeConfig, "ingress must decode to an object" unless ingress.is_a?(Hash)
-
-    assert_unsupported_runtime_key_absent!(ingress, deprecated_key: "service", field: "ingress.service")
-    assert_runtime_string_array!(ingress["hosts"], field: "ingress.hosts")
-    if ingress.key?("redirect_http") && ingress["redirect_http"] != true && ingress["redirect_http"] != false
-      raise InvalidRuntimeConfig, "ingress.redirect_http must be a boolean"
-    end
-    rules = ingress["rules"]
-    raise InvalidRuntimeConfig, "ingress.rules must be an array of objects" unless rules.is_a?(Array) && rules.all? { |rule| rule.is_a?(Hash) }
   end
 
   def assert_deprecated_runtime_key_absent!(hash, deprecated_key:, field:)

--- a/control-plane/app/models/release.rb
+++ b/control-plane/app/models/release.rb
@@ -400,6 +400,8 @@ class Release < ApplicationRecord
       assert_supported_runtime_service!(name, service)
     end
 
+    assert_supported_runtime_ingress!
+
     return unless tasks_config.key?("release")
 
     task = tasks_config["release"]
@@ -417,6 +419,18 @@ class Release < ApplicationRecord
     assert_deprecated_runtime_key_absent!(service, deprecated_key: "entrypoint", field: "services.#{name}.entrypoint")
     assert_runtime_string_array!(service["command"], field: "services.#{name}.command")
     assert_runtime_string_array!(service["args"], field: "services.#{name}.args")
+  end
+
+  def assert_supported_runtime_ingress!
+    return unless runtime_payload.key?("ingress")
+
+    ingress = runtime_payload["ingress"]
+    raise InvalidRuntimeConfig, "ingress must decode to an object" unless ingress.is_a?(Hash)
+
+    assert_unsupported_runtime_key_absent!(ingress, deprecated_key: "service", field: "ingress.service")
+    assert_runtime_string_array!(ingress["hosts"], field: "ingress.hosts")
+    rules = ingress["rules"]
+    raise InvalidRuntimeConfig, "ingress.rules must be an array of objects" unless rules.is_a?(Array) && rules.all? { |rule| rule.is_a?(Hash) }
   end
 
   def assert_deprecated_runtime_key_absent!(hash, deprecated_key:, field:)

--- a/control-plane/app/models/release.rb
+++ b/control-plane/app/models/release.rb
@@ -279,6 +279,15 @@ class Release < ApplicationRecord
   end
 
   def validate_ingress_config
+    payload = runtime_payload
+    raw_ingress = if payload.is_a?(Hash)
+      payload.key?("ingress") ? payload["ingress"] : payload[:ingress]
+    end
+    unless raw_ingress.nil? || raw_ingress.is_a?(Hash)
+      errors.add(:runtime_json, "ingress must be an object")
+      return
+    end
+
     ingress = ingress_config
     return if ingress.blank?
 
@@ -288,7 +297,7 @@ class Release < ApplicationRecord
       return
     end
 
-    normalized_hosts = hosts.map { |host| host.to_s.strip }.reject(&:blank?)
+    normalized_hosts = hosts.map { |host| IngressHostnames.normalize(host) }.reject(&:blank?)
     if normalized_hosts.length != hosts.length
       errors.add(:runtime_json, "ingress.hosts entries must be present")
     end
@@ -307,7 +316,7 @@ class Release < ApplicationRecord
       rule = stringify_hash(raw_rule)
       match = stringify_hash(rule["match"])
       target = stringify_hash(rule["target"])
-      host = match["host"].to_s.strip
+      host = IngressHostnames.normalize(match["host"])
       path_prefix = match["path_prefix"].to_s.strip.presence || "/"
       service_name = target["service"].to_s.strip
       port_name = target["port"].to_s.strip

--- a/control-plane/app/models/release.rb
+++ b/control-plane/app/models/release.rb
@@ -295,6 +295,10 @@ class Release < ApplicationRecord
       errors.add(:runtime_json, "ingress.hosts must be an array")
       hosts_valid = false
     end
+    if hosts.is_a?(Array) && !string_array?(hosts)
+      errors.add(:runtime_json, "ingress.hosts must be an array of strings")
+      hosts_valid = false
+    end
 
     rules = ingress["rules"]
     rules_valid = true
@@ -336,7 +340,7 @@ class Release < ApplicationRecord
     end
 
     redirect_http = ingress["redirect_http"]
-    unless redirect_http.nil? || redirect_http == true || redirect_http == false
+    if ingress.key?("redirect_http") && redirect_http != true && redirect_http != false
       errors.add(:runtime_json, "ingress.redirect_http must be a boolean")
     end
 
@@ -429,6 +433,9 @@ class Release < ApplicationRecord
 
     assert_unsupported_runtime_key_absent!(ingress, deprecated_key: "service", field: "ingress.service")
     assert_runtime_string_array!(ingress["hosts"], field: "ingress.hosts")
+    if ingress.key?("redirect_http") && ingress["redirect_http"] != true && ingress["redirect_http"] != false
+      raise InvalidRuntimeConfig, "ingress.redirect_http must be a boolean"
+    end
     rules = ingress["rules"]
     raise InvalidRuntimeConfig, "ingress.rules must be an array of objects" unless rules.is_a?(Array) && rules.all? { |rule| rule.is_a?(Hash) }
   end

--- a/control-plane/app/models/release.rb
+++ b/control-plane/app/models/release.rb
@@ -51,22 +51,21 @@ class Release < ApplicationRecord
     stringify_hash(runtime_payload["tasks"])
   end
 
+  def ingress_config
+    stringify_hash(runtime_payload["ingress"])
+  end
+
   def service_names
     services_config.keys.sort
   end
 
   def web_service_names
-    service_names.select { |name| service_kind(services_config[name]) == "web" }
+    service_names.select { |name| inferred_service_kind(name, services_config[name]) == "web" }
   end
 
   def release_task_config
     task = tasks_config["release"]
     task.is_a?(Hash) ? task : nil
-  end
-
-  def ingress_config
-    ingress = runtime_payload["ingress"]
-    ingress.is_a?(Hash) ? ingress : nil
   end
 
   def has_release_task?
@@ -78,7 +77,9 @@ class Release < ApplicationRecord
   end
 
   def required_labels
-    services_config.values.filter_map { |service| service_label(service).presence }.uniq.sort
+    service_names.filter_map do |name|
+      service_label(name, services_config[name]).presence
+    end.uniq.sort
   end
 
   def requires_label?(label)
@@ -89,7 +90,7 @@ class Release < ApplicationRecord
     service = services_config[name.to_s]
     return nil if service.blank?
 
-    service_label(service)
+    service_label(name.to_s, service)
   end
 
   def service_scheduled_on?(service_name, node)
@@ -97,8 +98,26 @@ class Release < ApplicationRecord
     label.present? && node.labeled?(label)
   end
 
+  def ingress_target_service_names
+    rules = Array(ingress_config["rules"]).filter_map do |rule|
+      target = rule.is_a?(Hash) ? stringify_hash(rule["target"]) : {}
+      target["service"].to_s.strip.presence
+    end
+    rules.uniq.sort
+  end
+
+  def ingress_scheduled_on?(node)
+    service_names = ingress_target_service_names
+    service_names.any? && service_names.all? { |service_name| service_scheduled_on?(service_name, node) }
+  end
+
   def ingress_service_name
-    ingress_config&.dig("service").to_s.strip.presence
+    names = ingress_target_service_names
+    return nil if names.empty?
+    return "web" if names.include?("web")
+    return names.first if names.one?
+
+    nil
   end
 
   def scheduled_services_for(node:)
@@ -107,7 +126,7 @@ class Release < ApplicationRecord
     environment = node.environment
     service_names.filter_map do |name|
       service = services_config[name]
-      next unless node.labeled?(service_label(service))
+      next unless node.labeled?(service_label(name, service))
 
       service_payload(name, service, organization: node.organization, environment: environment)
     end
@@ -122,7 +141,7 @@ class Release < ApplicationRecord
     service_name = task["service"].to_s.strip
     service = services_config[service_name]
     return nil if service.blank?
-    return nil unless node.labeled?(service_label(service))
+    return nil unless node.labeled?(service_label(service_name, service))
 
     task_payload(
       "release",
@@ -162,10 +181,6 @@ class Release < ApplicationRecord
       validate_service_config(name, service)
     end
 
-    if web_service_names.empty?
-      errors.add(:runtime_json, "must include at least one web service")
-    end
-
     validate_release_task
     validate_ingress_config
   end
@@ -177,12 +192,7 @@ class Release < ApplicationRecord
     end
 
     kind = service_kind(service)
-    if kind.blank?
-      errors.add(:runtime_json, "services.#{name}.kind must be present")
-      return
-    end
-
-    unless SERVICE_KINDS.include?(kind)
+    if kind.present? && !SERVICE_KINDS.include?(kind)
       errors.add(:runtime_json, "services.#{name}.kind must be one of #{SERVICE_KINDS.join(', ')}")
     end
 
@@ -216,9 +226,6 @@ class Release < ApplicationRecord
     end
 
     ports = service_ports(service)
-    if kind == "web" && http_port(service).to_i <= 0
-      errors.add(:runtime_json, "services.#{name} must expose an http port")
-    end
     if ports.map { |port| port["name"] }.uniq.length != ports.length
       errors.add(:runtime_json, "services.#{name}.ports must have unique names")
     end
@@ -230,7 +237,8 @@ class Release < ApplicationRecord
     end
 
     healthcheck = service["healthcheck"]
-    if kind == "web"
+    next_kind = inferred_service_kind(name, service)
+    if next_kind == "web"
       unless healthcheck.is_a?(Hash)
         errors.add(:runtime_json, "services.#{name}.healthcheck must be an object")
         return
@@ -241,6 +249,8 @@ class Release < ApplicationRecord
       unless healthcheck["port"].is_a?(Integer) && healthcheck["port"].positive?
         errors.add(:runtime_json, "services.#{name}.healthcheck.port must be a positive integer")
       end
+    elsif healthcheck.present? && !healthcheck.is_a?(Hash)
+      errors.add(:runtime_json, "services.#{name}.healthcheck must be an object")
     end
   end
 
@@ -266,63 +276,66 @@ class Release < ApplicationRecord
     unless task["env"].nil? || task["env"].is_a?(Hash)
       errors.add(:runtime_json, "tasks.release.env must be an object")
     end
-    if service_kind(service).blank?
-      errors.add(:runtime_json, "tasks.release.service must reference a service with kind")
-    end
   end
 
   def validate_ingress_config
-    if runtime_payload.key?("ingress") && !runtime_payload["ingress"].is_a?(Hash)
-      errors.add(:runtime_json, "ingress must decode to an object")
-      return
-    end
-
     ingress = ingress_config
-    if ingress.nil?
-      if web_service_names.length > 1
-        errors.add(:runtime_json, "ingress.service is required when multiple web services are defined")
-      end
+    return if ingress.blank?
+
+    hosts = Array(ingress["hosts"])
+    if hosts.blank?
+      errors.add(:runtime_json, "ingress.hosts must include at least one host")
       return
     end
 
-    hosts = ingress["hosts"]
-    unless hosts.nil? || string_array?(hosts)
-      errors.add(:runtime_json, "ingress.hosts must be an array of strings")
+    normalized_hosts = hosts.map { |host| host.to_s.strip }.reject(&:blank?)
+    if normalized_hosts.length != hosts.length
+      errors.add(:runtime_json, "ingress.hosts entries must be present")
     end
-    if string_array?(hosts) && IngressHostnames.normalize_all(hosts).length != hosts.length
+    if normalized_hosts.uniq.length != normalized_hosts.length
       errors.add(:runtime_json, "ingress.hosts must be unique")
     end
 
-    name = ingress["service"].to_s.strip
-    if name.blank?
-      errors.add(:runtime_json, "ingress.service is required")
+    rules = Array(ingress["rules"])
+    if rules.blank?
+      errors.add(:runtime_json, "ingress.rules must include at least one rule")
       return
     end
 
-    service = services_config[name]
-    if service.blank?
-      errors.add(:runtime_json, "ingress.service must reference an existing service")
-      return
-    end
-    if service_kind(service) != "web"
-      errors.add(:runtime_json, "ingress.service must reference a web service")
-    end
+    seen = {}
+    rules.each_with_index do |raw_rule, index|
+      rule = stringify_hash(raw_rule)
+      match = stringify_hash(rule["match"])
+      target = stringify_hash(rule["target"])
+      host = match["host"].to_s.strip
+      path_prefix = match["path_prefix"].to_s.strip.presence || "/"
+      service_name = target["service"].to_s.strip
+      port_name = target["port"].to_s.strip
 
-    tls = ingress["tls"]
-    unless tls.nil? || tls.is_a?(Hash)
-      errors.add(:runtime_json, "ingress.tls must be an object")
-      return
-    end
-    if tls.is_a?(Hash)
-      mode = tls["mode"].to_s.strip
-      if mode.present? && ![ "auto", "off", "manual" ].include?(mode)
-        errors.add(:runtime_json, "ingress.tls.mode must be auto, off, or manual")
+      if host.blank?
+        errors.add(:runtime_json, "ingress.rules[#{index}].match.host is required")
+      elsif !normalized_hosts.include?(host)
+        errors.add(:runtime_json, "ingress.rules[#{index}].match.host must exist in ingress.hosts")
       end
-    end
+      unless path_prefix.start_with?("/")
+        errors.add(:runtime_json, "ingress.rules[#{index}].match.path_prefix must start with /")
+      end
+      if service_name.blank?
+        errors.add(:runtime_json, "ingress.rules[#{index}].target.service is required")
+      elsif services_config[service_name].blank?
+        errors.add(:runtime_json, "ingress.rules[#{index}].target.service must reference an existing service")
+      end
+      if port_name.blank?
+        errors.add(:runtime_json, "ingress.rules[#{index}].target.port is required")
+      elsif services_config[service_name].present? && !service_port_names(services_config[service_name]).include?(port_name)
+        errors.add(:runtime_json, "ingress.rules[#{index}].target.port must reference an existing named port")
+      end
 
-    redirect_http = ingress["redirect_http"]
-    unless redirect_http.nil? || redirect_http == true || redirect_http == false
-      errors.add(:runtime_json, "ingress.redirect_http must be a boolean")
+      key = [host, path_prefix]
+      if seen[key]
+        errors.add(:runtime_json, "ingress.rules[#{index}] duplicates an existing host/path route")
+      end
+      seen[key] = true
     end
   end
 
@@ -349,21 +362,14 @@ class Release < ApplicationRecord
       assert_supported_runtime_service!(name, service)
     end
 
-    if tasks_config.key?("release")
-      task = tasks_config["release"]
-      raise InvalidRuntimeConfig, "tasks.release must decode to an object" unless task.is_a?(Hash)
+    return unless tasks_config.key?("release")
 
-      assert_deprecated_runtime_key_absent!(task, deprecated_key: "entrypoint", field: "tasks.release.entrypoint")
-      assert_runtime_string_array!(task["command"], field: "tasks.release.command")
-      assert_runtime_string_array!(task["args"], field: "tasks.release.args")
-    end
+    task = tasks_config["release"]
+    raise InvalidRuntimeConfig, "tasks.release must decode to an object" unless task.is_a?(Hash)
 
-    return unless runtime_payload.key?("ingress")
-
-    ingress = runtime_payload["ingress"]
-    raise InvalidRuntimeConfig, "ingress must decode to an object" unless ingress.is_a?(Hash)
-
-    assert_runtime_string_array!(ingress["hosts"], field: "ingress.hosts")
+    assert_deprecated_runtime_key_absent!(task, deprecated_key: "entrypoint", field: "tasks.release.entrypoint")
+    assert_runtime_string_array!(task["command"], field: "tasks.release.command")
+    assert_runtime_string_array!(task["args"], field: "tasks.release.args")
   end
 
   def assert_supported_runtime_service!(name, service)
@@ -394,7 +400,7 @@ class Release < ApplicationRecord
     image = service["image"].to_s.strip.presence || image_reference_for(organization)
     payload = {
       name: name,
-      kind: service_kind(service),
+      kind: inferred_service_kind(name, service),
       image: image,
       entrypoint: string_array(service["command"]),
       command: string_array(service["args"]),
@@ -475,8 +481,22 @@ class Release < ApplicationRecord
     service["kind"].to_s.strip
   end
 
-  def service_label(service)
-    service_kind(service)
+  def inferred_service_kind(name, service)
+    explicit = service_kind(service)
+    return explicit if explicit.present?
+    return "web" if name.to_s.strip == "web"
+    return "web" if http_port(service).to_i.positive?
+    return "web" if service["healthcheck"].is_a?(Hash)
+
+    "worker"
+  end
+
+  def service_label(name, service)
+    inferred_service_kind(name, service)
+  end
+
+  def service_port_names(service)
+    service_ports(service).map { |port| port["name"] }
   end
 
   def string_array(value)

--- a/control-plane/app/models/release.rb
+++ b/control-plane/app/models/release.rb
@@ -311,6 +311,22 @@ class Release < ApplicationRecord
       return
     end
 
+    tls = ingress["tls"]
+    unless tls.nil? || tls.is_a?(Hash)
+      errors.add(:runtime_json, "ingress.tls must be an object")
+    end
+    if tls.is_a?(Hash)
+      mode = tls["mode"].to_s.strip
+      unless mode.blank? || ["auto", "off", "manual"].include?(mode)
+        errors.add(:runtime_json, "ingress.tls.mode must be one of auto, off, or manual")
+      end
+    end
+
+    redirect_http = ingress["redirect_http"]
+    unless redirect_http.nil? || redirect_http == true || redirect_http == false
+      errors.add(:runtime_json, "ingress.redirect_http must be a boolean")
+    end
+
     seen = {}
     rules.each_with_index do |raw_rule, index|
       rule = stringify_hash(raw_rule)

--- a/control-plane/app/services/cloudflare/environment_ingress_provisioner.rb
+++ b/control-plane/app/services/cloudflare/environment_ingress_provisioner.rb
@@ -116,10 +116,15 @@ module Cloudflare
     end
 
     def desired_hosts_for(ingress)
-      return [ environment.environment_bundle.hostname ] if environment.environment_bundle&.hostname.present?
+      desired_hosts = []
+      if environment.environment_bundle&.hostname.present?
+        desired_hosts << environment.environment_bundle.hostname
+      end
 
       configured = IngressHostnames.normalize_all(release&.ingress_config&.dig("hosts"))
-      return configured if configured.any?
+      desired_hosts.concat(configured)
+      desired_hosts = desired_hosts.uniq
+      return desired_hosts if desired_hosts.any?
       return ingress.hosts if ingress.hosts.any?
 
       [ next_hostname! ]

--- a/control-plane/app/services/cloudflare/environment_ingress_provisioner.rb
+++ b/control-plane/app/services/cloudflare/environment_ingress_provisioner.rb
@@ -116,10 +116,11 @@ module Cloudflare
     end
 
     def desired_hosts_for(ingress)
+      return [ environment.environment_bundle.hostname ] if environment.environment_bundle&.hostname.present?
+
       configured = IngressHostnames.normalize_all(release&.ingress_config&.dig("hosts"))
       return configured if configured.any?
       return ingress.hosts if ingress.hosts.any?
-      return [ environment.environment_bundle.hostname ] if environment.environment_bundle&.hostname.present?
 
       [ next_hostname! ]
     end

--- a/control-plane/app/services/deployments/publisher.rb
+++ b/control-plane/app/services/deployments/publisher.rb
@@ -125,6 +125,10 @@ module Deployments
       ingress = environment.environment_ingress
       return false unless ingress&.status == EnvironmentIngress::STATUS_READY
 
+      if environment.environment_bundle&.hostname.present?
+        return true
+      end
+
       desired_hosts = IngressHostnames.normalize_all(release.ingress_config&.dig("hosts"))
       return true if desired_hosts.empty?
 

--- a/control-plane/app/services/deployments/publisher.rb
+++ b/control-plane/app/services/deployments/publisher.rb
@@ -125,12 +125,11 @@ module Deployments
       ingress = environment.environment_ingress
       return false unless ingress&.status == EnvironmentIngress::STATUS_READY
 
-      desired_hosts = []
       if environment.environment_bundle&.hostname.present?
-        desired_hosts << environment.environment_bundle.hostname
+        return true
       end
-      desired_hosts.concat(IngressHostnames.normalize_all(release.ingress_config&.dig("hosts")))
-      desired_hosts = IngressHostnames.normalize_all(desired_hosts).uniq
+
+      desired_hosts = IngressHostnames.normalize_all(release.ingress_config&.dig("hosts"))
       return true if desired_hosts.empty?
 
       ingress.hosts == desired_hosts

--- a/control-plane/app/services/deployments/publisher.rb
+++ b/control-plane/app/services/deployments/publisher.rb
@@ -125,11 +125,12 @@ module Deployments
       ingress = environment.environment_ingress
       return false unless ingress&.status == EnvironmentIngress::STATUS_READY
 
+      desired_hosts = []
       if environment.environment_bundle&.hostname.present?
-        return true
+        desired_hosts << environment.environment_bundle.hostname
       end
-
-      desired_hosts = IngressHostnames.normalize_all(release.ingress_config&.dig("hosts"))
+      desired_hosts.concat(IngressHostnames.normalize_all(release.ingress_config&.dig("hosts")))
+      desired_hosts = IngressHostnames.normalize_all(desired_hosts).uniq
       return true if desired_hosts.empty?
 
       ingress.hosts == desired_hosts

--- a/control-plane/app/services/deployments/publisher.rb
+++ b/control-plane/app/services/deployments/publisher.rb
@@ -19,7 +19,7 @@ module Deployments
 
       update_progress!("waiting for managed capacity") if environment.managed_runtime?
       ensure_managed_capacity!(deployment:) if environment.managed_runtime?
-      if release.ingress_service_name.present? && !ingress_ready?
+      if release.ingress_target_service_names.any? && !ingress_ready?
         update_progress!("provisioning ingress")
         provision_ingress!
       end
@@ -96,14 +96,20 @@ module Deployments
         raise SchedulingError, "at least one assigned node must match label #{label.inspect} for service #{service_name}"
       end
 
-      if environment.direct_dns_ingress? && release.ingress_service_name.present?
-        incompatible_nodes = nodes.select do |node|
-          release.service_scheduled_on?(release.ingress_service_name, node) &&
-            !node.supports_capability?(Node::CAPABILITY_DIRECT_DNS_INGRESS)
+      if release.ingress_target_service_names.any?
+        ingress_nodes = nodes.select { |node| release.ingress_scheduled_on?(node) }
+        if ingress_nodes.empty?
+          raise SchedulingError, "at least one assigned node must host every ingress-target service"
         end
-        if incompatible_nodes.any?
-          names = incompatible_nodes.map(&:name).sort.join(", ")
-          raise SchedulingError, "assigned ingress nodes do not support direct_dns ingress: #{names}"
+
+        if environment.direct_dns_ingress?
+          incompatible_nodes = ingress_nodes.reject do |node|
+            node.supports_capability?(Node::CAPABILITY_DIRECT_DNS_INGRESS)
+          end
+          if incompatible_nodes.any?
+            names = incompatible_nodes.map(&:name).sort.join(", ")
+            raise SchedulingError, "assigned ingress nodes do not support direct_dns ingress: #{names}"
+          end
         end
       end
 
@@ -232,7 +238,7 @@ module Deployments
       end
 
       sync_deployment_node_statuses!(deployment:, assigned_nodes:)
-      EnvironmentIngresses::ReconcileJob.perform_later(environment.id) if release.ingress_service_name.present?
+      EnvironmentIngresses::ReconcileJob.perform_later(environment.id) if release.ingress_target_service_names.any?
       update_progress!("waiting for node reconcile", deployment:)
     end
 

--- a/control-plane/app/services/environment_ingresses/eligible_nodes.rb
+++ b/control-plane/app/services/environment_ingresses/eligible_nodes.rb
@@ -21,9 +21,8 @@ module EnvironmentIngresses
     attr_reader :environment, :stale_node_after, :clock
 
     def eligible_node?(node)
-      service_name = environment.current_release&.ingress_service_name
-      return false if service_name.blank?
-      return false unless environment.current_release.service_scheduled_on?(service_name, node)
+      release = environment.current_release
+      return false unless release&.ingress_scheduled_on?(node)
       return false if node.public_ip.to_s.strip.blank?
       return false if node.provisioning_status != Node::PROVISIONING_READY
       return false unless node.supports_capability?(Node::CAPABILITY_DIRECT_DNS_INGRESS)

--- a/control-plane/app/services/environment_ingresses/reconciler.rb
+++ b/control-plane/app/services/environment_ingresses/reconciler.rb
@@ -53,6 +53,8 @@ module EnvironmentIngresses
     end
 
     def desired_hosts_for(ingress)
+      return [ environment.environment_bundle.hostname ] if environment.environment_bundle&.hostname.present?
+
       configured = IngressHostnames.normalize_all(release&.ingress_config&.dig("hosts"))
       return configured if configured.any?
       return ingress.hosts if ingress.hosts.any?

--- a/control-plane/app/services/environment_ingresses/reconciler.rb
+++ b/control-plane/app/services/environment_ingresses/reconciler.rb
@@ -53,10 +53,15 @@ module EnvironmentIngresses
     end
 
     def desired_hosts_for(ingress)
-      return [ environment.environment_bundle.hostname ] if environment.environment_bundle&.hostname.present?
+      desired_hosts = []
+      if environment.environment_bundle&.hostname.present?
+        desired_hosts << environment.environment_bundle.hostname
+      end
 
       configured = IngressHostnames.normalize_all(release&.ingress_config&.dig("hosts"))
-      return configured if configured.any?
+      desired_hosts.concat(configured)
+      desired_hosts = desired_hosts.uniq
+      return desired_hosts if desired_hosts.any?
       return ingress.hosts if ingress.hosts.any?
       return [ ingress.hostname ] if ingress.hostname.present?
 

--- a/control-plane/app/services/node_desired_state/ingress_payload.rb
+++ b/control-plane/app/services/node_desired_state/ingress_payload.rb
@@ -3,62 +3,65 @@
 module NodeDesiredState
   class IngressPayload
     def self.build(node:, environment:, release:)
-      ingress_config = release.ingress_config
-      ingress_service_name = release.ingress_service_name
-      return nil if ingress_service_name.blank?
-      return nil unless release.service_scheduled_on?(ingress_service_name, node)
+      target_services = release.ingress_target_service_names
+      return nil if target_services.blank?
+      return nil unless release.ingress_scheduled_on?(node)
       return nil unless Devopsellence::IngressConfig.managed?
 
       ingress = environment.environment_ingress
-      hosts = ingress&.hosts || []
-      return nil if hosts.empty?
+      return nil unless ingress&.hostname.present?
 
-      payload = {
-        hosts: hosts,
-        tls: normalize_tls(ingress_config&.dig("tls")),
-        redirectHttp: ingress_config&.key?("redirect_http") ? ingress_config["redirect_http"] : true,
-        routes: routes_for(environment:, hosts:, release:)
-      }.compact
+      hosts = configured_hosts(release)
+      hosts = [ingress.hostname] if hosts.empty?
 
       if environment.tunnel_ingress?
         return nil unless ingress.status == EnvironmentIngress::STATUS_READY
 
-        payload.merge(
+        {
+          hosts: hosts,
           mode: Environment::INGRESS_STRATEGY_TUNNEL,
-          tunnelTokenSecretRef: ingress.tunnel_token_secret_ref
-        )
+          tunnelTokenSecretRef: ingress.tunnel_token_secret_ref,
+          routes: routes_for(environment:, ingress:, release:)
+        }
       else
         return nil unless node.supports_capability?(Node::CAPABILITY_DIRECT_DNS_INGRESS)
 
-        payload.merge(
+        {
+          hosts: hosts,
           mode: "public",
-        )
+          tls: {
+            mode: "auto"
+          },
+          redirectHttp: true,
+          routes: routes_for(environment:, ingress:, release:)
+        }
       end
     end
 
-    def self.routes_for(environment:, hosts:, release:)
-      hosts.map do |host|
+    def self.routes_for(environment:, ingress:, release:)
+      Array(release.ingress_config["rules"]).map do |raw_rule|
+        rule = raw_rule.is_a?(Hash) ? raw_rule : {}
+        match = rule["match"].is_a?(Hash) ? rule["match"] : {}
+        target = rule["target"].is_a?(Hash) ? rule["target"] : {}
         {
           match: {
-            hostname: host
+            hostname: match["host"].to_s.strip.presence || ingress.hostname,
+            pathPrefix: match["path_prefix"].to_s.strip.presence || "/"
           },
           target: {
             environment: environment.name,
-            service: release.ingress_service_name,
-            port: "http"
+            service: target["service"],
+            port: target["port"]
           }
         }
       end
     end
 
-    def self.normalize_tls(tls)
-      return { mode: "auto" } unless tls.is_a?(Hash)
-
-      {
-        mode: tls["mode"].presence || "auto",
-        email: tls["email"],
-        caDirectoryUrl: tls["ca_directory_url"]
-      }.compact
+    def self.configured_hosts(release)
+      Array(release.ingress_config["hosts"]).filter_map do |host|
+        value = host.to_s.strip
+        value.presence
+      end.uniq
     end
   end
 end

--- a/control-plane/app/services/node_desired_state/ingress_payload.rb
+++ b/control-plane/app/services/node_desired_state/ingress_payload.rb
@@ -14,12 +14,17 @@ module NodeDesiredState
       hosts = configured_hosts(release)
       hosts = [ingress.hostname] if hosts.empty?
 
+      tls = configured_tls(release)
+      redirect_http = configured_redirect_http(release)
+
       if environment.tunnel_ingress?
         return nil unless ingress.status == EnvironmentIngress::STATUS_READY
 
         {
           hosts: hosts,
           mode: Environment::INGRESS_STRATEGY_TUNNEL,
+          tls: tls,
+          redirectHttp: redirect_http,
           tunnelTokenSecretRef: ingress.tunnel_token_secret_ref,
           routes: routes_for(environment:, ingress:, release:)
         }
@@ -29,10 +34,8 @@ module NodeDesiredState
         {
           hosts: hosts,
           mode: "public",
-          tls: {
-            mode: "auto"
-          },
-          redirectHttp: true,
+          tls: tls,
+          redirectHttp: redirect_http,
           routes: routes_for(environment:, ingress:, release:)
         }
       end
@@ -62,6 +65,22 @@ module NodeDesiredState
         value = host.to_s.strip
         value.presence
       end.uniq
+    end
+
+    def self.configured_tls(release)
+      tls = release.ingress_config["tls"]
+      tls = tls.is_a?(Hash) ? tls : {}
+      {
+        mode: tls["mode"].to_s.strip.presence || "auto",
+        email: tls["email"].to_s.strip.presence,
+        caDirectoryUrl: tls["ca_directory_url"].to_s.strip.presence
+      }.compact
+    end
+
+    def self.configured_redirect_http(release)
+      return release.ingress_config["redirect_http"] if release.ingress_config.key?("redirect_http")
+
+      true
     end
   end
 end

--- a/control-plane/app/services/node_desired_state/ingress_payload.rb
+++ b/control-plane/app/services/node_desired_state/ingress_payload.rb
@@ -42,22 +42,35 @@ module NodeDesiredState
     end
 
     def self.routes_for(environment:, ingress:, release:)
-      Array(release.ingress_config["rules"]).map do |raw_rule|
-        rule = raw_rule.is_a?(Hash) ? raw_rule : {}
-        match = rule["match"].is_a?(Hash) ? rule["match"] : {}
-        target = rule["target"].is_a?(Hash) ? rule["target"] : {}
+      Array(release.ingress_config["rules"]).map.with_index do |raw_rule, index|
+        rule = required_hash(raw_rule, field: "ingress.rules[#{index}]")
+        match = required_hash(rule["match"], field: "ingress.rules[#{index}].match")
+        target = required_hash(rule["target"], field: "ingress.rules[#{index}].target")
         {
           match: {
-            hostname: IngressHostnames.normalize(match["host"].to_s.strip.presence || ingress.hostname),
+            hostname: IngressHostnames.normalize(required_string(match["host"], field: "ingress.rules[#{index}].match.host")),
             pathPrefix: match["path_prefix"].to_s.strip.presence || "/"
           },
           target: {
             environment: environment.name,
-            service: target["service"],
-            port: target["port"]
+            service: required_string(target["service"], field: "ingress.rules[#{index}].target.service"),
+            port: required_string(target["port"], field: "ingress.rules[#{index}].target.port")
           }
         }
       end
+    end
+
+    def self.required_hash(value, field:)
+      raise Release::InvalidRuntimeConfig, "#{field} must decode to an object" unless value.is_a?(Hash)
+
+      value
+    end
+
+    def self.required_string(value, field:)
+      value = value.to_s.strip
+      raise Release::InvalidRuntimeConfig, "#{field} is required" if value.blank?
+
+      value
     end
 
     def self.configured_hosts(release)

--- a/control-plane/app/services/node_desired_state/ingress_payload.rb
+++ b/control-plane/app/services/node_desired_state/ingress_payload.rb
@@ -48,7 +48,7 @@ module NodeDesiredState
         target = rule["target"].is_a?(Hash) ? rule["target"] : {}
         {
           match: {
-            hostname: match["host"].to_s.strip.presence || ingress.hostname,
+            hostname: IngressHostnames.normalize(match["host"].to_s.strip.presence || ingress.hostname),
             pathPrefix: match["path_prefix"].to_s.strip.presence || "/"
           },
           target: {
@@ -61,10 +61,12 @@ module NodeDesiredState
     end
 
     def self.configured_hosts(release)
-      Array(release.ingress_config["hosts"]).filter_map do |host|
+      hosts = Array(release.ingress_config["hosts"]).filter_map do |host|
         value = host.to_s.strip
         value.presence
-      end.uniq
+      end
+
+      IngressHostnames.normalize_all(hosts)
     end
 
     def self.configured_tls(release)

--- a/control-plane/app/services/node_desired_state/ingress_payload.rb
+++ b/control-plane/app/services/node_desired_state/ingress_payload.rb
@@ -11,8 +11,7 @@ module NodeDesiredState
       ingress = environment.environment_ingress
       return nil unless ingress&.hostname.present?
 
-      hosts = configured_hosts(release)
-      hosts = [ingress.hostname] if hosts.empty?
+      hosts = desired_hosts(ingress:, release:)
 
       tls = configured_tls(release)
       redirect_http = configured_redirect_http(release)
@@ -79,6 +78,14 @@ module NodeDesiredState
         value.presence
       end
 
+      IngressHostnames.normalize_all(hosts)
+    end
+
+    def self.desired_hosts(ingress:, release:)
+      hosts = IngressHostnames.normalize_all(ingress.hosts)
+      hosts.concat(configured_hosts(release))
+      hosts = hosts.uniq
+      hosts = [ingress.hostname] if hosts.empty?
       IngressHostnames.normalize_all(hosts)
     end
 

--- a/control-plane/app/services/node_desired_state/ingress_payload.rb
+++ b/control-plane/app/services/node_desired_state/ingress_payload.rb
@@ -80,7 +80,12 @@ module NodeDesiredState
     end
 
     def self.configured_redirect_http(release)
-      return release.ingress_config["redirect_http"] if release.ingress_config.key?("redirect_http")
+      if release.ingress_config.key?("redirect_http")
+        value = release.ingress_config["redirect_http"]
+        raise Release::InvalidRuntimeConfig, "ingress.redirect_http must be a boolean" unless value == true || value == false
+
+        return value
+      end
 
       true
     end

--- a/control-plane/app/services/releases/runtime_attributes.rb
+++ b/control-plane/app/services/releases/runtime_attributes.rb
@@ -130,7 +130,7 @@ module Releases
         target = parse_hash(rule["target"] || rule[:target], field: :"ingress.rules[#{index}].target")
         {
           "match" => {
-            "host" => required_service_string(match["host"] || match[:host], field: :"ingress.rules[#{index}].match.host"),
+            "host" => IngressHostnames.normalize(required_service_string(match["host"] || match[:host], field: :"ingress.rules[#{index}].match.host")),
             "path_prefix" => optional_service_string(match["path_prefix"] || match[:path_prefix]) || "/"
           }.compact,
           "target" => {

--- a/control-plane/app/services/releases/runtime_attributes.rb
+++ b/control-plane/app/services/releases/runtime_attributes.rb
@@ -123,6 +123,7 @@ module Releases
       hosts = parse_ingress_hosts(ingress["hosts"] || ingress[:hosts])
       raise InvalidPayload, "ingress.hosts must include at least one host" if hosts.blank?
       host_set = hosts.index_with(true)
+      route_set = {}
       rules = parse_array(ingress["rules"] || ingress[:rules], field: :"ingress.rules").map.with_index do |entry, index|
         rule = parse_hash(entry, field: :"ingress.rules[#{index}]")
         match = parse_hash(rule["match"] || rule[:match], field: :"ingress.rules[#{index}].match")
@@ -131,6 +132,9 @@ module Releases
         path_prefix = optional_service_string(match["path_prefix"] || match[:path_prefix]) || "/"
         raise InvalidPayload, "ingress.rules[#{index}].match.host must exist in ingress.hosts" unless host_set[host]
         raise InvalidPayload, "ingress.rules[#{index}].match.path_prefix must start with /" unless path_prefix.start_with?("/")
+        route_key = [host, path_prefix]
+        raise InvalidPayload, "ingress.rules must be unique by host and path_prefix" if route_set[route_key]
+        route_set[route_key] = true
 
         {
           "match" => {

--- a/control-plane/app/services/releases/runtime_attributes.rb
+++ b/control-plane/app/services/releases/runtime_attributes.rb
@@ -120,14 +120,20 @@ module Releases
 
       hosts = parse_ingress_hosts(ingress["hosts"] || ingress[:hosts])
       raise InvalidPayload, "ingress.hosts must include at least one host" if hosts.blank?
+      host_set = hosts.index_with(true)
       rules = parse_array(ingress["rules"] || ingress[:rules], field: :"ingress.rules").map.with_index do |entry, index|
         rule = parse_hash(entry, field: :"ingress.rules[#{index}]")
         match = parse_hash(rule["match"] || rule[:match], field: :"ingress.rules[#{index}].match")
         target = parse_hash(rule["target"] || rule[:target], field: :"ingress.rules[#{index}].target")
+        host = IngressHostnames.normalize(required_service_string(match["host"] || match[:host], field: :"ingress.rules[#{index}].match.host"))
+        path_prefix = optional_service_string(match["path_prefix"] || match[:path_prefix]) || "/"
+        raise InvalidPayload, "ingress.rules[#{index}].match.host must exist in ingress.hosts" unless host_set[host]
+        raise InvalidPayload, "ingress.rules[#{index}].match.path_prefix must start with /" unless path_prefix.start_with?("/")
+
         {
           "match" => {
-            "host" => IngressHostnames.normalize(required_service_string(match["host"] || match[:host], field: :"ingress.rules[#{index}].match.host")),
-            "path_prefix" => optional_service_string(match["path_prefix"] || match[:path_prefix]) || "/"
+            "host" => host,
+            "path_prefix" => path_prefix
           }.compact,
           "target" => {
             "service" => required_service_string(target["service"] || target[:service], field: :"ingress.rules[#{index}].target.service"),

--- a/control-plane/app/services/releases/runtime_attributes.rb
+++ b/control-plane/app/services/releases/runtime_attributes.rb
@@ -123,7 +123,7 @@ module Releases
       ingress = parse_hash(value, field: :ingress)
       return nil if ingress.blank?
 
-      hosts = optional_service_array(ingress["hosts"] || ingress[:hosts], field: :"ingress.hosts")
+      hosts = parse_ingress_hosts(ingress["hosts"] || ingress[:hosts])
       rules = parse_array(ingress["rules"] || ingress[:rules], field: :"ingress.rules").map.with_index do |entry, index|
         rule = parse_hash(entry, field: :"ingress.rules[#{index}]")
         match = parse_hash(rule["match"] || rule[:match], field: :"ingress.rules[#{index}].match")
@@ -131,7 +131,7 @@ module Releases
         {
           "match" => {
             "host" => required_service_string(match["host"] || match[:host], field: :"ingress.rules[#{index}].match.host"),
-            "path_prefix" => optional_service_string(match["path_prefix"] || match[:path_prefix])
+            "path_prefix" => optional_service_string(match["path_prefix"] || match[:path_prefix]) || "/"
           }.compact,
           "target" => {
             "service" => required_service_string(target["service"] || target[:service], field: :"ingress.rules[#{index}].target.service"),
@@ -156,8 +156,18 @@ module Releases
       end
 
       redirect_http = ingress.key?("redirect_http") ? ingress["redirect_http"] : ingress[:redirect_http]
-      normalized["redirect_http"] = redirect_http unless redirect_http.nil?
+      normalized["redirect_http"] = parse_boolean!(redirect_http, field: :"ingress.redirect_http") unless redirect_http.nil?
       normalized.presence
+    end
+
+    def parse_ingress_hosts(value)
+      raw_hosts = optional_service_array(value, field: :"ingress.hosts")
+      return nil if raw_hosts.blank?
+
+      normalized_hosts = raw_hosts.map { |entry| IngressHostnames.normalize(entry) }.reject(&:blank?)
+      raise InvalidPayload, "ingress.hosts must be unique" if normalized_hosts.uniq.length != normalized_hosts.length
+
+      normalized_hosts
     end
 
     def parse_ports(value, field:)
@@ -254,6 +264,12 @@ module Releases
       raise InvalidPayload, "#{field} is required" if integer.nil?
 
       integer
+    end
+
+    def parse_boolean!(value, field:)
+      return value if value == true || value == false
+
+      raise InvalidPayload, "#{field} must be a boolean"
     end
   end
 end

--- a/control-plane/app/services/releases/runtime_attributes.rb
+++ b/control-plane/app/services/releases/runtime_attributes.rb
@@ -118,6 +118,8 @@ module Releases
       ingress = parse_hash(value, field: :ingress)
       return nil if ingress.blank?
 
+      reject_unsupported_key!(ingress, key: :service, field: :"ingress.service")
+
       hosts = parse_ingress_hosts(ingress["hosts"] || ingress[:hosts])
       raise InvalidPayload, "ingress.hosts must include at least one host" if hosts.blank?
       host_set = hosts.index_with(true)
@@ -158,8 +160,10 @@ module Releases
         }.compact
       end
 
-      redirect_http = ingress.key?("redirect_http") ? ingress["redirect_http"] : ingress[:redirect_http]
-      normalized["redirect_http"] = parse_boolean!(redirect_http, field: :"ingress.redirect_http") unless redirect_http.nil?
+      if ingress.key?("redirect_http") || ingress.key?(:redirect_http)
+        redirect_http = ingress.key?("redirect_http") ? ingress["redirect_http"] : ingress[:redirect_http]
+        normalized["redirect_http"] = parse_boolean!(redirect_http, field: :"ingress.redirect_http")
+      end
       normalized.presence
     end
 
@@ -245,6 +249,12 @@ module Releases
       return unless hash.key?(deprecated_key) || hash.key?(deprecated_key.to_s)
 
       raise InvalidPayload, "#{field} is no longer supported; use command or args"
+    end
+
+    def reject_unsupported_key!(hash, key:, field:)
+      return unless hash.key?(key) || hash.key?(key.to_s)
+
+      raise InvalidPayload, "#{field} is no longer supported"
     end
 
     def reject_unsupported_kind!(hash, field:)

--- a/control-plane/app/services/releases/runtime_attributes.rb
+++ b/control-plane/app/services/releases/runtime_attributes.rb
@@ -124,6 +124,7 @@ module Releases
       return nil if ingress.blank?
 
       hosts = parse_ingress_hosts(ingress["hosts"] || ingress[:hosts])
+      raise InvalidPayload, "ingress.hosts must include at least one host" if hosts.blank?
       rules = parse_array(ingress["rules"] || ingress[:rules], field: :"ingress.rules").map.with_index do |entry, index|
         rule = parse_hash(entry, field: :"ingress.rules[#{index}]")
         match = parse_hash(rule["match"] || rule[:match], field: :"ingress.rules[#{index}].match")
@@ -139,6 +140,7 @@ module Releases
           }
         }
       end
+      raise InvalidPayload, "ingress.rules must include at least one rule" if rules.blank?
 
       normalized = {
         "hosts" => hosts,

--- a/control-plane/app/services/releases/runtime_attributes.rb
+++ b/control-plane/app/services/releases/runtime_attributes.rb
@@ -5,7 +5,6 @@ require "json"
 module Releases
   class RuntimeAttributes
     InvalidPayload = Class.new(StandardError)
-    SERVICE_KINDS = [ "web", "worker", "accessory" ].freeze
 
     def initialize(params:)
       @params = params
@@ -79,14 +78,10 @@ module Releases
 
     def parse_service(value, field:)
       service = parse_hash(value, field:)
+      reject_unsupported_kind!(service, field: :"#{field}.kind")
       reject_deprecated_key!(service, deprecated_key: :entrypoint, field: :"#{field}.entrypoint")
-      kind = optional_service_string(service["kind"] || service[:kind])
-      if kind.present? && !SERVICE_KINDS.include?(kind)
-        raise InvalidPayload, "#{field}.kind must be one of #{SERVICE_KINDS.join(', ')}"
-      end
 
       normalized = {
-        "kind" => kind,
         "image" => optional_service_string(service["image"] || service[:image]),
         "command" => optional_service_array(service["command"] || service[:command], field: :"#{field}.command"),
         "args" => optional_service_array(service["args"] || service[:args], field: :"#{field}.args"),
@@ -244,6 +239,12 @@ module Releases
       return unless hash.key?(deprecated_key) || hash.key?(deprecated_key.to_s)
 
       raise InvalidPayload, "#{field} is no longer supported; use command or args"
+    end
+
+    def reject_unsupported_kind!(hash, field:)
+      return unless hash.key?(:kind) || hash.key?("kind")
+
+      raise InvalidPayload, "#{field} is no longer supported"
     end
 
     def required_service_string(value, field:)

--- a/control-plane/app/services/releases/runtime_attributes.rb
+++ b/control-plane/app/services/releases/runtime_attributes.rb
@@ -81,9 +81,7 @@ module Releases
       service = parse_hash(value, field:)
       reject_deprecated_key!(service, deprecated_key: :entrypoint, field: :"#{field}.entrypoint")
       kind = optional_service_string(service["kind"] || service[:kind])
-      raise InvalidPayload, "#{field}.kind must be present" if kind.blank?
-
-      unless SERVICE_KINDS.include?(kind)
+      if kind.present? && !SERVICE_KINDS.include?(kind)
         raise InvalidPayload, "#{field}.kind must be one of #{SERVICE_KINDS.join(', ')}"
       end
 
@@ -125,34 +123,41 @@ module Releases
       ingress = parse_hash(value, field: :ingress)
       return nil if ingress.blank?
 
-      redirect_http =
-        if ingress.key?("redirect_http")
-          ingress["redirect_http"]
-        elsif ingress.key?(:redirect_http)
-          ingress[:redirect_http]
-        end
-
-      tls = ingress["tls"] || ingress[:tls]
       hosts = optional_service_array(ingress["hosts"] || ingress[:hosts], field: :"ingress.hosts")
-      normalized_hosts = IngressHostnames.normalize_all(hosts)
-      if hosts.present? && normalized_hosts.length != hosts.length
-        raise InvalidPayload, "ingress.hosts must be unique"
+      rules = parse_array(ingress["rules"] || ingress[:rules], field: :"ingress.rules").map.with_index do |entry, index|
+        rule = parse_hash(entry, field: :"ingress.rules[#{index}]")
+        match = parse_hash(rule["match"] || rule[:match], field: :"ingress.rules[#{index}].match")
+        target = parse_hash(rule["target"] || rule[:target], field: :"ingress.rules[#{index}].target")
+        {
+          "match" => {
+            "host" => required_service_string(match["host"] || match[:host], field: :"ingress.rules[#{index}].match.host"),
+            "path_prefix" => optional_service_string(match["path_prefix"] || match[:path_prefix])
+          }.compact,
+          "target" => {
+            "service" => required_service_string(target["service"] || target[:service], field: :"ingress.rules[#{index}].target.service"),
+            "port" => required_service_string(target["port"] || target[:port], field: :"ingress.rules[#{index}].target.port")
+          }
+        }
       end
 
-      parsed = {
-        "hosts" => normalized_hosts.presence,
-        "service" => optional_service_string(ingress["service"] || ingress[:service]),
-        "redirect_http" => optional_boolean(redirect_http, field: :"ingress.redirect_http")
+      normalized = {
+        "hosts" => hosts,
+        "rules" => rules.presence
       }.compact
+
+      tls = ingress["tls"] || ingress[:tls]
       if tls.present?
         tls = parse_hash(tls, field: :"ingress.tls")
-        parsed["tls"] = {
+        normalized["tls"] = {
           "mode" => optional_service_string(tls["mode"] || tls[:mode]),
           "email" => optional_service_string(tls["email"] || tls[:email]),
           "ca_directory_url" => optional_service_string(tls["ca_directory_url"] || tls[:ca_directory_url])
         }.compact
       end
-      parsed
+
+      redirect_http = ingress.key?("redirect_http") ? ingress["redirect_http"] : ingress[:redirect_http]
+      normalized["redirect_http"] = redirect_http unless redirect_http.nil?
+      normalized.presence
     end
 
     def parse_ports(value, field:)
@@ -249,13 +254,6 @@ module Releases
       raise InvalidPayload, "#{field} is required" if integer.nil?
 
       integer
-    end
-
-    def optional_boolean(value, field:)
-      return nil if value.nil? || value == ""
-      return value if value == true || value == false
-
-      raise InvalidPayload, "#{field} must be a boolean"
     end
   end
 end

--- a/control-plane/test/integration/abuse_controls_test.rb
+++ b/control-plane/test/integration/abuse_controls_test.rb
@@ -298,7 +298,15 @@ class AbuseControlsTest < ActionDispatch::IntegrationTest
       services: {
         web: web_service_runtime(port: 80)
       },
-      ingress: { service: "web" }
+      ingress: {
+        hosts: ["app.example.com"],
+        rules: [
+          {
+            match: { host: "app.example.com", path_prefix: "/" },
+            target: { service: "web", port: "http" }
+          }
+        ]
+      }
     }
   end
 

--- a/control-plane/test/integration/api_cli_mvp_test.rb
+++ b/control-plane/test/integration/api_cli_mvp_test.rb
@@ -1462,7 +1462,15 @@ class ApiCliMvpTest < ActionDispatch::IntegrationTest
             ]
           )
         },
-        ingress: { service: "web" }
+        ingress: {
+          hosts: ["app.example.com"],
+          rules: [
+            {
+              match: { host: "app.example.com", path_prefix: "/" },
+              target: { service: "web", port: "http" }
+            }
+          ]
+        }
       },
       headers: auth_headers_for(user),
       as: :json
@@ -1490,7 +1498,15 @@ class ApiCliMvpTest < ActionDispatch::IntegrationTest
           image_repository: "shop-app",
           image_digest: "sha256:#{'b' * 64}",
           services: { web: web_service_runtime(port: 80) },
-          ingress: { service: "web" }
+          ingress: {
+          hosts: ["app.example.com"],
+          rules: [
+            {
+              match: { host: "app.example.com", path_prefix: "/" },
+              target: { service: "web", port: "http" }
+            }
+          ]
+        }
         },
         headers: auth_headers_for(user),
         as: :json
@@ -1554,7 +1570,15 @@ class ApiCliMvpTest < ActionDispatch::IntegrationTest
             volumes: [{ source: "app_storage", target: "/rails/storage" }]
           )
         },
-        ingress: { service: "web" }
+        ingress: {
+          hosts: ["app.example.com"],
+          rules: [
+            {
+              match: { host: "app.example.com", path_prefix: "/" },
+              target: { service: "web", port: "http" }
+            }
+          ]
+        }
       },
       headers: auth_headers_for(user),
       as: :json
@@ -1581,7 +1605,15 @@ class ApiCliMvpTest < ActionDispatch::IntegrationTest
         services: {
           web: web_service_runtime(port: 80, env: { "RAILS_ENV" => "production" })
         },
-        ingress: { service: "web" }
+        ingress: {
+          hosts: ["app.example.com"],
+          rules: [
+            {
+              match: { host: "app.example.com", path_prefix: "/" },
+              target: { service: "web", port: "http" }
+            }
+          ]
+        }
       },
       headers: auth_headers_for(user),
       as: :json

--- a/control-plane/test/integration/api_cli_mvp_test.rb
+++ b/control-plane/test/integration/api_cli_mvp_test.rb
@@ -1594,6 +1594,45 @@ class ApiCliMvpTest < ActionDispatch::IntegrationTest
     assert_equal false, release.requires_label?("worker")
   end
 
+  test "creates a release with explicit ingress rules" do
+    user = User.create!(email: "owner-#{SecureRandom.hex(4)}@example.com", confirmed_at: Time.current)
+    organization = Organization.create!(name: "acme")
+    OrganizationMembership.create!(organization: organization, user: user, role: OrganizationMembership::ROLE_OWNER)
+    project = organization.projects.create!(name: "ShopApp")
+
+    post "/api/v1/cli/projects/#{project.id}/releases",
+      params: {
+        git_sha: "a" * 40,
+        image_repository: "shop-app",
+        image_digest: "sha256:#{'b' * 64}",
+        services: {
+          web: web_service_runtime(port: 80, env: { "RAILS_ENV" => "production" }),
+          api: worker_service_runtime(command: ["./bin/api"]).merge(ports: [{ name: "metrics", port: 9090 }])
+        },
+        ingress: {
+          hosts: ["app.example.com"],
+          rules: [
+            {
+              match: { host: "app.example.com", path_prefix: "/api" },
+              target: { service: "api", port: "metrics" }
+            },
+            {
+              match: { host: "app.example.com", path_prefix: "/" },
+              target: { service: "web", port: "http" }
+            }
+          ]
+        }
+      },
+      headers: auth_headers_for(user),
+      as: :json
+
+    assert_response :created
+    release = project.releases.order(:id).last
+    runtime = JSON.parse(release.runtime_json)
+    assert_equal "metrics", runtime.dig("ingress", "rules", 0, "target", "port")
+    assert_equal "web", runtime.dig("ingress", "rules", 1, "target", "service")
+  end
+
   test "rejects release create without web runtime config" do
     user = User.create!(email: "owner-#{SecureRandom.hex(4)}@example.com", confirmed_at: Time.current)
     organization = Organization.create!(name: "acme")

--- a/control-plane/test/models/deployments_publisher_test.rb
+++ b/control-plane/test/models/deployments_publisher_test.rb
@@ -142,7 +142,7 @@ class DeploymentsPublisherTest < ActiveSupport::TestCase
     assert_equal release.image_reference_for(organization), service.fetch("image")
     assert_equal 3000, service.dig("ports", 0, "port")
     assert_equal({ "DATABASE_URL" => "projects/acme/secrets/db/versions/latest" }, service.fetch("secretRefs"))
-    assert_equal release.ingress_config.fetch("hosts"), desired_state.dig("ingress", "hosts")
+    assert_equal [hostname] + release.ingress_config.fetch("hosts"), desired_state.dig("ingress", "hosts")
     assert_equal({ "mode" => "manual", "email" => "ops@example.com", "caDirectoryUrl" => "https://ca.example.test/directory" }, desired_state.dig("ingress", "tls"))
     assert_equal false, desired_state.dig("ingress", "redirectHttp")
     assert_equal "gsm://projects/gcp-proj-a/secrets/env-#{environment.id}-ingress-cloudflare-tunnel-token/versions/latest", desired_state.dig("ingress", "tunnelTokenSecretRef")
@@ -214,7 +214,7 @@ class DeploymentsPublisherTest < ActiveSupport::TestCase
     Deployments::Publisher.new(environment: environment, release: release, store: store).call
 
     desired_state = store.desired_state_payload(bucket: organization.gcs_bucket_name, object_path: node.desired_state_object_path)
-    assert_equal ["app.example.com"], desired_state.dig("ingress", "hosts")
+    assert_equal [hostname, "app.example.com"], desired_state.dig("ingress", "hosts")
     assert_equal 2, desired_state.dig("ingress", "routes").size
     assert_equal "app.example.com", desired_state.dig("ingress", "routes", 0, "match", "hostname")
     assert_equal "/api", desired_state.dig("ingress", "routes", 0, "match", "pathPrefix")
@@ -285,7 +285,7 @@ class DeploymentsPublisherTest < ActiveSupport::TestCase
     Deployments::Publisher.new(environment: environment, release: release, store: store).call
 
     desired_state = store.desired_state_payload(bucket: organization.gcs_bucket_name, object_path: node.desired_state_object_path)
-    assert_equal ["app.example.com", "admin.example.com"], desired_state.dig("ingress", "hosts")
+    assert_equal ["managed.example.devopsellence.test", "app.example.com", "admin.example.com"], desired_state.dig("ingress", "hosts")
     assert_equal ["app.example.com", "admin.example.com"], desired_state.dig("ingress", "routes").map { |route| route.dig("match", "hostname") }
     assert_equal ["web", "admin"], desired_state.dig("ingress", "routes").map { |route| route.dig("target", "service") }
   end
@@ -501,7 +501,7 @@ class DeploymentsPublisherTest < ActiveSupport::TestCase
     services = desired_state_services(desired_state)
     assert_equal %w[web worker], services.map { |entry| entry.fetch("name") }
     assert_equal "./bin/jobs", services.second.dig("entrypoint", 0)
-    assert_equal release.ingress_config.fetch("hosts"), desired_state.dig("ingress", "hosts")
+    assert_equal [hostname] + release.ingress_config.fetch("hosts"), desired_state.dig("ingress", "hosts")
   end
 
   test "renders environment-scoped volume names in desired state" do
@@ -616,7 +616,7 @@ class DeploymentsPublisherTest < ActiveSupport::TestCase
       },
       desired_state_services(desired_state).first.fetch("secretRefs")
     )
-    assert_equal release.ingress_config.fetch("hosts"), desired_state.dig("ingress", "hosts")
+    assert_equal [hostname] + release.ingress_config.fetch("hosts"), desired_state.dig("ingress", "hosts")
   end
 
   test "provisions ingress before publishing web releases" do
@@ -713,7 +713,7 @@ class DeploymentsPublisherTest < ActiveSupport::TestCase
     Deployments::Publisher.new(environment: environment, release: release, store: store).call
 
     desired_state = store.desired_state_payload(bucket: organization.gcs_bucket_name, object_path: node.desired_state_object_path)
-    assert_equal release.ingress_config.fetch("hosts"), desired_state.dig("ingress", "hosts")
+    assert_equal [hostname] + release.ingress_config.fetch("hosts"), desired_state.dig("ingress", "hosts")
     assert_equal Environment::INGRESS_STRATEGY_TUNNEL, desired_state.dig("ingress", "mode")
   end
 
@@ -922,7 +922,7 @@ class DeploymentsPublisherTest < ActiveSupport::TestCase
 
     state_a = store.desired_state_payload(bucket: organization.gcs_bucket_name, object_path: node_a.reload.desired_state_object_path)
     state_b = store.desired_state_payload(bucket: organization.gcs_bucket_name, object_path: node_b.reload.desired_state_object_path)
-    assert_equal release.ingress_config.fetch("hosts"), state_a.dig("ingress", "hosts")
+    assert_equal [hostname] + release.ingress_config.fetch("hosts"), state_a.dig("ingress", "hosts")
     assert_equal({ "mode" => "manual", "email" => "ops@example.com" }, state_a.dig("ingress", "tls"))
     assert_equal false, state_a.dig("ingress", "redirectHttp")
 

--- a/control-plane/test/models/deployments_publisher_test.rb
+++ b/control-plane/test/models/deployments_publisher_test.rb
@@ -125,7 +125,7 @@ class DeploymentsPublisherTest < ActiveSupport::TestCase
     assert_equal release.image_reference_for(organization), service.fetch("image")
     assert_equal 3000, service.dig("ports", 0, "port")
     assert_equal({ "DATABASE_URL" => "projects/acme/secrets/db/versions/latest" }, service.fetch("secretRefs"))
-    assert_equal [ hostname ], desired_state.dig("ingress", "hosts")
+    assert_equal release.ingress_config.fetch("hosts"), desired_state.dig("ingress", "hosts")
     assert_equal "gsm://projects/gcp-proj-a/secrets/env-#{environment.id}-ingress-cloudflare-tunnel-token/versions/latest", desired_state.dig("ingress", "tunnelTokenSecretRef")
     assert_equal "Production", desired_state.dig("ingress", "routes", 0, "target", "environment")
     assert_equal "/up", service.dig("healthcheck", "path")
@@ -134,59 +134,7 @@ class DeploymentsPublisherTest < ActiveSupport::TestCase
     assert_equal 3, service.dig("healthcheck", "retries")
   end
 
-  test "publishes desired state ingress routes for every configured host" do
-    organization = Organization.create!(name: "org-#{SecureRandom.hex(3)}")
-    ensure_test_organization_runtime!(organization)
-    project = organization.projects.create!(name: "Project A")
-    environment = project.environments.create!(
-      name: "Production",
-      gcp_project_id: "gcp-proj-a",
-      gcp_project_number: "123456789",
-      service_account_email: "svc-a@gcp-proj-a.iam.gserviceaccount.com",
-      workload_identity_pool: "pool-a",
-      workload_identity_provider: "provider-a",
-      runtime_kind: Environment::RUNTIME_CUSTOMER_NODES
-    )
-    release = project.releases.create!(
-      git_sha: "abcd1234",
-      image_digest: "sha256:abc",
-      image_repository: "api",
-      runtime_json: release_runtime_json(ingress: {
-        "service" => "web",
-        "hosts" => [ "app.example.test", "www.example.test" ],
-        "tls" => { "mode" => "manual" },
-        "redirect_http" => false
-      }),
-      revision: "rel-1"
-    )
-    node, _access, _refresh = issue_test_node!(organization: organization, name: "node-a")
-    node.update!(environment: environment)
-    store = FakeObjectStore.new
-    ingress = environment.create_environment_ingress!(
-      hostname: "app.example.test",
-      cloudflare_tunnel_id: "tunnel-1",
-      gcp_secret_name: "env-#{environment.id}-ingress-cloudflare-tunnel-token",
-      status: EnvironmentIngress::STATUS_READY,
-      provisioned_at: Time.current
-    )
-    ingress.assign_hosts!([ "app.example.test", "www.example.test" ])
-
-    Gcp::EnvironmentRuntimeProvisioner.any_instance.stubs(:call).returns(
-      Gcp::EnvironmentRuntimeProvisioner::Result.new(status: :ready, message: nil)
-    )
-    EnvironmentIngresses::Reconciler.any_instance.stubs(:call).returns(environment.environment_ingress)
-    Gcp::EnvironmentSecretManager.any_instance.stubs(:ensure_ingress_access!).returns(true)
-
-    Deployments::Publisher.new(environment: environment, release: release, store: store).call
-
-    desired_state = store.desired_state_payload(bucket: organization.gcs_bucket_name, object_path: node.desired_state_object_path)
-    assert_equal [ "app.example.test", "www.example.test" ], desired_state.dig("ingress", "hosts")
-    assert_equal [ "app.example.test", "www.example.test" ], desired_state.dig("ingress", "routes").map { |route| route.dig("match", "hostname") }
-    assert_equal false, desired_state.dig("ingress", "redirectHttp")
-    assert_equal "manual", desired_state.dig("ingress", "tls", "mode")
-  end
-
-  test "skips ingress reprovision when stored ingress hosts only differ by case" do
+  test "publishes configured explicit ingress rules into desired state" do
     organization = Organization.create!(name: "org-#{SecureRandom.hex(3)}")
     ensure_test_organization_runtime!(organization)
     project = organization.projects.create!(name: "Project A")
@@ -205,35 +153,122 @@ class DeploymentsPublisherTest < ActiveSupport::TestCase
       image_repository: "api",
       runtime_json: JSON.generate(
         {
-          "services" => { "web" => web_service_runtime },
-          "tasks" => {},
+          "services" => {
+            "web" => web_service_runtime,
+            "api" => worker_service_runtime.merge("ports" => [{ "name" => "metrics", "port" => 9090 }])
+          },
           "ingress" => {
-            "service" => "web",
-            "hosts" => ["App.Example.Test", "WWW.Example.Test"]
+            "hosts" => ["app.example.com"],
+            "rules" => [
+              {
+                "match" => { "host" => "app.example.com", "path_prefix" => "/api" },
+                "target" => { "service" => "api", "port" => "metrics" }
+              },
+              {
+                "match" => { "host" => "app.example.com", "path_prefix" => "/" },
+                "target" => { "service" => "web", "port" => "http" }
+              }
+            ]
           }
         }
       ),
       revision: "rel-1"
     )
-    node, _access, _refresh = issue_test_node!(organization: organization, name: "node-a")
+    node, _access, _refresh = issue_test_node!(organization: organization, name: "node-a", labels: ["web", "worker"])
     node.update!(environment: environment)
     store = FakeObjectStore.new
-    ingress = environment.create_environment_ingress!(
-      hostname: "app.example.test",
+    hostname = "#{SecureRandom.alphanumeric(6).downcase}.devopsellence.io"
+    environment.create_environment_ingress!(
+      hostname: hostname,
       cloudflare_tunnel_id: "tunnel-1",
       gcp_secret_name: "env-#{environment.id}-ingress-cloudflare-tunnel-token",
       status: EnvironmentIngress::STATUS_READY,
       provisioned_at: Time.current
     )
-    ingress.assign_hosts!(["app.example.test", "www.example.test"])
 
     Gcp::EnvironmentRuntimeProvisioner.any_instance.stubs(:call).returns(
       Gcp::EnvironmentRuntimeProvisioner::Result.new(status: :ready, message: nil)
     )
-    EnvironmentIngresses::Reconciler.any_instance.expects(:call).never
+    EnvironmentIngresses::Reconciler.any_instance.stubs(:call).returns(environment.environment_ingress)
     Gcp::EnvironmentSecretManager.any_instance.stubs(:ensure_ingress_access!).returns(true)
 
     Deployments::Publisher.new(environment: environment, release: release, store: store).call
+
+    desired_state = store.desired_state_payload(bucket: organization.gcs_bucket_name, object_path: node.desired_state_object_path)
+    assert_equal ["app.example.com"], desired_state.dig("ingress", "hosts")
+    assert_equal 2, desired_state.dig("ingress", "routes").size
+    assert_equal "app.example.com", desired_state.dig("ingress", "routes", 0, "match", "hostname")
+    assert_equal "/api", desired_state.dig("ingress", "routes", 0, "match", "pathPrefix")
+    assert_equal "api", desired_state.dig("ingress", "routes", 0, "target", "service")
+    assert_equal "metrics", desired_state.dig("ingress", "routes", 0, "target", "port")
+    assert_equal "app.example.com", desired_state.dig("ingress", "routes", 1, "match", "hostname")
+    assert_equal "/", desired_state.dig("ingress", "routes", 1, "match", "pathPrefix")
+    assert_equal "web", desired_state.dig("ingress", "routes", 1, "target", "service")
+  end
+
+  test "publishes configured ingress hosts and preserves per-rule host fan-out" do
+    organization = Organization.create!(name: "org-#{SecureRandom.hex(3)}")
+    ensure_test_organization_runtime!(organization)
+    project = organization.projects.create!(name: "Project A")
+    environment = project.environments.create!(
+      name: "Production",
+      gcp_project_id: "gcp-proj-a",
+      gcp_project_number: "123456789",
+      service_account_email: "svc-a@gcp-proj-a.iam.gserviceaccount.com",
+      workload_identity_pool: "pool-a",
+      workload_identity_provider: "provider-a",
+      runtime_kind: Environment::RUNTIME_CUSTOMER_NODES
+    )
+    release = project.releases.create!(
+      git_sha: "abcd1234",
+      image_digest: "sha256:abc",
+      image_repository: "api",
+      runtime_json: JSON.generate(
+        {
+          "services" => {
+            "web" => web_service_runtime,
+            "admin" => web_service_runtime(command: ["./bin/admin"])
+          },
+          "ingress" => {
+            "hosts" => ["app.example.com", "admin.example.com"],
+            "rules" => [
+              {
+                "match" => { "host" => "app.example.com", "path_prefix" => "/" },
+                "target" => { "service" => "web", "port" => "http" }
+              },
+              {
+                "match" => { "host" => "admin.example.com", "path_prefix" => "/" },
+                "target" => { "service" => "admin", "port" => "http" }
+              }
+            ]
+          }
+        }
+      ),
+      revision: "rel-1"
+    )
+    node, _access, _refresh = issue_test_node!(organization: organization, name: "node-a", labels: ["web"])
+    node.update!(environment: environment)
+    store = FakeObjectStore.new
+    environment.create_environment_ingress!(
+      hostname: "managed.example.devopsellence.test",
+      cloudflare_tunnel_id: "tunnel-1",
+      gcp_secret_name: "env-#{environment.id}-ingress-cloudflare-tunnel-token",
+      status: EnvironmentIngress::STATUS_READY,
+      provisioned_at: Time.current
+    )
+
+    Gcp::EnvironmentRuntimeProvisioner.any_instance.stubs(:call).returns(
+      Gcp::EnvironmentRuntimeProvisioner::Result.new(status: :ready, message: nil)
+    )
+    EnvironmentIngresses::Reconciler.any_instance.stubs(:call).returns(environment.environment_ingress)
+    Gcp::EnvironmentSecretManager.any_instance.stubs(:ensure_ingress_access!).returns(true)
+
+    Deployments::Publisher.new(environment: environment, release: release, store: store).call
+
+    desired_state = store.desired_state_payload(bucket: organization.gcs_bucket_name, object_path: node.desired_state_object_path)
+    assert_equal ["app.example.com", "admin.example.com"], desired_state.dig("ingress", "hosts")
+    assert_equal ["app.example.com", "admin.example.com"], desired_state.dig("ingress", "routes").map { |route| route.dig("match", "hostname") }
+    assert_equal ["web", "admin"], desired_state.dig("ingress", "routes").map { |route| route.dig("target", "service") }
   end
 
   test "publishes immutable desired state object plus pointer and direct desired state path" do
@@ -447,7 +482,7 @@ class DeploymentsPublisherTest < ActiveSupport::TestCase
     services = desired_state_services(desired_state)
     assert_equal %w[web worker], services.map { |entry| entry.fetch("name") }
     assert_equal "./bin/jobs", services.second.dig("entrypoint", 0)
-    assert_equal [ hostname ], desired_state.dig("ingress", "hosts")
+    assert_equal release.ingress_config.fetch("hosts"), desired_state.dig("ingress", "hosts")
   end
 
   test "renders environment-scoped volume names in desired state" do
@@ -562,7 +597,7 @@ class DeploymentsPublisherTest < ActiveSupport::TestCase
       },
       desired_state_services(desired_state).first.fetch("secretRefs")
     )
-    assert_equal [ hostname ], desired_state.dig("ingress", "hosts")
+    assert_equal release.ingress_config.fetch("hosts"), desired_state.dig("ingress", "hosts")
   end
 
   test "provisions ingress before publishing web releases" do
@@ -659,7 +694,7 @@ class DeploymentsPublisherTest < ActiveSupport::TestCase
     Deployments::Publisher.new(environment: environment, release: release, store: store).call
 
     desired_state = store.desired_state_payload(bucket: organization.gcs_bucket_name, object_path: node.desired_state_object_path)
-    assert_equal [ hostname ], desired_state.dig("ingress", "hosts")
+    assert_equal release.ingress_config.fetch("hosts"), desired_state.dig("ingress", "hosts")
     assert_equal Environment::INGRESS_STRATEGY_TUNNEL, desired_state.dig("ingress", "mode")
   end
 
@@ -852,7 +887,7 @@ class DeploymentsPublisherTest < ActiveSupport::TestCase
 
     state_a = store.desired_state_payload(bucket: organization.gcs_bucket_name, object_path: node_a.reload.desired_state_object_path)
     state_b = store.desired_state_payload(bucket: organization.gcs_bucket_name, object_path: node_b.reload.desired_state_object_path)
-    assert_equal [ hostname ], state_a.dig("ingress", "hosts")
+    assert_equal release.ingress_config.fetch("hosts"), state_a.dig("ingress", "hosts")
 
     assert_equal [ "node-b", "worker-a" ], state_a.fetch("nodePeers").map { |peer| peer.fetch("name") }
     node_b_peer = state_a.fetch("nodePeers").find { |peer| peer.fetch("name") == "node-b" }

--- a/control-plane/test/models/deployments_publisher_test.rb
+++ b/control-plane/test/models/deployments_publisher_test.rb
@@ -77,12 +77,29 @@ class DeploymentsPublisherTest < ActiveSupport::TestCase
       git_sha: "abcd1234",
       image_digest: "sha256:abc",
       image_repository: "api",
-      runtime_json: release_runtime_json(services: {
-        "web" => web_service_runtime(
-          env: { "RAILS_ENV" => "production" },
-          secret_refs: [ { "name" => "DATABASE_URL", "secret" => "projects/acme/secrets/db/versions/latest" } ]
-        )
-      }),
+      runtime_json: release_runtime_json(
+        services: {
+          "web" => web_service_runtime(
+            env: { "RAILS_ENV" => "production" },
+            secret_refs: [ { "name" => "DATABASE_URL", "secret" => "projects/acme/secrets/db/versions/latest" } ]
+          )
+        },
+        ingress: {
+          "hosts" => ["app.devopsellence.test"],
+          "rules" => [
+            {
+              "match" => { "host" => "app.devopsellence.test", "path_prefix" => "/" },
+              "target" => { "service" => "web", "port" => "http" }
+            }
+          ],
+          "tls" => {
+            "mode" => "manual",
+            "email" => "ops@example.com",
+            "ca_directory_url" => "https://ca.example.test/directory"
+          },
+          "redirect_http" => false
+        }
+      ),
       revision: "rel-1"
     )
     node, _access, _refresh = issue_test_node!(organization: organization, name: "node-a")
@@ -126,6 +143,8 @@ class DeploymentsPublisherTest < ActiveSupport::TestCase
     assert_equal 3000, service.dig("ports", 0, "port")
     assert_equal({ "DATABASE_URL" => "projects/acme/secrets/db/versions/latest" }, service.fetch("secretRefs"))
     assert_equal release.ingress_config.fetch("hosts"), desired_state.dig("ingress", "hosts")
+    assert_equal({ "mode" => "manual", "email" => "ops@example.com", "caDirectoryUrl" => "https://ca.example.test/directory" }, desired_state.dig("ingress", "tls"))
+    assert_equal false, desired_state.dig("ingress", "redirectHttp")
     assert_equal "gsm://projects/gcp-proj-a/secrets/env-#{environment.id}-ingress-cloudflare-tunnel-token/versions/latest", desired_state.dig("ingress", "tunnelTokenSecretRef")
     assert_equal "Production", desired_state.dig("ingress", "routes", 0, "target", "environment")
     assert_equal "/up", service.dig("healthcheck", "path")
@@ -864,9 +883,25 @@ class DeploymentsPublisherTest < ActiveSupport::TestCase
       git_sha: "abcd1234",
       image_digest: "sha256:abc",
       image_repository: "api",
-      runtime_json: release_runtime_json(services: {
-        "web" => web_service_runtime(port: 80)
-      }),
+      runtime_json: release_runtime_json(
+        services: {
+          "web" => web_service_runtime(port: 80)
+        },
+        ingress: {
+          "hosts" => ["app.devopsellence.test"],
+          "rules" => [
+            {
+              "match" => { "host" => "app.devopsellence.test", "path_prefix" => "/" },
+              "target" => { "service" => "web", "port" => "http" }
+            }
+          ],
+          "tls" => {
+            "mode" => "manual",
+            "email" => "ops@example.com"
+          },
+          "redirect_http" => false
+        }
+      ),
       revision: "rel-1"
     )
     node_a, = issue_test_node!(organization: organization, name: "node-a", labels: ["web"], public_ip: "198.51.100.10")
@@ -888,6 +923,8 @@ class DeploymentsPublisherTest < ActiveSupport::TestCase
     state_a = store.desired_state_payload(bucket: organization.gcs_bucket_name, object_path: node_a.reload.desired_state_object_path)
     state_b = store.desired_state_payload(bucket: organization.gcs_bucket_name, object_path: node_b.reload.desired_state_object_path)
     assert_equal release.ingress_config.fetch("hosts"), state_a.dig("ingress", "hosts")
+    assert_equal({ "mode" => "manual", "email" => "ops@example.com" }, state_a.dig("ingress", "tls"))
+    assert_equal false, state_a.dig("ingress", "redirectHttp")
 
     assert_equal [ "node-b", "worker-a" ], state_a.fetch("nodePeers").map { |peer| peer.fetch("name") }
     node_b_peer = state_a.fetch("nodePeers").find { |peer| peer.fetch("name") == "node-b" }

--- a/control-plane/test/models/deployments_publisher_test.rb
+++ b/control-plane/test/models/deployments_publisher_test.rb
@@ -249,14 +249,14 @@ class DeploymentsPublisherTest < ActiveSupport::TestCase
             "admin" => web_service_runtime(command: ["./bin/admin"])
           },
           "ingress" => {
-            "hosts" => ["app.example.com", "admin.example.com"],
+            "hosts" => ["App.Example.com", "ADMIN.example.com"],
             "rules" => [
               {
-                "match" => { "host" => "app.example.com", "path_prefix" => "/" },
+                "match" => { "host" => "App.Example.com", "path_prefix" => "/" },
                 "target" => { "service" => "web", "port" => "http" }
               },
               {
-                "match" => { "host" => "admin.example.com", "path_prefix" => "/" },
+                "match" => { "host" => "ADMIN.example.com", "path_prefix" => "/" },
                 "target" => { "service" => "admin", "port" => "http" }
               }
             ]

--- a/control-plane/test/models/release_test.rb
+++ b/control-plane/test/models/release_test.rb
@@ -208,6 +208,26 @@ class ReleaseTest < ActiveSupport::TestCase
     assert_includes release.errors[:runtime_json], "ingress.tls.mode must be one of auto, off, or manual"
   end
 
+  test "rejects unsupported ingress service field" do
+    release = build_release(
+      runtime_json: release_runtime_json(
+        ingress: {
+          "hosts" => ["app.example.com"],
+          "service" => "web",
+          "rules" => [
+            {
+              "match" => { "host" => "app.example.com", "path_prefix" => "/" },
+              "target" => { "service" => "web", "port" => "http" }
+            }
+          ]
+        }
+      )
+    )
+
+    assert_not release.valid?
+    assert_includes release.errors[:runtime_json], "ingress.service is no longer supported"
+  end
+
   test "rejects explicit service kind fields" do
     release = build_release(
       runtime_json: release_runtime_json(

--- a/control-plane/test/models/release_test.rb
+++ b/control-plane/test/models/release_test.rb
@@ -3,34 +3,44 @@
 require "test_helper"
 
 class ReleaseTest < ActiveSupport::TestCase
-  test "requires explicit ingress service when multiple web services cannot infer a primary" do
+  test "accepts releases without ingress config" do
     release = build_release(
-      runtime_json: release_runtime_json(
-        services: {
-          "admin" => web_service_runtime,
-          "public" => web_service_runtime
-        },
-        ingress: nil
+      runtime_json: JSON.generate(
+        {
+          "services" => {
+            "admin" => web_service_runtime,
+            "public" => web_service_runtime
+          }
+        }
       )
     )
 
-    assert_not release.valid?
-    assert_includes release.errors[:runtime_json], "ingress.service is required when multiple web services are defined"
+    assert_predicate release, :valid?
+    assert_equal [], release.ingress_target_service_names
   end
 
-  test "requires explicit ingress service even when a canonical web service exists" do
+  test "uses configured ingress target services" do
     release = build_release(
       runtime_json: release_runtime_json(
         services: {
           "admin" => web_service_runtime,
           "web" => web_service_runtime
         },
-        ingress: nil
+        ingress: {
+          "hosts" => ["app.example.com"],
+          "rules" => [
+            {
+              "match" => { "host" => "app.example.com", "path_prefix" => "/" },
+              "target" => { "service" => "web", "port" => "http" }
+            }
+          ]
+        }
       )
     )
 
-    assert_not release.valid?
-    assert_includes release.errors[:runtime_json], "ingress.service is required when multiple web services are defined"
+    assert_predicate release, :valid?
+    assert_equal ["web"], release.ingress_target_service_names
+    assert_equal "web", release.ingress_service_name
   end
 
   test "release task command and args must be arrays" do
@@ -51,36 +61,40 @@ class ReleaseTest < ActiveSupport::TestCase
     assert_includes release.errors[:runtime_json], "tasks.release.args must be an array of strings"
   end
 
-  test "ingress hosts must be unique case-insensitively" do
-    release = build_release(
-      runtime_json: release_runtime_json(
-        ingress: {
-          "service" => "web",
-          "hosts" => ["App.Example.Test", "app.example.test"]
-        }
-      )
-    )
-
-    assert_not release.valid?
-    assert_includes release.errors[:runtime_json], "ingress.hosts must be unique"
-  end
-
-  test "ingress must decode to an object when present" do
+  test "accepts explicit ingress rules targeting generic services and custom ports" do
     release = build_release(
       runtime_json: JSON.generate(
         {
-          "services" => { "web" => web_service_runtime },
-          "tasks" => {},
-          "ingress" => "web"
+          "services" => {
+            "app" => {
+              "ports" => [{ "name" => "http", "port" => 3000 }],
+              "healthcheck" => { "path" => "/up", "port" => 3000 }
+            },
+            "api" => {
+              "ports" => [{ "name" => "metrics", "port" => 9090 }]
+            }
+          },
+          "ingress" => {
+            "hosts" => ["app.example.com"],
+            "rules" => [
+              {
+                "match" => { "host" => "app.example.com", "path_prefix" => "/api" },
+                "target" => { "service" => "api", "port" => "metrics" }
+              },
+              {
+                "match" => { "host" => "app.example.com", "path_prefix" => "/" },
+                "target" => { "service" => "app", "port" => "http" }
+              }
+            ]
+          }
         }
       )
     )
 
-    assert_not release.valid?
-    assert_includes release.errors[:runtime_json], "ingress must decode to an object"
+    assert_predicate release, :valid?
   end
 
-  test "blank kind does not contribute required labels and reports one kind error" do
+  test "blank kind still infers required labels from service shape" do
     release = build_release(
       runtime_json: release_runtime_json(
         services: {
@@ -89,10 +103,8 @@ class ReleaseTest < ActiveSupport::TestCase
       )
     )
 
-    assert_equal [], release.required_labels
-    assert_not release.valid?
-    kind_errors = release.errors[:runtime_json].grep(/\Aservices\.web\.kind /)
-    assert_equal [ "services.web.kind must be present" ], kind_errors
+    assert_equal ["web"], release.required_labels
+    assert_predicate release, :valid?
   end
 
   test "scheduled_services_for fails fast for stored legacy string command" do

--- a/control-plane/test/models/release_test.rb
+++ b/control-plane/test/models/release_test.rb
@@ -110,6 +110,24 @@ class ReleaseTest < ActiveSupport::TestCase
     assert_includes release.errors[:runtime_json], "ingress must be an object"
   end
 
+  test "rejects non-array ingress hosts and rules" do
+    release = build_release(
+      runtime_json: release_runtime_json(
+        ingress: {
+          "hosts" => "app.example.com",
+          "rules" => {
+            "match" => { "host" => "app.example.com", "path_prefix" => "/" },
+            "target" => { "service" => "web", "port" => "http" }
+          }
+        }
+      )
+    )
+
+    assert_not release.valid?
+    assert_includes release.errors[:runtime_json], "ingress.hosts must be an array"
+    assert_includes release.errors[:runtime_json], "ingress.rules must be an array"
+  end
+
   test "rejects invalid ingress tls and redirect settings" do
     release = build_release(
       runtime_json: release_runtime_json(

--- a/control-plane/test/models/release_test.rb
+++ b/control-plane/test/models/release_test.rb
@@ -94,6 +94,22 @@ class ReleaseTest < ActiveSupport::TestCase
     assert_predicate release, :valid?
   end
 
+  test "rejects non-object ingress payloads" do
+    release = build_release(
+      runtime_json: JSON.generate(
+        {
+          "services" => {
+            "web" => web_service_runtime
+          },
+          "ingress" => "web"
+        }
+      )
+    )
+
+    assert_not release.valid?
+    assert_includes release.errors[:runtime_json], "ingress must be an object"
+  end
+
   test "blank kind still infers required labels from service shape" do
     release = build_release(
       runtime_json: release_runtime_json(

--- a/control-plane/test/models/release_test.rb
+++ b/control-plane/test/models/release_test.rb
@@ -215,6 +215,46 @@ class ReleaseTest < ActiveSupport::TestCase
     assert_equal "services.web.kind is no longer supported", error.message
   end
 
+  test "scheduled_services_for fails fast for stored legacy ingress service" do
+    release = persisted_release(
+      runtime_json: release_runtime_json(
+        ingress: {
+          "hosts" => ["app.example.com"],
+          "service" => "web"
+        }
+      )
+    )
+
+    error = assert_raises(Release::InvalidRuntimeConfig) do
+      release.scheduled_services_for(node: build_node_for(release:))
+    end
+
+    assert_equal "ingress.service is no longer supported", error.message
+  end
+
+  test "scheduled_services_for fails fast for stored invalid ingress rules" do
+    release = persisted_release(
+      runtime_json: JSON.generate(
+        {
+          "services" => { "web" => web_service_runtime },
+          "ingress" => {
+            "hosts" => ["app.example.com"],
+            "rules" => {
+              "match" => { "host" => "app.example.com", "path_prefix" => "/" },
+              "target" => { "service" => "web", "port" => "http" }
+            }
+          }
+        }
+      )
+    )
+
+    error = assert_raises(Release::InvalidRuntimeConfig) do
+      release.scheduled_services_for(node: build_node_for(release:))
+    end
+
+    assert_equal "ingress.rules must be an array of objects", error.message
+  end
+
   test "release_task_for fails fast for stored deprecated entrypoint" do
     release = persisted_release(
       runtime_json: release_runtime_json(

--- a/control-plane/test/models/release_test.rb
+++ b/control-plane/test/models/release_test.rb
@@ -152,17 +152,17 @@ class ReleaseTest < ActiveSupport::TestCase
     assert_includes release.errors[:runtime_json], "ingress.tls.mode must be one of auto, off, or manual"
   end
 
-  test "blank kind still infers required labels from service shape" do
+  test "rejects explicit service kind fields" do
     release = build_release(
       runtime_json: release_runtime_json(
         services: {
-          "web" => web_service_runtime.merge("kind" => "")
+          "web" => web_service_runtime.merge("kind" => "web")
         }
       )
     )
 
-    assert_equal ["web"], release.required_labels
-    assert_predicate release, :valid?
+    assert_not release.valid?
+    assert_includes release.errors[:runtime_json], "services.web.kind is no longer supported"
   end
 
   test "scheduled_services_for fails fast for stored legacy string command" do
@@ -179,6 +179,22 @@ class ReleaseTest < ActiveSupport::TestCase
     end
 
     assert_equal "services.web.command must be an array of strings", error.message
+  end
+
+  test "scheduled_services_for fails fast for stored legacy service kind" do
+    release = persisted_release(
+      runtime_json: release_runtime_json(
+        services: {
+          "web" => web_service_runtime.merge("kind" => "web")
+        }
+      )
+    )
+
+    error = assert_raises(Release::InvalidRuntimeConfig) do
+      release.scheduled_services_for(node: build_node_for(release:))
+    end
+
+    assert_equal "services.web.kind is no longer supported", error.message
   end
 
   test "release_task_for fails fast for stored deprecated entrypoint" do

--- a/control-plane/test/models/release_test.rb
+++ b/control-plane/test/models/release_test.rb
@@ -128,6 +128,45 @@ class ReleaseTest < ActiveSupport::TestCase
     assert_includes release.errors[:runtime_json], "ingress.rules must be an array"
   end
 
+  test "rejects ingress hosts containing non-string entries" do
+    release = build_release(
+      runtime_json: release_runtime_json(
+        ingress: {
+          "hosts" => ["app.example.com", 123],
+          "rules" => [
+            {
+              "match" => { "host" => "app.example.com", "path_prefix" => "/" },
+              "target" => { "service" => "web", "port" => "http" }
+            }
+          ]
+        }
+      )
+    )
+
+    assert_not release.valid?
+    assert_includes release.errors[:runtime_json], "ingress.hosts must be an array of strings"
+  end
+
+  test "rejects null ingress redirect_http when explicitly present" do
+    release = build_release(
+      runtime_json: release_runtime_json(
+        ingress: {
+          "hosts" => ["app.example.com"],
+          "rules" => [
+            {
+              "match" => { "host" => "app.example.com", "path_prefix" => "/" },
+              "target" => { "service" => "web", "port" => "http" }
+            }
+          ],
+          "redirect_http" => nil
+        }
+      )
+    )
+
+    assert_not release.valid?
+    assert_includes release.errors[:runtime_json], "ingress.redirect_http must be a boolean"
+  end
+
   test "rejects invalid ingress tls and redirect settings" do
     release = build_release(
       runtime_json: release_runtime_json(
@@ -253,6 +292,29 @@ class ReleaseTest < ActiveSupport::TestCase
     end
 
     assert_equal "ingress.rules must be an array of objects", error.message
+  end
+
+  test "scheduled_services_for fails fast for stored null ingress redirect_http" do
+    release = persisted_release(
+      runtime_json: release_runtime_json(
+        ingress: {
+          "hosts" => ["app.example.com"],
+          "rules" => [
+            {
+              "match" => { "host" => "app.example.com", "path_prefix" => "/" },
+              "target" => { "service" => "web", "port" => "http" }
+            }
+          ],
+          "redirect_http" => nil
+        }
+      )
+    )
+
+    error = assert_raises(Release::InvalidRuntimeConfig) do
+      release.scheduled_services_for(node: build_node_for(release:))
+    end
+
+    assert_equal "ingress.redirect_http must be a boolean", error.message
   end
 
   test "release_task_for fails fast for stored deprecated entrypoint" do

--- a/control-plane/test/models/release_test.rb
+++ b/control-plane/test/models/release_test.rb
@@ -5,13 +5,12 @@ require "test_helper"
 class ReleaseTest < ActiveSupport::TestCase
   test "accepts releases without ingress config" do
     release = build_release(
-      runtime_json: JSON.generate(
-        {
-          "services" => {
-            "admin" => web_service_runtime,
-            "public" => web_service_runtime
-          }
-        }
+      runtime_json: release_runtime_json(
+        services: {
+          "admin" => web_service_runtime,
+          "public" => web_service_runtime
+        },
+        ingress: nil
       )
     )
 
@@ -252,69 +251,6 @@ class ReleaseTest < ActiveSupport::TestCase
     end
 
     assert_equal "services.web.kind is no longer supported", error.message
-  end
-
-  test "scheduled_services_for fails fast for stored legacy ingress service" do
-    release = persisted_release(
-      runtime_json: release_runtime_json(
-        ingress: {
-          "hosts" => ["app.example.com"],
-          "service" => "web"
-        }
-      )
-    )
-
-    error = assert_raises(Release::InvalidRuntimeConfig) do
-      release.scheduled_services_for(node: build_node_for(release:))
-    end
-
-    assert_equal "ingress.service is no longer supported", error.message
-  end
-
-  test "scheduled_services_for fails fast for stored invalid ingress rules" do
-    release = persisted_release(
-      runtime_json: JSON.generate(
-        {
-          "services" => { "web" => web_service_runtime },
-          "ingress" => {
-            "hosts" => ["app.example.com"],
-            "rules" => {
-              "match" => { "host" => "app.example.com", "path_prefix" => "/" },
-              "target" => { "service" => "web", "port" => "http" }
-            }
-          }
-        }
-      )
-    )
-
-    error = assert_raises(Release::InvalidRuntimeConfig) do
-      release.scheduled_services_for(node: build_node_for(release:))
-    end
-
-    assert_equal "ingress.rules must be an array of objects", error.message
-  end
-
-  test "scheduled_services_for fails fast for stored null ingress redirect_http" do
-    release = persisted_release(
-      runtime_json: release_runtime_json(
-        ingress: {
-          "hosts" => ["app.example.com"],
-          "rules" => [
-            {
-              "match" => { "host" => "app.example.com", "path_prefix" => "/" },
-              "target" => { "service" => "web", "port" => "http" }
-            }
-          ],
-          "redirect_http" => nil
-        }
-      )
-    )
-
-    error = assert_raises(Release::InvalidRuntimeConfig) do
-      release.scheduled_services_for(node: build_node_for(release:))
-    end
-
-    assert_equal "ingress.redirect_http must be a boolean", error.message
   end
 
   test "release_task_for fails fast for stored deprecated entrypoint" do

--- a/control-plane/test/models/release_test.rb
+++ b/control-plane/test/models/release_test.rb
@@ -110,6 +110,48 @@ class ReleaseTest < ActiveSupport::TestCase
     assert_includes release.errors[:runtime_json], "ingress must be an object"
   end
 
+  test "rejects invalid ingress tls and redirect settings" do
+    release = build_release(
+      runtime_json: release_runtime_json(
+        ingress: {
+          "hosts" => ["app.example.com"],
+          "rules" => [
+            {
+              "match" => { "host" => "app.example.com", "path_prefix" => "/" },
+              "target" => { "service" => "web", "port" => "http" }
+            }
+          ],
+          "tls" => "manual",
+          "redirect_http" => "yes"
+        }
+      )
+    )
+
+    assert_not release.valid?
+    assert_includes release.errors[:runtime_json], "ingress.tls must be an object"
+    assert_includes release.errors[:runtime_json], "ingress.redirect_http must be a boolean"
+  end
+
+  test "rejects unsupported ingress tls mode" do
+    release = build_release(
+      runtime_json: release_runtime_json(
+        ingress: {
+          "hosts" => ["app.example.com"],
+          "rules" => [
+            {
+              "match" => { "host" => "app.example.com", "path_prefix" => "/" },
+              "target" => { "service" => "web", "port" => "http" }
+            }
+          ],
+          "tls" => { "mode" => "bogus" }
+        }
+      )
+    )
+
+    assert_not release.valid?
+    assert_includes release.errors[:runtime_json], "ingress.tls.mode must be one of auto, off, or manual"
+  end
+
   test "blank kind still infers required labels from service shape" do
     release = build_release(
       runtime_json: release_runtime_json(

--- a/control-plane/test/services/cloudflare/environment_ingress_provisioner_test.rb
+++ b/control-plane/test/services/cloudflare/environment_ingress_provisioner_test.rb
@@ -255,6 +255,65 @@ module Cloudflare
       assert_equal ["app.example.test", "www.example.test"], client.configured_tunnels.first[:hostnames]
     end
 
+    test "merges bundled hostname with configured release hosts" do
+      organization = Organization.create!(name: "org-#{SecureRandom.hex(3)}")
+      ensure_test_organization_runtime!(organization)
+      project = organization.projects.create!(name: "Project A")
+      environment = project.environments.create!(
+        name: "production",
+        gcp_project_id: organization.gcp_project_id,
+        gcp_project_number: organization.gcp_project_number,
+        workload_identity_pool: organization.workload_identity_pool,
+        workload_identity_provider: organization.workload_identity_provider,
+        service_account_email: "env@#{organization.gcp_project_id}.iam.gserviceaccount.com"
+      )
+      bundle = ensure_test_environment_bundle!(environment)
+      release = project.releases.create!(
+        git_sha: "a" * 40,
+        revision: "rel-1",
+        image_repository: "shop-app",
+        image_digest: "sha256:#{"b" * 64}",
+        runtime_json: JSON.generate(
+          {
+            "services" => { "web" => web_service_runtime },
+            "tasks" => {},
+            "ingress" => {
+              "hosts" => ["app.example.test", "www.example.test"],
+              "rules" => [
+                {
+                  "match" => { "host" => "app.example.test", "path_prefix" => "/" },
+                  "target" => { "service" => "web", "port" => "http" }
+                },
+                {
+                  "match" => { "host" => "www.example.test", "path_prefix" => "/" },
+                  "target" => { "service" => "web", "port" => "http" }
+                }
+              ]
+            }
+          }
+        )
+      )
+      environment.update!(current_release: release)
+      environment.create_environment_ingress!(
+        hostname: bundle.hostname,
+        cloudflare_tunnel_id: bundle.cloudflare_tunnel_id,
+        gcp_secret_name: bundle.gcp_secret_name,
+        status: EnvironmentIngress::STATUS_READY,
+        provisioned_at: bundle.provisioned_at
+      )
+      client = FakeClient.new
+
+      ingress = EnvironmentIngressProvisioner.new(
+        environment: environment,
+        client: client,
+        secret_manager: FakeSecretManager.new,
+        release: release
+      ).call
+
+      assert_equal [bundle.hostname, "app.example.test", "www.example.test"], ingress.hosts
+      assert_equal [bundle.hostname, "app.example.test", "www.example.test"], client.configured_tunnels.first[:hostnames]
+    end
+
     test "restores tunnel routing from environment bundle data" do
       organization = Organization.create!(name: "org-#{SecureRandom.hex(3)}")
       ensure_test_organization_runtime!(organization)

--- a/control-plane/test/services/cloudflare/environment_ingress_provisioner_test.rb
+++ b/control-plane/test/services/cloudflare/environment_ingress_provisioner_test.rb
@@ -219,8 +219,17 @@ module Cloudflare
             "services" => { "web" => web_service_runtime },
             "tasks" => {},
             "ingress" => {
-              "service" => "web",
-              "hosts" => ["App.Example.Test", "WWW.Example.Test"]
+              "hosts" => ["App.Example.Test", "WWW.Example.Test"],
+              "rules" => [
+                {
+                  "match" => { "host" => "App.Example.Test", "path_prefix" => "/" },
+                  "target" => { "service" => "web", "port" => "http" }
+                },
+                {
+                  "match" => { "host" => "WWW.Example.Test", "path_prefix" => "/" },
+                  "target" => { "service" => "web", "port" => "http" }
+                }
+              ]
             }
           }
         )

--- a/control-plane/test/services/deployments/publisher_test.rb
+++ b/control-plane/test/services/deployments/publisher_test.rb
@@ -5,7 +5,7 @@ require "test_helper"
 
 module Deployments
   class PublisherTest < ActiveSupport::TestCase
-    test "ingress is not ready when bundled ingress is missing configured release hosts" do
+    test "ingress is ready for bundle-backed environments once the bundle host is ready" do
       organization = Organization.create!(name: "org-#{SecureRandom.hex(3)}")
       ensure_test_organization_runtime!(organization)
       project = organization.projects.create!(name: "Project A")
@@ -45,7 +45,7 @@ module Deployments
 
       publisher = Publisher.new(environment:, release:)
 
-      assert_not publisher.send(:ingress_ready?)
+      assert publisher.send(:ingress_ready?)
       ingress.assign_hosts!([ bundle.hostname, configured_host ])
       assert publisher.send(:ingress_ready?)
     end

--- a/control-plane/test/services/deployments/publisher_test.rb
+++ b/control-plane/test/services/deployments/publisher_test.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "securerandom"
+require "test_helper"
+
+module Deployments
+  class PublisherTest < ActiveSupport::TestCase
+    test "ingress is not ready when bundled ingress is missing configured release hosts" do
+      organization = Organization.create!(name: "org-#{SecureRandom.hex(3)}")
+      ensure_test_organization_runtime!(organization)
+      project = organization.projects.create!(name: "Project A")
+      environment = project.environments.create!(
+        name: "production",
+        gcp_project_id: organization.gcp_project_id,
+        gcp_project_number: organization.gcp_project_number,
+        workload_identity_pool: organization.workload_identity_pool,
+        workload_identity_provider: organization.workload_identity_provider,
+        service_account_email: "env@#{organization.gcp_project_id}.iam.gserviceaccount.com"
+      )
+      bundle = ensure_test_environment_bundle!(environment)
+      configured_host = "#{SecureRandom.alphanumeric(6).downcase}.devopsellence.io"
+      release = project.releases.create!(
+        git_sha: "a" * 40,
+        revision: "rel-1",
+        image_repository: "shop-app",
+        image_digest: "sha256:#{"b" * 64}",
+        runtime_json: release_runtime_json(ingress: {
+          "hosts" => [ configured_host ],
+          "rules" => [
+            {
+              "match" => { "host" => configured_host, "path_prefix" => "/" },
+              "target" => { "service" => "web", "port" => "http" }
+            }
+          ]
+        })
+      )
+      ingress = environment.create_environment_ingress!(
+        hostname: bundle.hostname,
+        cloudflare_tunnel_id: bundle.cloudflare_tunnel_id,
+        gcp_secret_name: bundle.gcp_secret_name,
+        status: EnvironmentIngress::STATUS_READY,
+        provisioned_at: bundle.provisioned_at
+      )
+      assert_equal [ bundle.hostname ], ingress.hosts
+
+      publisher = Publisher.new(environment:, release:)
+
+      assert_not publisher.send(:ingress_ready?)
+      ingress.assign_hosts!([ bundle.hostname, configured_host ])
+      assert publisher.send(:ingress_ready?)
+    end
+  end
+end

--- a/control-plane/test/services/environment_ingresses/reconciler_test.rb
+++ b/control-plane/test/services/environment_ingresses/reconciler_test.rb
@@ -57,5 +57,58 @@ module EnvironmentIngresses
 
       assert_equal [ desired_host ], ingress.reload.hosts
     end
+
+    test "keeps bundled hostname alongside configured release hosts when syncing" do
+      organization = Organization.create!(name: "org-#{SecureRandom.hex(3)}")
+      ensure_test_organization_runtime!(organization)
+      project = organization.projects.create!(name: "Project A")
+      environment = project.environments.create!(
+        name: "production",
+        gcp_project_id: organization.gcp_project_id,
+        gcp_project_number: organization.gcp_project_number,
+        workload_identity_pool: organization.workload_identity_pool,
+        workload_identity_provider: organization.workload_identity_provider,
+        service_account_email: "env@#{organization.gcp_project_id}.iam.gserviceaccount.com"
+      )
+      bundle = ensure_test_environment_bundle!(environment)
+      desired_host = "#{SecureRandom.alphanumeric(6).downcase}.devopsellence.io"
+      release = project.releases.create!(
+        git_sha: "a" * 40,
+        revision: "rel-1",
+        image_repository: "shop-app",
+        image_digest: "sha256:#{"b" * 64}",
+        runtime_json: release_runtime_json(ingress: {
+          "hosts" => [ desired_host ],
+          "rules" => [
+            {
+              "match" => { "host" => desired_host, "path_prefix" => "/" },
+              "target" => { "service" => "web", "port" => "http" }
+            }
+          ]
+        })
+      )
+      environment.update!(current_release: release)
+      ingress = environment.create_environment_ingress!(
+        hostname: bundle.hostname,
+        cloudflare_tunnel_id: bundle.cloudflare_tunnel_id,
+        gcp_secret_name: bundle.gcp_secret_name,
+        status: EnvironmentIngress::STATUS_READY,
+        provisioned_at: bundle.provisioned_at
+      )
+      client = Object.new
+      provisioner = mock("provisioner")
+
+      Cloudflare::EnvironmentIngressProvisioner.expects(:new).with(
+        environment: environment,
+        client: client,
+        release: release,
+        stale_hosts: []
+      ).returns(provisioner)
+      provisioner.expects(:call).returns(ingress)
+
+      Reconciler.new(environment: environment, client: client, release: release).call
+
+      assert_equal [ bundle.hostname, desired_host ], ingress.reload.hosts
+    end
   end
 end

--- a/control-plane/test/services/environment_ingresses/reconciler_test.rb
+++ b/control-plane/test/services/environment_ingresses/reconciler_test.rb
@@ -25,8 +25,13 @@ module EnvironmentIngresses
         image_repository: "shop-app",
         image_digest: "sha256:#{"b" * 64}",
         runtime_json: release_runtime_json(ingress: {
-          "service" => "web",
-          "hosts" => [ desired_host ]
+          "hosts" => [ desired_host ],
+          "rules" => [
+            {
+              "match" => { "host" => desired_host, "path_prefix" => "/" },
+              "target" => { "service" => "web", "port" => "http" }
+            }
+          ]
         })
       )
       environment.update!(current_release: release)

--- a/control-plane/test/services/node_desired_state/ingress_payload_test.rb
+++ b/control-plane/test/services/node_desired_state/ingress_payload_test.rb
@@ -13,5 +13,48 @@ module NodeDesiredState
 
       assert_equal "ingress.redirect_http must be a boolean", error.message
     end
+
+    test "builds routes from explicit rule targets" do
+      release = Struct.new(:ingress_config).new(
+        {
+          "rules" => [
+            {
+              "match" => { "host" => "APP.EXAMPLE.COM", "path_prefix" => "/api" },
+              "target" => { "service" => "api", "port" => "http" }
+            }
+          ]
+        }
+      )
+      environment = Struct.new(:name).new("Production")
+      ingress = Struct.new(:hostname).new("bundle.example.test")
+
+      assert_equal [
+        {
+          match: { hostname: "app.example.com", pathPrefix: "/api" },
+          target: { environment: "Production", service: "api", port: "http" }
+        }
+      ], IngressPayload.routes_for(environment:, ingress:, release:)
+    end
+
+    test "rejects malformed route targets instead of emitting invalid desired state" do
+      release = Struct.new(:ingress_config).new(
+        {
+          "rules" => [
+            {
+              "match" => { "host" => "app.example.com" },
+              "target" => { "service" => "web" }
+            }
+          ]
+        }
+      )
+      environment = Struct.new(:name).new("Production")
+      ingress = Struct.new(:hostname).new("bundle.example.test")
+
+      error = assert_raises(Release::InvalidRuntimeConfig) do
+        IngressPayload.routes_for(environment:, ingress:, release:)
+      end
+
+      assert_equal "ingress.rules[0].target.port is required", error.message
+    end
   end
 end

--- a/control-plane/test/services/node_desired_state/ingress_payload_test.rb
+++ b/control-plane/test/services/node_desired_state/ingress_payload_test.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module NodeDesiredState
+  class IngressPayloadTest < ActiveSupport::TestCase
+    test "rejects explicit null redirect_http instead of emitting null desired state" do
+      release = Struct.new(:ingress_config).new({ "redirect_http" => nil })
+
+      error = assert_raises(Release::InvalidRuntimeConfig) do
+        IngressPayload.configured_redirect_http(release)
+      end
+
+      assert_equal "ingress.redirect_http must be a boolean", error.message
+    end
+  end
+end

--- a/control-plane/test/services/node_desired_state/ingress_payload_test.rb
+++ b/control-plane/test/services/node_desired_state/ingress_payload_test.rb
@@ -36,6 +36,35 @@ module NodeDesiredState
       ], IngressPayload.routes_for(environment:, ingress:, release:)
     end
 
+    test "build includes provisioned ingress hosts alongside configured release hosts" do
+      release = Struct.new(:ingress_config).new(
+        {
+          "hosts" => [ "App.Example.com" ],
+          "rules" => [
+            {
+              "match" => { "host" => "app.example.com", "path_prefix" => "/" },
+              "target" => { "service" => "web", "port" => "http" }
+            }
+          ]
+        }
+      )
+      def release.ingress_target_service_names = [ "web" ]
+      def release.ingress_scheduled_on?(_node) = true
+
+      ingress = Struct.new(:hostname, :hosts, :status, :tunnel_token_secret_ref).new(
+        "bundle.example.test",
+        [ "bundle.example.test", "App.Example.com" ],
+        EnvironmentIngress::STATUS_READY,
+        "gsm://projects/example/secrets/tunnel-token/versions/latest"
+      )
+      environment = Struct.new(:environment_ingress, :name).new(ingress, "Production")
+      def environment.tunnel_ingress? = true
+
+      payload = IngressPayload.build(node: Object.new, environment:, release:)
+
+      assert_equal [ "bundle.example.test", "app.example.com" ], payload.fetch(:hosts)
+    end
+
     test "rejects malformed route targets instead of emitting invalid desired state" do
       release = Struct.new(:ingress_config).new(
         {

--- a/control-plane/test/services/releases/runtime_attributes_test.rb
+++ b/control-plane/test/services/releases/runtime_attributes_test.rb
@@ -403,6 +403,39 @@ module Releases
       assert_equal "ingress.rules[0].match.path_prefix must start with /", error.message
     end
 
+    test "rejects duplicate ingress rules after normalizing host and path prefix" do
+      error = assert_raises(RuntimeAttributes::InvalidPayload) do
+        RuntimeAttributes.new(
+          params: {
+            git_sha: "a" * 40,
+            image_repository: "api",
+            image_digest: "sha256:#{"b" * 64}",
+            services: {
+              web: {
+                ports: [{ name: "http", port: 3000 }],
+                healthcheck: { path: "/up", port: 3000 }
+              }
+            },
+            ingress: {
+              hosts: ["app.example.com"],
+              rules: [
+                {
+                  match: { host: "app.example.com", path_prefix: "/" },
+                  target: { service: "web", port: "http" }
+                },
+                {
+                  match: { host: "App.Example.Com", path_prefix: "/" },
+                  target: { service: "web", port: "http" }
+                }
+              ]
+            }
+          }
+        ).to_h
+      end
+
+      assert_equal "ingress.rules must be unique by host and path_prefix", error.message
+    end
+
     test "rejects ingress rules whose hosts are not declared in ingress.hosts" do
       error = assert_raises(RuntimeAttributes::InvalidPayload) do
         RuntimeAttributes.new(

--- a/control-plane/test/services/releases/runtime_attributes_test.rb
+++ b/control-plane/test/services/releases/runtime_attributes_test.rb
@@ -145,6 +145,7 @@ module Releases
               }
             },
             ingress: {
+              hosts: ["app.example.test"],
               rules: [
                 {
                   match: { host: "app.example.test", path_prefix: "/" },
@@ -174,6 +175,7 @@ module Releases
             }
             },
             ingress: {
+              hosts: ["app.example.test"],
               rules: [
                 {
                   match: { host: "app.example.test", path_prefix: "/" },
@@ -288,6 +290,57 @@ module Releases
       assert_equal "api", runtime.dig("ingress", "rules", 0, "target", "service")
       assert_equal "metrics", runtime.dig("ingress", "rules", 0, "target", "port")
       assert_equal "/", runtime.dig("ingress", "rules", 1, "match", "path_prefix")
+    end
+
+    test "rejects ingress without hosts" do
+      error = assert_raises(RuntimeAttributes::InvalidPayload) do
+        RuntimeAttributes.new(
+          params: {
+            git_sha: "a" * 40,
+            image_repository: "api",
+            image_digest: "sha256:#{"b" * 64}",
+            services: {
+              web: {
+                ports: [{ name: "http", port: 3000 }],
+                healthcheck: { path: "/up", port: 3000 }
+              }
+            },
+            ingress: {
+              rules: [
+                {
+                  match: { host: "app.example.com", path_prefix: "/" },
+                  target: { service: "web", port: "http" }
+                }
+              ]
+            }
+          }
+        ).to_h
+      end
+
+      assert_equal "ingress.hosts must include at least one host", error.message
+    end
+
+    test "rejects ingress without rules" do
+      error = assert_raises(RuntimeAttributes::InvalidPayload) do
+        RuntimeAttributes.new(
+          params: {
+            git_sha: "a" * 40,
+            image_repository: "api",
+            image_digest: "sha256:#{"b" * 64}",
+            services: {
+              web: {
+                ports: [{ name: "http", port: 3000 }],
+                healthcheck: { path: "/up", port: 3000 }
+              }
+            },
+            ingress: {
+              hosts: ["app.example.com"]
+            }
+          }
+        ).to_h
+      end
+
+      assert_equal "ingress.rules must include at least one rule", error.message
     end
   end
 end

--- a/control-plane/test/services/releases/runtime_attributes_test.rb
+++ b/control-plane/test/services/releases/runtime_attributes_test.rb
@@ -128,6 +128,36 @@ module Releases
       assert_equal "manual", runtime.dig("ingress", "tls", "mode")
     end
 
+    test "rejects legacy ingress service" do
+      error = assert_raises(RuntimeAttributes::InvalidPayload) do
+        RuntimeAttributes.new(
+          params: {
+            git_sha: "a" * 40,
+            image_repository: "api",
+            image_digest: "sha256:#{"b" * 64}",
+            services: {
+              web: {
+                ports: [{ name: "http", port: 3000 }],
+                healthcheck: { path: "/up", port: 3000 }
+              }
+            },
+            ingress: {
+              hosts: ["app.example.com"],
+              service: "web",
+              rules: [
+                {
+                  match: { host: "app.example.com", path_prefix: "/" },
+                  target: { service: "web", port: "http" }
+                }
+              ]
+            }
+          }
+        ).to_h
+      end
+
+      assert_equal "ingress.service is no longer supported", error.message
+    end
+
     test "rejects non-boolean ingress redirect_http" do
       error = assert_raises(RuntimeAttributes::InvalidPayload) do
         RuntimeAttributes.new(
@@ -150,6 +180,36 @@ module Releases
                 }
               ],
               redirect_http: "yes"
+            }
+          }
+        ).to_h
+      end
+
+      assert_equal "ingress.redirect_http must be a boolean", error.message
+    end
+
+    test "rejects null ingress redirect_http" do
+      error = assert_raises(RuntimeAttributes::InvalidPayload) do
+        RuntimeAttributes.new(
+          params: {
+            git_sha: "a" * 40,
+            image_repository: "api",
+            image_digest: "sha256:#{"b" * 64}",
+            services: {
+              web: {
+                ports: [{ name: "http", port: 3000 }],
+                healthcheck: { path: "/up", port: 3000 }
+              }
+            },
+            ingress: {
+              hosts: ["app.example.test"],
+              rules: [
+                {
+                  match: { host: "app.example.test", path_prefix: "/" },
+                  target: { service: "web", port: "http" }
+                }
+              ],
+              redirect_http: nil
             }
           }
         ).to_h

--- a/control-plane/test/services/releases/runtime_attributes_test.rb
+++ b/control-plane/test/services/releases/runtime_attributes_test.rb
@@ -19,23 +19,22 @@ module Releases
       assert_equal "services must be valid JSON", error.message
     end
 
-    test "raises invalid payload when service kind is blank" do
-      error = assert_raises(RuntimeAttributes::InvalidPayload) do
-        RuntimeAttributes.new(
-          params: {
-            git_sha: "a" * 40,
-            image_repository: "api",
-            image_digest: "sha256:#{"b" * 64}",
-            services: {
-              web: {
-                kind: "   "
-              }
+    test "allows blank service kind and preserves generic service shape" do
+      attrs = RuntimeAttributes.new(
+        params: {
+          git_sha: "a" * 40,
+          image_repository: "api",
+          image_digest: "sha256:#{"b" * 64}",
+          services: {
+            web: {
+              kind: "   "
             }
           }
-        ).to_h
-      end
+        }
+      ).to_h
 
-      assert_equal "services.web.kind must be present", error.message
+      runtime = JSON.parse(attrs.fetch(:runtime_json))
+      assert_equal({}, runtime.dig("services", "web").slice("kind"))
     end
 
     test "rejects deprecated entrypoint fields" do
@@ -216,6 +215,44 @@ module Releases
 
       runtime = JSON.parse(attrs.fetch(:runtime_json))
       assert_equal ["app.example.test", "www.example.test"], runtime.dig("ingress", "hosts")
+    end
+
+    test "preserves explicit ingress rules payload" do
+      attrs = RuntimeAttributes.new(
+        params: {
+          git_sha: "a" * 40,
+          image_repository: "api",
+          image_digest: "sha256:#{"b" * 64}",
+          services: {
+            app: {
+              ports: [{ name: "http", port: 3000 }],
+              healthcheck: { path: "/up", port: 3000 }
+            },
+            api: {
+              ports: [{ name: "metrics", port: 9090 }]
+            }
+          },
+          ingress: {
+            hosts: ["app.example.com"],
+            rules: [
+              {
+                match: { host: "app.example.com", path_prefix: "/api" },
+                target: { service: "api", port: "metrics" }
+              },
+              {
+                match: { host: "app.example.com", path_prefix: "/" },
+                target: { service: "app", port: "http" }
+              }
+            ]
+          }
+        }
+      ).to_h
+
+      runtime = JSON.parse(attrs.fetch(:runtime_json))
+      assert_equal ["app.example.com"], runtime.dig("ingress", "hosts")
+      assert_equal "api", runtime.dig("ingress", "rules", 0, "target", "service")
+      assert_equal "metrics", runtime.dig("ingress", "rules", 0, "target", "port")
+      assert_equal "/", runtime.dig("ingress", "rules", 1, "match", "path_prefix")
     end
   end
 end

--- a/control-plane/test/services/releases/runtime_attributes_test.rb
+++ b/control-plane/test/services/releases/runtime_attributes_test.rb
@@ -248,6 +248,8 @@ module Releases
 
       runtime = JSON.parse(attrs.fetch(:runtime_json))
       assert_equal ["app.example.test", "www.example.test"], runtime.dig("ingress", "hosts")
+      assert_equal "app.example.test", runtime.dig("ingress", "rules", 0, "match", "host")
+      assert_equal "www.example.test", runtime.dig("ingress", "rules", 1, "match", "host")
     end
 
     test "preserves explicit ingress rules payload" do

--- a/control-plane/test/services/releases/runtime_attributes_test.rb
+++ b/control-plane/test/services/releases/runtime_attributes_test.rb
@@ -103,8 +103,17 @@ module Releases
             }
           },
           ingress: {
-            service: "web",
             hosts: ["app.example.test", "www.example.test"],
+            rules: [
+              {
+                match: { host: "app.example.test", path_prefix: "/" },
+                target: { service: "web", port: "http" }
+              },
+              {
+                match: { host: "www.example.test", path_prefix: "/" },
+                target: { service: "web", port: "http" }
+              }
+            ],
             tls: {
               mode: "manual"
             }
@@ -117,7 +126,7 @@ module Releases
       assert_equal ["web"], runtime.dig("services", "web", "args")
       assert_equal ["release"], runtime.dig("tasks", "release", "args")
       assert_equal ["app.example.test", "www.example.test"], runtime.dig("ingress", "hosts")
-      assert_equal "web", runtime.dig("ingress", "service")
+      assert_equal "web", runtime.dig("ingress", "rules", 0, "target", "service")
       assert_equal "manual", runtime.dig("ingress", "tls", "mode")
     end
 
@@ -136,7 +145,12 @@ module Releases
               }
             },
             ingress: {
-              service: "web",
+              rules: [
+                {
+                  match: { host: "app.example.test", path_prefix: "/" },
+                  target: { service: "web", port: "http" }
+                }
+              ],
               redirect_http: "yes"
             }
           }
@@ -158,12 +172,17 @@ module Releases
               ports: [{ name: "http", port: 3000 }],
               healthcheck: { path: "/up", port: 3000 }
             }
-          },
-          ingress: {
-            service: "web",
-            redirect_http: false
+            },
+            ingress: {
+              rules: [
+                {
+                  match: { host: "app.example.test", path_prefix: "/" },
+                  target: { service: "web", port: "http" }
+                }
+              ],
+              redirect_http: false
+            }
           }
-        }
       ).to_h
 
       runtime = JSON.parse(attrs.fetch(:runtime_json))
@@ -185,8 +204,13 @@ module Releases
               }
             },
             ingress: {
-              service: "web",
-              hosts: ["App.Example.Test", "app.example.test"]
+              hosts: ["App.Example.Test", "app.example.test"],
+              rules: [
+                {
+                  match: { host: "app.example.test", path_prefix: "/" },
+                  target: { service: "web", port: "http" }
+                }
+              ]
             }
           }
         ).to_h
@@ -205,12 +229,21 @@ module Releases
               ports: [{ name: "http", port: 3000 }],
               healthcheck: { path: "/up", port: 3000 }
             }
-          },
-          ingress: {
-            service: "web",
-            hosts: ["App.Example.Test", "WWW.Example.Test"]
+            },
+            ingress: {
+              hosts: ["App.Example.Test", "WWW.Example.Test"],
+              rules: [
+                {
+                  match: { host: "App.Example.Test", path_prefix: "/" },
+                  target: { service: "web", port: "http" }
+                },
+                {
+                  match: { host: "WWW.Example.Test", path_prefix: "/" },
+                  target: { service: "web", port: "http" }
+                }
+              ]
+            }
           }
-        }
       ).to_h
 
       runtime = JSON.parse(attrs.fetch(:runtime_json))

--- a/control-plane/test/services/releases/runtime_attributes_test.rb
+++ b/control-plane/test/services/releases/runtime_attributes_test.rb
@@ -19,22 +19,23 @@ module Releases
       assert_equal "services must be valid JSON", error.message
     end
 
-    test "allows blank service kind and preserves generic service shape" do
-      attrs = RuntimeAttributes.new(
-        params: {
-          git_sha: "a" * 40,
-          image_repository: "api",
-          image_digest: "sha256:#{"b" * 64}",
-          services: {
-            web: {
-              kind: "   "
+    test "rejects explicit service kind fields" do
+      error = assert_raises(RuntimeAttributes::InvalidPayload) do
+        RuntimeAttributes.new(
+          params: {
+            git_sha: "a" * 40,
+            image_repository: "api",
+            image_digest: "sha256:#{"b" * 64}",
+            services: {
+              web: {
+                kind: "web"
+              }
             }
           }
-        }
-      ).to_h
+        ).to_h
+      end
 
-      runtime = JSON.parse(attrs.fetch(:runtime_json))
-      assert_equal({}, runtime.dig("services", "web").slice("kind"))
+      assert_equal "services.web.kind is no longer supported", error.message
     end
 
     test "rejects deprecated entrypoint fields" do
@@ -46,7 +47,6 @@ module Releases
             image_digest: "sha256:#{"b" * 64}",
             services: {
               web: {
-                kind: "web",
                 entrypoint: ["/app"],
                 ports: [{ name: "http", port: 3000 }],
                 healthcheck: { path: "/up", port: 3000 }
@@ -68,7 +68,6 @@ module Releases
             image_digest: "sha256:#{"b" * 64}",
             services: {
               web: {
-                kind: "web",
                 command: ["/app", 123],
                 ports: [{ name: "http", port: 3000 }],
                 healthcheck: { path: "/up", port: 3000 }
@@ -89,7 +88,6 @@ module Releases
           image_digest: "sha256:#{"b" * 64}",
           services: {
             web: {
-              kind: "web",
               command: ["/app"],
               args: ["web"],
               ports: [{ name: "http", port: 3000 }],
@@ -139,7 +137,6 @@ module Releases
             image_digest: "sha256:#{"b" * 64}",
             services: {
               web: {
-                kind: "web",
                 ports: [{ name: "http", port: 3000 }],
                 healthcheck: { path: "/up", port: 3000 }
               }
@@ -169,7 +166,6 @@ module Releases
           image_digest: "sha256:#{"b" * 64}",
           services: {
             web: {
-              kind: "web",
               ports: [{ name: "http", port: 3000 }],
               healthcheck: { path: "/up", port: 3000 }
             }
@@ -200,7 +196,6 @@ module Releases
             image_digest: "sha256:#{"b" * 64}",
             services: {
               web: {
-                kind: "web",
                 ports: [{ name: "http", port: 3000 }],
                 healthcheck: { path: "/up", port: 3000 }
               }
@@ -227,7 +222,6 @@ module Releases
           image_digest: "sha256:#{"b" * 64}",
           services: {
             web: {
-              kind: "web",
               ports: [{ name: "http", port: 3000 }],
               healthcheck: { path: "/up", port: 3000 }
             }

--- a/control-plane/test/services/releases/runtime_attributes_test.rb
+++ b/control-plane/test/services/releases/runtime_attributes_test.rb
@@ -314,6 +314,64 @@ module Releases
       assert_equal "ingress.hosts must include at least one host", error.message
     end
 
+    test "rejects ingress rule path prefixes without leading slash" do
+      error = assert_raises(RuntimeAttributes::InvalidPayload) do
+        RuntimeAttributes.new(
+          params: {
+            git_sha: "a" * 40,
+            image_repository: "api",
+            image_digest: "sha256:#{"b" * 64}",
+            services: {
+              web: {
+                ports: [{ name: "http", port: 3000 }],
+                healthcheck: { path: "/up", port: 3000 }
+              }
+            },
+            ingress: {
+              hosts: ["app.example.com"],
+              rules: [
+                {
+                  match: { host: "app.example.com", path_prefix: "api" },
+                  target: { service: "web", port: "http" }
+                }
+              ]
+            }
+          }
+        ).to_h
+      end
+
+      assert_equal "ingress.rules[0].match.path_prefix must start with /", error.message
+    end
+
+    test "rejects ingress rules whose hosts are not declared in ingress.hosts" do
+      error = assert_raises(RuntimeAttributes::InvalidPayload) do
+        RuntimeAttributes.new(
+          params: {
+            git_sha: "a" * 40,
+            image_repository: "api",
+            image_digest: "sha256:#{"b" * 64}",
+            services: {
+              web: {
+                ports: [{ name: "http", port: 3000 }],
+                healthcheck: { path: "/up", port: 3000 }
+              }
+            },
+            ingress: {
+              hosts: ["app.example.com"],
+              rules: [
+                {
+                  match: { host: "admin.example.com", path_prefix: "/" },
+                  target: { service: "web", port: "http" }
+                }
+              ]
+            }
+          }
+        ).to_h
+      end
+
+      assert_equal "ingress.rules[0].match.host must exist in ingress.hosts", error.message
+    end
+
     test "rejects ingress without rules" do
       error = assert_raises(RuntimeAttributes::InvalidPayload) do
         RuntimeAttributes.new(

--- a/control-plane/test/test_helper.rb
+++ b/control-plane/test/test_helper.rb
@@ -196,9 +196,11 @@ module ActiveSupport
       }.compact
     end
 
-    def release_runtime_json(services: nil, tasks: {}, ingress: nil)
+    DEFAULT_RELEASE_RUNTIME_INGRESS = Object.new.freeze
+
+    def release_runtime_json(services: nil, tasks: {}, ingress: DEFAULT_RELEASE_RUNTIME_INGRESS)
       services ||= { "web" => web_service_runtime }
-      ingress ||= {
+      ingress = {
         "hosts" => ["app.devopsellence.test"],
         "rules" => [
           {
@@ -206,7 +208,7 @@ module ActiveSupport
             "target" => { "service" => "web", "port" => "http" }
           }
         ]
-      }
+      } if ingress.equal?(DEFAULT_RELEASE_RUNTIME_INGRESS)
       ::JSON.generate(
         {
           "services" => services,

--- a/control-plane/test/test_helper.rb
+++ b/control-plane/test/test_helper.rb
@@ -198,9 +198,17 @@ module ActiveSupport
       }.compact
     end
 
-    def release_runtime_json(services: nil, tasks: {}, ingress: :__default__)
+    def release_runtime_json(services: nil, tasks: {}, ingress: nil)
       services ||= { "web" => web_service_runtime }
-      ingress = { "service" => "web" } if ingress == :__default__
+      ingress ||= {
+        "hosts" => ["app.devopsellence.test"],
+        "rules" => [
+          {
+            "match" => { "host" => "app.devopsellence.test", "path_prefix" => "/" },
+            "target" => { "service" => "web", "port" => "http" }
+          }
+        ]
+      }
       ::JSON.generate(
         {
           "services" => services,

--- a/control-plane/test/test_helper.rb
+++ b/control-plane/test/test_helper.rb
@@ -174,7 +174,6 @@ module ActiveSupport
 
     def web_service_runtime(port: 3000, healthcheck_path: "/up", healthcheck_port: nil, command: nil, args: nil, env: {}, secret_refs: [], volumes: [], image: nil)
       {
-        "kind" => "web",
         "image" => image,
         "command" => command,
         "args" => args,
@@ -188,7 +187,6 @@ module ActiveSupport
 
     def worker_service_runtime(command: nil, args: nil, env: {}, secret_refs: [], volumes: [], image: nil)
       {
-        "kind" => "worker",
         "image" => image,
         "command" => command,
         "args" => args,

--- a/docs/specs/2026-04-24-explicit-ingress-rules-and-generic-services.md
+++ b/docs/specs/2026-04-24-explicit-ingress-rules-and-generic-services.md
@@ -1,0 +1,444 @@
+# Explicit ingress rules with generic services
+
+## Summary
+
+Replace service kinds (`web`, `worker`, `accessory`) and singleton `ingress.service` routing with a simpler model:
+
+- all workloads are declared under `services`
+- service ports are explicit
+- ingress stays root-level
+- ingress uses explicit `rules[]`
+- every ingress rule explicitly targets a service and port
+- path-based and host-based fan-out are first-class
+
+This keeps `services` generic and makes exposure/routing an ingress concern instead of a service kind concern.
+
+---
+
+## Problem
+
+Today the repo config still couples routing to a special service classification:
+
+- `cli/internal/config/config.go` defines service kinds `web`, `worker`, and `accessory`
+- validation requires at least one `kind: web` service
+- `ingress` points to a single `ingress.service`
+- that target service must be `kind: web`
+
+That model is too narrow for where devopsellence is heading:
+
+1. The kinds do not carry enough distinct schema or lifecycle value to justify being first-class.
+2. Routing is artificially attached to one service instead of being an app-level concern.
+3. Path-based fan-out (`/api` -> one service, `/` -> another) does not fit naturally.
+4. The config shape is behind the desired-state model: the agent desired-state proto already has `ingress.routes[].match` and `ingress.routes[].target { environment, service, port }`.
+
+The result is a split model where repo config is more opinionated and less expressive than the runtime shape.
+
+---
+
+## Goals
+
+1. Remove the need for service kinds in repo config.
+2. Keep ingress at the root level.
+3. Make ingress routing explicit through `ingress.rules[]`.
+4. Require explicit `target.service` and `target.port` per ingress rule.
+5. Keep service ports explicit; do not rely on implicit ingress port inference.
+6. Support multiple hosts and path-based fan-out cleanly.
+7. Keep solo/shared semantics aligned by mapping the repo config directly onto the existing desired-state routing model.
+
+---
+
+## Non-goals
+
+1. Do not add higher-level roles as a replacement for kinds.
+2. Do not add implicit routing heuristics such as "the only service with an http port becomes the ingress target".
+3. Do not introduce advanced routing features yet beyond host + path prefix matching.
+4. Do not make ingress service-local.
+5. Do not preserve `kind` long-term as a semantic requirement in core behavior.
+
+---
+
+## Proposed config shape
+
+### Before
+
+```yaml
+schema_version: 5
+organization: acme
+project: demo
+default_environment: production
+
+build:
+  context: .
+  dockerfile: Dockerfile
+
+services:
+  web:
+    kind: web
+    command: ["./bin/web"]
+    ports:
+      - name: http
+        port: 3000
+    healthcheck:
+      path: /up
+      port: 3000
+
+  worker:
+    kind: worker
+    command: ["./bin/worker"]
+
+ingress:
+  service: web
+  hosts:
+    - app.example.com
+  tls:
+    mode: auto
+    email: ops@example.com
+  redirect_http: true
+```
+
+### After
+
+```yaml
+schema_version: 6
+organization: acme
+project: demo
+default_environment: production
+
+build:
+  context: .
+  dockerfile: Dockerfile
+
+services:
+  app:
+    command: ["./bin/web"]
+    ports:
+      - name: http
+        port: 3000
+    healthcheck:
+      path: /up
+      port: 3000
+
+  api:
+    command: ["./bin/api"]
+    ports:
+      - name: http
+        port: 4000
+    healthcheck:
+      path: /up
+      port: 4000
+
+  worker:
+    command: ["./bin/worker"]
+
+ingress:
+  hosts:
+    - app.example.com
+  tls:
+    mode: auto
+    email: ops@example.com
+  redirect_http: true
+  rules:
+    - match:
+        host: app.example.com
+        path_prefix: /api
+      target:
+        service: api
+        port: http
+
+    - match:
+        host: app.example.com
+        path_prefix: /
+      target:
+        service: app
+        port: http
+```
+
+### Single-service app
+
+Even the simple case stays explicit:
+
+```yaml
+services:
+  app:
+    command: ["./bin/web"]
+    ports:
+      - name: http
+        port: 3000
+
+ingress:
+  hosts:
+    - app.example.com
+  rules:
+    - match:
+        host: app.example.com
+        path_prefix: /
+      target:
+        service: app
+        port: http
+```
+
+---
+
+## Schema changes
+
+### `ServiceConfig`
+
+Remove:
+
+- `kind`
+
+Keep services as generic workload definitions with fields like:
+
+- `image`
+- `command`
+- `args`
+- `env`
+- `secret_refs`
+- `ports`
+- `healthcheck`
+- `volumes`
+
+### `IngressConfig`
+
+Replace:
+
+```yaml
+ingress:
+  service: web
+  hosts: [...]
+```
+
+with:
+
+```yaml
+ingress:
+  hosts: [...]
+  rules:
+    - match:
+        host: app.example.com
+        path_prefix: /
+      target:
+        service: app
+        port: http
+```
+
+Suggested config structs:
+
+```go
+type IngressConfig struct {
+    Hosts        []string            `yaml:"hosts,omitempty" json:"hosts,omitempty"`
+    Rules        []IngressRuleConfig `yaml:"rules,omitempty" json:"rules,omitempty"`
+    TLS          IngressTLSConfig    `yaml:"tls,omitempty" json:"tls,omitempty"`
+    RedirectHTTP bool                `yaml:"redirect_http,omitempty" json:"redirect_http,omitempty"`
+}
+
+type IngressRuleConfig struct {
+    Match  IngressMatchConfig  `yaml:"match" json:"match"`
+    Target IngressTargetConfig `yaml:"target" json:"target"`
+}
+
+type IngressMatchConfig struct {
+    Host       string `yaml:"host" json:"host"`
+    PathPrefix string `yaml:"path_prefix,omitempty" json:"path_prefix,omitempty"`
+}
+
+type IngressTargetConfig struct {
+    Service string `yaml:"service" json:"service"`
+    Port    string `yaml:"port" json:"port"`
+}
+```
+
+Notes:
+
+- Use `host` in repo config for the rule match to keep the field singular at rule level.
+- The desired-state protobuf currently uses `hostname`; config translation can map `host -> hostname`.
+- `target.environment` is not needed in repo config because the config is resolved for one target environment before desired-state generation.
+
+---
+
+## Validation rules
+
+### Services
+
+1. `services` must be non-empty.
+2. Service names must remain unique.
+3. If a service declares `ports`, port names must be unique within that service.
+4. No service kind validation exists.
+5. Do not require at least one `web` service.
+
+### Ingress
+
+1. `ingress.hosts` must be non-empty when `ingress` is present.
+2. `ingress.rules` must be non-empty when `ingress` is present.
+3. Every `rule.match.host` is required.
+4. Every `rule.match.host` must exist in `ingress.hosts`.
+5. Every `rule.match.path_prefix` must start with `/`; if omitted, normalize to `/`.
+6. Every `rule.target.service` is required and must reference an existing service.
+7. Every `rule.target.port` is required and must reference an existing named port on the target service.
+8. Reject duplicate routes for the same `(host, path_prefix)`.
+9. Do not require the target service to be a special kind.
+10. Do not require the target port to be named `http`; explicit named ports should be routable as long as Envoy/runtime handling supports them.
+
+### Healthchecks
+
+Do not keep `healthcheck` coupled to a removed `web` kind. A service with an HTTP healthcheck should be valid regardless of whether it has ingress.
+
+---
+
+## Desired-state mapping
+
+This change should move the repo config closer to the existing desired-state model rather than inventing a second routing abstraction.
+
+Current desired-state already supports:
+
+- `ingress.hosts`
+- `ingress.routes[]`
+- `ingress.routes[].match.hostname`
+- `ingress.routes[].match.path_prefix`
+- `ingress.routes[].target.environment`
+- `ingress.routes[].target.service`
+- `ingress.routes[].target.port`
+
+Config translation should therefore be straightforward:
+
+- copy `ingress.hosts`
+- map each config rule to a desired-state route
+- set `target.environment` from the selected deployment environment
+- copy explicit `target.service` and `target.port`
+
+### Node placement constraint
+
+When ingress rules target multiple services, the published ingress desired state must only be attached to nodes that host every targeted service for that environment. Do not advertise or provision public ingress on nodes that host only a subset of the routed services.
+
+---
+
+## Required implementation changes
+
+### CLI config model and validation
+
+Update `cli/internal/config/config.go` to:
+
+- remove `ServiceConfig.Kind`
+- remove `ServiceKindWeb`, `ServiceKindWorker`, `ServiceKindAccessory`
+- remove validation that requires a web service
+- replace `IngressConfig.Service` with `IngressConfig.Rules`
+- validate explicit rule targets and explicit target ports
+- stop defaulting service behavior based on kind
+
+### Solo desired-state generation
+
+Update `cli/internal/solo/desiredstate.go` to:
+
+- stop generating one route per host from `ingress.service`
+- serialize the configured `ingress.rules[]` directly
+- populate desired-state target environment from the selected environment
+- keep target ports explicit instead of forcing `http`
+
+### Agent desired-state validation
+
+Update `agent/internal/desiredstate/validate.go` to:
+
+- stop requiring ingress targets to be kind `web`
+- stop requiring target port to be `http`
+- validate only that the referenced target service and port exist
+
+### Runtime / routing assumptions
+
+Audit code paths that still assume:
+
+- ingress implies `kind web`
+- the routed port must be named `http`
+- there is a single ingress service
+
+The desired-state proto and merge logic already model per-route service+port targeting, so the remaining cleanup should mostly be validation and config translation.
+
+---
+
+## Migration
+
+This is a schema change and should be a clean break under `schema_version: 6`.
+
+### Automatic mapping from v5 to v6
+
+A straightforward migration exists for current configs:
+
+```yaml
+ingress:
+  service: web
+  hosts:
+    - app.example.com
+```
+
+becomes:
+
+```yaml
+ingress:
+  hosts:
+    - app.example.com
+  rules:
+    - match:
+        host: app.example.com
+        path_prefix: /
+      target:
+        service: web
+        port: http
+```
+
+For services:
+
+- drop `kind: web`
+- drop `kind: worker`
+- drop `kind: accessory`
+- preserve the rest unchanged
+
+### Compatibility stance
+
+Prefer a clean schema-versioned break over compatibility shims that keep the old taxonomy alive in the core model.
+
+---
+
+## Open questions
+
+1. Should `ingress.rules[].match.path_prefix` default to `/` when omitted, or should it be required for maximum explicitness?
+   - Recommendation: allow omission and normalize to `/`.
+
+2. Should `ingress.hosts` remain required if every rule already has a host?
+   - Recommendation: yes. It keeps TLS/certificate scope and route coverage obvious, and it matches current desired-state validation.
+
+3. Should `ports` be required on every ingress-targetable service?
+   - Recommendation: yes indirectly, because rule validation requires the target port to exist.
+
+---
+
+## Acceptance criteria
+
+1. Repo config no longer supports or requires service kinds.
+2. Repo config ingress uses explicit `rules[]` with `target.service` and `target.port`.
+3. Path-based routing to different services is supported in config and desired state.
+4. Ingress target validation no longer depends on `kind: web`.
+5. Ingress target validation no longer hardcodes `port: http`.
+6. README examples and setup output reflect the new schema.
+7. Solo and shared flows continue to produce the same desired-state ingress model.
+
+---
+
+## Suggested rollout
+
+1. Land schema and validation changes behind schema version 6.
+2. Update desired-state generation and agent validation.
+3. Update setup/init templates and README examples.
+4. Add migration/docs notes for old `ingress.service` + `kind` configs.
+
+---
+
+## Why this matches devopsellence direction
+
+This keeps the product centered on explicit runtime intent instead of category labels:
+
+- generic services
+- explicit ports
+- explicit routing
+- one ingress model
+- fewer magic distinctions between "web" and everything else
+
+That is more composable, easier to reason about, and better aligned with the existing desired-state routing shape.

--- a/test/e2e/e2e.rb
+++ b/test/e2e/e2e.rb
@@ -790,8 +790,7 @@ class E2E
       config.delete("release")
       config.delete("release_command")
       config["services"] ||= {}
-      config["services"]["web"] ||= { "kind" => "web" }
-      config["services"]["web"]["kind"] = "web"
+      config["services"]["web"] ||= {}
       config["services"]["web"]["ports"] = [ { "name" => "http", "port" => APP_PORT } ]
       config["services"]["web"]["healthcheck"] = { "path" => APP_HEALTH_PATH, "port" => APP_PORT }
       config["services"]["web"]["env"] ||= {}

--- a/test/e2e/solo_e2e.rb
+++ b/test/e2e/solo_e2e.rb
@@ -548,7 +548,6 @@ PY
       },
       "services" => {
         "web" => {
-          "kind" => "web",
           "ports" => [
             { "name" => "http", "port" => APP_PORT }
           ],


### PR DESCRIPTION
## Summary
- replace repo-config service kinds and singleton `ingress.service` with explicit `ingress.rules[]`
- carry structured ingress end to end through solo config, shared CLI payloads, control-plane runtime parsing, desired state emission, and agent validation
- allow ingress to target generic services and explicit named ports instead of requiring `kind: web` / `port: http`
- remove synthetic service-kind state and payload support from both CLI and control-plane inputs; service classification is now inferred only where runtime scheduling/desired state still needs it
- align ingress placement so a node only advertises/run ingress when it hosts every targeted service
- update README and add a spec doc for the schema/behavior change

## Notes
- solo desired state now preserves configured ingress hosts and explicit per-rule host/path/service/port routing
- shared/control-plane paths now store and validate the structured ingress config end to end
- incoming release payloads now reject `services.*.kind`; the control plane infers web/worker behavior from service shape instead of accepting explicit kind input
- bundle-backed shared ingress provisioning still treats the environment-owned ingress as canonical for provisioning readiness, while release routing now carries explicit rules and targets

## Testing
- `cd cli && mise x go@1.25.8 -- go test ./...`
- `cd agent && mise x go@1.25.8 -- go test ./...`
- `cd control-plane && mise x ruby@4.0.0 -- bundle install`
- `cd control-plane && DATABASE_URL=postgres://postgres:***@127.0.0.1/devopsellence_test RAILS_ENV=test mise x ruby@4.0.0 -- bundle exec rails test`

Closes #51