### PR TITLE
[codex] Address dogfood first-run friction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,7 @@ cd control-plane && mise run test -- test/path/file_test.rb
 
 - Explicit user product direction overrides reviewer suggestions.
 - If user says no legacy / no backward compat / clean slate, do not add backfills, shims, compat code, or rejection guards just to preserve or explicitly refute removed behavior; remove the deleted surface cleanly and simplify the codepath instead.
+- Open PRs as ready for review, not draft, unless the user explicitly asks for a draft.
 - After addressing a PR review thread, resolve the thread in GitHub so only remaining actionable feedback stays open.
 - Right after each PR is opened or updated with pushed fixes, request a fresh Copilot review with `gh pr edit <pr-number> --add-reviewer copilot-pull-request-reviewer`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,7 @@ cd control-plane && mise run test -- test/path/file_test.rb
 
 - Explicit user product direction overrides reviewer suggestions.
 - If user says no legacy / no backward compat / clean slate, do not add backfills, shims, compat code, or rejection guards just to preserve or explicitly refute removed behavior; remove the deleted surface cleanly and simplify the codepath instead.
+- After addressing a PR review thread, resolve the thread in GitHub so only remaining actionable feedback stays open.
 - Right after each PR is opened or updated with pushed fixes, request a fresh Copilot review with `gh pr edit <pr-number> --add-reviewer copilot-pull-request-reviewer`.
 
 ## Public Boundary

--- a/README.md
+++ b/README.md
@@ -27,10 +27,12 @@ Install the CLI:
 curl -fsSL https://www.devopsellence.com/lfg.sh | bash
 ```
 
-Install the agent skill:
+The installer writes to `~/.local/bin` by default. If that directory is not already on your `PATH`, it prints the shell command to add it.
+
+devopsellence is agent-first. The installer prints the agent skill command; to install the CLI and skill together:
 
 ```bash
-npx skills add devopsellence/devopsellence --skill devopsellence -g
+curl -fsSL https://www.devopsellence.com/lfg.sh | bash -s -- --install-agent-skill
 ```
 
 Check local tooling:
@@ -52,7 +54,7 @@ devopsellence provider login hetzner
 devopsellence setup
 ```
 
-For provider-created solo nodes, `devopsellence setup` now defaults to generating a workspace-scoped SSH keypair under `$XDG_STATE_HOME/devopsellence/solo/keys/` (default: `~/.local/state/devopsellence/solo/keys/`) and reuses it for later node creation from the same workspace.
+For provider-created solo nodes, `devopsellence setup` and `devopsellence node create` can generate a workspace-scoped SSH keypair under `$XDG_STATE_HOME/devopsellence/solo/keys/` (default: `~/.local/state/devopsellence/solo/keys/`) and reuse it for later node creation from the same workspace.
 
 Or create a Hetzner-backed node from the provider:
 

--- a/cli/internal/workflow/provider.go
+++ b/cli/internal/workflow/provider.go
@@ -155,7 +155,7 @@ func (a *App) ensureInteractiveProviderLogin(ctx context.Context, provider strin
 		return nil
 	}
 	if !a.Printer.Interactive {
-		return fmt.Errorf("run `devopsellence provider login %s --token <token>` or configure DEVOPSELLENCE_HETZNER_API_TOKEN/HCLOUD_TOKEN", providerSlug)
+		return ExitError{Code: 2, Err: fmt.Errorf("run `devopsellence provider login %s --token <token>` or configure DEVOPSELLENCE_HETZNER_API_TOKEN/HCLOUD_TOKEN", providerSlug)}
 	}
 	return runProviderLogin(a, ctx, ProviderLoginOptions{Provider: providerSlug})
 }

--- a/cli/internal/workflow/provider.go
+++ b/cli/internal/workflow/provider.go
@@ -151,8 +151,11 @@ func (a *App) ensureInteractiveProviderLogin(ctx context.Context, provider strin
 	if err != nil {
 		return err
 	}
-	if strings.TrimSpace(token) != "" || !a.Printer.Interactive {
+	if strings.TrimSpace(token) != "" {
 		return nil
+	}
+	if !a.Printer.Interactive {
+		return fmt.Errorf("run `devopsellence provider login %s --token <token>` or configure DEVOPSELLENCE_HETZNER_API_TOKEN/HCLOUD_TOKEN", providerSlug)
 	}
 	return runProviderLogin(a, ctx, ProviderLoginOptions{Provider: providerSlug})
 }

--- a/cli/internal/workflow/provider_test.go
+++ b/cli/internal/workflow/provider_test.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"context"
+	"errors"
 	"io"
 	"path/filepath"
 	"strings"
@@ -119,9 +120,14 @@ func TestEnsureInteractiveProviderLoginSkipsEnvAndNonInteractive(t *testing.T) {
 
 	app.Printer.Interactive = false
 	t.Setenv("DEVOPSELLENCE_HETZNER_API_TOKEN", "")
+	t.Setenv("HCLOUD_TOKEN", "")
 	err := app.ensureInteractiveProviderLogin(context.Background(), providerHetzner)
 	if err == nil {
 		t.Fatal("expected missing provider token error")
+	}
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 2 {
+		t.Fatalf("error = %#v, want ExitError code 2", err)
 	}
 	if !strings.Contains(err.Error(), "devopsellence provider login hetzner --token <token>") {
 		t.Fatalf("error = %v", err)

--- a/cli/internal/workflow/provider_test.go
+++ b/cli/internal/workflow/provider_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/devopsellence/cli/internal/output"
@@ -118,7 +119,11 @@ func TestEnsureInteractiveProviderLoginSkipsEnvAndNonInteractive(t *testing.T) {
 
 	app.Printer.Interactive = false
 	t.Setenv("DEVOPSELLENCE_HETZNER_API_TOKEN", "")
-	if err := app.ensureInteractiveProviderLogin(context.Background(), providerHetzner); err != nil {
-		t.Fatal(err)
+	err := app.ensureInteractiveProviderLogin(context.Background(), providerHetzner)
+	if err == nil {
+		t.Fatal("expected missing provider token error")
+	}
+	if !strings.Contains(err.Error(), "devopsellence provider login hetzner --token <token>") {
+		t.Fatalf("error = %v", err)
 	}
 }

--- a/cli/internal/workflow/root_test.go
+++ b/cli/internal/workflow/root_test.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -88,6 +89,10 @@ func TestSetupModeFlagPersistsWorkspaceMode(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "solo setup requires an interactive terminal") {
 		t.Fatalf("error = %v, want solo setup path", err)
+	}
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 2 {
+		t.Fatalf("error = %#v, want ExitError code 2", err)
 	}
 
 	app := NewApp(bytes.NewBuffer(nil), &stdout, &stdout, false, cwd)

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1974,7 +1974,7 @@ func (a *App) SoloNodeRemove(ctx context.Context, opts SoloNodeRemoveOptions) er
 
 func (a *App) SoloSetup(ctx context.Context, _ SoloSetupOptions) error {
 	if !a.Printer.Interactive {
-		return fmt.Errorf("solo setup requires an interactive terminal; use `devopsellence node create <name> --provider hetzner` for provider-managed nodes, or run `devopsellence setup` in a terminal to add an existing SSH node")
+		return ExitError{Code: 2, Err: fmt.Errorf("solo setup requires an interactive terminal; use `devopsellence node create <name> --provider hetzner` for provider-managed nodes, or run `devopsellence setup` in a terminal to add an existing SSH node")}
 	}
 	mode, err := a.promptLine("Node source (existing/hetzner)", "hetzner")
 	if err != nil {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1760,6 +1760,9 @@ func (a *App) SoloNodeCreate(ctx context.Context, opts SoloNodeCreateOptions) er
 	if _, ok := current.Nodes[opts.Name]; ok {
 		return fmt.Errorf("solo node %q already exists", opts.Name)
 	}
+	if err := a.ensureSoloNodeCreateSSHPublicKey(&opts, workspaceRoot); err != nil {
+		return err
+	}
 	created, err := a.createProviderNode(ctx, opts, cfg.Project)
 	if err != nil {
 		return err
@@ -1811,6 +1814,25 @@ func (a *App) runSoloNodeCreate(ctx context.Context, opts SoloNodeCreateOptions)
 		return a.soloNodeCreateFn(ctx, opts)
 	}
 	return a.SoloNodeCreate(ctx, opts)
+}
+
+func (a *App) ensureSoloNodeCreateSSHPublicKey(opts *SoloNodeCreateOptions, workspaceRoot string) error {
+	if strings.TrimSpace(opts.SSHPublicKey) != "" || defaultSoloSSHPublicKeyPath() != "" {
+		return nil
+	}
+	generatedKey, err := ensureGeneratedWorkspaceSSHKey(workspaceRoot)
+	if err != nil {
+		return err
+	}
+	opts.SSHPublicKey = generatedKey.PublicKeyPath
+	if !a.Printer.JSON {
+		action := "Reusing"
+		if generatedKey.Generated {
+			action = "Generated"
+		}
+		a.Printer.Println(fmt.Sprintf("%s workspace SSH key %s (%s)", action, generatedKey.PrivateKeyPath, generatedKey.Fingerprint))
+	}
+	return nil
 }
 
 func (a *App) SharedNodeCreate(ctx context.Context, opts SharedNodeCreateOptions) error {
@@ -1952,7 +1974,7 @@ func (a *App) SoloNodeRemove(ctx context.Context, opts SoloNodeRemoveOptions) er
 
 func (a *App) SoloSetup(ctx context.Context, _ SoloSetupOptions) error {
 	if !a.Printer.Interactive {
-		return fmt.Errorf("solo setup requires an interactive terminal; use `devopsellence node create`, or add a node to %s and run `devopsellence node attach`", solo.DefaultStatePath())
+		return fmt.Errorf("solo setup requires an interactive terminal; use `devopsellence node create <name> --provider hetzner` for provider-managed nodes, or run `devopsellence setup` in a terminal to add an existing SSH node")
 	}
 	mode, err := a.promptLine("Node source (existing/hetzner)", "hetzner")
 	if err != nil {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1817,7 +1817,10 @@ func (a *App) runSoloNodeCreate(ctx context.Context, opts SoloNodeCreateOptions)
 }
 
 func (a *App) ensureSoloNodeCreateSSHPublicKey(opts *SoloNodeCreateOptions, workspaceRoot string) error {
-	if strings.TrimSpace(opts.SSHPublicKey) != "" || defaultSoloSSHPublicKeyPath() != "" {
+	if strings.TrimSpace(opts.SSHPublicKey) != "" {
+		return nil
+	}
+	if _, _, err := readSoloSSHPublicKey(""); err == nil {
 		return nil
 	}
 	generatedKey, err := ensureGeneratedWorkspaceSSHKey(workspaceRoot)

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -1157,6 +1157,38 @@ func TestEnsureSoloNodeCreateSSHPublicKeyGeneratesWhenNoDefaultKey(t *testing.T)
 	}
 }
 
+func TestEnsureSoloNodeCreateSSHPublicKeyGeneratesWhenDefaultKeyIsEmpty(t *testing.T) {
+	stateDir := t.TempDir()
+	homeDir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateDir)
+	t.Setenv("HOME", homeDir)
+
+	if err := os.MkdirAll(filepath.Join(homeDir, ".ssh"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	defaultPublicKey := filepath.Join(homeDir, ".ssh", "id_ed25519.pub")
+	if err := os.WriteFile(defaultPublicKey, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	workspaceRoot := t.TempDir()
+	app := &App{Printer: output.New(io.Discard, io.Discard, false)}
+	opts := SoloNodeCreateOptions{}
+
+	if err := app.ensureSoloNodeCreateSSHPublicKey(&opts, workspaceRoot); err != nil {
+		t.Fatal(err)
+	}
+	if opts.SSHPublicKey == "" {
+		t.Fatal("SSHPublicKey empty, want generated public key path")
+	}
+	if opts.SSHPublicKey == defaultPublicKey {
+		t.Fatalf("SSHPublicKey = default empty key %q, want generated workspace key", opts.SSHPublicKey)
+	}
+	if !strings.HasPrefix(opts.SSHPublicKey, filepath.Join(stateDir, "devopsellence", "solo", "keys")) {
+		t.Fatalf("SSHPublicKey = %q, want generated state key", opts.SSHPublicKey)
+	}
+}
+
 func TestEnsureSoloNodeCreateSSHPublicKeyKeepsExplicitKey(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	customPublicKey := filepath.Join(t.TempDir(), "custom.pub")

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -1126,6 +1126,51 @@ func TestEnsureGeneratedWorkspaceSSHKeyRejectsMismatchedPublicKey(t *testing.T) 
 	}
 }
 
+func TestEnsureSoloNodeCreateSSHPublicKeyGeneratesWhenNoDefaultKey(t *testing.T) {
+	stateDir := t.TempDir()
+	homeDir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateDir)
+	t.Setenv("HOME", homeDir)
+
+	workspaceRoot := t.TempDir()
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard, false)}
+	opts := SoloNodeCreateOptions{}
+
+	if err := app.ensureSoloNodeCreateSSHPublicKey(&opts, workspaceRoot); err != nil {
+		t.Fatal(err)
+	}
+	if opts.SSHPublicKey == "" {
+		t.Fatal("SSHPublicKey empty, want generated public key path")
+	}
+	if !strings.HasPrefix(opts.SSHPublicKey, filepath.Join(stateDir, "devopsellence", "solo", "keys")) {
+		t.Fatalf("SSHPublicKey = %q, want generated state key", opts.SSHPublicKey)
+	}
+	if _, err := os.Stat(opts.SSHPublicKey); err != nil {
+		t.Fatalf("expected generated public key: %v", err)
+	}
+	if _, err := os.Stat(strings.TrimSuffix(opts.SSHPublicKey, ".pub")); err != nil {
+		t.Fatalf("expected generated private key: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "Generated workspace SSH key") {
+		t.Fatalf("output = %q, want generated key message", stdout.String())
+	}
+}
+
+func TestEnsureSoloNodeCreateSSHPublicKeyKeepsExplicitKey(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	customPublicKey := filepath.Join(t.TempDir(), "custom.pub")
+	opts := SoloNodeCreateOptions{SSHPublicKey: customPublicKey}
+	app := &App{Printer: output.New(io.Discard, io.Discard, false)}
+
+	if err := app.ensureSoloNodeCreateSSHPublicKey(&opts, t.TempDir()); err != nil {
+		t.Fatal(err)
+	}
+	if opts.SSHPublicKey != customPublicKey {
+		t.Fatalf("SSHPublicKey = %q, want %q", opts.SSHPublicKey, customPublicKey)
+	}
+}
+
 func TestSoloSetupDefaultsToHetznerAndGeneratedWorkspaceKey(t *testing.T) {
 	stateDir := t.TempDir()
 	t.Setenv("XDG_STATE_HOME", stateDir)

--- a/cli/scripts/release-local.sh
+++ b/cli/scripts/release-local.sh
@@ -110,6 +110,7 @@ case "$INSTALL_AGENT_SKILL" in
       echo "devopsellence CLI installed. Agent skill install requested, but npx was not found." >&2
       echo "Install the skill later with:" >&2
       echo "  npx skills add devopsellence/devopsellence --skill devopsellence -g" >&2
+      exit 1
     fi
     ;;
   *)

--- a/cli/scripts/release-local.sh
+++ b/cli/scripts/release-local.sh
@@ -5,6 +5,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 CLI_DIR="$ROOT_DIR/cli"
 TARGET_NAME="devopsellence"
 INSTALL_DIR="${DEVOPSELLENCE_CLI_INSTALL_DIR:-}"
+INSTALL_AGENT_SKILL="${DEVOPSELLENCE_INSTALL_AGENT_SKILL:-}"
 
 OS_RAW="$(uname -s | tr '[:upper:]' '[:lower:]')"
 ARCH_RAW="$(uname -m)"
@@ -28,11 +29,7 @@ case "$ARCH_RAW" in
 esac
 
 if [[ -z "$INSTALL_DIR" ]]; then
-  if [[ "$OS" == "darwin" ]]; then
-    INSTALL_DIR="$HOME/.local/bin"
-  else
-    INSTALL_DIR="/usr/local/bin"
-  fi
+  INSTALL_DIR="$HOME/.local/bin"
 fi
 
 BUILD_DIR="$CLI_DIR/dist/local-head"
@@ -101,5 +98,23 @@ case ":$PATH:" in
       echo "add $INSTALL_DIR to your PATH:"
       echo "  $PATH_EXPORT"
     fi
+    ;;
+esac
+
+case "$INSTALL_AGENT_SKILL" in
+  1|true|TRUE|yes|YES)
+    if command -v npx >/dev/null 2>&1; then
+      echo "installing devopsellence agent skill..."
+      npx skills add devopsellence/devopsellence --skill devopsellence -g
+    else
+      echo "devopsellence CLI installed. Agent skill install requested, but npx was not found." >&2
+      echo "Install the skill later with:" >&2
+      echo "  npx skills add devopsellence/devopsellence --skill devopsellence -g" >&2
+    fi
+    ;;
+  *)
+    echo "agent skill available:"
+    echo "  npx skills add devopsellence/devopsellence --skill devopsellence -g"
+    echo "or rerun installer with DEVOPSELLENCE_INSTALL_AGENT_SKILL=1"
     ;;
 esac

--- a/control-plane/app/controllers/cli_installs_controller.rb
+++ b/control-plane/app/controllers/cli_installs_controller.rb
@@ -219,7 +219,7 @@ class CliInstallsController < ActionController::Base
           echo "agent skill available:"
           echo "  npx skills add devopsellence/devopsellence --skill devopsellence -g"
           echo "or install CLI + skill together with:"
-          echo "  curl -fsSL $BASE_URL/lfg.sh?version=$CLI_VERSION | bash -s -- --install-agent-skill"
+          echo "  curl -fsSL \"$BASE_URL/lfg.sh?version=$CLI_VERSION\" | bash -s -- --install-agent-skill"
           ;;
       esac
     SH

--- a/control-plane/app/controllers/cli_installs_controller.rb
+++ b/control-plane/app/controllers/cli_installs_controller.rb
@@ -215,6 +215,7 @@ class CliInstallsController < ActionController::Base
             echo "devopsellence CLI installed. Agent skill install requested, but npx was not found." >&2
             echo "Install the skill later with:" >&2
             echo "  npx skills add devopsellence/devopsellence --skill devopsellence -g" >&2
+            exit 1
           fi
           ;;
         *)

--- a/control-plane/app/controllers/cli_installs_controller.rb
+++ b/control-plane/app/controllers/cli_installs_controller.rb
@@ -27,6 +27,7 @@ class CliInstallsController < ActionController::Base
       fi
       CLI_CHECKSUM_URL="${DEVOPSELLENCE_CLI_CHECKSUM_URL:-}"
       INSTALL_DIR="${DEVOPSELLENCE_CLI_INSTALL_DIR:-}"
+      INSTALL_AGENT_SKILL="${DEVOPSELLENCE_INSTALL_AGENT_SKILL:-}"
       TARGET_NAME="devopsellence"
 
       while [[ $# -gt 0 ]]; do
@@ -53,6 +54,10 @@ class CliInstallsController < ActionController::Base
             ;;
           --install-dir=*)
             INSTALL_DIR="${1#*=}"
+            shift
+            ;;
+          --install-agent-skill)
+            INSTALL_AGENT_SKILL=1
             shift
             ;;
           *)
@@ -103,11 +108,7 @@ class CliInstallsController < ActionController::Base
       esac
 
       if [[ -z "$INSTALL_DIR" ]]; then
-        if [[ "$OS" == "darwin" ]]; then
-          INSTALL_DIR="$HOME/.local/bin"
-        else
-          INSTALL_DIR="/usr/local/bin"
-        fi
+        INSTALL_DIR="$HOME/.local/bin"
       fi
 
       DOWNLOAD_URL="$BASE_URL/cli/download?os=$OS&arch=$ARCH&version=$CLI_VERSION"
@@ -200,6 +201,25 @@ class CliInstallsController < ActionController::Base
             echo "add $INSTALL_DIR to your PATH:"
             echo "  $PATH_EXPORT"
           fi
+          ;;
+      esac
+
+      case "$INSTALL_AGENT_SKILL" in
+        1|true|TRUE|yes|YES)
+          if command -v npx >/dev/null 2>&1; then
+            echo "installing devopsellence agent skill..."
+            npx skills add devopsellence/devopsellence --skill devopsellence -g
+          else
+            echo "devopsellence CLI installed. Agent skill install requested, but npx was not found." >&2
+            echo "Install the skill later with:" >&2
+            echo "  npx skills add devopsellence/devopsellence --skill devopsellence -g" >&2
+          fi
+          ;;
+        *)
+          echo "agent skill available:"
+          echo "  npx skills add devopsellence/devopsellence --skill devopsellence -g"
+          echo "or install CLI + skill together with:"
+          echo "  curl -fsSL $BASE_URL/lfg.sh?version=$CLI_VERSION | bash -s -- --install-agent-skill"
           ;;
       esac
     SH

--- a/control-plane/app/controllers/cli_installs_controller.rb
+++ b/control-plane/app/controllers/cli_installs_controller.rb
@@ -11,6 +11,7 @@ class CliInstallsController < ActionController::Base
     # For curl | bash installs, default the downloader to the exact host serving
     # the script so callers do not need to pass --base-url explicitly.
     default_base_url = ShellQuoting.single_quote(request.base_url)
+    script_install_url = ShellQuoting.single_quote("#{request.base_url}/lfg.sh")
     default_version = ShellQuoting.single_quote(params[:version].to_s.presence || Devopsellence::RuntimeConfig.current.stable_version)
 
     <<~SH
@@ -21,6 +22,7 @@ class CliInstallsController < ActionController::Base
       if [[ -z "$BASE_URL" ]]; then
         BASE_URL=#{default_base_url}
       fi
+      INSTALL_SCRIPT_URL=#{script_install_url}
       CLI_VERSION="${DEVOPSELLENCE_CLI_VERSION:-}"
       if [[ -z "$CLI_VERSION" ]]; then
         CLI_VERSION=#{default_version}
@@ -219,7 +221,7 @@ class CliInstallsController < ActionController::Base
           echo "agent skill available:"
           echo "  npx skills add devopsellence/devopsellence --skill devopsellence -g"
           echo "or install CLI + skill together with:"
-          echo "  curl -fsSL \"$BASE_URL/lfg.sh?version=$CLI_VERSION\" | bash -s -- --install-agent-skill"
+          echo "  curl -fsSL \"$INSTALL_SCRIPT_URL?version=$CLI_VERSION\" | bash -s -- --install-agent-skill"
           ;;
       esac
     SH

--- a/control-plane/app/views/marketing/docs.html.erb
+++ b/control-plane/app/views/marketing/docs.html.erb
@@ -164,7 +164,7 @@
         <div class="tl"><span class="tp">$</span> <%= @cli_install_command %></div>
       </div>
     </div>
-    <p>This installs the <code>devopsellence</code> binary. Run <code>devopsellence doctor</code> to verify your setup.</p>
+    <p>This installs the <code>devopsellence</code> binary to <code>~/.local/bin</code> by default and prints the shell command to add that directory to your <code>PATH</code> when needed. devopsellence is agent-first; the installer also prints the agent skill command, and accepts <code>--install-agent-skill</code> when you want the CLI and skill installed together. Run <code>devopsellence doctor</code> to verify your setup.</p>
 
     <h3>2. Choose a workspace mode</h3>
     <div class="terminal">
@@ -336,12 +336,11 @@
         <div class="tl"><span class="tp">$</span> devopsellence node create prod-1 \</div>
         <div class="tl">    --provider hetzner \</div>
         <div class="tl">    --region ash \</div>
-        <div class="tl">    --size cpx11 \</div>
-        <div class="tl">    --ssh-public-key ~/.ssh/id_ed25519.pub</div>
+        <div class="tl">    --size cpx11</div>
         <div class="tl"><span class="tp">$</span> devopsellence node attach prod-1</div>
       </div>
     </div>
-    <p>Provider-managed nodes record non-secret metadata like provider name, server ID, region, size, public host, SSH user, and labels in local solo state at <code>$XDG_STATE_HOME/devopsellence/solo/state.json</code> (default: <code>~/.local/state/devopsellence/solo/state.json</code> when <code>XDG_STATE_HOME</code> is unset). The provider API token and SSH private key value are not written to app config.</p>
+    <p>If no default SSH public key exists, <code>node create</code> generates and reuses a workspace-scoped keypair under local state. Pass <code>--ssh-public-key</code> when you want to use a specific key. Provider-managed nodes record non-secret metadata like provider name, server ID, region, size, public host, SSH user, and labels in local solo state at <code>$XDG_STATE_HOME/devopsellence/solo/state.json</code> (default: <code>~/.local/state/devopsellence/solo/state.json</code> when <code>XDG_STATE_HOME</code> is unset). The provider API token and SSH private key value are not written to app config.</p>
 
     <h3>Solo config</h3>
     <p><code>devopsellence.yml</code> stays workload-only in solo mode. Solo nodes, workspace/environment attachments, and the latest desired environment snapshots live in <code>$XDG_STATE_HOME/devopsellence/solo/state.json</code> (default: <code>~/.local/state/devopsellence/solo/state.json</code> when <code>XDG_STATE_HOME</code> is unset). Generated solo SSH keys stay local under <code>$XDG_STATE_HOME/devopsellence/solo/keys/</code>; SSH private key material is still never written into app config.</p>
@@ -993,11 +992,11 @@ tasks:
       </div>
       <div class="docs-field">
         <dt><code>devopsellence provider login hetzner</code></dt>
-        <dd>Save and validate a local Hetzner API token for node provisioning.</dd>
+        <dd>Save and validate a local Hetzner API token for node provisioning. Use <code>--token</code>, <code>--stdin</code>, <code>DEVOPSELLENCE_HETZNER_API_TOKEN</code>, or <code>HCLOUD_TOKEN</code> in noninteractive shells.</dd>
       </div>
       <div class="docs-field">
         <dt><code>devopsellence node create &lt;name&gt;</code></dt>
-        <dd>Create a provider-managed solo node. Hetzner is supported with <code>--provider hetzner</code>.</dd>
+        <dd>Create a provider-managed solo node. Hetzner is supported with <code>--provider hetzner</code>; a workspace SSH key is generated when no default public key is available.</dd>
       </div>
       <div class="docs-field">
         <dt><code>devopsellence node remove &lt;name&gt; --yes</code></dt>

--- a/control-plane/test/integration/installs_test.rb
+++ b/control-plane/test/integration/installs_test.rb
@@ -138,6 +138,24 @@ class InstallsTest < ActionDispatch::IntegrationTest
     assert_equal [ "skills", "add", "devopsellence/devopsellence", "--skill", "devopsellence", "-g" ], skill_args
   end
 
+  test "cli install script fails when requested agent skill cannot install without npx" do
+    get "/lfg.sh", params: { version: "master-0053792f6aec" }
+
+    assert_response :success
+
+    stdout, stderr, status, installed_cli, skill_args = run_cli_install_script(
+      response.body,
+      version: "master-0053792f6aec",
+      install_agent_skill: true,
+      include_npx: false
+    )
+
+    refute_predicate status, :success?, -> { "stdout:\n#{stdout}\nstderr:\n#{stderr}" }
+    assert_includes stderr, "Agent skill install requested, but npx was not found"
+    assert_equal "prerelease build\n", installed_cli
+    assert_nil skill_args
+  end
+
   test "cli install script defaults to user local bin on linux" do
     get "/lfg.sh", params: { version: "master-0053792f6aec" }
 
@@ -253,7 +271,7 @@ class InstallsTest < ActionDispatch::IntegrationTest
 
   private
 
-  def run_cli_install_script(script_body, version:, install_dir: :explicit, install_agent_skill: false)
+  def run_cli_install_script(script_body, version:, install_dir: :explicit, install_agent_skill: false, include_npx: true)
     Dir.mktmpdir("devopsellence-cli-install-test") do |tmpdir|
       fixtures_dir = File.join(tmpdir, "fixtures")
       fakebin_dir = File.join(tmpdir, "fakebin")
@@ -330,14 +348,16 @@ class InstallsTest < ActionDispatch::IntegrationTest
       SH
       FileUtils.chmod("u+x", uname_path)
 
-      npx_path = File.join(fakebin_dir, "npx")
-      File.write(npx_path, <<~SH)
-        #!/usr/bin/env bash
-        set -euo pipefail
+      if include_npx
+        npx_path = File.join(fakebin_dir, "npx")
+        File.write(npx_path, <<~SH)
+          #!/usr/bin/env bash
+          set -euo pipefail
 
-        printf '%s\\n' "$@" > #{skill_args_path.inspect}
-      SH
-      FileUtils.chmod("u+x", npx_path)
+          printf '%s\\n' "$@" > #{skill_args_path.inspect}
+        SH
+        FileUtils.chmod("u+x", npx_path)
+      end
 
       env = {
         "PATH" => "#{fakebin_dir}:#{ENV.fetch("PATH")}",

--- a/control-plane/test/integration/installs_test.rb
+++ b/control-plane/test/integration/installs_test.rb
@@ -58,6 +58,7 @@ class InstallsTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "BASE_URL='https://dev.devopsellence.com'"
     assert_includes response.body, 'INSTALL_DIR="${DEVOPSELLENCE_CLI_INSTALL_DIR:-}"'
     assert_includes response.body, 'INSTALL_AGENT_SKILL="${DEVOPSELLENCE_INSTALL_AGENT_SKILL:-}"'
+    assert_includes response.body, "INSTALL_SCRIPT_URL='https://dev.devopsellence.com/lfg.sh'"
     assert_includes response.body, "--install-agent-skill"
     assert_includes response.body, 'INSTALL_DIR="$HOME/.local/bin"'
     refute_includes response.body, 'INSTALL_DIR="/usr/local/bin"'
@@ -65,7 +66,7 @@ class InstallsTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "echo '$PATH_EXPORT' >> $RC_FILE"
     assert_includes response.body, "source $RC_FILE"
     assert_includes response.body, "npx skills add devopsellence/devopsellence --skill devopsellence -g"
-    assert_includes response.body, 'curl -fsSL "$BASE_URL/lfg.sh?version=$CLI_VERSION" | bash -s -- --install-agent-skill'
+    assert_includes response.body, 'curl -fsSL "$INSTALL_SCRIPT_URL?version=$CLI_VERSION" | bash -s -- --install-agent-skill'
   end
 
   test "cli install script ignores configured public base url when choosing default download host" do
@@ -79,7 +80,20 @@ class InstallsTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_includes response.body, 'BASE_URL="${DEVOPSELLENCE_BASE_URL:-}"'
     assert_includes response.body, "BASE_URL='https://dev.devopsellence.com'"
+    assert_includes response.body, "INSTALL_SCRIPT_URL='https://dev.devopsellence.com/lfg.sh'"
     refute_includes response.body, "https://app.devopsellence.com"
+  end
+
+  test "cli install script skill rerun command keeps script host separate from download override" do
+    https!
+    host! "dev.devopsellence.com"
+    get "/lfg.sh"
+
+    assert_response :success
+    assert_includes response.body, "BASE_URL='https://dev.devopsellence.com'"
+    assert_includes response.body, "INSTALL_SCRIPT_URL='https://dev.devopsellence.com/lfg.sh'"
+    assert_includes response.body, 'curl -fsSL "$INSTALL_SCRIPT_URL?version=$CLI_VERSION" | bash -s -- --install-agent-skill'
+    refute_includes response.body, 'curl -fsSL "$BASE_URL/lfg.sh'
   end
 
   test "cli install script accepts version from the query string" do

--- a/control-plane/test/integration/installs_test.rb
+++ b/control-plane/test/integration/installs_test.rb
@@ -57,12 +57,14 @@ class InstallsTest < ActionDispatch::IntegrationTest
     assert_includes response.body, 'BASE_URL="${DEVOPSELLENCE_BASE_URL:-}"'
     assert_includes response.body, "BASE_URL='https://dev.devopsellence.com'"
     assert_includes response.body, 'INSTALL_DIR="${DEVOPSELLENCE_CLI_INSTALL_DIR:-}"'
-    assert_includes response.body, 'if [[ "$OS" == "darwin" ]]; then'
+    assert_includes response.body, 'INSTALL_AGENT_SKILL="${DEVOPSELLENCE_INSTALL_AGENT_SKILL:-}"'
+    assert_includes response.body, "--install-agent-skill"
     assert_includes response.body, 'INSTALL_DIR="$HOME/.local/bin"'
-    assert_includes response.body, 'INSTALL_DIR="/usr/local/bin"'
+    refute_includes response.body, 'INSTALL_DIR="/usr/local/bin"'
     assert_includes response.body, "PATH_EXPORT='export PATH=\"'\"$INSTALL_DIR\"':$PATH\"'"
     assert_includes response.body, "echo '$PATH_EXPORT' >> $RC_FILE"
     assert_includes response.body, "source $RC_FILE"
+    assert_includes response.body, "npx skills add devopsellence/devopsellence --skill devopsellence -g"
   end
 
   test "cli install script ignores configured public base url when choosing default download host" do
@@ -101,6 +103,39 @@ class InstallsTest < ActionDispatch::IntegrationTest
 
     assert_predicate status, :success?, -> { "stdout:\n#{stdout}\nstderr:\n#{stderr}" }
     assert_includes stdout, "devopsellence CLI installed"
+    assert_equal "prerelease build\n", installed_cli
+  end
+
+  test "cli install script can install the agent skill when requested" do
+    get "/lfg.sh", params: { version: "master-0053792f6aec" }
+
+    assert_response :success
+
+    stdout, stderr, status, installed_cli, skill_args = run_cli_install_script(
+      response.body,
+      version: "master-0053792f6aec",
+      install_agent_skill: true
+    )
+
+    assert_predicate status, :success?, -> { "stdout:\n#{stdout}\nstderr:\n#{stderr}" }
+    assert_includes stdout, "installing devopsellence agent skill"
+    assert_equal "prerelease build\n", installed_cli
+    assert_equal [ "skills", "add", "devopsellence/devopsellence", "--skill", "devopsellence", "-g" ], skill_args
+  end
+
+  test "cli install script defaults to user local bin on linux" do
+    get "/lfg.sh", params: { version: "master-0053792f6aec" }
+
+    assert_response :success
+
+    stdout, stderr, status, installed_cli = run_cli_install_script(
+      response.body,
+      version: "master-0053792f6aec",
+      install_dir: nil
+    )
+
+    assert_predicate status, :success?, -> { "stdout:\n#{stdout}\nstderr:\n#{stderr}" }
+    assert_includes stdout, "/.local/bin/devopsellence"
     assert_equal "prerelease build\n", installed_cli
   end
 
@@ -203,18 +238,19 @@ class InstallsTest < ActionDispatch::IntegrationTest
 
   private
 
-  def run_cli_install_script(script_body, version:)
+  def run_cli_install_script(script_body, version:, install_dir: :explicit, install_agent_skill: false)
     Dir.mktmpdir("devopsellence-cli-install-test") do |tmpdir|
       fixtures_dir = File.join(tmpdir, "fixtures")
       fakebin_dir = File.join(tmpdir, "fakebin")
-      install_dir = File.join(tmpdir, "install")
+      effective_install_dir = install_dir == :explicit ? File.join(tmpdir, "install") : install_dir
       script_path = File.join(tmpdir, "lfg.sh")
       artifact_path = File.join(fixtures_dir, "cli-linux-amd64")
       checksums_path = File.join(fixtures_dir, "cli-SHA256SUMS")
+      skill_args_path = File.join(tmpdir, "skill-args")
 
       FileUtils.mkdir_p(fixtures_dir)
       FileUtils.mkdir_p(fakebin_dir)
-      FileUtils.mkdir_p(install_dir)
+      FileUtils.mkdir_p(effective_install_dir) if effective_install_dir
 
       File.write(artifact_path, "prerelease build\n")
       digest = Digest::SHA256.file(artifact_path).hexdigest
@@ -279,18 +315,30 @@ class InstallsTest < ActionDispatch::IntegrationTest
       SH
       FileUtils.chmod("u+x", uname_path)
 
+      npx_path = File.join(fakebin_dir, "npx")
+      File.write(npx_path, <<~SH)
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        printf '%s\\n' "$@" > #{skill_args_path.inspect}
+      SH
+      FileUtils.chmod("u+x", npx_path)
+
       env = {
         "PATH" => "#{fakebin_dir}:#{ENV.fetch("PATH")}",
         "HOME" => tmpdir,
         "SHELL" => ENV.fetch("SHELL", "/bin/bash"),
         "DEVOPSELLENCE_CLI_VERSION" => version,
-        "DEVOPSELLENCE_CLI_INSTALL_DIR" => install_dir,
         "DEVOPSELLENCE_BASE_URL" => "https://downloads.devopsellence.test"
       }
+      env["DEVOPSELLENCE_CLI_INSTALL_DIR"] = effective_install_dir if effective_install_dir
+      env["DEVOPSELLENCE_INSTALL_AGENT_SKILL"] = "1" if install_agent_skill
 
       stdout, stderr, status = Open3.capture3(env, script_path)
-      installed_cli = File.exist?(File.join(install_dir, "devopsellence")) ? File.read(File.join(install_dir, "devopsellence")) : nil
-      [ stdout, stderr, status, installed_cli ]
+      expected_install_dir = effective_install_dir || File.join(tmpdir, ".local", "bin")
+      installed_cli = File.exist?(File.join(expected_install_dir, "devopsellence")) ? File.read(File.join(expected_install_dir, "devopsellence")) : nil
+      skill_args = File.exist?(skill_args_path) ? File.readlines(skill_args_path, chomp: true) : nil
+      [ stdout, stderr, status, installed_cli, skill_args ]
     end
   end
 end

--- a/control-plane/test/integration/installs_test.rb
+++ b/control-plane/test/integration/installs_test.rb
@@ -359,8 +359,11 @@ class InstallsTest < ActionDispatch::IntegrationTest
         FileUtils.chmod("u+x", npx_path)
       end
 
+      path_entries = ENV.fetch("PATH").split(File::PATH_SEPARATOR)
+      path_entries = path_entries.reject { |entry| File.executable?(File.join(entry, "npx")) } unless include_npx
+
       env = {
-        "PATH" => "#{fakebin_dir}:#{ENV.fetch("PATH")}",
+        "PATH" => ([fakebin_dir] + path_entries).join(File::PATH_SEPARATOR),
         "HOME" => tmpdir,
         "SHELL" => ENV.fetch("SHELL", "/bin/bash"),
         "DEVOPSELLENCE_CLI_VERSION" => version,

--- a/control-plane/test/integration/installs_test.rb
+++ b/control-plane/test/integration/installs_test.rb
@@ -65,6 +65,7 @@ class InstallsTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "echo '$PATH_EXPORT' >> $RC_FILE"
     assert_includes response.body, "source $RC_FILE"
     assert_includes response.body, "npx skills add devopsellence/devopsellence --skill devopsellence -g"
+    assert_includes response.body, 'curl -fsSL "$BASE_URL/lfg.sh?version=$CLI_VERSION" | bash -s -- --install-agent-skill'
   end
 
   test "cli install script ignores configured public base url when choosing default download host" do


### PR DESCRIPTION
## Summary

- default CLI installer and local release script to rootless `~/.local/bin`
- generate a workspace SSH key for solo `node create` when no default public key exists
- improve noninteractive provider/setup recovery messages and update README/docs

## Why

Dogfood of `v0.2.0-preview` found first-run friction: the documented installer could require sudo, `node create` failed before generating a usable SSH key, and noninteractive recovery suggested editing solo state JSON.

## Validation

- `go test ./...` in `cli`
- `go test ./internal/workflow -run 'TestEnsureInteractiveProviderLogin|TestEnsureSoloNodeCreateSSHPublicKey|TestSoloSetupDefaultsToHetznerAndGeneratedWorkspaceKey|TestSetupModeFlagPersistsWorkspaceMode'`\n- `ruby -c control-plane/app/controllers/cli_installs_controller.rb`\n- `ruby -c control-plane/test/integration/installs_test.rb`\n- `git diff --check`\n\n`mise run test -- test/integration/installs_test.rb` is still blocked locally by missing bundle gems before tests start.