### PR TITLE
[codex] Add dogfood skill

### DIFF
--- a/.agents/skills/dogfood/SKILL.md
+++ b/.agents/skills/dogfood/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: dogfood
+description: Use when asked to dogfood devopsellence, run manual product QA, test DevX, simulate a new user journey, evaluate product completeness, or produce a dogfood report. The skill guides blind-pass and expert-pass testing with evidence, scenarios, rubrics, and repeatable run artifacts.
+---
+
+# Dogfood
+
+## Purpose
+
+Run devopsellence like a real user would. Find bugs, edge cases, product gaps, confusing language, missing docs, and DevX friction.
+
+Dogfood is not only e2e. It asks: can a target user complete the job, understand what happened, recover from failure, and trust the product?
+
+## Core Rules
+
+- Write `devopsellence` lowercase.
+- Prefer fresh temp apps and fresh state.
+- Start with a blind pass unless the user explicitly asks for code review first.
+- During blind pass, use only public/user-facing context: README, docs, CLI help, web UI, generated errors, logs surfaced by the product.
+- Do not read implementation source during blind pass.
+- After blind pass, run expert pass: inspect source, logs, DB, tests, and root causes.
+- Capture evidence: exact commands, key output excerpts, paths, screenshots when UI matters, and time-to-first-success.
+- Separate product gaps from bugs. Product completeness and DevX count even when code works.
+- Do not hide setup pain. Record confusing prompts, missing next steps, slow feedback, scary output, and cleanup uncertainty.
+- Keep secrets and private identifiers out of reports.
+
+## Workflow
+
+1. Pick scenario.
+   - If the user names one, use it.
+   - Otherwise choose the smallest scenario that answers the request.
+   - Read `references/scenarios.md` only when scenario detail is needed.
+
+2. Create run artifact.
+   - Prefer `ruby .agents/skills/dogfood/scripts/new_run.rb <scenario-slug>` from repo root.
+   - Use `/tmp/devopsellence-dogfood/...` unless the user asks for repo-tracked reports.
+   - Keep `commands.log` as you go.
+
+3. Blind pass.
+   - Use docs, CLI help, UI, and terminal feedback.
+   - Do not inspect source.
+   - Work from user goals, not privileged steps.
+   - Stop only for hard blockers; otherwise recover like a user would.
+
+4. Expert pass.
+   - Inspect implementation only after blind evidence is recorded.
+   - Root-cause failures and confusing behavior.
+   - Check whether existing tests cover the risk.
+
+5. Score and report.
+   - Read `references/rubric.md` for scoring when needed.
+   - Use `references/report-template.md` for final structure.
+   - Lead with outcome, top fixes, and evidence.
+
+6. Optional fixes.
+   - If user asks to fix findings, make small reviewable changes.
+   - Preserve unrelated worktree changes.
+   - Re-run the relevant scenario or narrower verification.
+
+## Scenario Defaults
+
+Use these default personas:
+
+- Solo founder: wants one containerized app live on one VM with ordinary tools.
+- Rails developer: understands app code, not infra details.
+- Infra-aware skeptic: checks logs, rollback/delete, status, and escape hatches.
+- Tired maintainer: bad input, broken deploy, needs clear recovery.
+
+Good default devopsellence journeys:
+
+- Solo first deploy for a fresh Rails app.
+- Existing app deploy with secrets.
+- Failed deploy diagnosis and recovery.
+- Status/log inspection after deploy.
+- Delete/cleanup after experiment.
+- Shared flow: connect node, deploy app, inspect status.
+
+## Evidence Standard
+
+For each important claim, include one of:
+
+- Command and output excerpt.
+- File path and line reference.
+- UI screenshot or described visual state.
+- Log line with timestamp when available.
+- Reproduction steps in user-facing terms.
+
+Do not over-quote logs. Keep enough to prove the point.
+
+## Output Shape
+
+Final response should be short unless user asks for the full report inline:
+
+- run path
+- outcome
+- top 3 findings
+- validation done
+- next suggested fix batch
+
+Write the full Markdown report to the run artifact.

--- a/.agents/skills/dogfood/agents/openai.yaml
+++ b/.agents/skills/dogfood/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Dogfood"
+  short_description: "Repeatable devopsellence dogfooding runs"
+  default_prompt: "Dogfood devopsellence: pick a scenario, run a blind pass, then an expert pass, and write a report."

--- a/.agents/skills/dogfood/references/report-template.md
+++ b/.agents/skills/dogfood/references/report-template.md
@@ -1,0 +1,70 @@
+# Dogfood Run
+
+Scenario:
+Persona:
+Date:
+Commit:
+Run path:
+Allowed blind-pass context:
+Environment:
+
+## Outcome
+
+Result:
+Time to first useful feedback:
+Time to first success:
+Blocking issue:
+
+## Top Fixes
+
+1.
+2.
+3.
+
+## Scores
+
+Product completeness:
+DevX:
+Observability:
+Docs and language:
+Trust:
+
+## Commands
+
+See `commands.log`.
+
+## Bugs
+
+- 
+
+## Product Completeness Gaps
+
+- 
+
+## DevX Gaps
+
+- 
+
+## Docs Gaps
+
+- 
+
+## Confusing Language
+
+- 
+
+## Good Moments
+
+- 
+
+## Expert-Pass Root Causes
+
+- 
+
+## Verification
+
+- 
+
+## Raw Evidence
+
+- 

--- a/.agents/skills/dogfood/references/rubric.md
+++ b/.agents/skills/dogfood/references/rubric.md
@@ -1,0 +1,43 @@
+# Dogfood Rubric
+
+Score each area 1-5. Use plain evidence, not vibes.
+
+## Product Completeness
+
+1. Cannot complete core goal.
+2. Goal possible only with privileged knowledge or manual hacks.
+3. Happy path works, important lifecycle gaps remain.
+4. Main lifecycle works with understandable recovery.
+5. Goal, recovery, cleanup, and confidence paths are complete.
+
+## DevX
+
+1. Setup or first command blocks progress.
+2. Frequent confusion; errors lack next steps.
+3. Usable but requires persistence and inference.
+4. Mostly clear; friction is localized.
+5. Fast, predictable, and confidence-building.
+
+## Observability
+
+1. User cannot tell what happened.
+2. Logs/status exist but are hard to find or interpret.
+3. Basic status works; root cause still takes guessing.
+4. Failures point to likely cause and next command.
+5. State, logs, revisions, and recovery are obvious.
+
+## Docs and Language
+
+1. Docs mislead or omit essential setup.
+2. User must search source or infer model.
+3. Docs cover happy path but not recovery.
+4. Docs explain model and common failure paths.
+5. Docs, CLI help, and product language reinforce each other.
+
+## Trust
+
+1. User fears data loss, secret leaks, or unknown infrastructure changes.
+2. Product hides important actions.
+3. Actions are visible but not fully explainable.
+4. Changes and blast radius are clear.
+5. Product feels boring, reversible, and inspectable.

--- a/.agents/skills/dogfood/references/scenarios.md
+++ b/.agents/skills/dogfood/references/scenarios.md
@@ -1,0 +1,90 @@
+# Dogfood Scenarios
+
+## solo-rails-first-deploy
+
+Persona: solo Rails founder, infra-aware but impatient.
+
+Goal: deploy a fresh Rails app with devopsellence solo.
+
+Allowed blind-pass context: README, docs, CLI help, command output, product logs/status surfaced by commands.
+
+Success:
+
+- App reachable.
+- Deploy status understandable.
+- Secret path discoverable.
+- Logs/status path discoverable.
+- Delete or cleanup path clear.
+
+Probe:
+
+- Install/setup friction.
+- First command discoverability.
+- Error recovery.
+- Time to first useful feedback.
+- Confidence after deploy.
+
+## existing-app-secrets-redeploy
+
+Persona: Rails developer adding production-like config.
+
+Goal: deploy an existing app, add a secret, redeploy, verify status.
+
+Success:
+
+- Secret command or workflow is discoverable.
+- Secret value does not leak in output/report.
+- Redeploy makes state understandable.
+- Failed secret usage has clear recovery.
+
+Probe:
+
+- Naming of app/environment/secret scopes.
+- Whether local and remote state are easy to distinguish.
+- Whether status explains which revision/config is active.
+
+## failed-deploy-recovery
+
+Persona: tired maintainer at night.
+
+Goal: diagnose and recover from a broken deploy.
+
+Failure seeds:
+
+- Bad image or build command.
+- Missing secret.
+- Bad port.
+- Unreachable node.
+- App starts then exits.
+
+Success:
+
+- Failure is surfaced without source inspection.
+- Next step is obvious.
+- Logs are reachable.
+- Retrying after fix is boring.
+
+Probe:
+
+- Error specificity.
+- Whether failed desired state is visible.
+- Whether rollback/delete/cleanup is understandable.
+
+## shared-node-connect-deploy
+
+Persona: user evaluating hosted/shared control plane.
+
+Goal: connect a node, deploy app, inspect status.
+
+Success:
+
+- Node enrollment is understandable.
+- Hosted vs local responsibilities are clear.
+- Status reflects node/app state.
+- Escape hatches remain ordinary: SSH, Docker, logs, JSON.
+
+Probe:
+
+- Account/environment naming.
+- Agent reconciliation mental model.
+- Trust boundary clarity.

--- a/.agents/skills/dogfood/scripts/new_run.rb
+++ b/.agents/skills/dogfood/scripts/new_run.rb
@@ -17,7 +17,13 @@ parser = OptionParser.new do |opts|
   opts.on("--out PATH", "Parent output directory") { |value| options[:out] = value }
 end
 
-parser.parse!
+begin
+  parser.parse!
+rescue OptionParser::ParseError => e
+  warn e.message
+  warn parser
+  exit 64
+end
 
 scenario = ARGV.shift
 unless scenario
@@ -33,7 +39,7 @@ if slug.empty?
 end
 
 now = Time.now.utc
-timestamp = now.strftime("%Y%m%dT%H%M%SZ")
+timestamp = now.strftime("%Y%m%dT%H%M%S%6NZ")
 run_dir = File.expand_path("#{timestamp}-#{slug}", options[:out])
 
 def git_value(root, *args)
@@ -45,6 +51,7 @@ end
 
 commit = git_value(options[:root], "rev-parse", "--short", "HEAD")
 branch = git_value(options[:root], "branch", "--show-current")
+branch = "detached" if branch.empty?
 
 template_path = File.expand_path("../references/report-template.md", __dir__)
 template = File.read(template_path)
@@ -54,7 +61,13 @@ report = template
   .sub("Commit:", "Commit: #{commit} (#{branch})")
   .sub("Run path:", "Run path: #{run_dir}")
 
-FileUtils.mkdir_p(run_dir)
+FileUtils.mkdir_p(options[:out])
+begin
+  Dir.mkdir(run_dir)
+rescue Errno::EEXIST
+  warn "run directory already exists: #{run_dir}"
+  exit 73
+end
 File.write(File.join(run_dir, "report.md"), report)
 File.write(File.join(run_dir, "commands.log"), "# Commands for #{scenario}\n")
 

--- a/.agents/skills/dogfood/scripts/new_run.rb
+++ b/.agents/skills/dogfood/scripts/new_run.rb
@@ -26,7 +26,14 @@ unless scenario
 end
 
 slug = scenario.downcase.gsub(/[^a-z0-9]+/, "-").gsub(/\A-|-+\z/, "")
-timestamp = Time.now.utc.strftime("%Y%m%dT%H%M%SZ")
+if slug.empty?
+  warn "SCENARIO_SLUG must contain at least one lowercase letter or digit after normalization"
+  warn parser
+  exit 64
+end
+
+now = Time.now.utc
+timestamp = now.strftime("%Y%m%dT%H%M%SZ")
 run_dir = File.expand_path("#{timestamp}-#{slug}", options[:out])
 
 def git_value(root, *args)
@@ -43,7 +50,7 @@ template_path = File.expand_path("../references/report-template.md", __dir__)
 template = File.read(template_path)
 report = template
   .sub("Scenario:", "Scenario: #{scenario}")
-  .sub("Date:", "Date: #{Time.now.utc.iso8601}")
+  .sub("Date:", "Date: #{now.iso8601}")
   .sub("Commit:", "Commit: #{commit} (#{branch})")
   .sub("Run path:", "Run path: #{run_dir}")
 

--- a/.agents/skills/dogfood/scripts/new_run.rb
+++ b/.agents/skills/dogfood/scripts/new_run.rb
@@ -25,6 +25,8 @@ rescue OptionParser::ParseError => e
   exit 64
 end
 
+options[:out] = File.expand_path(options[:out])
+
 scenario = ARGV.shift
 unless scenario
   warn parser

--- a/.agents/skills/dogfood/scripts/new_run.rb
+++ b/.agents/skills/dogfood/scripts/new_run.rb
@@ -49,26 +49,54 @@ rescue SystemCallError
   "unknown"
 end
 
+def exit_filesystem_error(action, path, error)
+  warn "#{action} #{path}: #{error.message}"
+  exit 73
+end
+
 commit = git_value(options[:root], "rev-parse", "--short", "HEAD")
 branch = git_value(options[:root], "branch", "--show-current")
 branch = "detached" if branch.empty?
 
 template_path = File.expand_path("../references/report-template.md", __dir__)
-template = File.read(template_path)
+begin
+  template = File.read(template_path)
+rescue SystemCallError => e
+  exit_filesystem_error("failed to read", template_path, e)
+end
 report = template
   .sub("Scenario:", "Scenario: #{scenario}")
   .sub("Date:", "Date: #{now.iso8601}")
   .sub("Commit:", "Commit: #{commit} (#{branch})")
   .sub("Run path:", "Run path: #{run_dir}")
 
-FileUtils.mkdir_p(options[:out])
+begin
+  FileUtils.mkdir_p(options[:out])
+rescue SystemCallError => e
+  exit_filesystem_error("failed to create output directory", options[:out], e)
+end
 begin
   Dir.mkdir(run_dir)
 rescue Errno::EEXIST
   warn "run directory already exists: #{run_dir}"
   exit 73
+rescue SystemCallError => e
+  exit_filesystem_error("failed to create run directory", run_dir, e)
 end
-File.write(File.join(run_dir, "report.md"), report)
-File.write(File.join(run_dir, "commands.log"), "# Commands for #{scenario}\n")
+
+report_path = File.join(run_dir, "report.md")
+commands_path = File.join(run_dir, "commands.log")
+
+begin
+  File.write(report_path, report)
+rescue SystemCallError => e
+  exit_filesystem_error("failed to write", report_path, e)
+end
+
+begin
+  File.write(commands_path, "# Commands for #{scenario}\n")
+rescue SystemCallError => e
+  exit_filesystem_error("failed to write", commands_path, e)
+end
 
 puts run_dir

--- a/.agents/skills/dogfood/scripts/new_run.rb
+++ b/.agents/skills/dogfood/scripts/new_run.rb
@@ -5,14 +5,15 @@ require "fileutils"
 require "open3"
 require "optparse"
 require "time"
+require "tmpdir"
 
 options = {
   root: Dir.pwd,
-  out: "/tmp/devopsellence-dogfood"
+  out: File.join(Dir.tmpdir, "devopsellence-dogfood")
 }
 
 parser = OptionParser.new do |opts|
-  opts.banner = "Usage: new_run.rb SCENARIO_SLUG [--root PATH] [--out PATH]"
+  opts.banner = "Usage: new_run.rb SCENARIO [--root PATH] [--out PATH]"
   opts.on("--root PATH", "Repository root used for git metadata") { |value| options[:root] = value }
   opts.on("--out PATH", "Parent output directory") { |value| options[:out] = value }
 end
@@ -32,10 +33,21 @@ unless scenario
   warn parser
   exit 64
 end
+scenario = scenario.strip
+if scenario.empty?
+  warn "SCENARIO must not be empty"
+  warn parser
+  exit 64
+end
+if scenario.match?(/[[:cntrl:]]/)
+  warn "SCENARIO must not contain control characters"
+  warn parser
+  exit 64
+end
 
 slug = scenario.downcase.gsub(/[^a-z0-9]+/, "-").gsub(/\A-|-+\z/, "")
 if slug.empty?
-  warn "SCENARIO_SLUG must contain at least one lowercase letter or digit after normalization"
+  warn "SCENARIO must contain at least one letter or digit after normalization"
   warn parser
   exit 64
 end

--- a/.agents/skills/dogfood/scripts/new_run.rb
+++ b/.agents/skills/dogfood/scripts/new_run.rb
@@ -1,0 +1,54 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "fileutils"
+require "open3"
+require "optparse"
+require "time"
+
+options = {
+  root: Dir.pwd,
+  out: "/tmp/devopsellence-dogfood"
+}
+
+parser = OptionParser.new do |opts|
+  opts.banner = "Usage: new_run.rb SCENARIO_SLUG [--root PATH] [--out PATH]"
+  opts.on("--root PATH", "Repository root used for git metadata") { |value| options[:root] = value }
+  opts.on("--out PATH", "Parent output directory") { |value| options[:out] = value }
+end
+
+parser.parse!
+
+scenario = ARGV.shift
+unless scenario
+  warn parser
+  exit 64
+end
+
+slug = scenario.downcase.gsub(/[^a-z0-9]+/, "-").gsub(/\A-|-+\z/, "")
+timestamp = Time.now.utc.strftime("%Y%m%dT%H%M%SZ")
+run_dir = File.expand_path("#{timestamp}-#{slug}", options[:out])
+
+def git_value(root, *args)
+  stdout, status = Open3.capture2("git", *args, chdir: root)
+  status.success? ? stdout.strip : "unknown"
+rescue SystemCallError
+  "unknown"
+end
+
+commit = git_value(options[:root], "rev-parse", "--short", "HEAD")
+branch = git_value(options[:root], "branch", "--show-current")
+
+template_path = File.expand_path("../references/report-template.md", __dir__)
+template = File.read(template_path)
+report = template
+  .sub("Scenario:", "Scenario: #{scenario}")
+  .sub("Date:", "Date: #{Time.now.utc.iso8601}")
+  .sub("Commit:", "Commit: #{commit} (#{branch})")
+  .sub("Run path:", "Run path: #{run_dir}")
+
+FileUtils.mkdir_p(run_dir)
+File.write(File.join(run_dir, "report.md"), report)
+File.write(File.join(run_dir, "commands.log"), "# Commands for #{scenario}\n")
+
+puts run_dir


### PR DESCRIPTION
## Summary

Adds a repo-local Codex skill named `dogfood` for repeatable devopsellence dogfooding runs.

The skill defines blind-pass and expert-pass testing, evidence rules, scenario defaults, scoring rubrics, and a Markdown report template. It also includes a small Ruby helper to create timestamped run artifacts under `/tmp/devopsellence-dogfood`.

## Validation

- `python3 /home/elvin/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/dogfood`
- `ruby .agents/skills/dogfood/scripts/new_run.rb solo-rails-first-deploy`