### PR TITLE
[codex] Add dogfood version targeting

### DIFF
--- a/.agents/skills/dogfood/SKILL.md
+++ b/.agents/skills/dogfood/SKILL.md
@@ -32,7 +32,7 @@ Dogfood is not only e2e. It asks: can a target user complete the job, understand
    - Read `references/scenarios.md` only when scenario detail is needed.
 
 2. Create run artifact.
-   - Prefer `ruby .agents/skills/dogfood/scripts/new_run.rb <scenario>` from repo root.
+   - Prefer `ruby .agents/skills/dogfood/scripts/new_run.rb <scenario>` from repo root; multi-word scenarios may be quoted or passed as multiple words.
    - If the user names a devopsellence version, pass `--version <version>`.
    - If no version is named, omit `--version` and dogfood the default stable installer/control-plane version.
    - Use the temp run path printed by the helper unless the user asks for repo-tracked reports.

--- a/.agents/skills/dogfood/SKILL.md
+++ b/.agents/skills/dogfood/SKILL.md
@@ -32,13 +32,16 @@ Dogfood is not only e2e. It asks: can a target user complete the job, understand
    - Read `references/scenarios.md` only when scenario detail is needed.
 
 2. Create run artifact.
-   - Prefer `ruby .agents/skills/dogfood/scripts/new_run.rb <scenario-slug>` from repo root.
-   - Use `/tmp/devopsellence-dogfood/...` unless the user asks for repo-tracked reports.
+   - Prefer `ruby .agents/skills/dogfood/scripts/new_run.rb <scenario>` from repo root.
+   - If the user names a devopsellence version, pass `--version <version>`.
+   - If no version is named, omit `--version` and dogfood the default stable installer/control-plane version.
+   - Use the temp run path printed by the helper unless the user asks for repo-tracked reports.
    - Keep `commands.log` as you go.
 
 3. Blind pass.
    - Use docs, CLI help, UI, and terminal feedback.
    - Do not inspect source.
+   - Install the requested target from `commands.log`: preview versions use `curl -fsSL https://www.devopsellence.com/lfg.sh?version=<version> | bash`; default stable uses `curl -fsSL https://www.devopsellence.com/lfg.sh | bash`.
    - Work from user goals, not privileged steps.
    - Stop only for hard blockers; otherwise recover like a user would.
 

--- a/.agents/skills/dogfood/references/report-template.md
+++ b/.agents/skills/dogfood/references/report-template.md
@@ -2,6 +2,8 @@
 
 Scenario:
 Persona:
+Target version:
+Install command:
 Date:
 Commit:
 Run path:

--- a/.agents/skills/dogfood/scripts/new_run.rb
+++ b/.agents/skills/dogfood/scripts/new_run.rb
@@ -9,11 +9,13 @@ require "tmpdir"
 
 options = {
   root: Dir.pwd,
-  out: File.join(Dir.tmpdir, "devopsellence-dogfood")
+  out: File.join(Dir.tmpdir, "devopsellence-dogfood"),
+  version: nil
 }
 
 parser = OptionParser.new do |opts|
-  opts.banner = "Usage: new_run.rb SCENARIO [--root PATH] [--out PATH]"
+  opts.banner = "Usage: new_run.rb SCENARIO [--version VERSION] [--root PATH] [--out PATH]"
+  opts.on("--version VERSION", "devopsellence version to dogfood; omit for default stable") { |value| options[:version] = value }
   opts.on("--root PATH", "Repository root used for git metadata") { |value| options[:root] = value }
   opts.on("--out PATH", "Parent output directory") { |value| options[:out] = value }
 end
@@ -52,6 +54,30 @@ if slug.empty?
   exit 64
 end
 
+version = options[:version]&.strip
+if version&.empty?
+  warn "VERSION must not be empty"
+  warn parser
+  exit 64
+end
+if version&.match?(/[[:cntrl:]]/)
+  warn "VERSION must not contain control characters"
+  warn parser
+  exit 64
+end
+if version && !version.match?(/\A[A-Za-z0-9][A-Za-z0-9._-]*\z/)
+  warn "VERSION may contain only letters, digits, dots, underscores, and dashes"
+  warn parser
+  exit 64
+end
+
+target_version = version || "default stable"
+install_command = if version
+  "curl -fsSL https://www.devopsellence.com/lfg.sh?version=#{version} | bash"
+else
+  "curl -fsSL https://www.devopsellence.com/lfg.sh | bash"
+end
+
 now = Time.now.utc
 timestamp = now.strftime("%Y%m%dT%H%M%S%6NZ")
 run_dir = File.expand_path("#{timestamp}-#{slug}", options[:out])
@@ -80,6 +106,8 @@ rescue SystemCallError => e
 end
 report = template
   .sub("Scenario:", "Scenario: #{scenario}")
+  .sub("Target version:", "Target version: #{target_version}")
+  .sub("Install command:", "Install command: #{install_command}")
   .sub("Date:", "Date: #{now.iso8601}")
   .sub("Commit:", "Commit: #{commit} (#{branch})")
   .sub("Run path:", "Run path: #{run_dir}")
@@ -108,7 +136,7 @@ rescue SystemCallError => e
 end
 
 begin
-  File.write(commands_path, "# Commands for #{scenario}\n")
+  File.write(commands_path, "# Commands for #{scenario}\n# Target version: #{target_version}\n# Install command:\n#{install_command}\n")
 rescue SystemCallError => e
   exit_filesystem_error("failed to write", commands_path, e)
 end

--- a/.agents/skills/dogfood/scripts/new_run.rb
+++ b/.agents/skills/dogfood/scripts/new_run.rb
@@ -30,8 +30,8 @@ end
 
 options[:out] = File.expand_path(options[:out])
 
-scenario = ARGV.shift
-unless scenario
+scenario = ARGV.join(" ")
+if scenario.empty?
   warn parser
   exit 64
 end


### PR DESCRIPTION
## Summary

Adds optional target-version support to the repo-local `dogfood` skill.

Dogfood run artifacts now record the target devopsellence version and seed the installer command. Omitting `--version` keeps the default stable installer path, while preview runs can pass values like `--version v0.2.0-preview` to seed `curl -fsSL https://www.devopsellence.com/lfg.sh?version=v0.2.0-preview | bash`.

## Validation

- `python3 /home/elvin/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/dogfood`
- `ruby -c .agents/skills/dogfood/scripts/new_run.rb`
- `ruby .agents/skills/dogfood/scripts/new_run.rb 'Solo Rails First Deploy'`
- `ruby .agents/skills/dogfood/scripts/new_run.rb 'Solo Rails First Deploy' --version v0.2.0-preview`
- Invalid version checks for slash, empty, and control-character input