### PR TITLE
[codex] fix solo dogfood recovery paths

### DIFF
--- a/.agents/skills/dogfood/SKILL.md
+++ b/.agents/skills/dogfood/SKILL.md
@@ -15,6 +15,7 @@ Dogfood is not only e2e. It asks: can a target user complete the job, understand
 
 - Write `devopsellence` lowercase.
 - Prefer fresh temp apps and fresh state.
+- For solo-mode node tests, prefer `zirk` VMs when available instead of provider-created nodes. Use `zirk health`, `zirk flavors`, `zirk create <name> --flavor <flavor>`, `zirk show <name>`, and `zirk exec <name> ...` as user-facing setup evidence; skip provider flows that require cloud API tokens unless the user explicitly asks for them.
 - Start with a blind pass unless the user explicitly asks for code review first.
 - During blind pass, use only public/user-facing context: README, docs, CLI help, web UI, generated errors, logs surfaced by the product.
 - Do not read implementation source during blind pass.
@@ -42,6 +43,7 @@ Dogfood is not only e2e. It asks: can a target user complete the job, understand
    - Use docs, CLI help, UI, and terminal feedback.
    - Do not inspect source.
    - Install the requested target from `commands.log`: preview versions use `curl -fsSL https://www.devopsellence.com/lfg.sh?version=<version> | bash`; default stable uses `curl -fsSL https://www.devopsellence.com/lfg.sh | bash`.
+   - For solo first-deploy scenarios, if `zirk` is installed and healthy, create a fresh VM and use it as the existing SSH node. Record `zirk` commands in `commands.log`. Prefer the smallest flavor that can run Docker builds/deploys reliably; avoid Hetzner/provider login unless provider behavior is the scenario.
    - Work from user goals, not privileged steps.
    - Stop only for hard blockers; otherwise recover like a user would.
 

--- a/README.md
+++ b/README.md
@@ -35,16 +35,16 @@ devopsellence is agent-first. The installer prints the agent skill command; to i
 curl -fsSL https://www.devopsellence.com/lfg.sh | bash -s -- --install-agent-skill
 ```
 
-Check local tooling:
-
-```bash
-devopsellence doctor
-```
-
 Choose the workspace mode once:
 
 ```bash
 devopsellence mode use solo
+```
+
+Check local tooling:
+
+```bash
+devopsellence doctor
 ```
 
 Prepare the app, connect a node, and install the agent:

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1022,10 +1022,12 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 	}
 
 	var jsonResults []map[string]any
+	readErrors := 0
 
 	for name, node := range nodes {
 		result, err := readSoloNodeStatus(ctx, node)
 		if err != nil {
+			readErrors++
 			if a.Printer.JSON {
 				jsonResults = append(jsonResults, map[string]any{
 					"node":  name,
@@ -1071,7 +1073,16 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 	}
 
 	if a.Printer.JSON {
-		return a.Printer.PrintJSON(map[string]any{"nodes": jsonResults})
+		if err := a.Printer.PrintJSON(map[string]any{"nodes": jsonResults}); err != nil {
+			return err
+		}
+		if readErrors > 0 {
+			return ExitError{Code: 1, Err: fmt.Errorf("status failed for %d node(s)", readErrors)}
+		}
+		return nil
+	}
+	if readErrors > 0 {
+		return ExitError{Code: 1, Err: fmt.Errorf("status failed for %d node(s)", readErrors)}
 	}
 	return nil
 }
@@ -1955,7 +1966,15 @@ func (a *App) SoloNodeRemove(ctx context.Context, opts SoloNodeRemoveOptions) er
 		return fmt.Errorf("node %q still has attached environments; detach it first", opts.Name)
 	}
 	if node.Provider == "" || node.ProviderServerID == "" {
-		return fmt.Errorf("node %q does not have provider metadata; refusing provider delete", opts.Name)
+		current.RemoveNode(opts.Name)
+		if err := a.writeSoloState(current); err != nil {
+			return err
+		}
+		if a.Printer.JSON {
+			return a.Printer.PrintJSON(map[string]any{"node": opts.Name, "action": "forgotten"})
+		}
+		a.Printer.Println("Removed solo node " + opts.Name + " from local state")
+		return nil
 	}
 	provider, err := a.resolveSoloProvider(node.Provider)
 	if err != nil {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1077,12 +1077,12 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 			return err
 		}
 		if readErrors > 0 {
-			return ExitError{Code: 1, Err: fmt.Errorf("status failed for %d node(s)", readErrors)}
+			return ExitError{Code: 1, Err: RenderedError{Err: fmt.Errorf("status failed for %d node(s)", readErrors)}}
 		}
 		return nil
 	}
 	if readErrors > 0 {
-		return ExitError{Code: 1, Err: fmt.Errorf("status failed for %d node(s)", readErrors)}
+		return ExitError{Code: 1, Err: RenderedError{Err: fmt.Errorf("status failed for %d node(s)", readErrors)}}
 	}
 	return nil
 }
@@ -1965,7 +1965,9 @@ func (a *App) SoloNodeRemove(ctx context.Context, opts SoloNodeRemoveOptions) er
 	if current.NodeHasAttachments(opts.Name) {
 		return fmt.Errorf("node %q still has attached environments; detach it first", opts.Name)
 	}
-	if node.Provider == "" || node.ProviderServerID == "" {
+	provider := strings.TrimSpace(node.Provider)
+	providerServerID := strings.TrimSpace(node.ProviderServerID)
+	if provider == "" && providerServerID == "" {
 		current.RemoveNode(opts.Name)
 		if err := a.writeSoloState(current); err != nil {
 			return err
@@ -1976,11 +1978,14 @@ func (a *App) SoloNodeRemove(ctx context.Context, opts SoloNodeRemoveOptions) er
 		a.Printer.Println("Removed solo node " + opts.Name + " from local state")
 		return nil
 	}
-	provider, err := a.resolveSoloProvider(node.Provider)
+	if provider == "" || providerServerID == "" {
+		return fmt.Errorf("node %q has incomplete provider metadata; refusing provider delete", opts.Name)
+	}
+	resolvedProvider, err := a.resolveSoloProvider(provider)
 	if err != nil {
 		return err
 	}
-	if err := provider.DeleteServer(ctx, node.ProviderServerID); err != nil {
+	if err := resolvedProvider.DeleteServer(ctx, providerServerID); err != nil {
 		return err
 	}
 	current.RemoveNode(opts.Name)

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -443,8 +444,78 @@ func TestSoloStatusReturnsFailureWhenNodeStatusReadFails(t *testing.T) {
 	if !errors.As(err, &exitErr) || exitErr.Code != 1 {
 		t.Fatalf("error = %#v, want ExitError code 1", err)
 	}
+	var renderedErr RenderedError
+	if !errors.As(exitErr.Err, &renderedErr) {
+		t.Fatalf("exit error = %#v, want RenderedError", exitErr.Err)
+	}
 	if !strings.Contains(stdout.String(), "[node-a] error: ssh root@203.0.113.10:") {
 		t.Fatalf("stdout = %q, want node read error", stdout.String())
+	}
+}
+
+func TestSoloStatusJSONReturnsFailureWithRenderedPayload(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	installFakeSoloCommands(t, []fakeSSHResponse{
+		{stderr: "permission denied\n", exitCode: 1},
+	})
+
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.SoloNode{
+			"node-a": {Host: "203.0.113.10", User: "root", Labels: []string{config.DefaultWebRole}},
+		},
+		Attachments: map[string]solo.AttachmentRecord{
+			workspaceRoot + "\nproduction": {
+				WorkspaceRoot: workspaceRoot,
+				WorkspaceKey:  workspaceRoot,
+				Environment:   "production",
+				NodeNames:     []string{"node-a"},
+			},
+		},
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{
+		Printer:     output.New(&stdout, io.Discard, true),
+		SoloState:   soloState,
+		ConfigStore: config.NewStore(),
+		Cwd:         workspaceRoot,
+	}
+
+	err := app.SoloStatus(context.Background(), SoloStatusOptions{})
+	if err == nil {
+		t.Fatal("expected status failure")
+	}
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 1 {
+		t.Fatalf("error = %#v, want ExitError code 1", err)
+	}
+	var renderedErr RenderedError
+	if !errors.As(exitErr.Err, &renderedErr) {
+		t.Fatalf("exit error = %#v, want RenderedError", exitErr.Err)
+	}
+
+	var payload struct {
+		Nodes []struct {
+			Node  string `json:"node"`
+			Error string `json:"error"`
+		} `json:"nodes"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal stdout JSON: %v\n%s", err, stdout.String())
+	}
+	if len(payload.Nodes) != 1 {
+		t.Fatalf("nodes = %#v, want one entry", payload.Nodes)
+	}
+	if payload.Nodes[0].Node != "node-a" || !strings.Contains(payload.Nodes[0].Error, "permission denied") {
+		t.Fatalf("payload = %#v, want node-a permission error", payload)
 	}
 }
 
@@ -543,6 +614,42 @@ func TestSoloNodeRemoveForManualNodeForgetsLocalState(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "Removed solo node manual-a from local state") {
 		t.Fatalf("stdout = %q, want local removal message", stdout.String())
+	}
+}
+
+func TestSoloNodeRemoveRejectsIncompleteProviderMetadata(t *testing.T) {
+	t.Parallel()
+
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.SoloNode{
+			"managed-a": {Host: "203.0.113.10", User: "root", Provider: "hetzner"},
+		},
+		Attachments: map[string]solo.AttachmentRecord{},
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	app := &App{
+		Printer:   output.New(io.Discard, io.Discard, false),
+		SoloState: soloState,
+	}
+
+	err := app.SoloNodeRemove(context.Background(), SoloNodeRemoveOptions{Name: "managed-a", Yes: true})
+	if err == nil {
+		t.Fatal("expected incomplete provider metadata error")
+	}
+	if !strings.Contains(err.Error(), "incomplete provider metadata") {
+		t.Fatalf("error = %v, want incomplete provider metadata", err)
+	}
+
+	loaded, err := soloState.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := loaded.Nodes["managed-a"]; !ok {
+		t.Fatalf("managed node removed despite incomplete metadata: %#v", loaded.Nodes)
 	}
 }
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -399,6 +399,55 @@ func TestSoloStatusNodesWithoutAttachmentsReturnsEmptySet(t *testing.T) {
 	}
 }
 
+func TestSoloStatusReturnsFailureWhenNodeStatusReadFails(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	installFakeSoloCommands(t, []fakeSSHResponse{
+		{stderr: "permission denied\n", exitCode: 1},
+	})
+
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.SoloNode{
+			"node-a": {Host: "203.0.113.10", User: "root", Labels: []string{config.DefaultWebRole}},
+		},
+		Attachments: map[string]solo.AttachmentRecord{
+			workspaceRoot + "\nproduction": {
+				WorkspaceRoot: workspaceRoot,
+				WorkspaceKey:  workspaceRoot,
+				Environment:   "production",
+				NodeNames:     []string{"node-a"},
+			},
+		},
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{
+		Printer:     output.New(&stdout, io.Discard, false),
+		SoloState:   soloState,
+		ConfigStore: config.NewStore(),
+		Cwd:         workspaceRoot,
+	}
+
+	err := app.SoloStatus(context.Background(), SoloStatusOptions{})
+	if err == nil {
+		t.Fatal("expected status failure")
+	}
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 1 {
+		t.Fatalf("error = %#v, want ExitError code 1", err)
+	}
+	if !strings.Contains(stdout.String(), "[node-a] error: ssh root@203.0.113.10:") {
+		t.Fatalf("stdout = %q, want node read error", stdout.String())
+	}
+}
+
 func TestEnsureLocalSoloSnapshotImageReturnsActionableError(t *testing.T) {
 	t.Parallel()
 
@@ -458,6 +507,42 @@ func TestRepublishSoloNodesReportsRemoteDockerCheck(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "[web-a] remote docker check:") {
 		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestSoloNodeRemoveForManualNodeForgetsLocalState(t *testing.T) {
+	t.Parallel()
+
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.SoloNode{
+			"manual-a": {Host: "203.0.113.10", User: "root", Labels: []string{config.DefaultWebRole}},
+		},
+		Attachments: map[string]solo.AttachmentRecord{},
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{
+		Printer:   output.New(&stdout, io.Discard, false),
+		SoloState: soloState,
+	}
+
+	if err := app.SoloNodeRemove(context.Background(), SoloNodeRemoveOptions{Name: "manual-a", Yes: true}); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := soloState.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := loaded.Nodes["manual-a"]; ok {
+		t.Fatalf("manual node still present: %#v", loaded.Nodes)
+	}
+	if !strings.Contains(stdout.String(), "Removed solo node manual-a from local state") {
+		t.Fatalf("stdout = %q, want local removal message", stdout.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

- allow `devopsellence node remove` to forget unattached manual solo nodes from local state
- make solo `devopsellence status` exit non-zero when node status reads fail while preserving text/JSON output
- align the README solo quickstart with the required mode selection order
- update the dogfood skill to prefer `zirk` VMs for solo node tests when available

## Why

The v0.2.0-preview dogfood run with `zirk` confirmed the solo happy path works, but found recovery gaps around manual node cleanup and status command trust. It also exposed that the quickstart tells users to run `doctor` before selecting a workspace mode.

## Validation

- `mise run test:cli -- ./internal/workflow`
- Dogfood evidence: `/tmp/devopsellence-dogfood/20260426T113550674599Z-solo-first-deploy/report.md`