### PR TITLE
[codex] Require explicit secret refs

### DIFF
--- a/cli/internal/agentsmd/agentsmd.go
+++ b/cli/internal/agentsmd/agentsmd.go
@@ -75,6 +75,7 @@ Common commands:
 Secrets:
 - `+"`devopsellence secret list`"+`
 - `+"`printf '%%s' \"$VALUE\" | devopsellence secret set NAME --service web --stdin`"+`
+- `+"`devopsellence secret set NAME --service web --store 1password --op-ref op://vault/item/field`"+`
 - `+"`devopsellence secret delete NAME --service web`"+`
 
 Solo mode:

--- a/cli/internal/agentsmd/agentsmd.go
+++ b/cli/internal/agentsmd/agentsmd.go
@@ -72,19 +72,19 @@ Common commands:
 - `+"`devopsellence deploy`"+`
 - `+"`devopsellence status`"+`
 
-Shared mode secrets:
+Secrets:
 - `+"`devopsellence secret list`"+`
 - `+"`printf '%%s' \"$VALUE\" | devopsellence secret set NAME --service web --stdin`"+`
 - `+"`devopsellence secret delete NAME --service web`"+`
 
-	Solo mode:
-	- `+"`devopsellence mode use solo`"+`
-	- `+"`devopsellence provider login hetzner`"+`
-	- `+"`devopsellence secret set NAME --value ...`"+`
-	- `+"`devopsellence node list`"+`
-	- `+"`devopsellence node logs NODE --follow`"+`
-	- `+"`devopsellence node create prod-1`"+`
-	- `+"`devopsellence node attach prod-1`"+`
+Solo mode:
+- `+"`devopsellence mode use solo`"+`
+- `+"`devopsellence provider login hetzner`"+`
+- `+"`devopsellence secret set NAME --service web --value ...`"+`
+- `+"`devopsellence node list`"+`
+- `+"`devopsellence node logs NODE --follow`"+`
+- `+"`devopsellence node create prod-1`"+`
+- `+"`devopsellence node attach prod-1`"+`
 
 Shared mode:
 - `+"`devopsellence mode use shared`"+`

--- a/cli/internal/solo/desiredstate.go
+++ b/cli/internal/solo/desiredstate.go
@@ -115,19 +115,31 @@ type nodePeerJSON struct {
 // git revision, and pre-resolved secrets. Secrets are merged into env vars;
 // no secret_refs appear in the output.
 func BuildDesiredState(cfg *config.ProjectConfig, imageTag, revision string, secrets map[string]string) ([]byte, error) {
-	return BuildDesiredStateForLabels(cfg, imageTag, revision, secrets, nil, cfg.ReleaseTask() != nil)
+	return buildDesiredStateForNode(cfg, imageTag, revision, func(string) map[string]string { return secrets }, nil, false, cfg.ReleaseTask() != nil)
+}
+
+func BuildDesiredStateWithScopedSecrets(cfg *config.ProjectConfig, imageTag, revision string, secrets ScopedSecrets) ([]byte, error) {
+	return BuildDesiredStateForNodeWithScopedSecrets(cfg, imageTag, revision, secrets, nil, false, cfg.ReleaseTask() != nil)
 }
 
 // BuildDesiredStateForLabels produces desired-state JSON for one solo node.
 // A nil labels slice runs all configured services. A non-nil labels slice
 // schedules only matching services.
 func BuildDesiredStateForLabels(cfg *config.ProjectConfig, imageTag, revision string, secrets map[string]string, labels []string, includeReleaseTask bool) ([]byte, error) {
-	return BuildDesiredStateForNode(cfg, imageTag, revision, secrets, labels, false, includeReleaseTask)
+	return buildDesiredStateForNode(cfg, imageTag, revision, func(string) map[string]string { return secrets }, labels, false, includeReleaseTask)
 }
 
 // BuildDesiredStateForNode produces desired-state JSON for one node, including
 // public ingress only when the node has the web label.
 func BuildDesiredStateForNode(cfg *config.ProjectConfig, imageTag, revision string, secrets map[string]string, labels []string, ingressNode bool, includeReleaseTask bool, nodePeers ...[]NodePeer) ([]byte, error) {
+	return buildDesiredStateForNode(cfg, imageTag, revision, func(string) map[string]string { return secrets }, labels, ingressNode, includeReleaseTask, nodePeers...)
+}
+
+func BuildDesiredStateForNodeWithScopedSecrets(cfg *config.ProjectConfig, imageTag, revision string, secrets ScopedSecrets, labels []string, ingressNode bool, includeReleaseTask bool, nodePeers ...[]NodePeer) ([]byte, error) {
+	return buildDesiredStateForNode(cfg, imageTag, revision, secrets.ValuesForService, labels, ingressNode, includeReleaseTask, nodePeers...)
+}
+
+func buildDesiredStateForNode(cfg *config.ProjectConfig, imageTag, revision string, secretsForService func(string) map[string]string, labels []string, ingressNode bool, includeReleaseTask bool, nodePeers ...[]NodePeer) ([]byte, error) {
 	ds := desiredStateJSON{
 		SchemaVersion: 2,
 		Revision:      revision,
@@ -150,7 +162,7 @@ func BuildDesiredStateForNode(cfg *config.ProjectConfig, imageTag, revision stri
 		if !shouldScheduleService(labels, serviceKind) {
 			continue
 		}
-		rendered, err := buildService(serviceName, service, imageTag, secrets)
+		rendered, err := buildService(serviceName, service, imageTag, secretsForService(serviceName))
 		if err != nil {
 			return nil, fmt.Errorf("build service %s: %w", serviceName, err)
 		}
@@ -162,7 +174,7 @@ func BuildDesiredStateForNode(cfg *config.ProjectConfig, imageTag, revision stri
 	}
 
 	if includeReleaseTask && cfg.ReleaseTask() != nil && shouldScheduleReleaseTask(labels, cfg) {
-		releaseTask, err := buildReleaseTask(cfg, imageTag, secrets)
+		releaseTask, err := buildReleaseTask(cfg, imageTag, secretsForService(cfg.ReleaseTask().Service))
 		if err != nil {
 			return nil, fmt.Errorf("build release task: %w", err)
 		}

--- a/cli/internal/solo/desiredstate_test.go
+++ b/cli/internal/solo/desiredstate_test.go
@@ -71,6 +71,38 @@ func TestBuildDesiredState_WebOnly(t *testing.T) {
 	}
 }
 
+func TestBuildDesiredStateWithScopedSecretsUsesServiceScope(t *testing.T) {
+	cfg := baseProject()
+	cfg.Services["worker"] = config.Service{
+		Command:    []string{"bundle", "exec", "sidekiq"},
+		SecretRefs: []config.SecretRef{{Name: "DATABASE_URL", Secret: "local"}},
+	}
+	secrets := ScopedSecrets{
+		"web":    {"DATABASE_URL": "postgres://web"},
+		"worker": {"DATABASE_URL": "postgres://worker"},
+	}
+
+	data, err := BuildDesiredStateWithScopedSecrets(cfg, "myapp:abc1234", "abc1234", secrets)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var ds desiredStateJSON
+	if err := json.Unmarshal(data, &ds); err != nil {
+		t.Fatal(err)
+	}
+	envByService := map[string]map[string]string{}
+	for _, service := range ds.Environments[0].Services {
+		envByService[service.Name] = service.Env
+	}
+	if got := envByService["web"]["DATABASE_URL"]; got != "postgres://web" {
+		t.Fatalf("web DATABASE_URL = %q", got)
+	}
+	if got := envByService["worker"]["DATABASE_URL"]; got != "postgres://worker" {
+		t.Fatalf("worker DATABASE_URL = %q", got)
+	}
+}
+
 func TestBuildDesiredState_WithNamedWorkerAndReleaseTask(t *testing.T) {
 	cfg := baseProject()
 	cfg.Services["jobs"] = config.Service{
@@ -395,8 +427,8 @@ func TestMergeIngressForNodeSortsRoutesByPortWhenMatchFieldsTie(t *testing.T) {
 		{
 			Services: []serviceJSON{{Name: "web", Kind: config.ServiceKindWeb}},
 			Ingress: &ingressJSON{
-				Mode: "public",
-				TLS:  ingressTLSJSON{Mode: "auto"},
+				Mode:  "public",
+				TLS:   ingressTLSJSON{Mode: "auto"},
 				Hosts: []string{"app.example.com"},
 				Routes: []ingressRouteJSON{{
 					Match:  ingressMatchJSON{Hostname: "app.example.com"},
@@ -409,8 +441,8 @@ func TestMergeIngressForNodeSortsRoutesByPortWhenMatchFieldsTie(t *testing.T) {
 		{
 			Services: []serviceJSON{{Name: "web", Kind: config.ServiceKindWeb}},
 			Ingress: &ingressJSON{
-				Mode: "public",
-				TLS:  ingressTLSJSON{Mode: "auto"},
+				Mode:  "public",
+				TLS:   ingressTLSJSON{Mode: "auto"},
 				Hosts: []string{"app.example.com"},
 				Routes: []ingressRouteJSON{{
 					Match:  ingressMatchJSON{Hostname: "app.example.com"},

--- a/cli/internal/solo/secrets.go
+++ b/cli/internal/solo/secrets.go
@@ -1,182 +1,149 @@
 package solo
 
 import (
-	"bufio"
 	"fmt"
-	"os"
-	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 )
 
-const envFile = ".env"
+type ScopedSecrets map[string]map[string]string
 
-func envPath(workspaceRoot string) string {
-	return filepath.Join(workspaceRoot, envFile)
+func (s ScopedSecrets) ValuesForService(serviceName string) map[string]string {
+	values := s[strings.TrimSpace(serviceName)]
+	if values == nil {
+		return map[string]string{}
+	}
+	out := make(map[string]string, len(values))
+	for name, value := range values {
+		out[name] = value
+	}
+	return out
 }
 
-// LoadSecrets reads KEY=VALUE pairs from .env in the workspace root.
-// Returns an empty map if the file does not exist.
-// Supports blank lines, # comments, optional quoting, and export prefix.
-func LoadSecrets(workspaceRoot string) (map[string]string, error) {
-	path := envPath(workspaceRoot)
-	f, err := os.Open(path)
+func (s ScopedSecrets) Value(serviceName, name string) string {
+	values := s[strings.TrimSpace(serviceName)]
+	if values == nil {
+		return ""
+	}
+	return values[strings.TrimSpace(name)]
+}
+
+func (s ScopedSecrets) Set(serviceName, name, value string) {
+	serviceName = strings.TrimSpace(serviceName)
+	name = strings.TrimSpace(name)
+	if serviceName == "" || name == "" {
+		return
+	}
+	if s[serviceName] == nil {
+		s[serviceName] = map[string]string{}
+	}
+	s[serviceName][name] = value
+}
+
+func (s *State) SetSecret(workspaceRoot, environment, serviceName, name, value string) (SecretRecord, error) {
+	s.ensureDefaults()
+	key, record, err := buildSecretRecord(workspaceRoot, environment, serviceName, name, value)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return map[string]string{}, nil
-		}
-		return nil, fmt.Errorf("read %s: %w", envFile, err)
+		return SecretRecord{}, err
 	}
-	defer f.Close()
-
-	secrets := map[string]string{}
-	scanner := bufio.NewScanner(f)
-	lineNum := 0
-	for scanner.Scan() {
-		lineNum++
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
-		}
-		// Strip optional "export " prefix.
-		line = strings.TrimPrefix(line, "export ")
-
-		key, value, ok := strings.Cut(line, "=")
-		if !ok {
-			return nil, fmt.Errorf("%s:%d: expected KEY=VALUE", envFile, lineNum)
-		}
-		key = strings.TrimSpace(key)
-		value = strings.TrimSpace(value)
-		value = unquote(value)
-		secrets[key] = value
-	}
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("read %s: %w", envFile, err)
-	}
-	return secrets, nil
+	record.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+	s.Secrets[key] = record
+	return record, nil
 }
 
-// SaveSecret sets a key in .env, preserving comments and ordering.
-// Creates the file if it doesn't exist.
-func SaveSecret(workspaceRoot, key, value string) error {
-	path := envPath(workspaceRoot)
-	lines, err := readLines(path)
-	if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("read %s: %w", envFile, err)
-	}
-
-	found := false
-	for i, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
-			continue
-		}
-		lineKey, _, ok := strings.Cut(strings.TrimPrefix(trimmed, "export "), "=")
-		if ok && strings.TrimSpace(lineKey) == key {
-			lines[i] = key + "=" + quoteIfNeeded(value)
-			found = true
-			break
-		}
-	}
-	if !found {
-		lines = append(lines, key+"="+quoteIfNeeded(value))
-	}
-
-	return writeLines(path, lines)
-}
-
-// DeleteSecret removes a key from .env.
-func DeleteSecret(workspaceRoot, key string) error {
-	path := envPath(workspaceRoot)
-	lines, err := readLines(path)
+func (s *State) DeleteSecret(workspaceRoot, environment, serviceName, name string) (SecretRecord, error) {
+	s.ensureDefaults()
+	key, record, err := buildSecretRecord(workspaceRoot, environment, serviceName, name, "")
 	if err != nil {
-		if os.IsNotExist(err) {
-			return fmt.Errorf("secret %q not found", key)
-		}
-		return fmt.Errorf("read %s: %w", envFile, err)
+		return SecretRecord{}, err
 	}
-
-	found := false
-	out := lines[:0]
-	for _, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		if trimmed != "" && !strings.HasPrefix(trimmed, "#") {
-			lineKey, _, ok := strings.Cut(strings.TrimPrefix(trimmed, "export "), "=")
-			if ok && strings.TrimSpace(lineKey) == key {
-				found = true
-				continue
-			}
-		}
-		out = append(out, line)
+	existing, ok := s.Secrets[key]
+	if !ok {
+		return SecretRecord{}, fmt.Errorf("secret %q for service %q in %s not found", record.Name, record.ServiceName, record.Environment)
 	}
-	if !found {
-		return fmt.Errorf("secret %q not found", key)
-	}
-
-	return writeLines(path, out)
+	delete(s.Secrets, key)
+	return existing, nil
 }
 
-// ListSecrets returns sorted key names from .env.
-func ListSecrets(workspaceRoot string) ([]string, error) {
-	secrets, err := LoadSecrets(workspaceRoot)
+func (s *State) ListSecrets(workspaceRoot, environment, serviceName string) ([]SecretRecord, error) {
+	s.ensureDefaults()
+	workspaceKey, err := CanonicalWorkspaceKey(workspaceRoot)
 	if err != nil {
 		return nil, err
 	}
-	keys := make([]string, 0, len(secrets))
-	for k := range secrets {
-		keys = append(keys, k)
+	environment = defaultEnvironmentName(environment)
+	serviceName = strings.TrimSpace(serviceName)
+	records := []SecretRecord{}
+	for _, record := range s.Secrets {
+		if record.WorkspaceKey != workspaceKey || record.Environment != environment {
+			continue
+		}
+		if serviceName != "" && record.ServiceName != serviceName {
+			continue
+		}
+		record.Value = ""
+		records = append(records, record)
 	}
-	sort.Strings(keys)
-	return keys, nil
+	sort.Slice(records, func(i, j int) bool {
+		if records[i].ServiceName != records[j].ServiceName {
+			return records[i].ServiceName < records[j].ServiceName
+		}
+		return records[i].Name < records[j].Name
+	})
+	return records, nil
 }
 
-func readLines(path string) ([]string, error) {
-	data, err := os.ReadFile(path)
+func (s *State) ScopedSecretValues(workspaceRoot, environment string) (ScopedSecrets, error) {
+	s.ensureDefaults()
+	workspaceKey, err := CanonicalWorkspaceKey(workspaceRoot)
 	if err != nil {
 		return nil, err
 	}
-	s := string(data)
-	if s == "" {
-		return nil, nil
-	}
-	// Preserve original line endings; split without stripping trailing newline.
-	lines := strings.Split(s, "\n")
-	// Remove trailing empty element from final newline.
-	if len(lines) > 0 && lines[len(lines)-1] == "" {
-		lines = lines[:len(lines)-1]
-	}
-	return lines, nil
-}
-
-func writeLines(path string, lines []string) error {
-	content := strings.Join(lines, "\n") + "\n"
-	return os.WriteFile(path, []byte(content), 0o600)
-}
-
-// unquote strips matching single or double quotes from a value and
-// unescapes backslash sequences inside double-quoted strings.
-func unquote(s string) string {
-	if len(s) >= 2 {
-		if s[0] == '\'' && s[len(s)-1] == '\'' {
-			return s[1 : len(s)-1]
+	environment = defaultEnvironmentName(environment)
+	values := ScopedSecrets{}
+	for _, record := range s.Secrets {
+		if record.WorkspaceKey != workspaceKey || record.Environment != environment {
+			continue
 		}
-		if s[0] == '"' && s[len(s)-1] == '"' {
-			inner := s[1 : len(s)-1]
-			inner = strings.ReplaceAll(inner, `\"`, `"`)
-			inner = strings.ReplaceAll(inner, `\\`, `\`)
-			return inner
-		}
+		values.Set(record.ServiceName, record.Name, record.Value)
 	}
-	return s
+	return values, nil
 }
 
-// quoteIfNeeded wraps the value in double quotes if it contains spaces,
-// #, quotes, or backslashes.
-func quoteIfNeeded(s string) string {
-	if strings.ContainsAny(s, " \t#\"'\\") {
-		s = strings.ReplaceAll(s, `\`, `\\`)
-		s = strings.ReplaceAll(s, `"`, `\"`)
-		return `"` + s + `"`
+func buildSecretRecord(workspaceRoot, environment, serviceName, name, value string) (string, SecretRecord, error) {
+	workspaceKey, err := CanonicalWorkspaceKey(workspaceRoot)
+	if err != nil {
+		return "", SecretRecord{}, err
 	}
-	return s
+	environment = defaultEnvironmentName(environment)
+	serviceName = strings.TrimSpace(serviceName)
+	name = strings.TrimSpace(name)
+	if serviceName == "" {
+		return "", SecretRecord{}, fmt.Errorf("service name is required")
+	}
+	if name == "" {
+		return "", SecretRecord{}, fmt.Errorf("secret name is required")
+	}
+	record := SecretRecord{
+		WorkspaceRoot: strings.TrimSpace(workspaceRoot),
+		WorkspaceKey:  workspaceKey,
+		Environment:   environment,
+		ServiceName:   serviceName,
+		Name:          name,
+		Value:         value,
+	}
+	if record.WorkspaceRoot == "" {
+		record.WorkspaceRoot = workspaceKey
+	}
+	return secretKey(workspaceKey, environment, serviceName, name), record, nil
+}
+
+func secretKey(workspaceKey, environment, serviceName, name string) string {
+	return strings.Join([]string{
+		strings.TrimSpace(workspaceKey),
+		defaultEnvironmentName(environment),
+		strings.TrimSpace(serviceName),
+		strings.TrimSpace(name),
+	}, "\n")
 }

--- a/cli/internal/solo/secrets.go
+++ b/cli/internal/solo/secrets.go
@@ -165,32 +165,41 @@ func buildSecretRecord(workspaceRoot, environment, serviceName, name string, mat
 	if err != nil {
 		return "", SecretRecord{}, err
 	}
-	trimmedValue := strings.TrimSpace(material.Value)
-	material.Reference = strings.TrimSpace(material.Reference)
-	switch store {
-	case SecretStorePlaintext:
-		if trimmedValue == "" {
-			return "", SecretRecord{}, errors.New("secret value is required")
-		}
-	case SecretStoreOnePassword:
-		if trimmedValue != "" {
-			return "", SecretRecord{}, errors.New("1Password secret value must not be stored locally")
-		}
-		if material.Reference == "" {
-			return "", SecretRecord{}, errors.New("1Password secret reference is required")
-		}
-		if !strings.HasPrefix(strings.ToLower(material.Reference), "op://") {
-			return "", SecretRecord{}, errors.New("1Password secret reference must start with op://")
-		}
-	default:
-		return "", SecretRecord{}, fmt.Errorf("unsupported secret store %q", store)
+	reference, err := validateSecretMaterial(store, material.Value, material.Reference)
+	if err != nil {
+		return "", SecretRecord{}, err
 	}
+	material.Reference = reference
 	record.Store = store
 	record.Reference = material.Reference
 	if store == SecretStorePlaintext {
 		record.Value = material.Value
 	}
 	return key, record, nil
+}
+
+func validateSecretMaterial(store, value, reference string) (string, error) {
+	trimmedValue := strings.TrimSpace(value)
+	reference = strings.TrimSpace(reference)
+	switch store {
+	case SecretStorePlaintext:
+		if trimmedValue == "" {
+			return "", errors.New("secret value is required")
+		}
+	case SecretStoreOnePassword:
+		if trimmedValue != "" {
+			return "", errors.New("1Password secret value must not be stored locally")
+		}
+		if reference == "" {
+			return "", errors.New("1Password secret reference is required")
+		}
+		if !strings.HasPrefix(strings.ToLower(reference), "op://") {
+			return "", errors.New("1Password secret reference must start with op://")
+		}
+	default:
+		return "", fmt.Errorf("unsupported secret store %q", store)
+	}
+	return reference, nil
 }
 
 func buildSecretRecordScope(workspaceRoot, environment, serviceName, name string) (string, SecretRecord, error) {

--- a/cli/internal/solo/secrets.go
+++ b/cli/internal/solo/secrets.go
@@ -165,14 +165,17 @@ func buildSecretRecord(workspaceRoot, environment, serviceName, name string, mat
 	if err != nil {
 		return "", SecretRecord{}, err
 	}
-	material.Value = strings.TrimSpace(material.Value)
+	trimmedValue := strings.TrimSpace(material.Value)
 	material.Reference = strings.TrimSpace(material.Reference)
 	switch store {
 	case SecretStorePlaintext:
-		if material.Value == "" {
+		if trimmedValue == "" {
 			return "", SecretRecord{}, errors.New("secret value is required")
 		}
 	case SecretStoreOnePassword:
+		if trimmedValue != "" {
+			return "", SecretRecord{}, errors.New("1Password secret value must not be stored locally")
+		}
 		if material.Reference == "" {
 			return "", SecretRecord{}, errors.New("1Password secret reference is required")
 		}
@@ -183,8 +186,10 @@ func buildSecretRecord(workspaceRoot, environment, serviceName, name string, mat
 		return "", SecretRecord{}, fmt.Errorf("unsupported secret store %q", store)
 	}
 	record.Store = store
-	record.Value = material.Value
 	record.Reference = material.Reference
+	if store == SecretStorePlaintext {
+		record.Value = material.Value
+	}
 	return key, record, nil
 }
 

--- a/cli/internal/solo/secrets.go
+++ b/cli/internal/solo/secrets.go
@@ -1,13 +1,25 @@
 package solo
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
 	"time"
 )
 
+const (
+	SecretStorePlaintext   = "plaintext"
+	SecretStoreOnePassword = "1password"
+)
+
 type ScopedSecrets map[string]map[string]string
+
+type SecretMaterial struct {
+	Store     string
+	Value     string
+	Reference string
+}
 
 func (s ScopedSecrets) ValuesForService(serviceName string) map[string]string {
 	values := s[strings.TrimSpace(serviceName)]
@@ -41,9 +53,20 @@ func (s ScopedSecrets) Set(serviceName, name, value string) {
 	s[serviceName][name] = value
 }
 
-func (s *State) SetSecret(workspaceRoot, environment, serviceName, name, value string) (SecretRecord, error) {
+func NormalizeSecretStore(store string) (string, error) {
+	switch strings.TrimSpace(strings.ToLower(store)) {
+	case "", SecretStorePlaintext:
+		return SecretStorePlaintext, nil
+	case SecretStoreOnePassword, "onepassword", "op":
+		return SecretStoreOnePassword, nil
+	default:
+		return "", fmt.Errorf("unsupported secret store %q", store)
+	}
+}
+
+func (s *State) SetSecret(workspaceRoot, environment, serviceName, name string, material SecretMaterial) (SecretRecord, error) {
 	s.ensureDefaults()
-	key, record, err := buildSecretRecord(workspaceRoot, environment, serviceName, name, value)
+	key, record, err := buildSecretRecord(workspaceRoot, environment, serviceName, name, material)
 	if err != nil {
 		return SecretRecord{}, err
 	}
@@ -54,7 +77,7 @@ func (s *State) SetSecret(workspaceRoot, environment, serviceName, name, value s
 
 func (s *State) DeleteSecret(workspaceRoot, environment, serviceName, name string) (SecretRecord, error) {
 	s.ensureDefaults()
-	key, record, err := buildSecretRecord(workspaceRoot, environment, serviceName, name, "")
+	key, record, err := buildSecretRecordScope(workspaceRoot, environment, serviceName, name)
 	if err != nil {
 		return SecretRecord{}, err
 	}
@@ -96,14 +119,13 @@ func (s *State) ListSecrets(workspaceRoot, environment, serviceName string) ([]S
 
 func (s *State) ScopedSecretValues(workspaceRoot, environment string) (ScopedSecrets, error) {
 	s.ensureDefaults()
-	workspaceKey, err := CanonicalWorkspaceKey(workspaceRoot)
+	records, err := s.SecretRecords(workspaceRoot, environment)
 	if err != nil {
 		return nil, err
 	}
-	environment = defaultEnvironmentName(environment)
 	values := ScopedSecrets{}
-	for _, record := range s.Secrets {
-		if record.WorkspaceKey != workspaceKey || record.Environment != environment {
+	for _, record := range records {
+		if record.Store != SecretStorePlaintext {
 			continue
 		}
 		values.Set(record.ServiceName, record.Name, record.Value)
@@ -111,7 +133,62 @@ func (s *State) ScopedSecretValues(workspaceRoot, environment string) (ScopedSec
 	return values, nil
 }
 
-func buildSecretRecord(workspaceRoot, environment, serviceName, name, value string) (string, SecretRecord, error) {
+func (s *State) SecretRecords(workspaceRoot, environment string) ([]SecretRecord, error) {
+	s.ensureDefaults()
+	workspaceKey, err := CanonicalWorkspaceKey(workspaceRoot)
+	if err != nil {
+		return nil, err
+	}
+	environment = defaultEnvironmentName(environment)
+	records := []SecretRecord{}
+	for _, record := range s.Secrets {
+		if record.WorkspaceKey != workspaceKey || record.Environment != environment {
+			continue
+		}
+		records = append(records, record)
+	}
+	sort.Slice(records, func(i, j int) bool {
+		if records[i].ServiceName != records[j].ServiceName {
+			return records[i].ServiceName < records[j].ServiceName
+		}
+		return records[i].Name < records[j].Name
+	})
+	return records, nil
+}
+
+func buildSecretRecord(workspaceRoot, environment, serviceName, name string, material SecretMaterial) (string, SecretRecord, error) {
+	key, record, err := buildSecretRecordScope(workspaceRoot, environment, serviceName, name)
+	if err != nil {
+		return "", SecretRecord{}, err
+	}
+	store, err := NormalizeSecretStore(material.Store)
+	if err != nil {
+		return "", SecretRecord{}, err
+	}
+	material.Value = strings.TrimSpace(material.Value)
+	material.Reference = strings.TrimSpace(material.Reference)
+	switch store {
+	case SecretStorePlaintext:
+		if material.Value == "" {
+			return "", SecretRecord{}, errors.New("secret value is required")
+		}
+	case SecretStoreOnePassword:
+		if material.Reference == "" {
+			return "", SecretRecord{}, errors.New("1Password secret reference is required")
+		}
+		if !strings.HasPrefix(strings.ToLower(material.Reference), "op://") {
+			return "", SecretRecord{}, errors.New("1Password secret reference must start with op://")
+		}
+	default:
+		return "", SecretRecord{}, fmt.Errorf("unsupported secret store %q", store)
+	}
+	record.Store = store
+	record.Value = material.Value
+	record.Reference = material.Reference
+	return key, record, nil
+}
+
+func buildSecretRecordScope(workspaceRoot, environment, serviceName, name string) (string, SecretRecord, error) {
 	workspaceKey, err := CanonicalWorkspaceKey(workspaceRoot)
 	if err != nil {
 		return "", SecretRecord{}, err
@@ -131,7 +208,6 @@ func buildSecretRecord(workspaceRoot, environment, serviceName, name, value stri
 		Environment:   environment,
 		ServiceName:   serviceName,
 		Name:          name,
-		Value:         value,
 	}
 	if record.WorkspaceRoot == "" {
 		record.WorkspaceRoot = workspaceKey

--- a/cli/internal/solo/secrets_test.go
+++ b/cli/internal/solo/secrets_test.go
@@ -70,6 +70,17 @@ func TestStateSecretValidation(t *testing.T) {
 	}
 }
 
+func TestStateSecretPreservesPlaintextWhitespace(t *testing.T) {
+	current := newState()
+	record, err := current.SetSecret(t.TempDir(), "production", "web", "TOKEN", SecretMaterial{Value: "  keep me  \n"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if record.Value != "  keep me  \n" {
+		t.Fatalf("record value = %q", record.Value)
+	}
+}
+
 func TestStateSecretOnePasswordReference(t *testing.T) {
 	current := newState()
 	record, err := current.SetSecret(t.TempDir(), "production", "web", "DATABASE_URL", SecretMaterial{
@@ -88,5 +99,12 @@ func TestStateSecretOnePasswordReference(t *testing.T) {
 		Reference: "not-op-ref",
 	}); err == nil {
 		t.Fatal("SetSecret invalid 1Password reference error = nil")
+	}
+	if _, err := current.SetSecret(t.TempDir(), "production", "web", "BROKEN", SecretMaterial{
+		Store:     SecretStoreOnePassword,
+		Value:     "must-not-persist",
+		Reference: "op://app-prod/db/password",
+	}); err == nil {
+		t.Fatal("SetSecret 1Password value error = nil")
 	}
 }

--- a/cli/internal/solo/secrets_test.go
+++ b/cli/internal/solo/secrets_test.go
@@ -1,179 +1,71 @@
 package solo
 
-import (
-	"os"
-	"path/filepath"
-	"testing"
-)
+import "testing"
 
-func TestLoadSecrets_NoFile(t *testing.T) {
-	secrets, err := LoadSecrets(t.TempDir())
+func TestStateSecretsCRUDScopesByWorkspaceEnvironmentAndService(t *testing.T) {
+	root := t.TempDir()
+	otherRoot := t.TempDir()
+	current := newState()
+
+	if _, err := current.SetSecret(root, "production", "web", "DATABASE_URL", "postgres://prod-web"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := current.SetSecret(root, "production", "worker", "DATABASE_URL", "postgres://prod-worker"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := current.SetSecret(root, "staging", "web", "DATABASE_URL", "postgres://staging-web"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := current.SetSecret(otherRoot, "production", "web", "DATABASE_URL", "postgres://other-web"); err != nil {
+		t.Fatal(err)
+	}
+
+	values, err := current.ScopedSecretValues(root, "production")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(secrets) != 0 {
-		t.Fatalf("expected empty, got %d", len(secrets))
+	if got := values.Value("web", "DATABASE_URL"); got != "postgres://prod-web" {
+		t.Fatalf("web DATABASE_URL = %q", got)
+	}
+	if got := values.Value("worker", "DATABASE_URL"); got != "postgres://prod-worker" {
+		t.Fatalf("worker DATABASE_URL = %q", got)
+	}
+
+	secrets, err := current.ListSecrets(root, "production", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(secrets) != 2 {
+		t.Fatalf("secrets = %#v, want 2 production records", secrets)
+	}
+	if secrets[0].ServiceName != "web" || secrets[0].Name != "DATABASE_URL" {
+		t.Fatalf("first secret = %#v", secrets[0])
+	}
+	if secrets[0].Value != "" {
+		t.Fatalf("listed secret exposed value: %#v", secrets[0])
+	}
+
+	if _, err := current.DeleteSecret(root, "production", "web", "DATABASE_URL"); err != nil {
+		t.Fatal(err)
+	}
+	values, err = current.ScopedSecretValues(root, "production")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := values.Value("web", "DATABASE_URL"); got != "" {
+		t.Fatalf("deleted web DATABASE_URL = %q", got)
+	}
+	if got := values.Value("worker", "DATABASE_URL"); got != "postgres://prod-worker" {
+		t.Fatalf("worker DATABASE_URL = %q", got)
 	}
 }
 
-func TestLoadSecrets_ParsesEnvFile(t *testing.T) {
-	dir := t.TempDir()
-	content := `# database config
-DB_URL=postgres://localhost/db
-API_KEY="secret 123"
-export RAILS_ENV=production
-QUOTED='single'
-
-# blank lines and comments are fine
-`
-	if err := os.WriteFile(filepath.Join(dir, ".env"), []byte(content), 0o600); err != nil {
-		t.Fatal(err)
+func TestStateSecretValidation(t *testing.T) {
+	current := newState()
+	if _, err := current.SetSecret(t.TempDir(), "production", "", "DATABASE_URL", "value"); err == nil {
+		t.Fatal("SetSecret missing service error = nil")
 	}
-
-	secrets, err := LoadSecrets(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if secrets["DB_URL"] != "postgres://localhost/db" {
-		t.Errorf("DB_URL = %q", secrets["DB_URL"])
-	}
-	if secrets["API_KEY"] != "secret 123" {
-		t.Errorf("API_KEY = %q (expected unquoted)", secrets["API_KEY"])
-	}
-	if secrets["RAILS_ENV"] != "production" {
-		t.Errorf("RAILS_ENV = %q (expected export prefix stripped)", secrets["RAILS_ENV"])
-	}
-	if secrets["QUOTED"] != "single" {
-		t.Errorf("QUOTED = %q (expected single quotes stripped)", secrets["QUOTED"])
-	}
-	if len(secrets) != 4 {
-		t.Errorf("expected 4 keys, got %d", len(secrets))
-	}
-}
-
-func TestSecretsCRUD(t *testing.T) {
-	dir := t.TempDir()
-
-	// Save two secrets (creates .env).
-	if err := SaveSecret(dir, "DB_URL", "postgres://localhost/db"); err != nil {
-		t.Fatal(err)
-	}
-	if err := SaveSecret(dir, "API_KEY", "secret123"); err != nil {
-		t.Fatal(err)
-	}
-
-	// List.
-	keys, err := ListSecrets(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(keys) != 2 {
-		t.Fatalf("expected 2 keys, got %d", len(keys))
-	}
-	if keys[0] != "API_KEY" || keys[1] != "DB_URL" {
-		t.Errorf("expected [API_KEY DB_URL], got %v", keys)
-	}
-
-	// Update existing.
-	if err := SaveSecret(dir, "DB_URL", "postgres://prod/db"); err != nil {
-		t.Fatal(err)
-	}
-	secrets, err := LoadSecrets(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if secrets["DB_URL"] != "postgres://prod/db" {
-		t.Errorf("expected updated value, got %q", secrets["DB_URL"])
-	}
-
-	// Delete.
-	if err := DeleteSecret(dir, "API_KEY"); err != nil {
-		t.Fatal(err)
-	}
-	keys, err = ListSecrets(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(keys) != 1 || keys[0] != "DB_URL" {
-		t.Errorf("expected [DB_URL] after delete, got %v", keys)
-	}
-
-	// Delete nonexistent.
-	if err := DeleteSecret(dir, "NOPE"); err == nil {
-		t.Error("expected error deleting nonexistent secret")
-	}
-
-	// File permissions.
-	info, err := os.Stat(filepath.Join(dir, ".env"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if info.Mode().Perm() != 0o600 {
-		t.Errorf("expected 0600 permissions, got %o", info.Mode().Perm())
-	}
-}
-
-func TestSaveSecret_PreservesComments(t *testing.T) {
-	dir := t.TempDir()
-	initial := "# My secrets\nDB_URL=old\n"
-	if err := os.WriteFile(filepath.Join(dir, ".env"), []byte(initial), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := SaveSecret(dir, "DB_URL", "new"); err != nil {
-		t.Fatal(err)
-	}
-	if err := SaveSecret(dir, "API_KEY", "abc"); err != nil {
-		t.Fatal(err)
-	}
-
-	data, _ := os.ReadFile(filepath.Join(dir, ".env"))
-	content := string(data)
-	if content != "# My secrets\nDB_URL=new\nAPI_KEY=abc\n" {
-		t.Errorf("unexpected content:\n%s", content)
-	}
-}
-
-func TestQuoteIfNeeded(t *testing.T) {
-	tests := []struct {
-		in, want string
-	}{
-		{"simple", "simple"},
-		{"has space", `"has space"`},
-		{"has#hash", `"has#hash"`},
-		{`has"quote`, `"has\"quote"`},
-		{`back\slash`, `"back\\slash"`},
-	}
-	for _, tt := range tests {
-		got := quoteIfNeeded(tt.in)
-		if got != tt.want {
-			t.Errorf("quoteIfNeeded(%q) = %q, want %q", tt.in, got, tt.want)
-		}
-	}
-}
-
-func TestSaveLoadRoundtrip_SpecialChars(t *testing.T) {
-	dir := t.TempDir()
-	cases := map[string]string{
-		"PLAIN":     "hello",
-		"SPACES":    "hello world",
-		"QUOTES":    `say "hi"`,
-		"BACKSLASH": `path\to\thing`,
-		"MIXED":     `a "b" c\d`,
-		"HASH":      "before#after",
-	}
-	for k, v := range cases {
-		if err := SaveSecret(dir, k, v); err != nil {
-			t.Fatalf("save %s: %v", k, err)
-		}
-	}
-	got, err := LoadSecrets(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	for k, want := range cases {
-		if got[k] != want {
-			t.Errorf("%s: got %q, want %q", k, got[k], want)
-		}
+	if _, err := current.SetSecret(t.TempDir(), "production", "web", "", "value"); err == nil {
+		t.Fatal("SetSecret missing name error = nil")
 	}
 }

--- a/cli/internal/solo/secrets_test.go
+++ b/cli/internal/solo/secrets_test.go
@@ -7,16 +7,16 @@ func TestStateSecretsCRUDScopesByWorkspaceEnvironmentAndService(t *testing.T) {
 	otherRoot := t.TempDir()
 	current := newState()
 
-	if _, err := current.SetSecret(root, "production", "web", "DATABASE_URL", "postgres://prod-web"); err != nil {
+	if _, err := current.SetSecret(root, "production", "web", "DATABASE_URL", SecretMaterial{Value: "postgres://prod-web"}); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := current.SetSecret(root, "production", "worker", "DATABASE_URL", "postgres://prod-worker"); err != nil {
+	if _, err := current.SetSecret(root, "production", "worker", "DATABASE_URL", SecretMaterial{Value: "postgres://prod-worker"}); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := current.SetSecret(root, "staging", "web", "DATABASE_URL", "postgres://staging-web"); err != nil {
+	if _, err := current.SetSecret(root, "staging", "web", "DATABASE_URL", SecretMaterial{Value: "postgres://staging-web"}); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := current.SetSecret(otherRoot, "production", "web", "DATABASE_URL", "postgres://other-web"); err != nil {
+	if _, err := current.SetSecret(otherRoot, "production", "web", "DATABASE_URL", SecretMaterial{Value: "postgres://other-web"}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -62,10 +62,31 @@ func TestStateSecretsCRUDScopesByWorkspaceEnvironmentAndService(t *testing.T) {
 
 func TestStateSecretValidation(t *testing.T) {
 	current := newState()
-	if _, err := current.SetSecret(t.TempDir(), "production", "", "DATABASE_URL", "value"); err == nil {
+	if _, err := current.SetSecret(t.TempDir(), "production", "", "DATABASE_URL", SecretMaterial{Value: "value"}); err == nil {
 		t.Fatal("SetSecret missing service error = nil")
 	}
-	if _, err := current.SetSecret(t.TempDir(), "production", "web", "", "value"); err == nil {
+	if _, err := current.SetSecret(t.TempDir(), "production", "web", "", SecretMaterial{Value: "value"}); err == nil {
 		t.Fatal("SetSecret missing name error = nil")
+	}
+}
+
+func TestStateSecretOnePasswordReference(t *testing.T) {
+	current := newState()
+	record, err := current.SetSecret(t.TempDir(), "production", "web", "DATABASE_URL", SecretMaterial{
+		Store:     SecretStoreOnePassword,
+		Reference: "op://app-prod/db/password",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if record.Store != SecretStoreOnePassword || record.Reference != "op://app-prod/db/password" || record.Value != "" {
+		t.Fatalf("record = %#v", record)
+	}
+
+	if _, err := current.SetSecret(t.TempDir(), "production", "web", "BROKEN", SecretMaterial{
+		Store:     SecretStoreOnePassword,
+		Reference: "not-op-ref",
+	}); err == nil {
+		t.Fatal("SetSecret invalid 1Password reference error = nil")
 	}
 }

--- a/cli/internal/solo/state.go
+++ b/cli/internal/solo/state.go
@@ -64,7 +64,9 @@ type SecretRecord struct {
 	Environment   string `json:"environment"`
 	ServiceName   string `json:"service_name"`
 	Name          string `json:"name"`
+	Store         string `json:"store,omitempty"`
 	Value         string `json:"value"`
+	Reference     string `json:"reference,omitempty"`
 	UpdatedAt     string `json:"updated_at,omitempty"`
 }
 
@@ -429,6 +431,11 @@ func normalizeSecretRecord(key string, secret SecretRecord) (string, SecretRecor
 	secret.Environment = defaultEnvironmentName(firstNonEmpty(secret.Environment, keyEnvironment))
 	secret.ServiceName = strings.TrimSpace(firstNonEmpty(secret.ServiceName, keyService))
 	secret.Name = strings.TrimSpace(firstNonEmpty(secret.Name, keyName))
+	normalizedStore, err := NormalizeSecretStore(secret.Store)
+	if err != nil {
+		return "", SecretRecord{}, err
+	}
+	secret.Store = normalizedStore
 	if secret.ServiceName == "" {
 		return "", SecretRecord{}, errors.New("service name is required")
 	}

--- a/cli/internal/solo/state.go
+++ b/cli/internal/solo/state.go
@@ -25,6 +25,7 @@ type State struct {
 	Nodes         map[string]config.SoloNode  `json:"nodes,omitempty"`
 	Attachments   map[string]AttachmentRecord `json:"attachments,omitempty"`
 	Snapshots     map[string]DeploySnapshot   `json:"snapshots,omitempty"`
+	Secrets       map[string]SecretRecord     `json:"secrets,omitempty"`
 }
 
 type AttachmentRecord struct {
@@ -55,6 +56,16 @@ type DeploySnapshot struct {
 	IngressService     string           `json:"ingress_service,omitempty"`
 	IngressServiceKind string           `json:"ingress_service_kind,omitempty"`
 	Metadata           SnapshotMetadata `json:"metadata,omitempty"`
+}
+
+type SecretRecord struct {
+	WorkspaceRoot string `json:"workspace_root"`
+	WorkspaceKey  string `json:"workspace_key"`
+	Environment   string `json:"environment"`
+	ServiceName   string `json:"service_name"`
+	Name          string `json:"name"`
+	Value         string `json:"value"`
+	UpdatedAt     string `json:"updated_at,omitempty"`
 }
 
 func DefaultStatePath() string {
@@ -163,6 +174,14 @@ func EnvironmentStateKey(workspaceRoot, environment string) (string, error) {
 }
 
 func BuildDeploySnapshot(cfg *config.ProjectConfig, workspaceRoot, configPath, imageTag, revision string, secrets map[string]string) (DeploySnapshot, error) {
+	return buildDeploySnapshot(cfg, workspaceRoot, configPath, imageTag, revision, func(string) map[string]string { return secrets })
+}
+
+func BuildDeploySnapshotWithScopedSecrets(cfg *config.ProjectConfig, workspaceRoot, configPath, imageTag, revision string, secrets ScopedSecrets) (DeploySnapshot, error) {
+	return buildDeploySnapshot(cfg, workspaceRoot, configPath, imageTag, revision, secrets.ValuesForService)
+}
+
+func buildDeploySnapshot(cfg *config.ProjectConfig, workspaceRoot, configPath, imageTag, revision string, secretsForService func(string) map[string]string) (DeploySnapshot, error) {
 	if cfg == nil {
 		return DeploySnapshot{}, fmt.Errorf("config is required")
 	}
@@ -189,14 +208,14 @@ func BuildDeploySnapshot(cfg *config.ProjectConfig, workspaceRoot, configPath, i
 	}
 	for _, serviceName := range cfg.ServiceNames() {
 		service := cfg.Services[serviceName]
-		rendered, err := buildService(serviceName, service, imageTag, secrets)
+		rendered, err := buildService(serviceName, service, imageTag, secretsForService(serviceName))
 		if err != nil {
 			return DeploySnapshot{}, fmt.Errorf("build service %s: %w", serviceName, err)
 		}
 		snapshot.Services = append(snapshot.Services, rendered)
 	}
 	if cfg.ReleaseTask() != nil {
-		releaseTask, err := buildReleaseTask(cfg, imageTag, secrets)
+		releaseTask, err := buildReleaseTask(cfg, imageTag, secretsForService(cfg.ReleaseTask().Service))
 		if err != nil {
 			return DeploySnapshot{}, fmt.Errorf("build release task: %w", err)
 		}
@@ -279,6 +298,7 @@ func newState() State {
 		Nodes:         map[string]config.SoloNode{},
 		Attachments:   map[string]AttachmentRecord{},
 		Snapshots:     map[string]DeploySnapshot{},
+		Secrets:       map[string]SecretRecord{},
 	}
 }
 
@@ -294,6 +314,9 @@ func (s *State) ensureDefaults() {
 	}
 	if s.Snapshots == nil {
 		s.Snapshots = map[string]DeploySnapshot{}
+	}
+	if s.Secrets == nil {
+		s.Secrets = map[string]SecretRecord{}
 	}
 }
 
@@ -350,6 +373,21 @@ func normalizeState(current State) (State, error) {
 	}
 	current.Snapshots = normalizedSnapshots
 
+	secretKeys := make([]string, 0, len(current.Secrets))
+	for key := range current.Secrets {
+		secretKeys = append(secretKeys, key)
+	}
+	sort.Strings(secretKeys)
+	normalizedSecrets := make(map[string]SecretRecord, len(current.Secrets))
+	for _, key := range secretKeys {
+		normalizedKey, secret, err := normalizeSecretRecord(key, current.Secrets[key])
+		if err != nil {
+			return State{}, fmt.Errorf("normalize secret %q: %w", key, err)
+		}
+		normalizedSecrets[normalizedKey] = secret
+	}
+	current.Secrets = normalizedSecrets
+
 	return current, nil
 }
 
@@ -377,6 +415,27 @@ func normalizeSnapshotRecord(key string, snapshot DeploySnapshot) (string, Deplo
 	snapshot.WorkspaceKey = workspaceKey
 	snapshot.Environment = defaultEnvironmentName(firstNonEmpty(snapshot.Environment, keyEnvironment))
 	return snapshot.WorkspaceKey + "\n" + snapshot.Environment, snapshot, nil
+}
+
+func normalizeSecretRecord(key string, secret SecretRecord) (string, SecretRecord, error) {
+	workspaceRoot, workspaceKey, err := normalizeWorkspaceIdentity(key, secret.WorkspaceRoot, secret.WorkspaceKey)
+	if err != nil {
+		return "", SecretRecord{}, err
+	}
+	keyWorkspace, keyEnvironment, keyService, keyName := splitSecretStateKey(key)
+	_ = keyWorkspace
+	secret.WorkspaceRoot = workspaceRoot
+	secret.WorkspaceKey = workspaceKey
+	secret.Environment = defaultEnvironmentName(firstNonEmpty(secret.Environment, keyEnvironment))
+	secret.ServiceName = strings.TrimSpace(firstNonEmpty(secret.ServiceName, keyService))
+	secret.Name = strings.TrimSpace(firstNonEmpty(secret.Name, keyName))
+	if secret.ServiceName == "" {
+		return "", SecretRecord{}, errors.New("service name is required")
+	}
+	if secret.Name == "" {
+		return "", SecretRecord{}, errors.New("secret name is required")
+	}
+	return secretKey(secret.WorkspaceKey, secret.Environment, secret.ServiceName, secret.Name), secret, nil
 }
 
 func normalizeWorkspaceIdentity(key, workspaceRoot, workspaceKey string) (string, string, error) {
@@ -407,6 +466,15 @@ func splitEnvironmentStateKey(key string) (string, string) {
 		environment = strings.TrimSpace(parts[1])
 	}
 	return workspace, environment
+}
+
+func splitSecretStateKey(key string) (string, string, string, string) {
+	parts := strings.SplitN(key, "\n", 4)
+	values := [4]string{}
+	for i := range parts {
+		values[i] = strings.TrimSpace(parts[i])
+	}
+	return values[0], values[1], values[2], values[3]
 }
 
 func firstNonEmpty(values ...string) string {

--- a/cli/internal/solo/state.go
+++ b/cli/internal/solo/state.go
@@ -424,8 +424,7 @@ func normalizeSecretRecord(key string, secret SecretRecord) (string, SecretRecor
 	if err != nil {
 		return "", SecretRecord{}, err
 	}
-	keyWorkspace, keyEnvironment, keyService, keyName := splitSecretStateKey(key)
-	_ = keyWorkspace
+	_, keyEnvironment, keyService, keyName := splitSecretStateKey(key)
 	secret.WorkspaceRoot = workspaceRoot
 	secret.WorkspaceKey = workspaceKey
 	secret.Environment = defaultEnvironmentName(firstNonEmpty(secret.Environment, keyEnvironment))

--- a/cli/internal/solo/state.go
+++ b/cli/internal/solo/state.go
@@ -441,6 +441,11 @@ func normalizeSecretRecord(key string, secret SecretRecord) (string, SecretRecor
 	if secret.Name == "" {
 		return "", SecretRecord{}, errors.New("secret name is required")
 	}
+	reference, err := validateSecretMaterial(secret.Store, secret.Value, secret.Reference)
+	if err != nil {
+		return "", SecretRecord{}, err
+	}
+	secret.Reference = reference
 	return secretKey(secret.WorkspaceKey, secret.Environment, secret.ServiceName, secret.Name), secret, nil
 }
 

--- a/cli/internal/solo/state_test.go
+++ b/cli/internal/solo/state_test.go
@@ -156,6 +156,63 @@ func TestStateStoreReadNormalizesLegacySnapshots(t *testing.T) {
 	}
 }
 
+func TestStateStoreReadRejectsInvalidSecretRecords(t *testing.T) {
+	t.Parallel()
+
+	for name, payload := range map[string]string{
+		"empty plaintext": `{
+  "schema_version": 1,
+  "secrets": {
+    "/workspace/demo\nproduction\nweb\nDATABASE_URL": {
+      "workspace_root": "/workspace/demo",
+      "environment": "production",
+      "service_name": "web",
+      "name": "DATABASE_URL",
+      "store": "plaintext",
+      "value": ""
+    }
+  }
+}`,
+		"1password value": `{
+  "schema_version": 1,
+  "secrets": {
+    "/workspace/demo\nproduction\nweb\nDATABASE_URL": {
+      "workspace_root": "/workspace/demo",
+      "environment": "production",
+      "service_name": "web",
+      "name": "DATABASE_URL",
+      "store": "1password",
+      "value": "do-not-store",
+      "reference": "op://app/db/password"
+    }
+  }
+}`,
+		"1password reference": `{
+  "schema_version": 1,
+  "secrets": {
+    "/workspace/demo\nproduction\nweb\nDATABASE_URL": {
+      "workspace_root": "/workspace/demo",
+      "environment": "production",
+      "service_name": "web",
+      "name": "DATABASE_URL",
+      "store": "1password",
+      "reference": "not-op"
+    }
+  }
+}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "solo-state.json")
+			if err := os.WriteFile(path, []byte(payload), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := NewStateStore(path).Read(); err == nil {
+				t.Fatal("Read() error = nil")
+			}
+		})
+	}
+}
+
 func TestAttachmentKeysForNodeDoesNotMutateState(t *testing.T) {
 	t.Parallel()
 
@@ -317,7 +374,7 @@ func TestRedactDeploySnapshotSecretsRemovesSecretValues(t *testing.T) {
 
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")
 	cfg.Services["web"] = config.ServiceConfig{
-		Env:  map[string]string{"PLAIN": "value"},
+		Env: map[string]string{"PLAIN": "value"},
 		SecretRefs: []config.SecretRef{
 			{Name: "DATABASE_URL"},
 		},

--- a/cli/internal/workflow/app.go
+++ b/cli/internal/workflow/app.go
@@ -1784,7 +1784,7 @@ func (a *App) SecretSet(ctx context.Context, opts SecretSetOptions) error {
 	if err != nil {
 		return err
 	}
-	if err := a.requireConfiguredService(workspace.Discovery.WorkspaceRoot, serviceName); err != nil {
+	if err := a.requireConfigurableSecretRef(workspace.Discovery.WorkspaceRoot, serviceName, opts.Name); err != nil {
 		return err
 	}
 	result, err := a.API.UpsertEnvironmentSecret(ctx, tokens.AccessToken, workspace.Environment.ID, serviceName, opts.Name, value)
@@ -2035,6 +2035,25 @@ func (a *App) requireConfiguredService(workspaceRoot, serviceName string) error 
 	return nil
 }
 
+func (a *App) requireConfigurableSecretRef(workspaceRoot, serviceName, name string) error {
+	serviceName = strings.TrimSpace(serviceName)
+	cfg, err := a.ConfigStore.Read(workspaceRoot)
+	if err != nil {
+		return wrapError(err)
+	}
+	if cfg == nil {
+		return ExitError{Code: 2, Err: errors.New("missing devopsellence.yml; run `devopsellence setup` first")}
+	}
+	service, ok := cfg.Services[serviceName]
+	if !ok {
+		return ExitError{Code: 2, Err: fmt.Errorf("service %q not found in devopsellence.yml", serviceName)}
+	}
+	if serviceSecretRefConflict(service, name) {
+		return ExitError{Code: 2, Err: fmt.Errorf("service %q already defines %s in env; remove it before adding a secret_ref with the same name", serviceName, name)}
+	}
+	return nil
+}
+
 func (a *App) upsertWorkspaceSecretRef(workspaceRoot, serviceName string, ref config.SecretRef) (bool, error) {
 	serviceName = strings.TrimSpace(serviceName)
 	cfg, err := a.ConfigStore.Read(workspaceRoot)
@@ -2047,7 +2066,11 @@ func (a *App) upsertWorkspaceSecretRef(workspaceRoot, serviceName string, ref co
 	if _, ok := cfg.Services[serviceName]; !ok {
 		return false, ExitError{Code: 2, Err: fmt.Errorf("service %q not found in devopsellence.yml", serviceName)}
 	}
-	if !ensureServiceSecretRef(cfg, serviceName, ref) {
+	changed, err := ensureServiceSecretRef(cfg, serviceName, ref)
+	if err != nil {
+		return false, err
+	}
+	if !changed {
 		return false, nil
 	}
 	if _, err := a.ConfigStore.Write(workspaceRoot, *cfg); err != nil {

--- a/cli/internal/workflow/app.go
+++ b/cli/internal/workflow/app.go
@@ -85,6 +85,7 @@ type App struct {
 	soloNodeCreateFn    func(context.Context, SoloNodeCreateOptions) error
 	soloNodeAttachFn    func(context.Context, SoloNodeAttachOptions) error
 	soloRuntimeDoctorFn func(context.Context, SoloDoctorOptions) error
+	soloSecretResolveFn func(context.Context, solo.SecretRecord) (string, error)
 	promptReaderSource  io.Reader
 	promptReader        *bufio.Reader
 }

--- a/cli/internal/workflow/app.go
+++ b/cli/internal/workflow/app.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"context"
 	"crypto/rand"
-	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -48,10 +47,7 @@ const (
 	defaultDeployProgressTimeout      = 10 * time.Minute
 	defaultNodeDiagnosePollInterval   = 500 * time.Millisecond
 	defaultNodeDiagnoseWaitTimeout    = 20 * time.Second
-	railsMasterKeySecretName          = "RAILS_MASTER_KEY"
-	railsMasterKeyRelativePath        = "config/master.key"
 	deployEnvVarsOverrideEnv          = "DEVOPSELLENCE_ENV_VARS"
-	deploySecretsOverrideEnv          = "DEVOPSELLENCE_SECRETS"
 )
 
 type ExitError struct {
@@ -140,12 +136,11 @@ type ConfigResolveOptions struct {
 }
 
 type DeployOptions struct {
-	Organization           string
-	Project                string
-	Image                  string
-	Environment            string
-	NonInteractive         bool
-	SkipRailsMasterKeySync bool
+	Organization   string
+	Project        string
+	Image          string
+	Environment    string
+	NonInteractive bool
 }
 
 type DeleteOptions struct {
@@ -597,8 +592,6 @@ func (a *App) Deploy(ctx context.Context, opts DeployOptions) error {
 	var result map[string]any
 	var accessToken string
 	var deployTokens auth.Tokens
-	var syncedRailsSecretServices []string
-	var railsSecretSyncNotice string
 	var buildPushDuration time.Duration
 	var autoInitSummary string
 	run := func(runCtx context.Context, update, log func(string)) error {
@@ -671,21 +664,14 @@ func (a *App) Deploy(ctx context.Context, opts DeployOptions) error {
 			return ExitError{Code: 1, Err: err}
 		}
 		cfg = resolvedCfg
-		a.warnAboutPrebuiltImageConfig(opts, discovered, cfg)
+		a.warnAboutPrebuiltImageConfig(opts, cfg)
 		a.API.BaseURL = firstNonEmpty(preflight.Tokens.APIBase, a.API.BaseURL)
 
 		envVarOverrides, err := parseRuntimeValueOverrides(os.Getenv(deployEnvVarsOverrideEnv), deployEnvVarsOverrideEnv)
 		if err != nil {
 			return err
 		}
-		secretOverrides, err := parseRuntimeValueOverrides(os.Getenv(deploySecretsOverrideEnv), deploySecretsOverrideEnv)
-		if err != nil {
-			return err
-		}
 		if err := validateRuntimeOverrides(cfg, envVarOverrides, deployEnvVarsOverrideEnv); err != nil {
-			return err
-		}
-		if err := validateRuntimeOverrides(cfg, secretOverrides, deploySecretsOverrideEnv); err != nil {
 			return err
 		}
 		cfg = applyEnvVarOverrides(cfg, envVarOverrides)
@@ -715,16 +701,6 @@ func (a *App) Deploy(ctx context.Context, opts DeployOptions) error {
 			project = target.Project
 			env = target.Environment
 		}
-
-		if err := a.syncDeploySecretOverrides(ctx, withAuth, update, env, cfg, secretOverrides); err != nil {
-			return err
-		}
-		syncedServices, syncNotice, err := a.ensureRailsDeploySecrets(ctx, withAuth, update, discovered.WorkspaceRoot, cfg, env, opts)
-		if err != nil {
-			return err
-		}
-		syncedRailsSecretServices = syncedServices
-		railsSecretSyncNotice = syncNotice
 
 		repository, digest, resolvedBuildPushDuration, inferredImagePort, err := a.resolveImage(
 			ctx,
@@ -837,17 +813,11 @@ func (a *App) Deploy(ctx context.Context, opts DeployOptions) error {
 		}
 		return wrapError(err)
 	}
-	if !a.Printer.JSON && railsSecretSyncNotice != "" {
-		a.Printer.Println("Rails:", railsSecretSyncNotice)
-	}
 	if !a.Printer.JSON && autoInitSummary != "" {
 		a.Printer.Println("Deploy:", autoInitSummary)
 	}
 	if !a.Printer.JSON && stringFromMap(result, "public_url") != "" {
 		a.Printer.Println("Ingress URL:", stringFromMap(result, "public_url"))
-	}
-	if !a.Printer.JSON && len(syncedRailsSecretServices) > 0 {
-		a.Printer.Println("Rails:", "synced RAILS_MASTER_KEY for", strings.Join(syncedRailsSecretServices, ", ")+".")
 	}
 
 	progress, err := a.waitForDeployment(ctx, accessToken, result)
@@ -1802,9 +1772,22 @@ func (a *App) SecretSet(ctx context.Context, opts SecretSetOptions) error {
 	if err != nil {
 		return err
 	}
+	if err := a.requireConfiguredService(workspace.Discovery.WorkspaceRoot, opts.ServiceName); err != nil {
+		return err
+	}
 	result, err := a.API.UpsertEnvironmentSecret(ctx, tokens.AccessToken, workspace.Environment.ID, opts.ServiceName, opts.Name, value)
 	if err != nil {
 		return wrapError(err)
+	}
+	configUpdated := false
+	if ref := stringFromMap(result, "secret_ref"); ref != "" {
+		updated, err := a.upsertWorkspaceSecretRef(workspace.Discovery.WorkspaceRoot, opts.ServiceName, config.SecretRef{Name: opts.Name, Secret: ref})
+		if err != nil {
+			return err
+		}
+		configUpdated = updated
+		result["config_updated"] = updated
+		result["config_path"] = a.ConfigStore.PathFor(workspace.Discovery.WorkspaceRoot)
 	}
 	result["schema_version"] = outputSchemaVersion
 	if a.Printer.JSON {
@@ -1815,6 +1798,9 @@ func (a *App) SecretSet(ctx context.Context, opts SecretSetOptions) error {
 	}
 	a.Printer.Println("Saved secret", stringFromMap(result, "name"), "for", stringFromMap(result, "service_name")+".")
 	a.Printer.Println("Ref:", stringFromMap(result, "secret_ref"))
+	if configUpdated {
+		a.Printer.Println("Updated:", a.ConfigStore.PathFor(workspace.Discovery.WorkspaceRoot))
+	}
 	return nil
 }
 
@@ -1846,9 +1832,6 @@ func (a *App) SecretList(ctx context.Context, opts SecretListOptions) error {
 	}
 	for _, secret := range secrets {
 		line := secret.ServiceName + " " + secret.Name + " -> " + secret.SecretRef
-		if secret.Name == railsMasterKeySecretName {
-			line += " (auto-managed from config/master.key)"
-		}
 		a.Printer.Println(line)
 	}
 	return nil
@@ -1869,10 +1852,19 @@ func (a *App) SecretDelete(ctx context.Context, opts SecretDeleteOptions) error 
 	if err != nil {
 		return err
 	}
+	if err := a.requireConfiguredService(workspace.Discovery.WorkspaceRoot, opts.ServiceName); err != nil {
+		return err
+	}
 	result, err := a.API.DeleteEnvironmentSecret(ctx, tokens.AccessToken, workspace.Environment.ID, opts.ServiceName, opts.Name)
 	if err != nil {
 		return wrapError(err)
 	}
+	configUpdated, err := a.removeWorkspaceSecretRef(workspace.Discovery.WorkspaceRoot, opts.ServiceName, opts.Name)
+	if err != nil {
+		return err
+	}
+	result["config_updated"] = configUpdated
+	result["config_path"] = a.ConfigStore.PathFor(workspace.Discovery.WorkspaceRoot)
 	result["schema_version"] = outputSchemaVersion
 	if a.Printer.JSON {
 		return a.Printer.PrintJSON(result)
@@ -1881,7 +1873,64 @@ func (a *App) SecretDelete(ctx context.Context, opts SecretDeleteOptions) error 
 		a.Printer.Errorln("Could not infer Rails module name; using directory name", fmt.Sprintf("%q.", workspace.Discovery.ProjectName))
 	}
 	a.Printer.Println("Deleted secret", stringFromMap(result, "name"), "for", stringFromMap(result, "service_name")+".")
+	if configUpdated {
+		a.Printer.Println("Updated:", a.ConfigStore.PathFor(workspace.Discovery.WorkspaceRoot))
+	}
 	return nil
+}
+
+func (a *App) requireConfiguredService(workspaceRoot, serviceName string) error {
+	cfg, err := a.ConfigStore.Read(workspaceRoot)
+	if err != nil {
+		return wrapError(err)
+	}
+	if cfg == nil {
+		return ExitError{Code: 2, Err: errors.New("missing devopsellence.yml; run `devopsellence setup` first")}
+	}
+	if _, ok := cfg.Services[serviceName]; !ok {
+		return ExitError{Code: 2, Err: fmt.Errorf("service %q not found in devopsellence.yml", serviceName)}
+	}
+	return nil
+}
+
+func (a *App) upsertWorkspaceSecretRef(workspaceRoot, serviceName string, ref config.SecretRef) (bool, error) {
+	cfg, err := a.ConfigStore.Read(workspaceRoot)
+	if err != nil {
+		return false, wrapError(err)
+	}
+	if cfg == nil {
+		return false, ExitError{Code: 2, Err: errors.New("missing devopsellence.yml; run `devopsellence setup` first")}
+	}
+	if _, ok := cfg.Services[serviceName]; !ok {
+		return false, ExitError{Code: 2, Err: fmt.Errorf("service %q not found in devopsellence.yml", serviceName)}
+	}
+	if !ensureServiceSecretRef(cfg, serviceName, ref) {
+		return false, nil
+	}
+	if _, err := a.ConfigStore.Write(workspaceRoot, *cfg); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (a *App) removeWorkspaceSecretRef(workspaceRoot, serviceName, name string) (bool, error) {
+	cfg, err := a.ConfigStore.Read(workspaceRoot)
+	if err != nil {
+		return false, wrapError(err)
+	}
+	if cfg == nil {
+		return false, ExitError{Code: 2, Err: errors.New("missing devopsellence.yml; run `devopsellence setup` first")}
+	}
+	if _, ok := cfg.Services[serviceName]; !ok {
+		return false, ExitError{Code: 2, Err: fmt.Errorf("service %q not found in devopsellence.yml", serviceName)}
+	}
+	if !removeServiceSecretRef(cfg, serviceName, name) {
+		return false, nil
+	}
+	if _, err := a.ConfigStore.Write(workspaceRoot, *cfg); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func (a *App) Claim(ctx context.Context, opts ClaimOptions) error {
@@ -2553,127 +2602,6 @@ func (a *App) chooseOrganizationInput(ctx context.Context, callAuth authCall) (s
 	return choice, nil
 }
 
-func (a *App) ensureRailsDeploySecrets(ctx context.Context, callAuth authCall, notify func(string), workspaceRoot string, cfg config.ProjectConfig, env api.Environment, opts DeployOptions) ([]string, string, error) {
-	if cfg.App.Type != config.AppTypeRails {
-		return nil, "", nil
-	}
-	if opts.SkipRailsMasterKeySync {
-		return nil, "skipping RAILS_MASTER_KEY sync (--no-rails-master-key-sync).", nil
-	}
-
-	keyPath := filepath.Join(workspaceRoot, railsMasterKeyRelativePath)
-	data, err := os.ReadFile(keyPath)
-	if err == nil {
-		value := strings.TrimSpace(string(data))
-		if value == "" {
-			return nil, "", ExitError{Code: 1, Err: fmt.Errorf("Rails app detected, but %s is empty", keyPath)}
-		}
-		services := railsRuntimeServices(cfg)
-		existing, err := a.currentEnvironmentSecrets(ctx, callAuth, env.ID)
-		if err != nil {
-			return nil, "", err
-		}
-		valueSHA256 := secretValueSHA256(value)
-		servicesToSync := make([]string, 0, len(services))
-		servicesAlreadyCurrent := make([]string, 0, len(services))
-		for _, serviceName := range services {
-			existingSecret, ok := environmentSecretByServiceAndName(existing, serviceName, railsMasterKeySecretName)
-			if ok && existingSecret.ValueSHA256 == valueSHA256 {
-				servicesAlreadyCurrent = append(servicesAlreadyCurrent, serviceName)
-			} else {
-				servicesToSync = append(servicesToSync, serviceName)
-			}
-		}
-		if len(servicesToSync) == 0 {
-			return nil, "RAILS_MASTER_KEY already current for " + strings.Join(servicesAlreadyCurrent, ", ") + ".", nil
-		}
-		notice := "syncing RAILS_MASTER_KEY from config/master.key for " + strings.Join(services, ", ") + "."
-		if notify != nil {
-			notify("Syncing Rails master key from config/master.key to managed secret RAILS_MASTER_KEY for " + strings.Join(servicesToSync, ", ") + "…")
-		}
-		errCh := make(chan error, len(servicesToSync))
-		sem := make(chan struct{}, 2)
-		var wg sync.WaitGroup
-		for _, serviceName := range servicesToSync {
-			serviceName := serviceName
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				select {
-				case sem <- struct{}{}:
-				case <-ctx.Done():
-					errCh <- ctx.Err()
-					return
-				}
-				defer func() { <-sem }()
-				if notify != nil {
-					notify("Creating/updating Rails master key secret for " + serviceName + "…")
-				}
-				errCh <- callAuth(func(accessToken string) error {
-					_, callErr := a.API.UpsertEnvironmentSecret(ctx, accessToken, env.ID, serviceName, railsMasterKeySecretName, value)
-					return callErr
-				})
-			}()
-		}
-		wg.Wait()
-		close(errCh)
-		for err := range errCh {
-			if err != nil {
-				return nil, "", err
-			}
-		}
-		return servicesToSync, notice, nil
-	}
-	if !errors.Is(err, os.ErrNotExist) {
-		return nil, "", err
-	}
-	return nil, "", nil
-}
-
-func (a *App) currentEnvironmentSecrets(ctx context.Context, callAuth authCall, environmentID int) ([]api.EnvironmentSecret, error) {
-	var secrets []api.EnvironmentSecret
-	if err := callAuth(func(accessToken string) error {
-		var callErr error
-		secrets, callErr = a.API.ListEnvironmentSecrets(ctx, accessToken, environmentID)
-		return callErr
-	}); err != nil {
-		return nil, err
-	}
-
-	return secrets, nil
-}
-
-func railsRuntimeServices(cfg config.ProjectConfig) []string {
-	services := []string{}
-	for _, name := range cfg.ServiceNames() {
-		if looksLikeCloudflaredService(name, cfg.Services[name]) {
-			continue
-		}
-		services = append(services, name)
-	}
-	return services
-}
-
-func looksLikeCloudflaredService(name string, service config.ServiceConfig) bool {
-	if strings.EqualFold(strings.TrimSpace(name), "cloudflared") {
-		return true
-	}
-	image := strings.ToLower(strings.TrimSpace(service.Image))
-	if strings.Contains(image, "cloudflare/cloudflared") {
-		return true
-	}
-	for _, value := range append(append([]string{}, service.Command...), service.Args...) {
-		if strings.EqualFold(strings.TrimSpace(value), "cloudflared") {
-			return true
-		}
-	}
-	return false
-}
-
-func runtimeServices(cfg config.ProjectConfig) []string {
-	return cfg.ServiceNames()
-}
-
 func parseRuntimeValueOverrides(raw string, fieldName string) (runtimeValueOverrides, error) {
 	text := strings.TrimSpace(raw)
 	if text == "" {
@@ -2764,53 +2692,6 @@ func mergeStringMaps(parts ...map[string]string) map[string]string {
 		}
 	}
 	return merged
-}
-
-func (a *App) syncDeploySecretOverrides(ctx context.Context, callAuth authCall, notify func(string), env api.Environment, cfg config.ProjectConfig, overrides runtimeValueOverrides) error {
-	serviceNames := runtimeServices(cfg)
-	for _, serviceName := range serviceNames {
-		secrets := mergeStringMaps(overrides.All, scopedRuntimeOverrides(overrides, serviceName))
-		for name, value := range secrets {
-			if notify != nil {
-				notify("Syncing managed secret " + name + " for " + serviceName + "…")
-			}
-			if err := callAuth(func(accessToken string) error {
-				_, callErr := a.API.UpsertEnvironmentSecret(ctx, accessToken, env.ID, serviceName, name, value)
-				return callErr
-			}); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}
-
-func scopedRuntimeOverrides(overrides runtimeValueOverrides, serviceName string) map[string]string {
-	return overrides.Services[serviceName]
-}
-
-func hasEnvironmentSecret(secrets []api.EnvironmentSecret, serviceName, name string) bool {
-	for _, secret := range secrets {
-		if secret.ServiceName == serviceName && secret.Name == name {
-			return true
-		}
-	}
-	return false
-}
-
-func environmentSecretByServiceAndName(secrets []api.EnvironmentSecret, serviceName, name string) (api.EnvironmentSecret, bool) {
-	for _, secret := range secrets {
-		if secret.ServiceName == serviceName && secret.Name == name {
-			return secret, true
-		}
-	}
-
-	return api.EnvironmentSecret{}, false
-}
-
-func secretValueSHA256(value string) string {
-	sum := sha256.Sum256([]byte(value))
-	return hex.EncodeToString(sum[:])
 }
 
 func (a *App) callWithAuthRetry(ctx context.Context, token *string, interactive bool, notify func(string), fn func(string) error) error {
@@ -4379,7 +4260,7 @@ func (a *App) printNodeDiagnose(request api.NodeDiagnoseRequest) {
 	}
 }
 
-func (a *App) warnAboutPrebuiltImageConfig(opts DeployOptions, discovered discovery.Result, cfg config.ProjectConfig) {
+func (a *App) warnAboutPrebuiltImageConfig(opts DeployOptions, cfg config.ProjectConfig) {
 	if strings.TrimSpace(opts.Image) == "" || a.Printer.JSON {
 		return
 	}
@@ -4389,8 +4270,5 @@ func (a *App) warnAboutPrebuiltImageConfig(opts DeployOptions, discovered discov
 
 	a.Printer.Errorln("Using --image skips the local build.")
 	a.Printer.Errorln("Deploy will still use devopsellence.yml for port and healthcheck settings.")
-	if _, err := os.Stat(filepath.Join(discovered.WorkspaceRoot, railsMasterKeyRelativePath)); err == nil {
-		a.Printer.Errorln("Deploy will also sync RAILS_MASTER_KEY from config/master.key.")
-	}
 	a.Printer.Errorln("If this image is not a Rails image, update devopsellence.yml before deploy.")
 }

--- a/cli/internal/workflow/app.go
+++ b/cli/internal/workflow/app.go
@@ -1765,7 +1765,8 @@ func (a *App) NodeDiagnose(ctx context.Context, opts NodeDiagnoseOptions) error 
 }
 
 func (a *App) SecretSet(ctx context.Context, opts SecretSetOptions) error {
-	if strings.TrimSpace(opts.ServiceName) == "" {
+	serviceName := strings.TrimSpace(opts.ServiceName)
+	if serviceName == "" {
 		return ExitError{Code: 2, Err: errors.New("missing required option: --service")}
 	}
 	if strings.TrimSpace(opts.Name) == "" {
@@ -1783,17 +1784,17 @@ func (a *App) SecretSet(ctx context.Context, opts SecretSetOptions) error {
 	if err != nil {
 		return err
 	}
-	if err := a.requireConfiguredService(workspace.Discovery.WorkspaceRoot, opts.ServiceName); err != nil {
+	if err := a.requireConfiguredService(workspace.Discovery.WorkspaceRoot, serviceName); err != nil {
 		return err
 	}
-	result, err := a.API.UpsertEnvironmentSecret(ctx, tokens.AccessToken, workspace.Environment.ID, opts.ServiceName, opts.Name, value)
+	result, err := a.API.UpsertEnvironmentSecret(ctx, tokens.AccessToken, workspace.Environment.ID, serviceName, opts.Name, value)
 	if err != nil {
 		return wrapError(err)
 	}
 	configUpdated := false
 	configUpdateErr := ""
 	if ref := stringFromMap(result, "secret_ref"); ref != "" {
-		updated, err := a.upsertWorkspaceSecretRef(workspace.Discovery.WorkspaceRoot, opts.ServiceName, config.SecretRef{Name: opts.Name, Secret: ref})
+		updated, err := a.upsertWorkspaceSecretRef(workspace.Discovery.WorkspaceRoot, serviceName, config.SecretRef{Name: opts.Name, Secret: ref})
 		if err != nil {
 			configUpdateErr = err.Error()
 		} else {
@@ -1867,7 +1868,8 @@ func (a *App) SecretList(ctx context.Context, opts SecretListOptions) error {
 }
 
 func (a *App) SecretDelete(ctx context.Context, opts SecretDeleteOptions) error {
-	if strings.TrimSpace(opts.ServiceName) == "" {
+	serviceName := strings.TrimSpace(opts.ServiceName)
+	if serviceName == "" {
 		return ExitError{Code: 2, Err: errors.New("missing required option: --service")}
 	}
 	if strings.TrimSpace(opts.Name) == "" {
@@ -1881,14 +1883,14 @@ func (a *App) SecretDelete(ctx context.Context, opts SecretDeleteOptions) error 
 	if err != nil {
 		return err
 	}
-	if err := a.requireConfiguredService(workspace.Discovery.WorkspaceRoot, opts.ServiceName); err != nil {
+	if err := a.requireConfiguredService(workspace.Discovery.WorkspaceRoot, serviceName); err != nil {
 		return err
 	}
-	result, err := a.API.DeleteEnvironmentSecret(ctx, tokens.AccessToken, workspace.Environment.ID, opts.ServiceName, opts.Name)
+	result, err := a.API.DeleteEnvironmentSecret(ctx, tokens.AccessToken, workspace.Environment.ID, serviceName, opts.Name)
 	if err != nil {
 		return wrapError(err)
 	}
-	configUpdated, err := a.removeWorkspaceSecretRef(workspace.Discovery.WorkspaceRoot, opts.ServiceName, opts.Name)
+	configUpdated, err := a.removeWorkspaceSecretRef(workspace.Discovery.WorkspaceRoot, serviceName, opts.Name)
 	configUpdateErr := ""
 	if err != nil {
 		configUpdateErr = err.Error()
@@ -2019,6 +2021,7 @@ func yesNo(value bool) string {
 }
 
 func (a *App) requireConfiguredService(workspaceRoot, serviceName string) error {
+	serviceName = strings.TrimSpace(serviceName)
 	cfg, err := a.ConfigStore.Read(workspaceRoot)
 	if err != nil {
 		return wrapError(err)
@@ -2033,6 +2036,7 @@ func (a *App) requireConfiguredService(workspaceRoot, serviceName string) error 
 }
 
 func (a *App) upsertWorkspaceSecretRef(workspaceRoot, serviceName string, ref config.SecretRef) (bool, error) {
+	serviceName = strings.TrimSpace(serviceName)
 	cfg, err := a.ConfigStore.Read(workspaceRoot)
 	if err != nil {
 		return false, wrapError(err)
@@ -2053,6 +2057,7 @@ func (a *App) upsertWorkspaceSecretRef(workspaceRoot, serviceName string, ref co
 }
 
 func (a *App) removeWorkspaceSecretRef(workspaceRoot, serviceName, name string) (bool, error) {
+	serviceName = strings.TrimSpace(serviceName)
 	cfg, err := a.ConfigStore.Read(workspaceRoot)
 	if err != nil {
 		return false, wrapError(err)

--- a/cli/internal/workflow/app.go
+++ b/cli/internal/workflow/app.go
@@ -1807,7 +1807,13 @@ func (a *App) SecretSet(ctx context.Context, opts SecretSetOptions) error {
 	}
 	result["schema_version"] = outputSchemaVersion
 	if a.Printer.JSON {
-		return a.Printer.PrintJSON(result)
+		if err := a.Printer.PrintJSON(result); err != nil {
+			return err
+		}
+		if configUpdateErr != "" {
+			return ExitError{Code: 1, Err: fmt.Errorf("secret saved, but devopsellence.yml was not updated: %s", configUpdateErr)}
+		}
+		return nil
 	}
 	if workspace.Discovery.AppType == config.AppTypeRails && workspace.Discovery.FallbackUsed {
 		a.Printer.Errorln("Could not infer Rails module name; using directory name", fmt.Sprintf("%q.", workspace.Discovery.ProjectName))
@@ -1816,7 +1822,7 @@ func (a *App) SecretSet(ctx context.Context, opts SecretSetOptions) error {
 	a.Printer.Println("Ref:", stringFromMap(result, "secret_ref"))
 	if configUpdateErr != "" {
 		a.Printer.Errorln("Secret saved, but devopsellence.yml was not updated:", configUpdateErr)
-		return nil
+		return ExitError{Code: 1, Err: fmt.Errorf("secret saved, but devopsellence.yml was not updated: %s", configUpdateErr)}
 	}
 	if configUpdated {
 		a.Printer.Println("Updated:", a.ConfigStore.PathFor(workspace.Discovery.WorkspaceRoot))
@@ -1895,7 +1901,13 @@ func (a *App) SecretDelete(ctx context.Context, opts SecretDeleteOptions) error 
 	}
 	result["schema_version"] = outputSchemaVersion
 	if a.Printer.JSON {
-		return a.Printer.PrintJSON(result)
+		if err := a.Printer.PrintJSON(result); err != nil {
+			return err
+		}
+		if configUpdateErr != "" {
+			return ExitError{Code: 1, Err: fmt.Errorf("secret deleted, but devopsellence.yml was not updated: %s", configUpdateErr)}
+		}
+		return nil
 	}
 	if workspace.Discovery.AppType == config.AppTypeRails && workspace.Discovery.FallbackUsed {
 		a.Printer.Errorln("Could not infer Rails module name; using directory name", fmt.Sprintf("%q.", workspace.Discovery.ProjectName))
@@ -1903,7 +1915,7 @@ func (a *App) SecretDelete(ctx context.Context, opts SecretDeleteOptions) error 
 	a.Printer.Println("Deleted secret", stringFromMap(result, "name"), "for", stringFromMap(result, "service_name")+".")
 	if configUpdateErr != "" {
 		a.Printer.Errorln("Secret deleted, but devopsellence.yml was not updated:", configUpdateErr)
-		return nil
+		return ExitError{Code: 1, Err: fmt.Errorf("secret deleted, but devopsellence.yml was not updated: %s", configUpdateErr)}
 	}
 	if configUpdated {
 		a.Printer.Println("Updated:", a.ConfigStore.PathFor(workspace.Discovery.WorkspaceRoot))

--- a/cli/internal/workflow/app.go
+++ b/cli/internal/workflow/app.go
@@ -300,6 +300,17 @@ type SecretDeleteOptions struct {
 	Name         string
 }
 
+type listedSecret struct {
+	ServiceName string `json:"service_name"`
+	Name        string `json:"name"`
+	SecretRef   string `json:"secret_ref,omitempty"`
+	Store       string `json:"store,omitempty"`
+	Reference   string `json:"reference,omitempty"`
+	Configured  bool   `json:"configured"`
+	Stored      bool   `json:"stored"`
+	Exposed     bool   `json:"exposed"`
+}
+
 type TokenCreateOptions struct {
 	Name string
 }
@@ -1780,14 +1791,19 @@ func (a *App) SecretSet(ctx context.Context, opts SecretSetOptions) error {
 		return wrapError(err)
 	}
 	configUpdated := false
+	configUpdateErr := ""
 	if ref := stringFromMap(result, "secret_ref"); ref != "" {
 		updated, err := a.upsertWorkspaceSecretRef(workspace.Discovery.WorkspaceRoot, opts.ServiceName, config.SecretRef{Name: opts.Name, Secret: ref})
 		if err != nil {
-			return err
+			configUpdateErr = err.Error()
+		} else {
+			configUpdated = updated
 		}
-		configUpdated = updated
 		result["config_updated"] = updated
 		result["config_path"] = a.ConfigStore.PathFor(workspace.Discovery.WorkspaceRoot)
+		if configUpdateErr != "" {
+			result["config_error"] = configUpdateErr
+		}
 	}
 	result["schema_version"] = outputSchemaVersion
 	if a.Printer.JSON {
@@ -1798,6 +1814,10 @@ func (a *App) SecretSet(ctx context.Context, opts SecretSetOptions) error {
 	}
 	a.Printer.Println("Saved secret", stringFromMap(result, "name"), "for", stringFromMap(result, "service_name")+".")
 	a.Printer.Println("Ref:", stringFromMap(result, "secret_ref"))
+	if configUpdateErr != "" {
+		a.Printer.Errorln("Secret saved, but devopsellence.yml was not updated:", configUpdateErr)
+		return nil
+	}
 	if configUpdated {
 		a.Printer.Println("Updated:", a.ConfigStore.PathFor(workspace.Discovery.WorkspaceRoot))
 	}
@@ -1817,22 +1837,25 @@ func (a *App) SecretList(ctx context.Context, opts SecretListOptions) error {
 	if err != nil {
 		return wrapError(err)
 	}
+	items, err := a.sharedSecretListItems(workspace.Discovery.WorkspaceRoot, secrets)
+	if err != nil {
+		return err
+	}
 	if a.Printer.JSON {
 		return a.Printer.PrintJSON(map[string]any{
 			"schema_version": outputSchemaVersion,
-			"secrets":        secrets,
+			"secrets":        items,
 		})
 	}
 	if workspace.Discovery.AppType == config.AppTypeRails && workspace.Discovery.FallbackUsed {
 		a.Printer.Errorln("Could not infer Rails module name; using directory name", fmt.Sprintf("%q.", workspace.Discovery.ProjectName))
 	}
-	if len(secrets) == 0 {
+	if len(items) == 0 {
 		a.Printer.Println("No secrets configured.")
 		return nil
 	}
-	for _, secret := range secrets {
-		line := secret.ServiceName + " " + secret.Name + " -> " + secret.SecretRef
-		a.Printer.Println(line)
+	for _, item := range items {
+		a.Printer.Println(formatListedSecret(item))
 	}
 	return nil
 }
@@ -1860,11 +1883,16 @@ func (a *App) SecretDelete(ctx context.Context, opts SecretDeleteOptions) error 
 		return wrapError(err)
 	}
 	configUpdated, err := a.removeWorkspaceSecretRef(workspace.Discovery.WorkspaceRoot, opts.ServiceName, opts.Name)
+	configUpdateErr := ""
 	if err != nil {
-		return err
+		configUpdateErr = err.Error()
+		configUpdated = false
 	}
 	result["config_updated"] = configUpdated
 	result["config_path"] = a.ConfigStore.PathFor(workspace.Discovery.WorkspaceRoot)
+	if configUpdateErr != "" {
+		result["config_error"] = configUpdateErr
+	}
 	result["schema_version"] = outputSchemaVersion
 	if a.Printer.JSON {
 		return a.Printer.PrintJSON(result)
@@ -1873,10 +1901,109 @@ func (a *App) SecretDelete(ctx context.Context, opts SecretDeleteOptions) error 
 		a.Printer.Errorln("Could not infer Rails module name; using directory name", fmt.Sprintf("%q.", workspace.Discovery.ProjectName))
 	}
 	a.Printer.Println("Deleted secret", stringFromMap(result, "name"), "for", stringFromMap(result, "service_name")+".")
+	if configUpdateErr != "" {
+		a.Printer.Errorln("Secret deleted, but devopsellence.yml was not updated:", configUpdateErr)
+		return nil
+	}
 	if configUpdated {
 		a.Printer.Println("Updated:", a.ConfigStore.PathFor(workspace.Discovery.WorkspaceRoot))
 	}
 	return nil
+}
+
+func (a *App) sharedSecretListItems(workspaceRoot string, secrets []api.EnvironmentSecret) ([]listedSecret, error) {
+	cfg, err := a.ConfigStore.Read(workspaceRoot)
+	if err != nil {
+		return nil, wrapError(err)
+	}
+	items := map[string]listedSecret{}
+	if cfg != nil {
+		for _, serviceName := range cfg.ServiceNames() {
+			for _, ref := range cfg.Services[serviceName].SecretRefs {
+				key := secretListKey(serviceName, ref.Name)
+				items[key] = listedSecret{
+					ServiceName: serviceName,
+					Name:        ref.Name,
+					SecretRef:   strings.TrimSpace(ref.Secret),
+					Store:       secretListStore(strings.TrimSpace(ref.Secret), "managed"),
+					Configured:  true,
+					Exposed:     true,
+				}
+			}
+		}
+	}
+	for _, secret := range secrets {
+		key := secretListKey(secret.ServiceName, secret.Name)
+		item := items[key]
+		if item.ServiceName == "" {
+			item = listedSecret{
+				ServiceName: secret.ServiceName,
+				Name:        secret.Name,
+				Store:       "managed",
+			}
+		}
+		if strings.TrimSpace(item.SecretRef) == "" {
+			item.SecretRef = strings.TrimSpace(secret.SecretRef)
+		}
+		item.Reference = strings.TrimSpace(secret.SecretRef)
+		item.Stored = true
+		items[key] = item
+	}
+	return sortListedSecrets(items), nil
+}
+
+func secretListKey(serviceName, name string) string {
+	return strings.TrimSpace(serviceName) + "\x00" + strings.TrimSpace(name)
+}
+
+func secretListStore(secretRef, fallback string) string {
+	if strings.HasPrefix(strings.ToLower(strings.TrimSpace(secretRef)), "op://") {
+		return solo.SecretStoreOnePassword
+	}
+	store, _, ok := parseDevopsellenceSecretRef(secretRef)
+	if ok {
+		return store
+	}
+	return fallback
+}
+
+func sortListedSecrets(items map[string]listedSecret) []listedSecret {
+	result := make([]listedSecret, 0, len(items))
+	for _, item := range items {
+		result = append(result, item)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].ServiceName != result[j].ServiceName {
+			return result[i].ServiceName < result[j].ServiceName
+		}
+		return result[i].Name < result[j].Name
+	})
+	return result
+}
+
+func formatListedSecret(item listedSecret) string {
+	parts := []string{
+		item.ServiceName,
+		item.Name,
+		"exposed=" + yesNo(item.Exposed),
+		"configured=" + yesNo(item.Configured),
+		"stored=" + yesNo(item.Stored),
+	}
+	if item.Store != "" {
+		parts = append(parts, "store="+item.Store)
+	}
+	line := strings.Join(parts, " ")
+	if item.SecretRef != "" {
+		line += " -> " + item.SecretRef
+	}
+	return line
+}
+
+func yesNo(value bool) string {
+	if value {
+		return "yes"
+	}
+	return "no"
 }
 
 func (a *App) requireConfiguredService(workspaceRoot, serviceName string) error {

--- a/cli/internal/workflow/management_test.go
+++ b/cli/internal/workflow/management_test.go
@@ -11,7 +11,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
-	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -21,7 +20,6 @@ import (
 	"github.com/devopsellence/cli/internal/api"
 	"github.com/devopsellence/cli/internal/auth"
 	"github.com/devopsellence/cli/internal/config"
-	"github.com/devopsellence/cli/internal/discovery"
 	"github.com/devopsellence/cli/internal/docker"
 	"github.com/devopsellence/cli/internal/git"
 	"github.com/devopsellence/cli/internal/output"
@@ -1007,6 +1005,14 @@ func TestSecretSetUsesWorkspaceEnvironment(t *testing.T) {
 	if value := stringValueAny(captured["value"]); value != "super-secret" {
 		t.Fatalf("value = %v, want super-secret", captured["value"])
 	}
+	cfg, err := config.LoadFromRoot(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	refs := cfg.Services["web"].SecretRefs
+	if len(refs) != 1 || refs[0].Name != "SECRET_KEY_BASE" || refs[0].Secret != "gsm://projects/test/secrets/abc/versions/latest" {
+		t.Fatalf("secret refs = %#v", refs)
+	}
 }
 
 func TestSecretSetReadsValueFromStdin(t *testing.T) {
@@ -1077,8 +1083,11 @@ func TestSecretListUsesWorkspaceEnvironment(t *testing.T) {
 	if !strings.Contains(stdout.String(), "SECRET_KEY_BASE") {
 		t.Fatalf("SecretList() output = %q, want secret listing", stdout.String())
 	}
-	if !strings.Contains(stdout.String(), "RAILS_MASTER_KEY -> gsm://projects/test/secrets/rails/versions/latest (auto-managed from config/master.key)") {
-		t.Fatalf("SecretList() output = %q, want Rails auto-managed note", stdout.String())
+	if !strings.Contains(stdout.String(), "RAILS_MASTER_KEY -> gsm://projects/test/secrets/rails/versions/latest") {
+		t.Fatalf("SecretList() output = %q, want Rails secret listing", stdout.String())
+	}
+	if strings.Contains(stdout.String(), "auto-managed") {
+		t.Fatalf("SecretList() output = %q, unexpected auto-managed note", stdout.String())
 	}
 }
 
@@ -1086,7 +1095,11 @@ func TestSecretDeleteUsesWorkspaceEnvironment(t *testing.T) {
 	t.Parallel()
 
 	root := makeRailsRoot(t, "ShopApp")
-	if _, err := config.Write(root, config.DefaultProjectConfig("default", "ShopApp", "staging")); err != nil {
+	project := config.DefaultProjectConfig("default", "ShopApp", "staging")
+	web := project.Services["web"]
+	web.SecretRefs = []config.SecretRef{{Name: "SECRET_KEY_BASE", Secret: "gsm://projects/test/secrets/abc/versions/latest"}}
+	project.Services["web"] = web
+	if _, err := config.Write(root, project); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
 
@@ -1112,6 +1125,13 @@ func TestSecretDeleteUsesWorkspaceEnvironment(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "Deleted secret SECRET_KEY_BASE for web.") {
 		t.Fatalf("SecretDelete() output = %q", stdout.String())
+	}
+	cfg, err := config.LoadFromRoot(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if refs := cfg.Services["web"].SecretRefs; len(refs) != 0 {
+		t.Fatalf("secret refs = %#v, want none", refs)
 	}
 }
 
@@ -1536,7 +1556,7 @@ func TestDeployUsesResolveDeployTargetWhenAvailable(t *testing.T) {
 	}
 }
 
-func TestDeployAppliesGitHubActionRuntimeOverrides(t *testing.T) {
+func TestDeployAppliesGitHubActionEnvVarOverrides(t *testing.T) {
 	root := makeGitGenericRoot(t)
 	project := config.DefaultProjectConfigForType("default", filepath.Base(root), "production", config.AppTypeGeneric)
 	web := project.Services[config.DefaultWebServiceName]
@@ -1552,10 +1572,8 @@ func TestDeployAppliesGitHubActionRuntimeOverrides(t *testing.T) {
 	commitAll(t, root, "add config")
 
 	t.Setenv(deployEnvVarsOverrideEnv, `{"all":{"RAILS_ENV":"production"},"web":{"WEB_ONLY":"true"},"worker":{"QUEUE":"critical"}}`)
-	t.Setenv(deploySecretsOverrideEnv, `{"all":{"DATABASE_URL":"postgres://db"},"worker":{"REDIS_URL":"redis://cache"}}`)
 
 	var releaseCaptured api.ReleaseCreateRequest
-	var secretPayloads []map[string]any
 	app := newTestAppWithDeployTarget(t, root, roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		switch {
 		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/cli/deploy_target":
@@ -1566,17 +1584,6 @@ func TestDeployAppliesGitHubActionRuntimeOverrides(t *testing.T) {
 				"project_created":      false,
 				"environment":          map[string]any{"id": 44, "name": "production", "project_id": 11},
 				"environment_created":  false,
-			}), nil
-		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/cli/environments/44/secrets":
-			var payload map[string]any
-			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
-				t.Fatalf("decode secret payload: %v", err)
-			}
-			secretPayloads = append(secretPayloads, payload)
-			return jsonResponseWithStatus(t, http.StatusCreated, map[string]any{
-				"name":         payload["name"],
-				"service_name": payload["service_name"],
-				"secret_ref":   "gsm://projects/test/secrets/" + payload["name"].(string) + "/versions/latest",
 			}), nil
 		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/cli/projects/11/releases":
 			if err := json.NewDecoder(r.Body).Decode(&releaseCaptured); err != nil {
@@ -1638,15 +1645,6 @@ func TestDeployAppliesGitHubActionRuntimeOverrides(t *testing.T) {
 	}
 	if got, want := workerPayload["env"], map[string]any{"WORKER_FROM_CONFIG": "1", "RAILS_ENV": "production", "QUEUE": "critical"}; !equalJSONMap(got, want) {
 		t.Fatalf("worker env = %#v, want %#v", got, want)
-	}
-
-	wantSecrets := []map[string]any{
-		{"service_name": "web", "name": "DATABASE_URL", "value": "postgres://db"},
-		{"service_name": "worker", "name": "DATABASE_URL", "value": "postgres://db"},
-		{"service_name": "worker", "name": "REDIS_URL", "value": "redis://cache"},
-	}
-	if !equalSecretPayloads(secretPayloads, wantSecrets) {
-		t.Fatalf("secret payloads = %#v, want %#v", secretPayloads, wantSecrets)
 	}
 }
 
@@ -2159,362 +2157,6 @@ func TestDeleteUsesWorkspaceEnvironment(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "Customer nodes unassigned: 2 Managed servers scheduled for delete: 1") {
 		t.Fatalf("Delete() output = %q", stdout.String())
-	}
-}
-
-func TestDeployRailsSyncsMasterKeySecret(t *testing.T) {
-	t.Parallel()
-
-	root := makeGitRailsRoot(t, "ShopApp")
-	project := config.DefaultProjectConfig("default", "ShopApp", "production")
-	project.Services["worker"] = config.ServiceConfig{Command: []string{"bin/jobs"}}
-	if _, err := config.Write(root, project); err != nil {
-		t.Fatalf("write config: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(root, "config", "master.key"), []byte("master-key-value\n"), 0o600); err != nil {
-		t.Fatalf("write master.key: %v", err)
-	}
-	commitAll(t, root, "configure deploy state")
-
-	secretValues := map[string]string{}
-	var secretValuesMu sync.Mutex
-	var stdout bytes.Buffer
-	app := newTestApp(t, root, roundTripFunc(func(r *http.Request) (*http.Response, error) {
-		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/cli/organizations":
-			return jsonResponse(t, map[string]any{"organizations": []map[string]any{{"id": 7, "name": "default", "role": "owner"}}}), nil
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/cli/projects":
-			return jsonResponse(t, map[string]any{"projects": []map[string]any{{"id": 11, "name": "ShopApp"}}}), nil
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/cli/projects/11/environments":
-			return jsonResponse(t, map[string]any{"environments": []map[string]any{{"id": 44, "name": "production"}}}), nil
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/cli/environments/44/secrets":
-			return jsonResponse(t, map[string]any{"secrets": []map[string]any{}}), nil
-		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/cli/environments/44/secrets":
-			var payload map[string]any
-			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
-				t.Fatalf("decode secret payload: %v", err)
-			}
-			secretValuesMu.Lock()
-			secretValues[stringValueAny(payload["service_name"])] = stringValueAny(payload["value"])
-			secretValuesMu.Unlock()
-			return jsonResponse(t, map[string]any{"name": stringValueAny(payload["name"]), "service_name": stringValueAny(payload["service_name"]), "secret_ref": "gsm://projects/test/secrets/abc/versions/latest"}), nil
-		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/cli/projects/11/releases":
-			return jsonResponseWithStatus(t, http.StatusCreated, map[string]any{"id": 22}), nil
-		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/cli/releases/22/publish":
-			return jsonResponseWithStatus(t, http.StatusCreated, map[string]any{
-				"deployment_id":  77,
-				"assigned_nodes": 1,
-				"public_url":     "https://shop.example.test",
-			}), nil
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/cli/deployments/77":
-			return jsonResponse(t, map[string]any{
-				"id":          77,
-				"sequence":    1,
-				"status":      "published",
-				"environment": map[string]any{"id": 44, "name": "production"},
-				"release":     map[string]any{"id": 22, "revision": "rel-1"},
-				"summary": map[string]any{
-					"assigned_nodes": 1,
-					"pending":        0,
-					"reconciling":    0,
-					"settled":        1,
-					"error":          0,
-					"active":         false,
-					"complete":       true,
-					"failed":         false,
-				},
-				"nodes": []map[string]any{
-					{"id": 1, "name": "node-a", "phase": "settled", "message": "revision healthy"},
-				},
-			}), nil
-		default:
-			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
-			return nil, nil
-		}
-	}))
-	app.Printer = output.New(&stdout, io.Discard, false)
-	app.DeployPollInterval = 5 * time.Millisecond
-	app.DeployTimeout = 500 * time.Millisecond
-
-	if err := app.Deploy(context.Background(), DeployOptions{Image: "example.com/shop@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}); err != nil {
-		t.Fatalf("Deploy() error = %v", err)
-	}
-	secretValuesMu.Lock()
-	if got := secretValues["web"]; got != "master-key-value" {
-		secretValuesMu.Unlock()
-		t.Fatalf("web secret value = %q, want master-key-value", got)
-	}
-	if got := secretValues["worker"]; got != "master-key-value" {
-		secretValuesMu.Unlock()
-		t.Fatalf("worker secret value = %q, want master-key-value", got)
-	}
-	secretValuesMu.Unlock()
-	if !strings.Contains(stdout.String(), "Rails: syncing RAILS_MASTER_KEY from config/master.key for web, worker.") {
-		t.Fatalf("Deploy() output = %q, want explicit Rails sync notice", stdout.String())
-	}
-	if !strings.Contains(stdout.String(), "synced RAILS_MASTER_KEY for web, worker.") {
-		t.Fatalf("Deploy() output = %q, want Rails secret sync summary", stdout.String())
-	}
-}
-
-func TestDeployRailsCanSkipMasterKeySync(t *testing.T) {
-	t.Parallel()
-
-	root := makeGitRailsRoot(t, "ShopApp")
-	project := config.DefaultProjectConfig("default", "ShopApp", "production")
-	if _, err := config.Write(root, project); err != nil {
-		t.Fatalf("write config: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(root, "config", "master.key"), []byte("master-key-value\n"), 0o600); err != nil {
-		t.Fatalf("write master.key: %v", err)
-	}
-	commitAll(t, root, "configure deploy state")
-
-	var stdout bytes.Buffer
-	app := newTestApp(t, root, roundTripFunc(func(r *http.Request) (*http.Response, error) {
-		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/cli/organizations":
-			return jsonResponse(t, map[string]any{"organizations": []map[string]any{{"id": 7, "name": "default", "role": "owner"}}}), nil
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/cli/projects":
-			return jsonResponse(t, map[string]any{"projects": []map[string]any{{"id": 11, "name": "ShopApp"}}}), nil
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/cli/projects/11/environments":
-			return jsonResponse(t, map[string]any{"environments": []map[string]any{{"id": 44, "name": "production"}}}), nil
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/cli/environments/44/secrets":
-			return jsonResponse(t, map[string]any{"secrets": []map[string]any{}}), nil
-		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/cli/environments/44/secrets":
-			t.Fatalf("unexpected Rails secret sync request")
-			return nil, nil
-		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/cli/projects/11/releases":
-			return jsonResponseWithStatus(t, http.StatusCreated, map[string]any{"id": 22}), nil
-		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/cli/releases/22/publish":
-			return jsonResponseWithStatus(t, http.StatusCreated, map[string]any{
-				"deployment_id":  77,
-				"assigned_nodes": 1,
-				"public_url":     "https://shop.example.test",
-			}), nil
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/cli/deployments/77":
-			return jsonResponse(t, map[string]any{
-				"id":          77,
-				"sequence":    1,
-				"status":      "published",
-				"environment": map[string]any{"id": 44, "name": "production"},
-				"release":     map[string]any{"id": 22, "revision": "rel-1"},
-				"summary": map[string]any{
-					"assigned_nodes": 1,
-					"pending":        0,
-					"reconciling":    0,
-					"settled":        1,
-					"error":          0,
-					"active":         false,
-					"complete":       true,
-					"failed":         false,
-				},
-				"nodes": []map[string]any{
-					{"id": 1, "name": "node-a", "phase": "settled", "message": "revision healthy"},
-				},
-			}), nil
-		default:
-			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
-			return nil, nil
-		}
-	}))
-	app.Printer = output.New(&stdout, io.Discard, false)
-	app.DeployPollInterval = 5 * time.Millisecond
-	app.DeployTimeout = 500 * time.Millisecond
-
-	if err := app.Deploy(context.Background(), DeployOptions{
-		Image:                  "example.com/shop@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-		SkipRailsMasterKeySync: true,
-	}); err != nil {
-		t.Fatalf("Deploy() error = %v", err)
-	}
-	if !strings.Contains(stdout.String(), "Rails: skipping RAILS_MASTER_KEY sync (--no-rails-master-key-sync).") {
-		t.Fatalf("Deploy() output = %q, want skip notice", stdout.String())
-	}
-	if strings.Contains(stdout.String(), "synced RAILS_MASTER_KEY") {
-		t.Fatalf("Deploy() output = %q, unexpected sync summary", stdout.String())
-	}
-}
-
-func TestDeployRailsDoesNotSyncMasterKeyToHelperServices(t *testing.T) {
-	t.Parallel()
-
-	root := makeGitRailsRoot(t, "ShopApp")
-	project := config.DefaultProjectConfig("default", "ShopApp", "production")
-	project.Services["worker"] = config.ServiceConfig{}
-	web := project.Services["web"]
-	web.Image = "ghcr.io/acme/shop:latest"
-	project.Services["web"] = web
-	project.Services["cloudflared"] = config.ServiceConfig{
-		Image:   "docker.io/cloudflare/cloudflared:latest",
-		Command: []string{"cloudflared"},
-		Args:    []string{"tunnel", "run"},
-	}
-	if _, err := config.Write(root, project); err != nil {
-		t.Fatalf("write config: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(root, "config", "master.key"), []byte("master-key-value\n"), 0o600); err != nil {
-		t.Fatalf("write master.key: %v", err)
-	}
-	commitAll(t, root, "configure deploy state")
-
-	var stdout bytes.Buffer
-	secretValues := map[string]string{}
-	var secretValuesMu sync.Mutex
-	app := newTestApp(t, root, roundTripFunc(func(r *http.Request) (*http.Response, error) {
-		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/cli/organizations":
-			return jsonResponse(t, map[string]any{"organizations": []map[string]any{{"id": 7, "name": "default", "role": "owner"}}}), nil
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/cli/projects":
-			return jsonResponse(t, map[string]any{"projects": []map[string]any{{"id": 11, "name": "ShopApp"}}}), nil
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/cli/projects/11/environments":
-			return jsonResponse(t, map[string]any{"environments": []map[string]any{{"id": 44, "name": "production"}}}), nil
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/cli/environments/44/secrets":
-			return jsonResponse(t, map[string]any{"secrets": []map[string]any{}}), nil
-		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/cli/environments/44/secrets":
-			var payload map[string]any
-			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
-				t.Fatalf("decode secret request: %v", err)
-			}
-			secretValuesMu.Lock()
-			secretValues[stringValueAny(payload["service_name"])] = stringValueAny(payload["value"])
-			secretValuesMu.Unlock()
-			return jsonResponse(t, map[string]any{"name": stringValueAny(payload["name"]), "service_name": stringValueAny(payload["service_name"]), "secret_ref": "gsm://projects/test/secrets/abc/versions/latest"}), nil
-		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/cli/projects/11/releases":
-			return jsonResponseWithStatus(t, http.StatusCreated, map[string]any{"id": 22}), nil
-		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/cli/releases/22/publish":
-			return jsonResponseWithStatus(t, http.StatusCreated, map[string]any{
-				"deployment_id":  77,
-				"assigned_nodes": 1,
-				"public_url":     "https://shop.example.test",
-			}), nil
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/cli/deployments/77":
-			return jsonResponse(t, map[string]any{
-				"id":          77,
-				"sequence":    1,
-				"status":      "published",
-				"environment": map[string]any{"id": 44, "name": "production"},
-				"release":     map[string]any{"id": 22, "revision": "rel-1"},
-				"summary": map[string]any{
-					"assigned_nodes": 1,
-					"pending":        0,
-					"reconciling":    0,
-					"settled":        1,
-					"error":          0,
-					"active":         false,
-					"complete":       true,
-					"failed":         false,
-				},
-				"nodes": []map[string]any{{"id": 1, "name": "node-a", "phase": "settled", "message": "revision healthy"}},
-			}), nil
-		default:
-			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
-			return nil, nil
-		}
-	}))
-	app.Printer = output.New(&stdout, io.Discard, false)
-	app.DeployPollInterval = 5 * time.Millisecond
-	app.DeployTimeout = 500 * time.Millisecond
-
-	if err := app.Deploy(context.Background(), DeployOptions{Image: "example.com/shop@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}); err != nil {
-		t.Fatalf("Deploy() error = %v", err)
-	}
-	secretValuesMu.Lock()
-	defer secretValuesMu.Unlock()
-	if got := secretValues["web"]; got != "master-key-value" {
-		t.Fatalf("web secret value = %q, want master-key-value", got)
-	}
-	if got := secretValues["worker"]; got != "master-key-value" {
-		t.Fatalf("worker secret value = %q, want master-key-value", got)
-	}
-	if _, ok := secretValues["cloudflared"]; ok {
-		t.Fatalf("cloudflared unexpectedly received Rails master key: %#v", secretValues)
-	}
-	if !strings.Contains(stdout.String(), "Rails: syncing RAILS_MASTER_KEY from config/master.key for web, worker.") {
-		t.Fatalf("Deploy() output = %q, want Rails sync notice limited to app services", stdout.String())
-	}
-}
-
-func TestDeployRailsSkipsNoOpMasterKeyUpsertWhenDigestMatches(t *testing.T) {
-	t.Parallel()
-
-	root := makeGitRailsRoot(t, "ShopApp")
-	project := config.DefaultProjectConfig("default", "ShopApp", "production")
-	if _, err := config.Write(root, project); err != nil {
-		t.Fatalf("write config: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(root, "config", "master.key"), []byte("master-key-value\n"), 0o600); err != nil {
-		t.Fatalf("write master.key: %v", err)
-	}
-	commitAll(t, root, "configure deploy state")
-
-	var stdout bytes.Buffer
-	app := newTestApp(t, root, roundTripFunc(func(r *http.Request) (*http.Response, error) {
-		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/cli/organizations":
-			return jsonResponse(t, map[string]any{"organizations": []map[string]any{{"id": 7, "name": "default", "role": "owner"}}}), nil
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/cli/projects":
-			return jsonResponse(t, map[string]any{"projects": []map[string]any{{"id": 11, "name": "ShopApp"}}}), nil
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/cli/projects/11/environments":
-			return jsonResponse(t, map[string]any{"environments": []map[string]any{{"id": 44, "name": "production"}}}), nil
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/cli/environments/44/secrets":
-			return jsonResponse(t, map[string]any{
-				"secrets": []map[string]any{{
-					"service_name": "web",
-					"name":         "RAILS_MASTER_KEY",
-					"secret_ref":   "gsm://projects/test/secrets/abc/versions/latest",
-					"value_sha256": "b244ce38fa8ece00bd70b7528e38e96c958c7afec2d06d30c9a532c307a3221c",
-				}},
-			}), nil
-		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/cli/environments/44/secrets":
-			t.Fatalf("unexpected Rails secret sync request")
-			return nil, nil
-		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/cli/projects/11/releases":
-			return jsonResponseWithStatus(t, http.StatusCreated, map[string]any{"id": 22}), nil
-		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/cli/releases/22/publish":
-			return jsonResponseWithStatus(t, http.StatusCreated, map[string]any{
-				"deployment_id":  77,
-				"assigned_nodes": 1,
-				"public_url":     "https://shop.example.test",
-			}), nil
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/cli/deployments/77":
-			return jsonResponse(t, map[string]any{
-				"id":          77,
-				"sequence":    1,
-				"status":      "published",
-				"environment": map[string]any{"id": 44, "name": "production"},
-				"release":     map[string]any{"id": 22, "revision": "rel-1"},
-				"summary": map[string]any{
-					"assigned_nodes": 1,
-					"pending":        0,
-					"reconciling":    0,
-					"settled":        1,
-					"error":          0,
-					"active":         false,
-					"complete":       true,
-					"failed":         false,
-				},
-				"nodes": []map[string]any{
-					{"id": 1, "name": "node-a", "phase": "settled", "message": "revision healthy"},
-				},
-			}), nil
-		default:
-			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
-			return nil, nil
-		}
-	}))
-	app.Printer = output.New(&stdout, io.Discard, false)
-	app.DeployPollInterval = 5 * time.Millisecond
-	app.DeployTimeout = 500 * time.Millisecond
-
-	if err := app.Deploy(context.Background(), DeployOptions{Image: "example.com/shop@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}); err != nil {
-		t.Fatalf("Deploy() error = %v", err)
-	}
-	if !strings.Contains(stdout.String(), "Rails: RAILS_MASTER_KEY already current for web.") {
-		t.Fatalf("Deploy() output = %q, want current-secret notice", stdout.String())
-	}
-	if strings.Contains(stdout.String(), "synced RAILS_MASTER_KEY") {
-		t.Fatalf("Deploy() output = %q, unexpected sync summary", stdout.String())
 	}
 }
 
@@ -3439,7 +3081,7 @@ func TestWarnAboutPrebuiltImageConfigForRails(t *testing.T) {
 	cfg := config.DefaultProjectConfig("default", "ShopApp", "production")
 	app.warnAboutPrebuiltImageConfig(DeployOptions{
 		Image: "docker.io/mccutchen/go-httpbin@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-	}, discovery.Result{WorkspaceRoot: root}, cfg)
+	}, cfg)
 
 	text := stderr.String()
 	if !strings.Contains(text, "Using --image skips the local build.") {
@@ -3447,107 +3089,6 @@ func TestWarnAboutPrebuiltImageConfigForRails(t *testing.T) {
 	}
 	if !strings.Contains(text, "If this image is not a Rails image, update devopsellence.yml before deploy.") {
 		t.Fatalf("warning output = %q", text)
-	}
-}
-
-func TestDeployRailsSecretSyncRunsConcurrently(t *testing.T) {
-	t.Parallel()
-
-	root := makeGitRailsRoot(t, "ShopApp")
-	project := config.DefaultProjectConfig("default", "ShopApp", "production")
-	project.Services["worker"] = config.ServiceConfig{Command: []string{"bin/jobs"}}
-	if _, err := config.Write(root, project); err != nil {
-		t.Fatalf("write config: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(root, "config", "master.key"), []byte("master-key-value\n"), 0o600); err != nil {
-		t.Fatalf("write master.key: %v", err)
-	}
-	commitAll(t, root, "configure deploy state")
-
-	bothStarted := make(chan struct{})
-	releaseSecrets := make(chan struct{})
-	var once sync.Once
-	var mu sync.Mutex
-	seen := map[string]bool{}
-
-	app := newTestApp(t, root, roundTripFunc(func(r *http.Request) (*http.Response, error) {
-		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/cli/organizations":
-			return jsonResponse(t, map[string]any{"organizations": []map[string]any{{"id": 7, "name": "default", "role": "owner"}}}), nil
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/cli/projects":
-			return jsonResponse(t, map[string]any{"projects": []map[string]any{{"id": 11, "name": "ShopApp"}}}), nil
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/cli/projects/11/environments":
-			return jsonResponse(t, map[string]any{"environments": []map[string]any{{"id": 44, "name": "production"}}}), nil
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/cli/environments/44/secrets":
-			return jsonResponse(t, map[string]any{"secrets": []map[string]any{}}), nil
-		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/cli/environments/44/secrets":
-			var payload map[string]any
-			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
-				t.Fatalf("decode secret payload: %v", err)
-			}
-			service := stringValueAny(payload["service_name"])
-			mu.Lock()
-			seen[service] = true
-			if len(seen) == 2 {
-				once.Do(func() { close(bothStarted) })
-			}
-			mu.Unlock()
-			<-releaseSecrets
-			return jsonResponse(t, map[string]any{"name": stringValueAny(payload["name"]), "service_name": service, "secret_ref": "gsm://projects/test/secrets/abc/versions/latest"}), nil
-		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/cli/projects/11/releases":
-			return jsonResponseWithStatus(t, http.StatusCreated, map[string]any{"id": 22}), nil
-		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/cli/releases/22/publish":
-			return jsonResponseWithStatus(t, http.StatusCreated, map[string]any{
-				"deployment_id":  77,
-				"assigned_nodes": 1,
-				"public_url":     "https://shop.example.test",
-			}), nil
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/cli/deployments/77":
-			return jsonResponse(t, map[string]any{
-				"id":          77,
-				"sequence":    1,
-				"status":      "published",
-				"environment": map[string]any{"id": 44, "name": "production"},
-				"release":     map[string]any{"id": 22, "revision": "rel-1"},
-				"summary": map[string]any{
-					"assigned_nodes": 1,
-					"pending":        0,
-					"reconciling":    0,
-					"settled":        1,
-					"error":          0,
-					"active":         false,
-					"complete":       true,
-					"failed":         false,
-				},
-				"nodes": []map[string]any{
-					{"id": 1, "name": "node-a", "phase": "settled", "message": "revision healthy"},
-				},
-			}), nil
-		default:
-			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
-			return nil, nil
-		}
-	}))
-	app.DeployPollInterval = 5 * time.Millisecond
-	app.DeployTimeout = 500 * time.Millisecond
-
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- app.Deploy(context.Background(), DeployOptions{
-			Image:          "example.com/shop@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-			NonInteractive: true,
-		})
-	}()
-
-	select {
-	case <-bothStarted:
-	case <-time.After(250 * time.Millisecond):
-		t.Fatal("secret sync did not start both requests concurrently")
-	}
-	close(releaseSecrets)
-
-	if err := <-errCh; err != nil {
-		t.Fatalf("Deploy() error = %v", err)
 	}
 }
 
@@ -3854,28 +3395,6 @@ func equalJSONMap(got any, want map[string]any) bool {
 	}
 	for key, value := range want {
 		if typed[key] != value {
-			return false
-		}
-	}
-	return true
-}
-
-func equalSecretPayloads(got []map[string]any, want []map[string]any) bool {
-	if len(got) != len(want) {
-		return false
-	}
-	sort.Slice(got, func(i, j int) bool {
-		left := stringValueAny(got[i]["service_name"]) + "\x00" + stringValueAny(got[i]["name"])
-		right := stringValueAny(got[j]["service_name"]) + "\x00" + stringValueAny(got[j]["name"])
-		return left < right
-	})
-	sort.Slice(want, func(i, j int) bool {
-		left := stringValueAny(want[i]["service_name"]) + "\x00" + stringValueAny(want[i]["name"])
-		right := stringValueAny(want[j]["service_name"]) + "\x00" + stringValueAny(want[j]["name"])
-		return left < right
-	})
-	for idx := range want {
-		if !equalJSONMap(got[idx], want[idx]) {
 			return false
 		}
 	}

--- a/cli/internal/workflow/management_test.go
+++ b/cli/internal/workflow/management_test.go
@@ -996,7 +996,7 @@ func TestSecretSetUsesWorkspaceEnvironment(t *testing.T) {
 			return nil, nil
 		}
 	}))
-	if err := app.SecretSet(context.Background(), SecretSetOptions{ServiceName: "web", Name: "SECRET_KEY_BASE", Value: "super-secret", ValueProvided: true}); err != nil {
+	if err := app.SecretSet(context.Background(), SecretSetOptions{ServiceName: " web ", Name: "SECRET_KEY_BASE", Value: "super-secret", ValueProvided: true}); err != nil {
 		t.Fatalf("SecretSet() error = %v", err)
 	}
 	if serviceName := stringValueAny(captured["service_name"]); serviceName != "web" {
@@ -1133,7 +1133,7 @@ func TestSecretDeleteUsesWorkspaceEnvironment(t *testing.T) {
 		}
 	}))
 	app.Printer.Out = &stdout
-	if err := app.SecretDelete(context.Background(), SecretDeleteOptions{ServiceName: "web", Name: "SECRET_KEY_BASE"}); err != nil {
+	if err := app.SecretDelete(context.Background(), SecretDeleteOptions{ServiceName: " web ", Name: "SECRET_KEY_BASE"}); err != nil {
 		t.Fatalf("SecretDelete() error = %v", err)
 	}
 	if !strings.Contains(stdout.String(), "Deleted secret SECRET_KEY_BASE for web.") {

--- a/cli/internal/workflow/management_test.go
+++ b/cli/internal/workflow/management_test.go
@@ -1053,7 +1053,14 @@ func TestSecretListUsesWorkspaceEnvironment(t *testing.T) {
 	t.Parallel()
 
 	root := makeRailsRoot(t, "ShopApp")
-	if _, err := config.Write(root, config.DefaultProjectConfig("default", "ShopApp", "staging")); err != nil {
+	project := config.DefaultProjectConfig("default", "ShopApp", "staging")
+	web := project.Services["web"]
+	web.SecretRefs = []config.SecretRef{
+		{Name: "SECRET_KEY_BASE", Secret: "gsm://projects/test/secrets/abc/versions/latest"},
+		{Name: "ONLY_IN_CONFIG", Secret: "gsm://projects/test/secrets/config-only/versions/latest"},
+	}
+	project.Services["web"] = web
+	if _, err := config.Write(root, project); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
 
@@ -1083,8 +1090,14 @@ func TestSecretListUsesWorkspaceEnvironment(t *testing.T) {
 	if !strings.Contains(stdout.String(), "SECRET_KEY_BASE") {
 		t.Fatalf("SecretList() output = %q, want secret listing", stdout.String())
 	}
-	if !strings.Contains(stdout.String(), "RAILS_MASTER_KEY -> gsm://projects/test/secrets/rails/versions/latest") {
-		t.Fatalf("SecretList() output = %q, want Rails secret listing", stdout.String())
+	if !strings.Contains(stdout.String(), "web SECRET_KEY_BASE exposed=yes configured=yes stored=yes store=managed -> gsm://projects/test/secrets/abc/versions/latest") {
+		t.Fatalf("SecretList() output = %q, want exposed configured secret", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "web ONLY_IN_CONFIG exposed=yes configured=yes stored=no store=managed -> gsm://projects/test/secrets/config-only/versions/latest") {
+		t.Fatalf("SecretList() output = %q, want config-only secret", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "web RAILS_MASTER_KEY exposed=no configured=no stored=yes store=managed -> gsm://projects/test/secrets/rails/versions/latest") {
+		t.Fatalf("SecretList() output = %q, want store-only Rails secret listing", stdout.String())
 	}
 	if strings.Contains(stdout.String(), "auto-managed") {
 		t.Fatalf("SecretList() output = %q, unexpected auto-managed note", stdout.String())

--- a/cli/internal/workflow/root.go
+++ b/cli/internal/workflow/root.go
@@ -694,7 +694,7 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 	secretSetCommand.Flags().StringVar(&secretSharedSetOpts.Organization, "org", "", "Organization name override (shared mode)")
 	secretSetCommand.Flags().StringVar(&secretSharedSetOpts.Project, "project", "", "Project name override (shared mode)")
 	secretSetCommand.Flags().StringVar(&secretEnvironment, "env", "", "Environment name override")
-	secretSetCommand.Flags().StringVar(&secretServiceName, "service", "", "Service name")
+	secretSetCommand.Flags().StringVar(&secretServiceName, "service", "", "Service name (required)")
 	secretSetCommand.Flags().StringVar(&secretStore, "store", "", "Solo secret store: plaintext or 1password")
 	secretSetCommand.Flags().StringVar(&secretReference, "op-ref", "", "1Password secret reference for solo mode")
 	secretSetCommand.Flags().StringVar(&secretValue, "value", "", "Secret value")
@@ -743,7 +743,7 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 	secretDeleteCommand.Flags().StringVar(&secretSharedDeleteOpts.Organization, "org", "", "Organization name override (shared mode)")
 	secretDeleteCommand.Flags().StringVar(&secretSharedDeleteOpts.Project, "project", "", "Project name override (shared mode)")
 	secretDeleteCommand.Flags().StringVar(&secretEnvironment, "env", "", "Environment name override")
-	secretDeleteCommand.Flags().StringVar(&secretServiceName, "service", "", "Service name")
+	secretDeleteCommand.Flags().StringVar(&secretServiceName, "service", "", "Service name (required)")
 	secretCommand.AddCommand(secretSetCommand, secretListCommand, secretDeleteCommand)
 	root.AddCommand(secretCommand)
 

--- a/cli/internal/workflow/root.go
+++ b/cli/internal/workflow/root.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -654,6 +655,8 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 	var secretValueStdin bool
 	var secretEnvironment string
 	var secretServiceName string
+	var secretStore string
+	var secretReference string
 	secretCommand := &cobra.Command{
 		Use:   "secret",
 		Short: "Manage secrets for the selected workspace mode",
@@ -666,6 +669,8 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 			secretSoloSetOpts.Key = strings.TrimSpace(args[0])
 			secretSoloSetOpts.Environment = secretEnvironment
 			secretSoloSetOpts.ServiceName = secretServiceName
+			secretSoloSetOpts.Store = secretStore
+			secretSoloSetOpts.Reference = secretReference
 			secretSoloSetOpts.Value = secretValue
 			secretSoloSetOpts.ValueStdin = secretValueStdin
 			secretSharedSetOpts.Name = strings.TrimSpace(args[0])
@@ -676,6 +681,12 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 			return runByMode(func(ctx context.Context) error {
 				return app.SoloSecretsSet(ctx, secretSoloSetOpts)
 			}, func(ctx context.Context) error {
+				if strings.TrimSpace(secretReference) != "" {
+					return ExitError{Code: 2, Err: errors.New("--op-ref is only supported in solo mode")}
+				}
+				if strings.TrimSpace(secretStore) != "" && !strings.EqualFold(strings.TrimSpace(secretStore), "plaintext") {
+					return ExitError{Code: 2, Err: errors.New("--store is only supported in solo mode")}
+				}
 				secretSharedSetOpts.ValueProvided = cmd.Flags().Changed("value")
 				return app.SecretSet(ctx, secretSharedSetOpts)
 			})(cmd, args)
@@ -685,11 +696,14 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 	secretSetCommand.Flags().StringVar(&secretSharedSetOpts.Project, "project", "", "Project name override (shared mode)")
 	secretSetCommand.Flags().StringVar(&secretEnvironment, "env", "", "Environment name override")
 	secretSetCommand.Flags().StringVar(&secretServiceName, "service", "", "Service name")
+	secretSetCommand.Flags().StringVar(&secretStore, "store", "", "Solo secret store: plaintext or 1password")
+	secretSetCommand.Flags().StringVar(&secretReference, "op-ref", "", "1Password secret reference for solo mode")
 	secretSetCommand.Flags().StringVar(&secretValue, "value", "", "Secret value")
 	secretSetCommand.Flags().BoolVar(&secretValueStdin, "stdin", false, "Read secret value from stdin")
 	secretSetCommand.Example = strings.Join([]string{
 		"  devopsellence secret set SECRET_KEY_BASE --service web --value super-secret",
 		"  printf '%s' \"$VALUE\" | devopsellence secret set SECRET_KEY_BASE --service web --stdin",
+		"  devopsellence secret set DATABASE_URL --service web --env production --store 1password --op-ref op://app-prod/db/password",
 	}, "\n")
 	secretListCommand := &cobra.Command{
 		Use:   "list",

--- a/cli/internal/workflow/root.go
+++ b/cli/internal/workflow/root.go
@@ -652,6 +652,8 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 	var secretSoloDeleteOpts SoloSecretsDeleteOptions
 	var secretValue string
 	var secretValueStdin bool
+	var secretEnvironment string
+	var secretServiceName string
 	secretCommand := &cobra.Command{
 		Use:   "secret",
 		Short: "Manage secrets for the selected workspace mode",
@@ -662,9 +664,13 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			secretSoloSetOpts.Key = strings.TrimSpace(args[0])
+			secretSoloSetOpts.Environment = secretEnvironment
+			secretSoloSetOpts.ServiceName = secretServiceName
 			secretSoloSetOpts.Value = secretValue
 			secretSoloSetOpts.ValueStdin = secretValueStdin
 			secretSharedSetOpts.Name = strings.TrimSpace(args[0])
+			secretSharedSetOpts.Environment = secretEnvironment
+			secretSharedSetOpts.ServiceName = secretServiceName
 			secretSharedSetOpts.Value = secretValue
 			secretSharedSetOpts.ValueStdin = secretValueStdin
 			return runByMode(func(ctx context.Context) error {
@@ -677,8 +683,8 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 	}
 	secretSetCommand.Flags().StringVar(&secretSharedSetOpts.Organization, "org", "", "Organization name override (shared mode)")
 	secretSetCommand.Flags().StringVar(&secretSharedSetOpts.Project, "project", "", "Project name override (shared mode)")
-	secretSetCommand.Flags().StringVar(&secretSharedSetOpts.Environment, "env", "", "Environment name override (shared mode)")
-	secretSetCommand.Flags().StringVar(&secretSharedSetOpts.ServiceName, "service", "", "Service name (required in shared mode)")
+	secretSetCommand.Flags().StringVar(&secretEnvironment, "env", "", "Environment name override")
+	secretSetCommand.Flags().StringVar(&secretServiceName, "service", "", "Service name")
 	secretSetCommand.Flags().StringVar(&secretValue, "value", "", "Secret value")
 	secretSetCommand.Flags().BoolVar(&secretValueStdin, "stdin", false, "Read secret value from stdin")
 	secretSetCommand.Example = strings.Join([]string{
@@ -688,22 +694,32 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 	secretListCommand := &cobra.Command{
 		Use:   "list",
 		Short: "List secrets",
-		RunE: runByMode(func(ctx context.Context) error {
-			return app.SoloSecretsList(ctx, secretSoloListOpts)
-		}, func(ctx context.Context) error {
-			return app.SecretList(ctx, secretSharedListOpts)
-		}),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			secretSoloListOpts.Environment = secretEnvironment
+			secretSoloListOpts.ServiceName = secretServiceName
+			secretSharedListOpts.Environment = secretEnvironment
+			return runByMode(func(ctx context.Context) error {
+				return app.SoloSecretsList(ctx, secretSoloListOpts)
+			}, func(ctx context.Context) error {
+				return app.SecretList(ctx, secretSharedListOpts)
+			})(cmd, args)
+		},
 	}
 	secretListCommand.Flags().StringVar(&secretSharedListOpts.Organization, "org", "", "Organization name override (shared mode)")
 	secretListCommand.Flags().StringVar(&secretSharedListOpts.Project, "project", "", "Project name override (shared mode)")
-	secretListCommand.Flags().StringVar(&secretSharedListOpts.Environment, "env", "", "Environment name override (shared mode)")
+	secretListCommand.Flags().StringVar(&secretEnvironment, "env", "", "Environment name override")
+	secretListCommand.Flags().StringVar(&secretServiceName, "service", "", "Service name filter (solo mode)")
 	secretDeleteCommand := &cobra.Command{
 		Use:   "delete <name>",
 		Short: "Delete a secret",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			secretSoloDeleteOpts.Key = strings.TrimSpace(args[0])
+			secretSoloDeleteOpts.Environment = secretEnvironment
+			secretSoloDeleteOpts.ServiceName = secretServiceName
 			secretSharedDeleteOpts.Name = strings.TrimSpace(args[0])
+			secretSharedDeleteOpts.Environment = secretEnvironment
+			secretSharedDeleteOpts.ServiceName = secretServiceName
 			return runByMode(func(ctx context.Context) error {
 				return app.SoloSecretsDelete(ctx, secretSoloDeleteOpts)
 			}, func(ctx context.Context) error {
@@ -713,8 +729,8 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 	}
 	secretDeleteCommand.Flags().StringVar(&secretSharedDeleteOpts.Organization, "org", "", "Organization name override (shared mode)")
 	secretDeleteCommand.Flags().StringVar(&secretSharedDeleteOpts.Project, "project", "", "Project name override (shared mode)")
-	secretDeleteCommand.Flags().StringVar(&secretSharedDeleteOpts.Environment, "env", "", "Environment name override (shared mode)")
-	secretDeleteCommand.Flags().StringVar(&secretSharedDeleteOpts.ServiceName, "service", "", "Service name (shared mode)")
+	secretDeleteCommand.Flags().StringVar(&secretEnvironment, "env", "", "Environment name override")
+	secretDeleteCommand.Flags().StringVar(&secretServiceName, "service", "", "Service name")
 	secretCommand.AddCommand(secretSetCommand, secretListCommand, secretDeleteCommand)
 	root.AddCommand(secretCommand)
 

--- a/cli/internal/workflow/root.go
+++ b/cli/internal/workflow/root.go
@@ -565,7 +565,6 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 	deployCommand.Flags().StringVar(&deploySharedOpts.Image, "image", "", "Deploy an existing digest ref instead of building locally (shared mode)")
 	deployCommand.Flags().StringVar(&deploySharedOpts.Environment, "env", os.Getenv("DEVOPSELLENCE_ENVIRONMENT"), "Environment name override (shared mode)")
 	deployCommand.Flags().BoolVar(&deploySharedOpts.NonInteractive, "non-interactive", false, "Disable interactive prompts if re-initialization is needed (shared mode)")
-	deployCommand.Flags().BoolVar(&deploySharedOpts.SkipRailsMasterKeySync, "no-rails-master-key-sync", false, "Do not auto-sync config/master.key to the shared secret RAILS_MASTER_KEY")
 	root.AddCommand(deployCommand)
 
 	var ingressSetOpts IngressSetOptions

--- a/cli/internal/workflow/root_test.go
+++ b/cli/internal/workflow/root_test.go
@@ -3,8 +3,12 @@ package workflow
 import (
 	"bytes"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/devopsellence/cli/internal/solo"
 )
 
 func TestRootVersionCommand(t *testing.T) {
@@ -109,6 +113,53 @@ func TestRootSecretSetRejectsExplicitEmptyValue(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "secret value is required") {
 		t.Fatalf("error = %v, want secret value is required", err)
+	}
+}
+
+func TestRootSoloSecretSetHonorsEnvironmentAndService(t *testing.T) {
+	var stdout bytes.Buffer
+	cwd := rootTestWorkspaceWithMode(t, ModeSolo)
+	if err := os.WriteFile(filepath.Join(cwd, "devopsellence.yml"), []byte(strings.Join([]string{
+		"schema_version: 6",
+		"organization: solo",
+		"project: demo",
+		"default_environment: production",
+		"build:",
+		"  context: .",
+		"  dockerfile: Dockerfile",
+		"services:",
+		"  web:",
+		"    ports:",
+		"      - name: http",
+		"        port: 3000",
+		"    healthcheck:",
+		"      path: /up",
+		"      port: 3000",
+	}, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, cwd)
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{"secret", "set", "DATABASE_URL", "--env", "staging", "--service", "web", "--value", "postgres://staging"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	current, err := solo.NewStateStore(solo.DefaultStatePath()).Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+	values, err := current.ScopedSecretValues(cwd, "staging")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := values.Value("web", "DATABASE_URL"); got != "postgres://staging" {
+		t.Fatalf("web DATABASE_URL = %q", got)
+	}
+	if got := values.Value("worker", "DATABASE_URL"); got != "" {
+		t.Fatalf("worker DATABASE_URL = %q", got)
 	}
 }
 

--- a/cli/internal/workflow/root_test.go
+++ b/cli/internal/workflow/root_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/devopsellence/cli/internal/config"
 	"github.com/devopsellence/cli/internal/solo"
 )
 
@@ -142,6 +143,14 @@ func TestRootSoloSecretSetHonorsEnvironmentAndService(t *testing.T) {
 	if got := values.Value("worker", "DATABASE_URL"); got != "" {
 		t.Fatalf("worker DATABASE_URL = %q", got)
 	}
+	cfg, err := config.LoadFromRoot(cwd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	refs := cfg.Services["web"].SecretRefs
+	if len(refs) != 1 || refs[0].Name != "DATABASE_URL" || refs[0].Secret != "devopsellence://plaintext/DATABASE_URL" {
+		t.Fatalf("secret refs = %#v", refs)
+	}
 }
 
 func TestRootSoloSecretSetAcceptsOnePasswordReference(t *testing.T) {
@@ -169,6 +178,14 @@ func TestRootSoloSecretSetAcceptsOnePasswordReference(t *testing.T) {
 	}
 	if secrets[0].Store != solo.SecretStoreOnePassword || secrets[0].Reference != "op://app/db/password" {
 		t.Fatalf("secret = %#v", secrets[0])
+	}
+	cfg, err := config.LoadFromRoot(cwd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	refs := cfg.Services["web"].SecretRefs
+	if len(refs) != 1 || refs[0].Name != "DATABASE_URL" || refs[0].Secret != "op://app/db/password" {
+		t.Fatalf("secret refs = %#v", refs)
 	}
 }
 

--- a/cli/internal/workflow/root_test.go
+++ b/cli/internal/workflow/root_test.go
@@ -221,6 +221,34 @@ func TestRootSoloSecretSetAcceptsOnePasswordReference(t *testing.T) {
 	}
 }
 
+func TestRootSoloSecretSetRejectsEnvConflict(t *testing.T) {
+	var stdout bytes.Buffer
+	cwd := rootTestSoloWorkspace(t)
+	cfg, err := config.LoadFromRoot(cwd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	web := cfg.Services["web"]
+	web.Env = map[string]string{"DATABASE_URL": "postgres://static"}
+	cfg.Services["web"] = web
+	if _, err := config.Write(cwd, *cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, cwd)
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{"secret", "set", "DATABASE_URL", "--service", "web", "--value", "postgres://secret"})
+
+	err = cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() error = nil, want env conflict")
+	}
+	if !strings.Contains(err.Error(), "already defines DATABASE_URL in env") {
+		t.Fatalf("error = %v, want env conflict", err)
+	}
+}
+
 func TestRootHelpShowsModeFirstFlows(t *testing.T) {
 	t.Parallel()
 

--- a/cli/internal/workflow/root_test.go
+++ b/cli/internal/workflow/root_test.go
@@ -123,7 +123,7 @@ func TestRootSoloSecretSetHonorsEnvironmentAndService(t *testing.T) {
 	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, cwd)
 	cmd.SetOut(&stdout)
 	cmd.SetErr(&stdout)
-	cmd.SetArgs([]string{"secret", "set", "DATABASE_URL", "--env", "staging", "--service", "web", "--value", "postgres://staging"})
+	cmd.SetArgs([]string{"secret", "set", "DATABASE_URL", "--env", "staging", "--service", " web ", "--value", "postgres://staging"})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)

--- a/cli/internal/workflow/root_test.go
+++ b/cli/internal/workflow/root_test.go
@@ -151,6 +151,38 @@ func TestRootSoloSecretSetHonorsEnvironmentAndService(t *testing.T) {
 	if len(refs) != 1 || refs[0].Name != "DATABASE_URL" || refs[0].Secret != "devopsellence://plaintext/DATABASE_URL" {
 		t.Fatalf("secret refs = %#v", refs)
 	}
+
+	web := cfg.Services["web"]
+	web.SecretRefs = append(web.SecretRefs, config.SecretRef{Name: "ONLY_IN_CONFIG", Secret: "devopsellence://plaintext/ONLY_IN_CONFIG"})
+	cfg.Services["web"] = web
+	if _, err := config.Write(cwd, *cfg); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := current.SetSecret(cwd, "staging", "web", "ONLY_IN_STORE", solo.SecretMaterial{Value: "store-only"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := solo.NewStateStore(solo.DefaultStatePath()).Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout.Reset()
+	cmd = NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, cwd)
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{"secret", "list", "--env", "staging", "--service", "web"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("list Execute() error = %v", err)
+	}
+	output := stdout.String()
+	for _, want := range []string{
+		"web DATABASE_URL exposed=yes configured=yes stored=yes store=plaintext -> devopsellence://plaintext/DATABASE_URL",
+		"web ONLY_IN_CONFIG exposed=yes configured=yes stored=no store=plaintext -> devopsellence://plaintext/ONLY_IN_CONFIG",
+		"web ONLY_IN_STORE exposed=no configured=no stored=yes store=plaintext -> devopsellence://plaintext/ONLY_IN_STORE",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("secret list output = %q, missing %q", output, want)
+		}
+	}
 }
 
 func TestRootSoloSecretSetAcceptsOnePasswordReference(t *testing.T) {

--- a/cli/internal/workflow/root_test.go
+++ b/cli/internal/workflow/root_test.go
@@ -118,26 +118,7 @@ func TestRootSecretSetRejectsExplicitEmptyValue(t *testing.T) {
 
 func TestRootSoloSecretSetHonorsEnvironmentAndService(t *testing.T) {
 	var stdout bytes.Buffer
-	cwd := rootTestWorkspaceWithMode(t, ModeSolo)
-	if err := os.WriteFile(filepath.Join(cwd, "devopsellence.yml"), []byte(strings.Join([]string{
-		"schema_version: 6",
-		"organization: solo",
-		"project: demo",
-		"default_environment: production",
-		"build:",
-		"  context: .",
-		"  dockerfile: Dockerfile",
-		"services:",
-		"  web:",
-		"    ports:",
-		"      - name: http",
-		"        port: 3000",
-		"    healthcheck:",
-		"      path: /up",
-		"      port: 3000",
-	}, "\n")+"\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	cwd := rootTestSoloWorkspace(t)
 	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, cwd)
 	cmd.SetOut(&stdout)
 	cmd.SetErr(&stdout)
@@ -160,6 +141,34 @@ func TestRootSoloSecretSetHonorsEnvironmentAndService(t *testing.T) {
 	}
 	if got := values.Value("worker", "DATABASE_URL"); got != "" {
 		t.Fatalf("worker DATABASE_URL = %q", got)
+	}
+}
+
+func TestRootSoloSecretSetAcceptsOnePasswordReference(t *testing.T) {
+	var stdout bytes.Buffer
+	cwd := rootTestSoloWorkspace(t)
+	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, cwd)
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{"secret", "set", "DATABASE_URL", "--env", "staging", "--service", "web", "--store", "1password", "--op-ref", "op://app/db/password"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	current, err := solo.NewStateStore(solo.DefaultStatePath()).Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+	secrets, err := current.ListSecrets(cwd, "staging", "web")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(secrets) != 1 {
+		t.Fatalf("secrets = %#v", secrets)
+	}
+	if secrets[0].Store != solo.SecretStoreOnePassword || secrets[0].Reference != "op://app/db/password" {
+		t.Fatalf("secret = %#v", secrets[0])
 	}
 }
 
@@ -258,6 +267,31 @@ func rootTestWorkspaceWithMode(t *testing.T, mode Mode) string {
 	cmd.SetArgs([]string{"mode", "use", string(mode)})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("mode use error = %v", err)
+	}
+	return cwd
+}
+
+func rootTestSoloWorkspace(t *testing.T) string {
+	t.Helper()
+	cwd := rootTestWorkspaceWithMode(t, ModeSolo)
+	if err := os.WriteFile(filepath.Join(cwd, "devopsellence.yml"), []byte(strings.Join([]string{
+		"schema_version: 6",
+		"organization: solo",
+		"project: demo",
+		"default_environment: production",
+		"build:",
+		"  context: .",
+		"  dockerfile: Dockerfile",
+		"services:",
+		"  web:",
+		"    ports:",
+		"      - name: http",
+		"        port: 3000",
+		"    healthcheck:",
+		"      path: /up",
+		"      port: 3000",
+	}, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
 	}
 	return cwd
 }

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -697,10 +697,11 @@ func (a *App) resolveSoloSecretValues(ctx context.Context, current solo.State, w
 		local[record.ServiceName+"\x00"+record.Name] = record
 	}
 	values := solo.ScopedSecrets{}
+	cache := map[string]string{}
 	for _, serviceName := range cfg.ServiceNames() {
 		service := cfg.Services[serviceName]
 		for _, ref := range service.SecretRefs {
-			value, err := a.resolveSoloSecretRef(ctx, serviceName, ref, local)
+			value, err := a.resolveSoloSecretRef(ctx, serviceName, ref, local, cache)
 			if err != nil {
 				return nil, err
 			}
@@ -710,10 +711,13 @@ func (a *App) resolveSoloSecretValues(ctx context.Context, current solo.State, w
 	return values, nil
 }
 
-func (a *App) resolveSoloSecretRef(ctx context.Context, serviceName string, ref config.SecretRef, local map[string]solo.SecretRecord) (string, error) {
+func (a *App) resolveSoloSecretRef(ctx context.Context, serviceName string, ref config.SecretRef, local map[string]solo.SecretRecord, cache map[string]string) (string, error) {
 	source := strings.TrimSpace(ref.Secret)
+	if source == "" {
+		return "", fmt.Errorf("missing secret reference for %s.%s", serviceName, ref.Name)
+	}
 	if strings.HasPrefix(strings.ToLower(source), "op://") {
-		return a.resolveOnePasswordSecret(ctx, source)
+		return a.resolveOnePasswordSecretCached(ctx, source, cache)
 	}
 	store, name, ok := parseDevopsellenceSecretRef(source)
 	if !ok {
@@ -730,7 +734,38 @@ func (a *App) resolveSoloSecretRef(ctx context.Context, serviceName string, ref 
 	if recordStore != store {
 		return "", fmt.Errorf("local solo secret %s for service %s uses %s store, config references %s", name, serviceName, recordStore, store)
 	}
+	if recordStore == solo.SecretStoreOnePassword && strings.TrimSpace(record.Reference) != "" {
+		return a.resolveSoloSecretRecordCached(ctx, record, cache)
+	}
 	return a.resolveSoloSecretRecord(ctx, record)
+}
+
+func (a *App) resolveSoloSecretRecordCached(ctx context.Context, record solo.SecretRecord, cache map[string]string) (string, error) {
+	reference := strings.TrimSpace(record.Reference)
+	if reference == "" {
+		return a.resolveSoloSecretRecord(ctx, record)
+	}
+	if value, ok := cache[reference]; ok {
+		return value, nil
+	}
+	value, err := a.resolveSoloSecretRecord(ctx, record)
+	if err != nil {
+		return "", err
+	}
+	cache[reference] = value
+	return value, nil
+}
+
+func (a *App) resolveOnePasswordSecretCached(ctx context.Context, reference string, cache map[string]string) (string, error) {
+	if value, ok := cache[reference]; ok {
+		return value, nil
+	}
+	value, err := a.resolveOnePasswordSecret(ctx, reference)
+	if err != nil {
+		return "", err
+	}
+	cache[reference] = value
+	return value, nil
 }
 
 func parseDevopsellenceSecretRef(value string) (string, string, bool) {
@@ -1082,14 +1117,14 @@ func (a *App) SoloSecretsSet(_ context.Context, opts SoloSecretsSetOptions) erro
 	if err != nil {
 		return err
 	}
+	if err := a.writeSoloState(current); err != nil {
+		return err
+	}
 	configUpdated := ensureServiceSecretRef(cfg, opts.ServiceName, soloSecretConfigRef(record))
 	if configUpdated {
 		if _, err := a.ConfigStore.Write(workspaceRoot, *cfg); err != nil {
-			return err
+			return fmt.Errorf("secret saved locally but update devopsellence.yml failed: %w", err)
 		}
-	}
-	if err := a.writeSoloState(current); err != nil {
-		return err
 	}
 	if a.Printer.JSON {
 		return a.Printer.PrintJSON(map[string]any{"key": record.Name, "service_name": record.ServiceName, "environment": record.Environment, "store": record.Store, "reference": record.Reference, "config_updated": configUpdated, "config_path": a.ConfigStore.PathFor(workspaceRoot), "action": "saved"})
@@ -1135,6 +1170,9 @@ func soloSecretMaterial(store string, opts SoloSecretsSetOptions) (solo.SecretMa
 		}
 		if reference == "" {
 			return solo.SecretMaterial{}, ExitError{Code: 2, Err: errors.New("missing required option: --op-ref")}
+		}
+		if !strings.HasPrefix(strings.ToLower(reference), "op://") {
+			return solo.SecretMaterial{}, ExitError{Code: 2, Err: errors.New("1Password secret reference must start with op://")}
 		}
 		return solo.SecretMaterial{Store: store, Reference: reference}, nil
 	default:
@@ -1212,21 +1250,61 @@ func (a *App) SoloSecretsList(_ context.Context, opts SoloSecretsListOptions) er
 	if err != nil {
 		return err
 	}
+	items := soloSecretListItems(cfg, secrets, opts.ServiceName)
 	if a.Printer.JSON {
-		return a.Printer.PrintJSON(map[string]any{"environment": environmentName, "secrets": secrets})
+		return a.Printer.PrintJSON(map[string]any{"environment": environmentName, "secrets": items})
 	}
-	if len(secrets) == 0 {
+	if len(items) == 0 {
 		a.Printer.Println("No secrets configured")
 		return nil
 	}
-	for _, secret := range secrets {
-		line := secret.ServiceName + " " + secret.Name + " [" + secret.Store + "]"
-		if secret.Reference != "" {
-			line += " -> " + secret.Reference
-		}
-		a.Printer.Println(line)
+	for _, item := range items {
+		a.Printer.Println(formatListedSecret(item))
 	}
 	return nil
+}
+
+func soloSecretListItems(cfg *config.ProjectConfig, secrets []solo.SecretRecord, serviceFilter string) []listedSecret {
+	items := map[string]listedSecret{}
+	filter := strings.TrimSpace(serviceFilter)
+	if cfg != nil {
+		for _, serviceName := range cfg.ServiceNames() {
+			if filter != "" && serviceName != filter {
+				continue
+			}
+			for _, ref := range cfg.Services[serviceName].SecretRefs {
+				key := secretListKey(serviceName, ref.Name)
+				secretRef := strings.TrimSpace(ref.Secret)
+				items[key] = listedSecret{
+					ServiceName: serviceName,
+					Name:        ref.Name,
+					SecretRef:   secretRef,
+					Store:       secretListStore(secretRef, "configured"),
+					Configured:  true,
+					Exposed:     true,
+				}
+			}
+		}
+	}
+	for _, secret := range secrets {
+		key := secretListKey(secret.ServiceName, secret.Name)
+		item := items[key]
+		if item.ServiceName == "" {
+			item = listedSecret{
+				ServiceName: secret.ServiceName,
+				Name:        secret.Name,
+				Store:       secret.Store,
+			}
+		}
+		if strings.TrimSpace(item.SecretRef) == "" {
+			item.SecretRef = soloSecretConfigRef(secret).Secret
+		}
+		item.Reference = strings.TrimSpace(secret.Reference)
+		item.Store = firstNonEmpty(item.Store, secret.Store)
+		item.Stored = true
+		items[key] = item
+	}
+	return sortListedSecrets(items)
 }
 
 func (a *App) SoloNodeList(_ context.Context, _ SoloNodeListOptions) error {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1107,8 +1107,12 @@ func (a *App) SoloSecretsSet(_ context.Context, opts SoloSecretsSetOptions) erro
 	if serviceName == "" {
 		return ExitError{Code: 2, Err: errors.New("missing required option: --service")}
 	}
-	if _, ok := cfg.Services[serviceName]; !ok {
+	service, ok := cfg.Services[serviceName]
+	if !ok {
 		return ExitError{Code: 2, Err: fmt.Errorf("service %q not found in devopsellence.yml", serviceName)}
+	}
+	if serviceSecretRefConflict(service, opts.Key) {
+		return ExitError{Code: 2, Err: fmt.Errorf("service %q already defines %s in env; remove it before adding a secret_ref with the same name", serviceName, opts.Key)}
 	}
 	current, err := a.readSoloState()
 	if err != nil {
@@ -1121,7 +1125,10 @@ func (a *App) SoloSecretsSet(_ context.Context, opts SoloSecretsSetOptions) erro
 	if err := a.writeSoloState(current); err != nil {
 		return err
 	}
-	configUpdated := ensureServiceSecretRef(cfg, serviceName, soloSecretConfigRef(record))
+	configUpdated, err := ensureServiceSecretRef(cfg, serviceName, soloSecretConfigRef(record))
+	if err != nil {
+		return fmt.Errorf("secret saved locally but update devopsellence.yml failed: %w", err)
+	}
 	if configUpdated {
 		if _, err := a.ConfigStore.Write(workspaceRoot, *cfg); err != nil {
 			return fmt.Errorf("secret saved locally but update devopsellence.yml failed: %w", err)
@@ -1189,28 +1196,44 @@ func soloSecretConfigRef(record solo.SecretRecord) config.SecretRef {
 	return config.SecretRef{Name: record.Name, Secret: secret}
 }
 
-func ensureServiceSecretRef(cfg *config.ProjectConfig, serviceName string, ref config.SecretRef) bool {
+func serviceSecretRefConflict(service config.ServiceConfig, name string) bool {
+	name = strings.TrimSpace(name)
+	if _, ok := service.Env[name]; !ok {
+		return false
+	}
+	for _, existing := range service.SecretRefs {
+		if existing.Name == name {
+			return false
+		}
+	}
+	return true
+}
+
+func ensureServiceSecretRef(cfg *config.ProjectConfig, serviceName string, ref config.SecretRef) (bool, error) {
 	serviceName = strings.TrimSpace(serviceName)
 	if cfg == nil {
-		return false
+		return false, nil
 	}
 	service, ok := cfg.Services[serviceName]
 	if !ok {
-		return false
+		return false, nil
 	}
 	for i, existing := range service.SecretRefs {
 		if existing.Name == ref.Name {
 			if existing.Secret == ref.Secret {
-				return false
+				return false, nil
 			}
 			service.SecretRefs[i] = ref
 			cfg.Services[serviceName] = service
-			return true
+			return true, nil
 		}
+	}
+	if serviceSecretRefConflict(service, ref.Name) {
+		return false, fmt.Errorf("service %q already defines %s in env; remove it before adding a secret_ref with the same name", serviceName, ref.Name)
 	}
 	service.SecretRefs = append(service.SecretRefs, ref)
 	cfg.Services[serviceName] = service
-	return true
+	return true, nil
 }
 
 func removeServiceSecretRef(cfg *config.ProjectConfig, serviceName, name string) bool {
@@ -1255,7 +1278,7 @@ func (a *App) SoloSecretsList(_ context.Context, opts SoloSecretsListOptions) er
 	}
 	items := soloSecretListItems(cfg, secrets, opts.ServiceName)
 	if a.Printer.JSON {
-		return a.Printer.PrintJSON(map[string]any{"environment": environmentName, "secrets": items})
+		return a.Printer.PrintJSON(map[string]any{"schema_version": outputSchemaVersion, "environment": environmentName, "secrets": items})
 	}
 	if len(items) == 0 {
 		a.Printer.Println("No secrets configured")

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1103,24 +1103,25 @@ func (a *App) SoloSecretsSet(_ context.Context, opts SoloSecretsSetOptions) erro
 		return err
 	}
 	environmentName := soloEnvironmentName(cfg, opts.Environment)
-	if strings.TrimSpace(opts.ServiceName) == "" {
+	serviceName := strings.TrimSpace(opts.ServiceName)
+	if serviceName == "" {
 		return ExitError{Code: 2, Err: errors.New("missing required option: --service")}
 	}
-	if _, ok := cfg.Services[opts.ServiceName]; !ok {
-		return ExitError{Code: 2, Err: fmt.Errorf("service %q not found in devopsellence.yml", opts.ServiceName)}
+	if _, ok := cfg.Services[serviceName]; !ok {
+		return ExitError{Code: 2, Err: fmt.Errorf("service %q not found in devopsellence.yml", serviceName)}
 	}
 	current, err := a.readSoloState()
 	if err != nil {
 		return err
 	}
-	record, err := current.SetSecret(workspaceRoot, environmentName, opts.ServiceName, opts.Key, material)
+	record, err := current.SetSecret(workspaceRoot, environmentName, serviceName, opts.Key, material)
 	if err != nil {
 		return err
 	}
 	if err := a.writeSoloState(current); err != nil {
 		return err
 	}
-	configUpdated := ensureServiceSecretRef(cfg, opts.ServiceName, soloSecretConfigRef(record))
+	configUpdated := ensureServiceSecretRef(cfg, serviceName, soloSecretConfigRef(record))
 	if configUpdated {
 		if _, err := a.ConfigStore.Write(workspaceRoot, *cfg); err != nil {
 			return fmt.Errorf("secret saved locally but update devopsellence.yml failed: %w", err)
@@ -1189,6 +1190,7 @@ func soloSecretConfigRef(record solo.SecretRecord) config.SecretRef {
 }
 
 func ensureServiceSecretRef(cfg *config.ProjectConfig, serviceName string, ref config.SecretRef) bool {
+	serviceName = strings.TrimSpace(serviceName)
 	if cfg == nil {
 		return false
 	}
@@ -1212,6 +1214,7 @@ func ensureServiceSecretRef(cfg *config.ProjectConfig, serviceName string, ref c
 }
 
 func removeServiceSecretRef(cfg *config.ProjectConfig, serviceName, name string) bool {
+	serviceName = strings.TrimSpace(serviceName)
 	if cfg == nil {
 		return false
 	}
@@ -1453,24 +1456,25 @@ func (a *App) SoloSecretsDelete(_ context.Context, opts SoloSecretsDeleteOptions
 		return err
 	}
 	environmentName := soloEnvironmentName(cfg, opts.Environment)
-	if strings.TrimSpace(opts.ServiceName) == "" {
+	serviceName := strings.TrimSpace(opts.ServiceName)
+	if serviceName == "" {
 		return ExitError{Code: 2, Err: errors.New("missing required option: --service")}
 	}
-	if _, ok := cfg.Services[opts.ServiceName]; !ok {
-		return ExitError{Code: 2, Err: fmt.Errorf("service %q not found in devopsellence.yml", opts.ServiceName)}
+	if _, ok := cfg.Services[serviceName]; !ok {
+		return ExitError{Code: 2, Err: fmt.Errorf("service %q not found in devopsellence.yml", serviceName)}
 	}
 	current, err := a.readSoloState()
 	if err != nil {
 		return err
 	}
-	record, err := current.DeleteSecret(workspaceRoot, environmentName, opts.ServiceName, opts.Key)
+	record, err := current.DeleteSecret(workspaceRoot, environmentName, serviceName, opts.Key)
 	if err != nil {
 		return err
 	}
 	if err := a.writeSoloState(current); err != nil {
 		return err
 	}
-	configUpdated := removeServiceSecretRef(cfg, opts.ServiceName, opts.Key)
+	configUpdated := removeServiceSecretRef(cfg, serviceName, opts.Key)
 	if configUpdated {
 		if _, err := a.ConfigStore.Write(workspaceRoot, *cfg); err != nil {
 			return fmt.Errorf("secret deleted locally but update devopsellence.yml failed: %w", err)

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -286,14 +286,9 @@ func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 		return fmt.Errorf("docker build: %w", err)
 	}
 
-	secrets, err := a.resolveSoloSecretValues(ctx, current, workspaceRoot, environmentName)
+	secrets, err := a.resolveSoloSecretValues(ctx, current, workspaceRoot, environmentName, cfg)
 	if err != nil {
 		return fmt.Errorf("load secrets: %w", err)
-	}
-	if notice, err := applySoloRailsMasterKey(workspaceRoot, cfg, secrets); err != nil {
-		return err
-	} else if notice != "" && !a.Printer.JSON {
-		a.Printer.Println("Rails: " + notice)
 	}
 
 	snapshot, err := solo.BuildDeploySnapshotWithScopedSecrets(cfg, workspaceRoot, a.ConfigStore.PathFor(workspaceRoot), imageTag, shortSHA, secrets)
@@ -678,12 +673,9 @@ func (a *App) resolveStoredDeploySnapshot(ctx context.Context, current solo.Stat
 	if cfg == nil {
 		return solo.DeploySnapshot{}, fmt.Errorf("missing devopsellence.yml for %s", snapshot.WorkspaceRoot)
 	}
-	secrets, err := a.resolveSoloSecretValues(ctx, current, snapshot.WorkspaceRoot, snapshot.Environment)
+	secrets, err := a.resolveSoloSecretValues(ctx, current, snapshot.WorkspaceRoot, snapshot.Environment, cfg)
 	if err != nil {
 		return solo.DeploySnapshot{}, fmt.Errorf("load secrets for %s: %w", snapshot.WorkspaceRoot, err)
-	}
-	if _, err := applySoloRailsMasterKey(snapshot.WorkspaceRoot, cfg, secrets); err != nil {
-		return solo.DeploySnapshot{}, err
 	}
 	configPath := strings.TrimSpace(snapshot.Metadata.ConfigPath)
 	if configPath == "" {
@@ -692,20 +684,74 @@ func (a *App) resolveStoredDeploySnapshot(ctx context.Context, current solo.Stat
 	return solo.BuildDeploySnapshotWithScopedSecrets(cfg, snapshot.WorkspaceRoot, configPath, snapshot.Image, snapshot.Revision, secrets)
 }
 
-func (a *App) resolveSoloSecretValues(ctx context.Context, current solo.State, workspaceRoot, environment string) (solo.ScopedSecrets, error) {
+func (a *App) resolveSoloSecretValues(ctx context.Context, current solo.State, workspaceRoot, environment string, cfg *config.ProjectConfig) (solo.ScopedSecrets, error) {
+	if cfg == nil {
+		return solo.ScopedSecrets{}, nil
+	}
 	records, err := current.SecretRecords(workspaceRoot, environment)
 	if err != nil {
 		return nil, err
 	}
-	values := solo.ScopedSecrets{}
+	local := map[string]solo.SecretRecord{}
 	for _, record := range records {
-		value, err := a.resolveSoloSecretRecord(ctx, record)
-		if err != nil {
-			return nil, err
+		local[record.ServiceName+"\x00"+record.Name] = record
+	}
+	values := solo.ScopedSecrets{}
+	for _, serviceName := range cfg.ServiceNames() {
+		service := cfg.Services[serviceName]
+		for _, ref := range service.SecretRefs {
+			value, err := a.resolveSoloSecretRef(ctx, serviceName, ref, local)
+			if err != nil {
+				return nil, err
+			}
+			values.Set(serviceName, ref.Name, value)
 		}
-		values.Set(record.ServiceName, record.Name, value)
 	}
 	return values, nil
+}
+
+func (a *App) resolveSoloSecretRef(ctx context.Context, serviceName string, ref config.SecretRef, local map[string]solo.SecretRecord) (string, error) {
+	source := strings.TrimSpace(ref.Secret)
+	if strings.HasPrefix(strings.ToLower(source), "op://") {
+		return a.resolveOnePasswordSecret(ctx, source)
+	}
+	store, name, ok := parseDevopsellenceSecretRef(source)
+	if !ok {
+		return "", fmt.Errorf("unsupported solo secret reference %q for %s.%s", source, serviceName, ref.Name)
+	}
+	record, ok := local[serviceName+"\x00"+name]
+	if !ok {
+		return "", fmt.Errorf("missing local solo secret %s for service %s in %s store", name, serviceName, store)
+	}
+	recordStore, err := solo.NormalizeSecretStore(record.Store)
+	if err != nil {
+		return "", err
+	}
+	if recordStore != store {
+		return "", fmt.Errorf("local solo secret %s for service %s uses %s store, config references %s", name, serviceName, recordStore, store)
+	}
+	return a.resolveSoloSecretRecord(ctx, record)
+}
+
+func parseDevopsellenceSecretRef(value string) (string, string, bool) {
+	const prefix = "devopsellence://"
+	value = strings.TrimSpace(value)
+	if !strings.HasPrefix(strings.ToLower(value), prefix) {
+		return "", "", false
+	}
+	parts := strings.SplitN(value[len(prefix):], "/", 2)
+	if len(parts) != 2 {
+		return "", "", false
+	}
+	store, err := solo.NormalizeSecretStore(parts[0])
+	if err != nil {
+		return "", "", false
+	}
+	name := strings.TrimSpace(parts[1])
+	if name == "" {
+		return "", "", false
+	}
+	return store, name, true
 }
 
 func (a *App) resolveSoloSecretRecord(ctx context.Context, record solo.SecretRecord) (string, error) {
@@ -1025,6 +1071,9 @@ func (a *App) SoloSecretsSet(_ context.Context, opts SoloSecretsSetOptions) erro
 	if strings.TrimSpace(opts.ServiceName) == "" {
 		return ExitError{Code: 2, Err: errors.New("missing required option: --service")}
 	}
+	if _, ok := cfg.Services[opts.ServiceName]; !ok {
+		return ExitError{Code: 2, Err: fmt.Errorf("service %q not found in devopsellence.yml", opts.ServiceName)}
+	}
 	current, err := a.readSoloState()
 	if err != nil {
 		return err
@@ -1033,17 +1082,26 @@ func (a *App) SoloSecretsSet(_ context.Context, opts SoloSecretsSetOptions) erro
 	if err != nil {
 		return err
 	}
+	configUpdated := ensureServiceSecretRef(cfg, opts.ServiceName, soloSecretConfigRef(record))
+	if configUpdated {
+		if _, err := a.ConfigStore.Write(workspaceRoot, *cfg); err != nil {
+			return err
+		}
+	}
 	if err := a.writeSoloState(current); err != nil {
 		return err
 	}
 	if a.Printer.JSON {
-		return a.Printer.PrintJSON(map[string]any{"key": record.Name, "service_name": record.ServiceName, "environment": record.Environment, "store": record.Store, "reference": record.Reference, "action": "saved"})
+		return a.Printer.PrintJSON(map[string]any{"key": record.Name, "service_name": record.ServiceName, "environment": record.Environment, "store": record.Store, "reference": record.Reference, "config_updated": configUpdated, "config_path": a.ConfigStore.PathFor(workspaceRoot), "action": "saved"})
 	}
 	if record.Store == solo.SecretStoreOnePassword {
 		a.Printer.Println(fmt.Sprintf("Secret %q saved for %s in %s from 1Password", record.Name, record.ServiceName, record.Environment))
-		return nil
+	} else {
+		a.Printer.Println(fmt.Sprintf("Secret %q saved for %s in %s", record.Name, record.ServiceName, record.Environment))
 	}
-	a.Printer.Println(fmt.Sprintf("Secret %q saved for %s in %s", record.Name, record.ServiceName, record.Environment))
+	if configUpdated {
+		a.Printer.Println("Updated:", a.ConfigStore.PathFor(workspaceRoot))
+	}
 	return nil
 }
 
@@ -1082,6 +1140,62 @@ func soloSecretMaterial(store string, opts SoloSecretsSetOptions) (solo.SecretMa
 	default:
 		return solo.SecretMaterial{}, ExitError{Code: 2, Err: fmt.Errorf("unsupported secret store %q", store)}
 	}
+}
+
+func soloSecretConfigRef(record solo.SecretRecord) config.SecretRef {
+	secret := "devopsellence://" + record.Store + "/" + record.Name
+	if strings.TrimSpace(record.Reference) != "" {
+		secret = strings.TrimSpace(record.Reference)
+	}
+	return config.SecretRef{Name: record.Name, Secret: secret}
+}
+
+func ensureServiceSecretRef(cfg *config.ProjectConfig, serviceName string, ref config.SecretRef) bool {
+	if cfg == nil {
+		return false
+	}
+	service, ok := cfg.Services[serviceName]
+	if !ok {
+		return false
+	}
+	for i, existing := range service.SecretRefs {
+		if existing.Name == ref.Name {
+			if existing.Secret == ref.Secret {
+				return false
+			}
+			service.SecretRefs[i] = ref
+			cfg.Services[serviceName] = service
+			return true
+		}
+	}
+	service.SecretRefs = append(service.SecretRefs, ref)
+	cfg.Services[serviceName] = service
+	return true
+}
+
+func removeServiceSecretRef(cfg *config.ProjectConfig, serviceName, name string) bool {
+	if cfg == nil {
+		return false
+	}
+	service, ok := cfg.Services[serviceName]
+	if !ok {
+		return false
+	}
+	filtered := make([]config.SecretRef, 0, len(service.SecretRefs))
+	changed := false
+	for _, existing := range service.SecretRefs {
+		if existing.Name == name {
+			changed = true
+			continue
+		}
+		filtered = append(filtered, existing)
+	}
+	if !changed {
+		return false
+	}
+	service.SecretRefs = filtered
+	cfg.Services[serviceName] = service
+	return true
 }
 
 func (a *App) SoloSecretsList(_ context.Context, opts SoloSecretsListOptions) error {
@@ -1264,6 +1378,9 @@ func (a *App) SoloSecretsDelete(_ context.Context, opts SoloSecretsDeleteOptions
 	if strings.TrimSpace(opts.ServiceName) == "" {
 		return ExitError{Code: 2, Err: errors.New("missing required option: --service")}
 	}
+	if _, ok := cfg.Services[opts.ServiceName]; !ok {
+		return ExitError{Code: 2, Err: fmt.Errorf("service %q not found in devopsellence.yml", opts.ServiceName)}
+	}
 	current, err := a.readSoloState()
 	if err != nil {
 		return err
@@ -1272,13 +1389,22 @@ func (a *App) SoloSecretsDelete(_ context.Context, opts SoloSecretsDeleteOptions
 	if err != nil {
 		return err
 	}
+	configUpdated := removeServiceSecretRef(cfg, opts.ServiceName, opts.Key)
+	if configUpdated {
+		if _, err := a.ConfigStore.Write(workspaceRoot, *cfg); err != nil {
+			return err
+		}
+	}
 	if err := a.writeSoloState(current); err != nil {
 		return err
 	}
 	if a.Printer.JSON {
-		return a.Printer.PrintJSON(map[string]any{"key": record.Name, "service_name": record.ServiceName, "environment": record.Environment, "action": "deleted"})
+		return a.Printer.PrintJSON(map[string]any{"key": record.Name, "service_name": record.ServiceName, "environment": record.Environment, "config_updated": configUpdated, "config_path": a.ConfigStore.PathFor(workspaceRoot), "action": "deleted"})
 	}
 	a.Printer.Println(fmt.Sprintf("Secret %q deleted for %s in %s", record.Name, record.ServiceName, record.Environment))
+	if configUpdated {
+		a.Printer.Println("Updated:", a.ConfigStore.PathFor(workspaceRoot))
+	}
 	return nil
 }
 
@@ -2290,81 +2416,6 @@ func parseSoloLabels(value string) ([]string, error) {
 		return nil, fmt.Errorf("at least one solo node label is required")
 	}
 	return labels, nil
-}
-
-func applySoloRailsMasterKey(workspaceRoot string, cfg *config.ProjectConfig, secrets solo.ScopedSecrets) (string, error) {
-	if cfg == nil || cfg.App.Type != config.AppTypeRails {
-		return "", nil
-	}
-	if secrets == nil {
-		secrets = solo.ScopedSecrets{}
-	}
-
-	serviceNames := cfg.ServiceNames()
-	missingServices := []string{}
-	for _, serviceName := range serviceNames {
-		if strings.TrimSpace(secrets.Value(serviceName, railsMasterKeySecretName)) == "" {
-			missingServices = append(missingServices, serviceName)
-		}
-	}
-
-	source := "managed secret store"
-	if len(missingServices) > 0 {
-		keyPath := filepath.Join(workspaceRoot, railsMasterKeyRelativePath)
-		data, err := os.ReadFile(keyPath)
-		if err != nil {
-			if errors.Is(err, os.ErrNotExist) {
-				if len(missingServices) == len(serviceNames) {
-					return "", nil
-				}
-				missingServices = nil
-			} else {
-				return "", fmt.Errorf("read Rails master key: %w", err)
-			}
-		}
-		if len(missingServices) > 0 {
-			value := strings.TrimSpace(string(data))
-			if value == "" {
-				return "", fmt.Errorf("Rails app detected, but %s is empty", keyPath)
-			}
-			for _, serviceName := range missingServices {
-				secrets.Set(serviceName, railsMasterKeySecretName, value)
-			}
-			source = railsMasterKeyRelativePath
-		}
-	}
-
-	services := []string{}
-	for _, serviceName := range serviceNames {
-		if strings.TrimSpace(secrets.Value(serviceName, railsMasterKeySecretName)) == "" {
-			continue
-		}
-		service := cfg.Services[serviceName]
-		if addServiceSecretRef(&service, railsMasterKeySecretName) {
-			cfg.Services[serviceName] = service
-			services = append(services, serviceName)
-		}
-	}
-	if len(services) == 0 {
-		return "", nil
-	}
-	return fmt.Sprintf("using RAILS_MASTER_KEY from %s for %s.", source, strings.Join(services, ", ")), nil
-}
-
-func addServiceSecretRef(svc *config.ServiceConfig, name string) bool {
-	if svc == nil {
-		return false
-	}
-	if _, ok := svc.Env[name]; ok {
-		return false
-	}
-	for _, ref := range svc.SecretRefs {
-		if ref.Name == name {
-			return false
-		}
-	}
-	svc.SecretRefs = append(svc.SecretRefs, config.SecretRef{Name: name})
-	return true
 }
 
 func installSoloAgent(ctx context.Context, node config.SoloNode, opts SoloAgentInstallOptions, reporter soloInstallReporter) error {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -36,15 +36,22 @@ type SoloStatusOptions struct {
 }
 
 type SoloSecretsSetOptions struct {
-	Key        string
-	Value      string
-	ValueStdin bool
+	Key         string
+	ServiceName string
+	Environment string
+	Value       string
+	ValueStdin  bool
 }
 
-type SoloSecretsListOptions struct{}
+type SoloSecretsListOptions struct {
+	ServiceName string
+	Environment string
+}
 
 type SoloSecretsDeleteOptions struct {
-	Key string
+	Key         string
+	ServiceName string
+	Environment string
 }
 
 type SoloNodeListOptions struct{}
@@ -276,7 +283,7 @@ func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 		return fmt.Errorf("docker build: %w", err)
 	}
 
-	secrets, err := solo.LoadSecrets(workspaceRoot)
+	secrets, err := current.ScopedSecretValues(workspaceRoot, environmentName)
 	if err != nil {
 		return fmt.Errorf("load secrets: %w", err)
 	}
@@ -286,7 +293,7 @@ func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 		a.Printer.Println("Rails: " + notice)
 	}
 
-	snapshot, err := solo.BuildDeploySnapshot(cfg, workspaceRoot, a.ConfigStore.PathFor(workspaceRoot), imageTag, shortSHA, secrets)
+	snapshot, err := solo.BuildDeploySnapshotWithScopedSecrets(cfg, workspaceRoot, a.ConfigStore.PathFor(workspaceRoot), imageTag, shortSHA, secrets)
 	if err != nil {
 		return err
 	}
@@ -660,7 +667,7 @@ func (a *App) republishSoloNodes(ctx context.Context, current solo.State, nodeNa
 	return revisions, nil
 }
 
-func (a *App) resolveStoredDeploySnapshot(snapshot solo.DeploySnapshot) (solo.DeploySnapshot, error) {
+func (a *App) resolveStoredDeploySnapshot(current solo.State, snapshot solo.DeploySnapshot) (solo.DeploySnapshot, error) {
 	cfg, err := a.ConfigStore.Read(snapshot.WorkspaceRoot)
 	if err != nil {
 		return solo.DeploySnapshot{}, err
@@ -668,7 +675,7 @@ func (a *App) resolveStoredDeploySnapshot(snapshot solo.DeploySnapshot) (solo.De
 	if cfg == nil {
 		return solo.DeploySnapshot{}, fmt.Errorf("missing devopsellence.yml for %s", snapshot.WorkspaceRoot)
 	}
-	secrets, err := solo.LoadSecrets(snapshot.WorkspaceRoot)
+	secrets, err := current.ScopedSecretValues(snapshot.WorkspaceRoot, snapshot.Environment)
 	if err != nil {
 		return solo.DeploySnapshot{}, fmt.Errorf("load secrets for %s: %w", snapshot.WorkspaceRoot, err)
 	}
@@ -679,7 +686,7 @@ func (a *App) resolveStoredDeploySnapshot(snapshot solo.DeploySnapshot) (solo.De
 	if configPath == "" {
 		configPath = a.ConfigStore.PathFor(snapshot.WorkspaceRoot)
 	}
-	return solo.BuildDeploySnapshot(cfg, snapshot.WorkspaceRoot, configPath, snapshot.Image, snapshot.Revision, secrets)
+	return solo.BuildDeploySnapshotWithScopedSecrets(cfg, snapshot.WorkspaceRoot, configPath, snapshot.Image, snapshot.Revision, secrets)
 }
 
 func (a *App) preparedSoloNodeDesiredStateInputs(current solo.State, nodeName string, node config.SoloNode, resolvedSnapshotCache map[string]solo.DeploySnapshot) (struct {
@@ -703,7 +710,7 @@ func (a *App) preparedSoloNodeDesiredStateInputs(current solo.State, nodeName st
 		key := strings.TrimSpace(snapshot.WorkspaceKey) + "\n" + strings.TrimSpace(snapshot.Environment)
 		resolvedSnapshot, ok := resolvedSnapshotCache[key]
 		if !ok {
-			resolvedSnapshot, err = a.resolveStoredDeploySnapshot(snapshot)
+			resolvedSnapshot, err = a.resolveStoredDeploySnapshot(current, snapshot)
 			if err != nil {
 				return struct {
 					snapshots    []solo.DeploySnapshot
@@ -935,38 +942,55 @@ func (a *App) SoloSecretsSet(_ context.Context, opts SoloSecretsSetOptions) erro
 	if strings.TrimSpace(opts.Value) == "" {
 		return ExitError{Code: 2, Err: errors.New("secret value is required")}
 	}
-	_, workspaceRoot, err := a.loadSoloProjectConfig()
+	cfg, workspaceRoot, err := a.loadSoloProjectConfig()
 	if err != nil {
 		return err
 	}
-	if err := solo.SaveSecret(workspaceRoot, opts.Key, opts.Value); err != nil {
+	environmentName := soloEnvironmentName(cfg, opts.Environment)
+	if strings.TrimSpace(opts.ServiceName) == "" {
+		return ExitError{Code: 2, Err: errors.New("missing required option: --service")}
+	}
+	current, err := a.readSoloState()
+	if err != nil {
+		return err
+	}
+	record, err := current.SetSecret(workspaceRoot, environmentName, opts.ServiceName, opts.Key, opts.Value)
+	if err != nil {
+		return err
+	}
+	if err := a.writeSoloState(current); err != nil {
 		return err
 	}
 	if a.Printer.JSON {
-		return a.Printer.PrintJSON(map[string]any{"key": opts.Key, "action": "saved"})
+		return a.Printer.PrintJSON(map[string]any{"key": record.Name, "service_name": record.ServiceName, "environment": record.Environment, "action": "saved"})
 	}
-	a.Printer.Println(fmt.Sprintf("Secret %q saved", opts.Key))
+	a.Printer.Println(fmt.Sprintf("Secret %q saved for %s in %s", record.Name, record.ServiceName, record.Environment))
 	return nil
 }
 
-func (a *App) SoloSecretsList(_ context.Context, _ SoloSecretsListOptions) error {
-	_, workspaceRoot, err := a.loadSoloProjectConfig()
+func (a *App) SoloSecretsList(_ context.Context, opts SoloSecretsListOptions) error {
+	cfg, workspaceRoot, err := a.loadSoloProjectConfig()
 	if err != nil {
 		return err
 	}
-	keys, err := solo.ListSecrets(workspaceRoot)
+	environmentName := soloEnvironmentName(cfg, opts.Environment)
+	current, err := a.readSoloState()
+	if err != nil {
+		return err
+	}
+	secrets, err := current.ListSecrets(workspaceRoot, environmentName, opts.ServiceName)
 	if err != nil {
 		return err
 	}
 	if a.Printer.JSON {
-		return a.Printer.PrintJSON(map[string]any{"keys": keys})
+		return a.Printer.PrintJSON(map[string]any{"environment": environmentName, "secrets": secrets})
 	}
-	if len(keys) == 0 {
+	if len(secrets) == 0 {
 		a.Printer.Println("No secrets configured")
 		return nil
 	}
-	for _, k := range keys {
-		a.Printer.Println(k)
+	for _, secret := range secrets {
+		a.Printer.Println(secret.ServiceName + " " + secret.Name)
 	}
 	return nil
 }
@@ -1112,17 +1136,29 @@ func (a *App) SoloNodeDetach(ctx context.Context, opts SoloNodeDetachOptions) er
 }
 
 func (a *App) SoloSecretsDelete(_ context.Context, opts SoloSecretsDeleteOptions) error {
-	_, workspaceRoot, err := a.loadSoloProjectConfig()
+	cfg, workspaceRoot, err := a.loadSoloProjectConfig()
 	if err != nil {
 		return err
 	}
-	if err := solo.DeleteSecret(workspaceRoot, opts.Key); err != nil {
+	environmentName := soloEnvironmentName(cfg, opts.Environment)
+	if strings.TrimSpace(opts.ServiceName) == "" {
+		return ExitError{Code: 2, Err: errors.New("missing required option: --service")}
+	}
+	current, err := a.readSoloState()
+	if err != nil {
+		return err
+	}
+	record, err := current.DeleteSecret(workspaceRoot, environmentName, opts.ServiceName, opts.Key)
+	if err != nil {
+		return err
+	}
+	if err := a.writeSoloState(current); err != nil {
 		return err
 	}
 	if a.Printer.JSON {
-		return a.Printer.PrintJSON(map[string]any{"key": opts.Key, "action": "deleted"})
+		return a.Printer.PrintJSON(map[string]any{"key": record.Name, "service_name": record.ServiceName, "environment": record.Environment, "action": "deleted"})
 	}
-	a.Printer.Println(fmt.Sprintf("Secret %q deleted", opts.Key))
+	a.Printer.Println(fmt.Sprintf("Secret %q deleted for %s in %s", record.Name, record.ServiceName, record.Environment))
 	return nil
 }
 
@@ -2136,34 +2172,53 @@ func parseSoloLabels(value string) ([]string, error) {
 	return labels, nil
 }
 
-func applySoloRailsMasterKey(workspaceRoot string, cfg *config.ProjectConfig, secrets map[string]string) (string, error) {
+func applySoloRailsMasterKey(workspaceRoot string, cfg *config.ProjectConfig, secrets solo.ScopedSecrets) (string, error) {
 	if cfg == nil || cfg.App.Type != config.AppTypeRails {
 		return "", nil
 	}
 	if secrets == nil {
-		secrets = map[string]string{}
+		secrets = solo.ScopedSecrets{}
 	}
 
-	source := ".env"
-	if strings.TrimSpace(secrets[railsMasterKeySecretName]) == "" {
+	serviceNames := cfg.ServiceNames()
+	missingServices := []string{}
+	for _, serviceName := range serviceNames {
+		if strings.TrimSpace(secrets.Value(serviceName, railsMasterKeySecretName)) == "" {
+			missingServices = append(missingServices, serviceName)
+		}
+	}
+
+	source := "managed secret store"
+	if len(missingServices) > 0 {
 		keyPath := filepath.Join(workspaceRoot, railsMasterKeyRelativePath)
 		data, err := os.ReadFile(keyPath)
 		if err != nil {
 			if errors.Is(err, os.ErrNotExist) {
-				return "", nil
+				if len(missingServices) == len(serviceNames) {
+					return "", nil
+				}
+				missingServices = nil
+			} else {
+				return "", fmt.Errorf("read Rails master key: %w", err)
 			}
-			return "", fmt.Errorf("read Rails master key: %w", err)
 		}
-		value := strings.TrimSpace(string(data))
-		if value == "" {
-			return "", fmt.Errorf("Rails app detected, but %s is empty", keyPath)
+		if len(missingServices) > 0 {
+			value := strings.TrimSpace(string(data))
+			if value == "" {
+				return "", fmt.Errorf("Rails app detected, but %s is empty", keyPath)
+			}
+			for _, serviceName := range missingServices {
+				secrets.Set(serviceName, railsMasterKeySecretName, value)
+			}
+			source = railsMasterKeyRelativePath
 		}
-		secrets[railsMasterKeySecretName] = value
-		source = railsMasterKeyRelativePath
 	}
 
 	services := []string{}
-	for _, serviceName := range cfg.ServiceNames() {
+	for _, serviceName := range serviceNames {
+		if strings.TrimSpace(secrets.Value(serviceName, railsMasterKeySecretName)) == "" {
+			continue
+		}
 		service := cfg.Services[serviceName]
 		if addServiceSecretRef(&service, railsMasterKeySecretName) {
 			cfg.Services[serviceName] = service

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1,6 +1,7 @@
 package workflow
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -39,6 +40,8 @@ type SoloSecretsSetOptions struct {
 	Key         string
 	ServiceName string
 	Environment string
+	Store       string
+	Reference   string
 	Value       string
 	ValueStdin  bool
 }
@@ -283,7 +286,7 @@ func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 		return fmt.Errorf("docker build: %w", err)
 	}
 
-	secrets, err := current.ScopedSecretValues(workspaceRoot, environmentName)
+	secrets, err := a.resolveSoloSecretValues(ctx, current, workspaceRoot, environmentName)
 	if err != nil {
 		return fmt.Errorf("load secrets: %w", err)
 	}
@@ -571,7 +574,7 @@ func (a *App) republishSoloNodes(ctx context.Context, current solo.State, nodeNa
 	prepared := make(map[string]preparedSoloNodeState, len(sortedNodeNames))
 	resolvedSnapshotCache := map[string]solo.DeploySnapshot{}
 	for _, nodeName := range sortedNodeNames {
-		inputs, err := a.preparedSoloNodeDesiredStateInputs(current, nodeName, nodes[nodeName], resolvedSnapshotCache)
+		inputs, err := a.preparedSoloNodeDesiredStateInputs(ctx, current, nodeName, nodes[nodeName], resolvedSnapshotCache)
 		if err != nil {
 			return nil, err
 		}
@@ -667,7 +670,7 @@ func (a *App) republishSoloNodes(ctx context.Context, current solo.State, nodeNa
 	return revisions, nil
 }
 
-func (a *App) resolveStoredDeploySnapshot(current solo.State, snapshot solo.DeploySnapshot) (solo.DeploySnapshot, error) {
+func (a *App) resolveStoredDeploySnapshot(ctx context.Context, current solo.State, snapshot solo.DeploySnapshot) (solo.DeploySnapshot, error) {
 	cfg, err := a.ConfigStore.Read(snapshot.WorkspaceRoot)
 	if err != nil {
 		return solo.DeploySnapshot{}, err
@@ -675,7 +678,7 @@ func (a *App) resolveStoredDeploySnapshot(current solo.State, snapshot solo.Depl
 	if cfg == nil {
 		return solo.DeploySnapshot{}, fmt.Errorf("missing devopsellence.yml for %s", snapshot.WorkspaceRoot)
 	}
-	secrets, err := current.ScopedSecretValues(snapshot.WorkspaceRoot, snapshot.Environment)
+	secrets, err := a.resolveSoloSecretValues(ctx, current, snapshot.WorkspaceRoot, snapshot.Environment)
 	if err != nil {
 		return solo.DeploySnapshot{}, fmt.Errorf("load secrets for %s: %w", snapshot.WorkspaceRoot, err)
 	}
@@ -689,7 +692,71 @@ func (a *App) resolveStoredDeploySnapshot(current solo.State, snapshot solo.Depl
 	return solo.BuildDeploySnapshotWithScopedSecrets(cfg, snapshot.WorkspaceRoot, configPath, snapshot.Image, snapshot.Revision, secrets)
 }
 
-func (a *App) preparedSoloNodeDesiredStateInputs(current solo.State, nodeName string, node config.SoloNode, resolvedSnapshotCache map[string]solo.DeploySnapshot) (struct {
+func (a *App) resolveSoloSecretValues(ctx context.Context, current solo.State, workspaceRoot, environment string) (solo.ScopedSecrets, error) {
+	records, err := current.SecretRecords(workspaceRoot, environment)
+	if err != nil {
+		return nil, err
+	}
+	values := solo.ScopedSecrets{}
+	for _, record := range records {
+		value, err := a.resolveSoloSecretRecord(ctx, record)
+		if err != nil {
+			return nil, err
+		}
+		values.Set(record.ServiceName, record.Name, value)
+	}
+	return values, nil
+}
+
+func (a *App) resolveSoloSecretRecord(ctx context.Context, record solo.SecretRecord) (string, error) {
+	if a.soloSecretResolveFn != nil {
+		return a.soloSecretResolveFn(ctx, record)
+	}
+	store, err := solo.NormalizeSecretStore(record.Store)
+	if err != nil {
+		return "", err
+	}
+	switch store {
+	case solo.SecretStorePlaintext:
+		return record.Value, nil
+	case solo.SecretStoreOnePassword:
+		return a.resolveOnePasswordSecret(ctx, record.Reference)
+	default:
+		return "", fmt.Errorf("unsupported secret store %q", store)
+	}
+}
+
+func (a *App) resolveOnePasswordSecret(ctx context.Context, reference string) (string, error) {
+	if strings.TrimSpace(reference) == "" {
+		return "", errors.New("1Password secret reference is required")
+	}
+	lookPath := a.LookPath
+	if lookPath == nil {
+		lookPath = exec.LookPath
+	}
+	opPath, err := lookPath("op")
+	if err != nil {
+		return "", fmt.Errorf("1Password CLI `op` not found; install and sign in to 1Password CLI before deploying secrets from 1Password: %w", err)
+	}
+	cmd := exec.CommandContext(ctx, opPath, "read", reference)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		detail := strings.TrimSpace(stderr.String())
+		if detail != "" {
+			return "", fmt.Errorf("read 1Password secret %s: %w: %s", reference, err, detail)
+		}
+		return "", fmt.Errorf("read 1Password secret %s: %w", reference, err)
+	}
+	value := strings.TrimRight(string(out), "\r\n")
+	if value == "" {
+		return "", fmt.Errorf("read 1Password secret %s: empty value", reference)
+	}
+	return value, nil
+}
+
+func (a *App) preparedSoloNodeDesiredStateInputs(ctx context.Context, current solo.State, nodeName string, node config.SoloNode, resolvedSnapshotCache map[string]solo.DeploySnapshot) (struct {
 	snapshots    []solo.DeploySnapshot
 	releaseNodes map[string]string
 	peers        []solo.NodePeer
@@ -710,7 +777,7 @@ func (a *App) preparedSoloNodeDesiredStateInputs(current solo.State, nodeName st
 		key := strings.TrimSpace(snapshot.WorkspaceKey) + "\n" + strings.TrimSpace(snapshot.Environment)
 		resolvedSnapshot, ok := resolvedSnapshotCache[key]
 		if !ok {
-			resolvedSnapshot, err = a.resolveStoredDeploySnapshot(current, snapshot)
+			resolvedSnapshot, err = a.resolveStoredDeploySnapshot(ctx, current, snapshot)
 			if err != nil {
 				return struct {
 					snapshots    []solo.DeploySnapshot
@@ -929,6 +996,13 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 }
 
 func (a *App) SoloSecretsSet(_ context.Context, opts SoloSecretsSetOptions) error {
+	store, err := soloSecretStore(opts)
+	if err != nil {
+		return err
+	}
+	if opts.ValueStdin && store != solo.SecretStorePlaintext {
+		return ExitError{Code: 2, Err: errors.New("--stdin is only supported for plaintext solo secrets")}
+	}
 	if opts.ValueStdin {
 		data, err := io.ReadAll(a.In)
 		if err != nil {
@@ -939,8 +1013,9 @@ func (a *App) SoloSecretsSet(_ context.Context, opts SoloSecretsSetOptions) erro
 	if strings.TrimSpace(opts.Key) == "" {
 		return ExitError{Code: 2, Err: errors.New("secret name is required")}
 	}
-	if strings.TrimSpace(opts.Value) == "" {
-		return ExitError{Code: 2, Err: errors.New("secret value is required")}
+	material, err := soloSecretMaterial(store, opts)
+	if err != nil {
+		return err
 	}
 	cfg, workspaceRoot, err := a.loadSoloProjectConfig()
 	if err != nil {
@@ -954,7 +1029,7 @@ func (a *App) SoloSecretsSet(_ context.Context, opts SoloSecretsSetOptions) erro
 	if err != nil {
 		return err
 	}
-	record, err := current.SetSecret(workspaceRoot, environmentName, opts.ServiceName, opts.Key, opts.Value)
+	record, err := current.SetSecret(workspaceRoot, environmentName, opts.ServiceName, opts.Key, material)
 	if err != nil {
 		return err
 	}
@@ -962,10 +1037,51 @@ func (a *App) SoloSecretsSet(_ context.Context, opts SoloSecretsSetOptions) erro
 		return err
 	}
 	if a.Printer.JSON {
-		return a.Printer.PrintJSON(map[string]any{"key": record.Name, "service_name": record.ServiceName, "environment": record.Environment, "action": "saved"})
+		return a.Printer.PrintJSON(map[string]any{"key": record.Name, "service_name": record.ServiceName, "environment": record.Environment, "store": record.Store, "reference": record.Reference, "action": "saved"})
+	}
+	if record.Store == solo.SecretStoreOnePassword {
+		a.Printer.Println(fmt.Sprintf("Secret %q saved for %s in %s from 1Password", record.Name, record.ServiceName, record.Environment))
+		return nil
 	}
 	a.Printer.Println(fmt.Sprintf("Secret %q saved for %s in %s", record.Name, record.ServiceName, record.Environment))
 	return nil
+}
+
+func soloSecretStore(opts SoloSecretsSetOptions) (string, error) {
+	store := opts.Store
+	if strings.TrimSpace(store) == "" && strings.TrimSpace(opts.Reference) != "" {
+		store = solo.SecretStoreOnePassword
+	}
+	normalized, err := solo.NormalizeSecretStore(store)
+	if err != nil {
+		return "", ExitError{Code: 2, Err: err}
+	}
+	return normalized, nil
+}
+
+func soloSecretMaterial(store string, opts SoloSecretsSetOptions) (solo.SecretMaterial, error) {
+	value := strings.TrimSpace(opts.Value)
+	reference := strings.TrimSpace(opts.Reference)
+	switch store {
+	case solo.SecretStorePlaintext:
+		if reference != "" {
+			return solo.SecretMaterial{}, ExitError{Code: 2, Err: errors.New("--op-ref requires --store 1password")}
+		}
+		if value == "" {
+			return solo.SecretMaterial{}, ExitError{Code: 2, Err: errors.New("secret value is required")}
+		}
+		return solo.SecretMaterial{Store: store, Value: opts.Value}, nil
+	case solo.SecretStoreOnePassword:
+		if value != "" {
+			return solo.SecretMaterial{}, ExitError{Code: 2, Err: errors.New("1Password solo secrets use --op-ref instead of --value")}
+		}
+		if reference == "" {
+			return solo.SecretMaterial{}, ExitError{Code: 2, Err: errors.New("missing required option: --op-ref")}
+		}
+		return solo.SecretMaterial{Store: store, Reference: reference}, nil
+	default:
+		return solo.SecretMaterial{}, ExitError{Code: 2, Err: fmt.Errorf("unsupported secret store %q", store)}
+	}
 }
 
 func (a *App) SoloSecretsList(_ context.Context, opts SoloSecretsListOptions) error {
@@ -990,7 +1106,11 @@ func (a *App) SoloSecretsList(_ context.Context, opts SoloSecretsListOptions) er
 		return nil
 	}
 	for _, secret := range secrets {
-		a.Printer.Println(secret.ServiceName + " " + secret.Name)
+		line := secret.ServiceName + " " + secret.Name + " [" + secret.Store + "]"
+		if secret.Reference != "" {
+			line += " -> " + secret.Reference
+		}
+		a.Printer.Println(line)
 	}
 	return nil
 }

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1467,14 +1467,14 @@ func (a *App) SoloSecretsDelete(_ context.Context, opts SoloSecretsDeleteOptions
 	if err != nil {
 		return err
 	}
+	if err := a.writeSoloState(current); err != nil {
+		return err
+	}
 	configUpdated := removeServiceSecretRef(cfg, opts.ServiceName, opts.Key)
 	if configUpdated {
 		if _, err := a.ConfigStore.Write(workspaceRoot, *cfg); err != nil {
-			return err
+			return fmt.Errorf("secret deleted locally but update devopsellence.yml failed: %w", err)
 		}
-	}
-	if err := a.writeSoloState(current); err != nil {
-		return err
 	}
 	if a.Printer.JSON {
 		return a.Printer.PrintJSON(map[string]any{"key": record.Name, "service_name": record.ServiceName, "environment": record.Environment, "config_updated": configUpdated, "config_path": a.ConfigStore.PathFor(workspaceRoot), "action": "deleted"})

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -927,9 +927,17 @@ func TestResolveSoloSecretValuesUsesStoreResolver(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
+	if _, err := current.SetSecret(root, "production", "jobs", "DATABASE_URL", solo.SecretMaterial{
+		Store:     solo.SecretStoreOnePassword,
+		Reference: "op://app/db/password",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	opReads := 0
 	app := &App{
 		soloSecretResolveFn: func(_ context.Context, record solo.SecretRecord) (string, error) {
 			if record.Store == solo.SecretStoreOnePassword {
+				opReads++
 				return "postgres://op", nil
 			}
 			return record.Value, nil
@@ -942,6 +950,9 @@ func TestResolveSoloSecretValuesUsesStoreResolver(t *testing.T) {
 	cfg.Services["worker"] = config.ServiceConfig{
 		SecretRefs: []config.SecretRef{{Name: "DATABASE_URL", Secret: "devopsellence://1password/DATABASE_URL"}},
 	}
+	cfg.Services["jobs"] = config.ServiceConfig{
+		SecretRefs: []config.SecretRef{{Name: "DATABASE_URL", Secret: "devopsellence://1password/DATABASE_URL"}},
+	}
 
 	values, err := app.resolveSoloSecretValues(context.Background(), current, root, "production", &cfg)
 	if err != nil {
@@ -952,6 +963,12 @@ func TestResolveSoloSecretValuesUsesStoreResolver(t *testing.T) {
 	}
 	if got := values.Value("worker", "DATABASE_URL"); got != "postgres://op" {
 		t.Fatalf("worker DATABASE_URL = %q", got)
+	}
+	if got := values.Value("jobs", "DATABASE_URL"); got != "postgres://op" {
+		t.Fatalf("jobs DATABASE_URL = %q", got)
+	}
+	if opReads != 1 {
+		t.Fatalf("1Password reads = %d, want 1", opReads)
 	}
 }
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -959,6 +959,39 @@ func TestApplySoloRailsMasterKeyUsesConfigMasterKey(t *testing.T) {
 	}
 }
 
+func TestResolveSoloSecretValuesUsesStoreResolver(t *testing.T) {
+	root := t.TempDir()
+	var current solo.State
+	if _, err := current.SetSecret(root, "production", "web", "DATABASE_URL", solo.SecretMaterial{Value: "postgres://plain"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := current.SetSecret(root, "production", "worker", "DATABASE_URL", solo.SecretMaterial{
+		Store:     solo.SecretStoreOnePassword,
+		Reference: "op://app/db/password",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	app := &App{
+		soloSecretResolveFn: func(_ context.Context, record solo.SecretRecord) (string, error) {
+			if record.Store == solo.SecretStoreOnePassword {
+				return "postgres://op", nil
+			}
+			return record.Value, nil
+		},
+	}
+
+	values, err := app.resolveSoloSecretValues(context.Background(), current, root, "production")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := values.Value("web", "DATABASE_URL"); got != "postgres://plain" {
+		t.Fatalf("web DATABASE_URL = %q", got)
+	}
+	if got := values.Value("worker", "DATABASE_URL"); got != "postgres://op" {
+		t.Fatalf("worker DATABASE_URL = %q", got)
+	}
+}
+
 func TestApplySoloRailsMasterKeyLetsManagedSecretOverrideMasterKey(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(dir, "config"), 0o755); err != nil {

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -915,50 +915,6 @@ func TestRemoteReadOptionalFileCommandSupportsPasswordlessSudo(t *testing.T) {
 	}
 }
 
-func TestApplySoloRailsMasterKeyUsesConfigMasterKey(t *testing.T) {
-	dir := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(dir, "config"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, "config", "master.key"), []byte("from-master-key\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	cfg := &config.ProjectConfig{
-		App: config.AppConfig{Type: config.AppTypeRails},
-		Services: map[string]config.ServiceConfig{
-			config.DefaultWebServiceName: {
-				Env:         map[string]string{},
-				Ports:       []config.ServicePort{{Name: "http", Port: 3000}},
-				Healthcheck: &config.HTTPHealthcheck{Path: "/up", Port: 3000},
-			},
-			"worker": {
-				Env: map[string]string{},
-			},
-		},
-	}
-	secrets := solo.ScopedSecrets{}
-	notice, err := applySoloRailsMasterKey(dir, cfg, secrets)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got := secrets.Value(config.DefaultWebServiceName, railsMasterKeySecretName); got != "from-master-key" {
-		t.Fatalf("web RAILS_MASTER_KEY = %q", got)
-	}
-	if got := secrets.Value("worker", railsMasterKeySecretName); got != "from-master-key" {
-		t.Fatalf("worker RAILS_MASTER_KEY = %q", got)
-	}
-	if !strings.Contains(notice, "config/master.key") {
-		t.Fatalf("notice = %q, want config/master.key", notice)
-	}
-	for _, serviceName := range []string{config.DefaultWebServiceName, "worker"} {
-		refs := cfg.Services[serviceName].SecretRefs
-		if len(refs) != 1 || refs[0].Name != railsMasterKeySecretName {
-			t.Fatalf("secret refs = %#v, want RAILS_MASTER_KEY", refs)
-		}
-	}
-}
-
 func TestResolveSoloSecretValuesUsesStoreResolver(t *testing.T) {
 	root := t.TempDir()
 	var current solo.State
@@ -979,8 +935,15 @@ func TestResolveSoloSecretValuesUsesStoreResolver(t *testing.T) {
 			return record.Value, nil
 		},
 	}
+	cfg := config.DefaultProjectConfig("default", "demo", "production")
+	web := cfg.Services["web"]
+	web.SecretRefs = []config.SecretRef{{Name: "DATABASE_URL", Secret: "devopsellence://plaintext/DATABASE_URL"}}
+	cfg.Services["web"] = web
+	cfg.Services["worker"] = config.ServiceConfig{
+		SecretRefs: []config.SecretRef{{Name: "DATABASE_URL", Secret: "devopsellence://1password/DATABASE_URL"}},
+	}
 
-	values, err := app.resolveSoloSecretValues(context.Background(), current, root, "production")
+	values, err := app.resolveSoloSecretValues(context.Background(), current, root, "production", &cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -989,40 +952,6 @@ func TestResolveSoloSecretValuesUsesStoreResolver(t *testing.T) {
 	}
 	if got := values.Value("worker", "DATABASE_URL"); got != "postgres://op" {
 		t.Fatalf("worker DATABASE_URL = %q", got)
-	}
-}
-
-func TestApplySoloRailsMasterKeyLetsManagedSecretOverrideMasterKey(t *testing.T) {
-	dir := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(dir, "config"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, "config", "master.key"), []byte("from-master-key\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	cfg := &config.ProjectConfig{
-		App: config.AppConfig{Type: config.AppTypeRails},
-		Services: map[string]config.ServiceConfig{
-			config.DefaultWebServiceName: {
-				Env:         map[string]string{},
-				Ports:       []config.ServicePort{{Name: "http", Port: 3000}},
-				Healthcheck: &config.HTTPHealthcheck{Path: "/up", Port: 3000},
-			},
-		},
-	}
-	secrets := solo.ScopedSecrets{
-		config.DefaultWebServiceName: {railsMasterKeySecretName: "from-store"},
-	}
-	notice, err := applySoloRailsMasterKey(dir, cfg, secrets)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got := secrets.Value(config.DefaultWebServiceName, railsMasterKeySecretName); got != "from-store" {
-		t.Fatalf("RAILS_MASTER_KEY = %q, want from-store", got)
-	}
-	if !strings.Contains(notice, "managed secret store") {
-		t.Fatalf("notice = %q, want managed secret store", notice)
 	}
 }
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -937,13 +937,16 @@ func TestApplySoloRailsMasterKeyUsesConfigMasterKey(t *testing.T) {
 			},
 		},
 	}
-	secrets := map[string]string{}
+	secrets := solo.ScopedSecrets{}
 	notice, err := applySoloRailsMasterKey(dir, cfg, secrets)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if secrets[railsMasterKeySecretName] != "from-master-key" {
-		t.Fatalf("RAILS_MASTER_KEY = %q", secrets[railsMasterKeySecretName])
+	if got := secrets.Value(config.DefaultWebServiceName, railsMasterKeySecretName); got != "from-master-key" {
+		t.Fatalf("web RAILS_MASTER_KEY = %q", got)
+	}
+	if got := secrets.Value("worker", railsMasterKeySecretName); got != "from-master-key" {
+		t.Fatalf("worker RAILS_MASTER_KEY = %q", got)
 	}
 	if !strings.Contains(notice, "config/master.key") {
 		t.Fatalf("notice = %q, want config/master.key", notice)
@@ -956,7 +959,7 @@ func TestApplySoloRailsMasterKeyUsesConfigMasterKey(t *testing.T) {
 	}
 }
 
-func TestApplySoloRailsMasterKeyLetsEnvOverrideMasterKey(t *testing.T) {
+func TestApplySoloRailsMasterKeyLetsManagedSecretOverrideMasterKey(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(dir, "config"), 0o755); err != nil {
 		t.Fatal(err)
@@ -975,16 +978,18 @@ func TestApplySoloRailsMasterKeyLetsEnvOverrideMasterKey(t *testing.T) {
 			},
 		},
 	}
-	secrets := map[string]string{railsMasterKeySecretName: "from-env"}
+	secrets := solo.ScopedSecrets{
+		config.DefaultWebServiceName: {railsMasterKeySecretName: "from-store"},
+	}
 	notice, err := applySoloRailsMasterKey(dir, cfg, secrets)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if secrets[railsMasterKeySecretName] != "from-env" {
-		t.Fatalf("RAILS_MASTER_KEY = %q, want from-env", secrets[railsMasterKeySecretName])
+	if got := secrets.Value(config.DefaultWebServiceName, railsMasterKeySecretName); got != "from-store" {
+		t.Fatalf("RAILS_MASTER_KEY = %q, want from-store", got)
 	}
-	if !strings.Contains(notice, ".env") {
-		t.Fatalf("notice = %q, want .env", notice)
+	if !strings.Contains(notice, "managed secret store") {
+		t.Fatalf("notice = %q, want managed secret store", notice)
 	}
 }
 

--- a/cli/skills/devopsellence/SKILL.md
+++ b/cli/skills/devopsellence/SKILL.md
@@ -73,6 +73,7 @@ Prefer stdin over literal secret values in prompts or shell history:
 
 ```bash
 printf '%s' "$VALUE" | devopsellence secret set NAME --service web --stdin
+devopsellence secret set NAME --service web --store 1password --op-ref op://vault/item/field
 devopsellence secret list --env production
 devopsellence secret delete NAME --service web
 ```

--- a/cli/skills/devopsellence/SKILL.md
+++ b/cli/skills/devopsellence/SKILL.md
@@ -73,7 +73,7 @@ Prefer stdin over literal secret values in prompts or shell history:
 
 ```bash
 printf '%s' "$VALUE" | devopsellence secret set NAME --service web --stdin
-devopsellence secret list
+devopsellence secret list --env production
 devopsellence secret delete NAME --service web
 ```
 

--- a/test/e2e/e2e.rb
+++ b/test/e2e/e2e.rb
@@ -511,6 +511,7 @@ class E2E
         env: cli_env,
         input: stdin_secret_value
       )
+      commit_all!("Configure e2e secrets")
 
       deploy_output = run!(
         cli_binary.to_s, "deploy", "--non-interactive",

--- a/test/e2e/solo_e2e.rb
+++ b/test/e2e/solo_e2e.rb
@@ -624,9 +624,9 @@ PY
   end
 
   def set_secrets!
-    # Use CLI to set secrets (writes to .env in app dir).
+    # Use CLI to set secrets and update devopsellence.yml secret_refs.
     run!(
-      cli_binary.to_s, "secret", "set", SECRET_VALUE_NAME, "--value", "secret-solo-123",
+      cli_binary.to_s, "secret", "set", SECRET_VALUE_NAME, "--service", "web", "--value", "secret-solo-123",
       chdir: @app_dir.to_s,
       timeout: 30,
       env: ssh_env
@@ -640,6 +640,7 @@ PY
       env: ssh_env
     )
     raise "secret not listed" unless output.include?(SECRET_VALUE_NAME)
+    commit_all!("Configure solo e2e secrets")
     puts "[ok] Secret saved and listed"
   end
 


### PR DESCRIPTION
## Summary
- scope solo secrets by workspace, environment, service, and secret name in machine-local solo state
- add extendable solo secret stores with plaintext and 1Password references
- require explicit `secret_refs` for deploy secret hydration instead of implicit `.env`, `DEVOPSELLENCE_SECRETS`, or Rails `config/master.key` sync
- make `secret set` / `secret delete` update `devopsellence.yml` secret refs in both solo and shared modes

## Tests
- `mise run test:cli`

## Follow-up
- #54 tracks optional setup-time `.env` import.