### PR TITLE
Remove CLI JSON mode switch

### DIFF
--- a/cli/internal/output/output.go
+++ b/cli/internal/output/output.go
@@ -2,23 +2,20 @@ package output
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
 )
 
-// Printer writes command results. The CLI is agent-primary, so JSON is the
-// default and prompt-driven affordances are disabled.
+// Printer writes command results. The CLI is agent-primary and emits JSON-only
+// output so automation can consume every command safely.
 type Printer struct {
-	Out  io.Writer
-	Err  io.Writer
-	JSON bool
+	Out io.Writer
+	Err io.Writer
 }
 
 func New(out, err io.Writer) Printer {
 	return Printer{
-		Out:  out,
-		Err:  err,
-		JSON: true,
+		Out: out,
+		Err: err,
 	}
 }
 
@@ -27,25 +24,4 @@ func (p Printer) PrintJSON(value any) error {
 	encoder.SetIndent("", "  ")
 	encoder.SetEscapeHTML(false)
 	return encoder.Encode(value)
-}
-
-func (p Printer) Println(args ...any) {
-	if p.JSON {
-		return
-	}
-	fmt.Fprintln(p.Out, args...)
-}
-
-func (p Printer) Printf(format string, args ...any) {
-	if p.JSON {
-		return
-	}
-	fmt.Fprintf(p.Out, format, args...)
-}
-
-func (p Printer) Errorln(args ...any) {
-	if p.JSON {
-		return
-	}
-	fmt.Fprintln(p.Err, args...)
 }

--- a/cli/internal/workflow/app.go
+++ b/cli/internal/workflow/app.go
@@ -1283,9 +1283,7 @@ func (a *App) NodeAssign(ctx context.Context, opts NodeAssignOptions) error {
 	if err != nil {
 		return err
 	}
-	var onProgress func(string)
-
-	result, err := a.API.CreateEnvironmentAssignment(ctx, tokens.AccessToken, workspace.Environment.ID, opts.NodeID, onProgress)
+	result, err := a.API.CreateEnvironmentAssignment(ctx, tokens.AccessToken, workspace.Environment.ID, opts.NodeID, nil)
 	if err != nil {
 		return wrapError(err)
 	}
@@ -1391,10 +1389,17 @@ func (a *App) NodeDiagnose(ctx context.Context, opts NodeDiagnoseOptions) error 
 		}
 	}
 
-	return a.Printer.PrintJSON(map[string]any{
+	if err := a.Printer.PrintJSON(map[string]any{
 		"schema_version": outputSchemaVersion,
 		"request":        request,
-	})
+	}); err != nil {
+		return err
+	}
+	if strings.TrimSpace(request.Status) == "failed" {
+		message := firstNonEmpty(strings.TrimSpace(request.ErrorMessage), fmt.Sprintf("diagnose request %d failed", request.ID))
+		return ExitError{Code: 1, Err: fmt.Errorf("node diagnose failed: %s", message)}
+	}
+	return nil
 
 }
 

--- a/cli/internal/workflow/app.go
+++ b/cli/internal/workflow/app.go
@@ -959,10 +959,10 @@ func (a *App) waitForDeployment(ctx context.Context, token string, result map[st
 	rolloutCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	return a.waitForDeploymentPlain(rolloutCtx, token, deploymentID, pollInterval)
+	return a.pollDeploymentProgress(rolloutCtx, token, deploymentID, pollInterval)
 }
 
-func (a *App) waitForDeploymentPlain(ctx context.Context, token string, deploymentID int, pollInterval time.Duration) (api.DeploymentProgress, error) {
+func (a *App) pollDeploymentProgress(ctx context.Context, token string, deploymentID int, pollInterval time.Duration) (api.DeploymentProgress, error) {
 	var latest api.DeploymentProgress
 
 	for {

--- a/cli/internal/workflow/app.go
+++ b/cli/internal/workflow/app.go
@@ -26,10 +26,7 @@ import (
 	"github.com/devopsellence/cli/internal/output"
 	"github.com/devopsellence/cli/internal/solo"
 	"github.com/devopsellence/cli/internal/state"
-	"github.com/devopsellence/cli/internal/ui"
 	"github.com/devopsellence/devopsellence/deployment-core/pkg/deploycore/config"
-
-	"gopkg.in/yaml.v3"
 )
 
 const OutputSchemaVersion = 1
@@ -403,18 +400,12 @@ func (a *App) Logout() error {
 	if err != nil {
 		return ExitError{Code: 1, Err: err}
 	}
-	if a.Printer.JSON {
-		return a.Printer.PrintJSON(map[string]any{
-			"schema_version": outputSchemaVersion,
-			"deleted":        deleted,
-		})
-	}
-	if deleted {
-		a.Printer.Println("Signed out.")
-		return nil
-	}
-	a.Printer.Println("Not signed in.")
-	return nil
+
+	return a.Printer.PrintJSON(map[string]any{
+		"schema_version": outputSchemaVersion,
+		"deleted":        deleted,
+	})
+
 }
 
 func (a *App) Whoami(ctx context.Context, _ WhoamiOptions) error {
@@ -437,21 +428,8 @@ func (a *App) Whoami(ctx context.Context, _ WhoamiOptions) error {
 		result["trial_state"] = trialState
 	}
 
-	if a.Printer.JSON {
-		return a.Printer.PrintJSON(result)
-	}
+	return a.Printer.PrintJSON(result)
 
-	a.Printer.Println("Signed in.")
-	a.Printer.Println("Account kind:", firstNonEmpty(tokens.AccountKind, "unknown"))
-	a.Printer.Println("Auth mode:", authMode(tokens))
-	a.Printer.Println("API base:", firstNonEmpty(tokens.APIBase, a.API.BaseURL))
-	if strings.TrimSpace(tokens.ExpiresAt) != "" {
-		a.Printer.Println("Expires at:", tokens.ExpiresAt)
-	}
-	if trialState := trialState(tokens); trialState != "" {
-		a.Printer.Println("Trial state:", trialState)
-	}
-	return nil
 }
 
 func (a *App) AliasLFG(_ context.Context) error {
@@ -459,17 +437,15 @@ func (a *App) AliasLFG(_ context.Context) error {
 	if err != nil {
 		return ExitError{Code: 1, Err: err}
 	}
-	if a.Printer.JSON {
-		return a.Printer.PrintJSON(map[string]any{
-			"schema_version": outputSchemaVersion,
-			"created":        true,
-			"alias":          result.AliasName,
-			"alias_path":     result.AliasPath,
-			"target_path":    result.TargetPath,
-		})
-	}
-	a.Printer.Println("Created lfg alias at " + result.AliasPath + ".")
-	return nil
+
+	return a.Printer.PrintJSON(map[string]any{
+		"schema_version": outputSchemaVersion,
+		"created":        true,
+		"alias":          result.AliasName,
+		"alias_path":     result.AliasPath,
+		"target_path":    result.TargetPath,
+	})
+
 }
 
 func (a *App) installAlias(aliasName string) (aliasInstallResult, error) {
@@ -509,7 +485,6 @@ func (a *App) installAlias(aliasName string) (aliasInstallResult, error) {
 }
 
 func (a *App) Init(ctx context.Context, opts InitOptions) error {
-	renderer := ui.DefaultRenderer()
 	tokens, err := a.ensureAuth(ctx, true)
 	if err != nil {
 		return err
@@ -550,44 +525,14 @@ func (a *App) Init(ctx context.Context, opts InitOptions) error {
 		return err
 	}
 
-	if a.Printer.JSON {
-		return a.Printer.PrintJSON(result)
-	}
+	return a.Printer.PrintJSON(result)
 
-	a.Printer.Println(renderer.Success("Initialized " + initialized.Discovered.ProjectName))
-	if initialized.Discovered.AppType == config.AppTypeRails && initialized.Discovered.FallbackUsed {
-		a.Printer.Errorln("Could not infer Rails module name; using directory name", fmt.Sprintf("%q.", initialized.Discovered.ProjectName))
-	}
-	a.Printer.Println(ui.RenderCard(ui.Card{
-		Title: "Workspace",
-		Rows: []ui.Row{
-			{Label: "Organization", Value: initialized.Organization.Name},
-			{Label: "Project", Value: initialized.Project.Name},
-			{Label: "Environment", Value: initialized.Environment.Name},
-			{Label: "Config", Value: result["config_path"].(string)},
-		},
-	}))
-	if initialized.CreatedOrg {
-		a.Printer.Println("Created organization", initialized.Organization.Name)
-	}
-	if initialized.CreatedProject {
-		a.Printer.Println("Created project", initialized.Project.Name)
-	}
-	if initialized.CreatedEnv {
-		a.Printer.Println("Created environment", initialized.Environment.Name)
-	}
-	if initialized.Discovered.AppType == config.AppTypeGeneric {
-		a.Printer.Println("Generic app detected. Review", result["config_path"].(string), "and adjust build/web settings before deploy if needed.")
-	}
-	return nil
 }
 
 func (a *App) Deploy(ctx context.Context, opts DeployOptions) error {
-	renderer := ui.DefaultRenderer()
 	startedAt := time.Now()
 	var result map[string]any
 	var accessToken string
-	var deployTokens auth.Tokens
 	var buildPushDuration time.Duration
 	var autoInitSummary string
 	run := func(runCtx context.Context, update, log func(string)) error {
@@ -627,7 +572,6 @@ func (a *App) Deploy(ctx context.Context, opts DeployOptions) error {
 		if err != nil {
 			return err
 		}
-		deployTokens = preflight.Tokens
 		accessToken = preflight.Tokens.AccessToken
 		session := newAuthSession(a, preflight.Tokens.AccessToken, update)
 		withAuth := func(fn func(string) error) error {
@@ -660,7 +604,6 @@ func (a *App) Deploy(ctx context.Context, opts DeployOptions) error {
 			return ExitError{Code: 1, Err: err}
 		}
 		cfg = resolvedCfg
-		a.warnAboutPrebuiltImageConfig(opts, cfg)
 		a.API.BaseURL = firstNonEmpty(preflight.Tokens.APIBase, a.API.BaseURL)
 
 		envVarOverrides, err := parseRuntimeValueOverrides(os.Getenv(deployEnvVarsOverrideEnv), deployEnvVarsOverrideEnv)
@@ -790,12 +733,6 @@ func (a *App) Deploy(ctx context.Context, opts DeployOptions) error {
 	if err != nil {
 		return wrapError(err)
 	}
-	if !a.Printer.JSON && autoInitSummary != "" {
-		a.Printer.Println("Deploy:", autoInitSummary)
-	}
-	if !a.Printer.JSON && stringFromMap(result, "public_url") != "" {
-		a.Printer.Println("Ingress URL:", stringFromMap(result, "public_url"))
-	}
 
 	progress, err := a.waitForDeployment(ctx, accessToken, result)
 	if err != nil {
@@ -815,35 +752,8 @@ func (a *App) Deploy(ctx context.Context, opts DeployOptions) error {
 		result["public_url"] = progress.Ingress.PublicURL
 	}
 
-	if a.Printer.JSON {
-		return a.Printer.PrintJSON(result)
-	}
-	a.Printer.Println(renderer.Success("Deploy complete."))
-	rows := []ui.Row{
-		{Label: "Project", Value: nestedString(result, "project", "name")},
-		{Label: "Environment", Value: nestedString(result, "environment", "name")},
-		{Label: "Git SHA", Value: stringFromMap(result, "git_sha")},
-		{Label: "Rollout", Value: fmt.Sprintf("%d/%d settled", progress.Summary.Settled, progress.Summary.AssignedNodes)},
-		{Label: "Image Build/Push", Value: formatDuration(timings.BuildPush)},
-		{Label: "Control Plane", Value: formatDuration(maxDuration(timings.Total-timings.BuildPush, 0))},
-		{Label: "Total", Value: formatDuration(timings.Total)},
-		{Label: "URL", Value: stringFromMap(result, "public_url")},
-	}
-	if trialExpiresAt := stringFromMap(result, "trial_expires_at"); trialExpiresAt != "" {
-		rows = append(rows, ui.Row{Label: "Trial Expires", Value: trialExpiresAt})
-	}
-	a.Printer.Println(ui.RenderCard(ui.Card{
-		Title: "Release",
-		Rows:  rows,
-	}))
-	if warning := stringFromMap(result, "warning"); warning != "" {
-		a.Printer.Println("Warning:", warning)
-	}
-	if a.shouldPrintClaimReminder(deployTokens, result) {
-		a.Printer.Println("Claim this account before local state is lost: devopsellence auth claim --email you@example.com")
-		_ = a.markClaimReminderShown(deployTokens.AnonymousID)
-	}
-	return nil
+	return a.Printer.PrintJSON(result)
+
 }
 
 type deployReadOnlyPreflight struct {
@@ -950,15 +860,9 @@ func (a *App) Delete(ctx context.Context, opts DeleteOptions) error {
 	result["schema_version"] = outputSchemaVersion
 	result["organization"] = map[string]any{"id": workspace.Organization.ID, "name": workspace.Organization.Name}
 	result["project"] = map[string]any{"id": workspace.Project.ID, "name": workspace.Project.Name}
-	if a.Printer.JSON {
-		return a.Printer.PrintJSON(result)
-	}
-	a.Printer.Println("Deleted environment", workspace.Environment.Name+".")
-	a.Printer.Println(
-		"Customer nodes unassigned:", fmt.Sprintf("%d", len(anySlice(result["customer_node_ids"]))),
-		"Managed servers scheduled for delete:", fmt.Sprintf("%d", len(anySlice(result["managed_node_ids"]))),
-	)
-	return nil
+
+	return a.Printer.PrintJSON(result)
+
 }
 
 func (a *App) ensureDeployWorktreeClean(discovered discovery.Result, existing *config.ProjectConfig) error {
@@ -1060,9 +964,6 @@ func (a *App) waitForDeployment(ctx context.Context, token string, result map[st
 
 func (a *App) waitForDeploymentPlain(ctx context.Context, token string, deploymentID int, pollInterval time.Duration) (api.DeploymentProgress, error) {
 	var latest api.DeploymentProgress
-	lastSummary := ""
-	lastMilestone := ""
-	nodeStates := map[int]string{}
 
 	for {
 		err := a.callWithAuthRetry(ctx, &token, nil, func(accessToken string) error {
@@ -1083,34 +984,6 @@ func (a *App) waitForDeploymentPlain(ctx context.Context, token string, deployme
 				}
 			}
 			return latest, err
-		}
-
-		if !a.Printer.JSON {
-			summary := fmt.Sprintf("rollout pending=%d reconciling=%d settled=%d error=%d",
-				latest.Summary.Pending,
-				latest.Summary.Reconciling,
-				latest.Summary.Settled,
-				latest.Summary.Error,
-			)
-			if detail := deploymentStatusDetail(latest); detail != "" {
-				summary += " - " + detail
-			}
-			if summary != lastSummary {
-				a.Printer.Println(summary)
-				lastSummary = summary
-			}
-			if milestone := rolloutMilestone(latest); milestone != "" && milestone != lastMilestone {
-				a.Printer.Println("milestone:", milestone)
-				lastMilestone = milestone
-			}
-			for _, node := range latest.Nodes {
-				state := node.Phase + "|" + firstNonEmpty(node.Error, node.Message)
-				if nodeStates[node.ID] == state {
-					continue
-				}
-				a.Printer.Println(" ", firstNonEmpty(node.Name, fmt.Sprintf("node-%d", node.ID))+":", nodePhaseDetail(node))
-				nodeStates[node.ID] = state
-			}
 		}
 
 		if latest.Summary.Complete {
@@ -1146,30 +1019,9 @@ func (a *App) Status(ctx context.Context, opts StatusOptions) error {
 	}
 	status["schema_version"] = outputSchemaVersion
 	status["project_id"] = workspace.Project.ID
-	if a.Printer.JSON {
-		return a.Printer.PrintJSON(status)
-	}
-	rows := []ui.Row{
-		{Label: "Organization", Value: nestedString(status, "organization", "name")},
-		{Label: "Project", Value: nestedString(status, "project", "name")},
-		{Label: "Environment", Value: nestedString(status, "environment", "name")},
-		{Label: "Ingress", Value: nestedString(status, "environment", "ingress_strategy")},
-		{Label: "Assigned", Value: fmt.Sprintf("%d", intFromMap(status, "assigned_nodes"))},
-		{Label: "Release", Value: formatRelease(status["current_release"])},
-		{Label: "Deployment", Value: formatDeployment(status["latest_deployment"])},
-		{Label: "URL", Value: nestedString(status, "ingress", "public_url")},
-	}
-	if trialExpiresAt := stringFromMap(status, "trial_expires_at"); trialExpiresAt != "" {
-		rows = append(rows, ui.Row{Label: "Trial Expires", Value: trialExpiresAt})
-	}
-	a.Printer.Println(ui.RenderCard(ui.Card{
-		Title: "Environment",
-		Rows:  rows,
-	}))
-	if warning := stringFromMap(status, "warning"); warning != "" {
-		a.Printer.Println("Warning:", warning)
-	}
-	return nil
+
+	return a.Printer.PrintJSON(status)
+
 }
 
 func (a *App) Doctor(ctx context.Context) error {
@@ -1289,17 +1141,9 @@ func (a *App) Doctor(ctx context.Context) error {
 		"ok":             ok,
 		"checks":         checks,
 	}
-	if a.Printer.JSON {
-		return a.Printer.PrintJSON(result)
-	}
-	for _, check := range checks {
-		prefix := "FAIL"
-		if check["ok"] == true {
-			prefix = "OK"
-		}
-		a.Printer.Println(prefix, fmt.Sprintf("%v:", check["name"]), check["detail"])
-	}
-	return nil
+
+	return a.Printer.PrintJSON(result)
+
 }
 
 func (a *App) ConfigResolve(opts ConfigResolveOptions) error {
@@ -1307,19 +1151,13 @@ func (a *App) ConfigResolve(opts ConfigResolveOptions) error {
 	if err != nil {
 		return wrapError(err)
 	}
-	if a.Printer.JSON {
-		return a.Printer.PrintJSON(map[string]any{
-			"schema_version":       outputSchemaVersion,
-			"selected_environment": selectedEnvironment,
-			"config":               resolved,
-		})
-	}
-	data, err := yaml.Marshal(resolved)
-	if err != nil {
-		return ExitError{Code: 1, Err: err}
-	}
-	fmt.Fprint(a.Printer.Out, string(data))
-	return nil
+
+	return a.Printer.PrintJSON(map[string]any{
+		"schema_version":       outputSchemaVersion,
+		"selected_environment": selectedEnvironment,
+		"config":               resolved,
+	})
+
 }
 
 func (a *App) NodeBootstrap(ctx context.Context, opts NodeBootstrapOptions) error {
@@ -1357,52 +1195,8 @@ func (a *App) NodeBootstrap(ctx context.Context, opts NodeBootstrapOptions) erro
 		result["assignment_mode"] = firstNonEmpty(stringFromMap(result, "assignment_mode"), "environment")
 	}
 
-	if a.Printer.JSON {
-		return a.Printer.PrintJSON(result)
-	}
-	if !opts.Unassigned && workspace.Discovery.AppType == config.AppTypeRails && workspace.Discovery.FallbackUsed {
-		a.Printer.Errorln("Could not infer Rails module name; using directory name", fmt.Sprintf("%q.", workspace.Discovery.ProjectName))
-	}
-	if bootstrap.Initialized != nil {
-		a.Printer.Println(ui.DefaultRenderer().Muted("Initialized workspace config for this app automatically."))
-	}
+	return a.Printer.PrintJSON(result)
 
-	expiresAt := stringFromMap(result, "expires_at")
-	if t, err := time.Parse(time.RFC3339, expiresAt); err == nil {
-		local := t.Local()
-		expiresAt = local.Format("Jan 2, 2006 at 3:04 PM ") + local.Format("MST")
-	}
-
-	rows := []ui.Row{
-		{Label: "Organization", Value: organization.Name},
-	}
-	if opts.Unassigned {
-		rows = append(rows, ui.Row{Label: "Assignment", Value: "Unassigned"})
-	} else {
-		rows = append(rows,
-			ui.Row{Label: "Project", Value: workspace.Project.Name},
-			ui.Row{Label: "Environment", Value: workspace.Environment.Name},
-		)
-	}
-	rows = append(rows, ui.Row{Label: "Token expires", Value: expiresAt})
-	a.Printer.Println(ui.RenderCard(ui.Card{Rows: rows}))
-	a.Printer.Println("\n" + ui.DefaultRenderer().Muted("⚡ Run on your server to install the devopsellence agent and register it:"))
-	r := ui.DefaultRenderer()
-	a.Printer.Println(r.Accent(stringFromMap(result, "install_command")))
-	a.Printer.Println("")
-	if opts.Unassigned {
-		a.Printer.Println(r.Muted("· Registers the node without assigning it to an environment"))
-		a.Printer.Println(r.Muted("· Later: run `devopsellence node attach <id>` to attach it"))
-	} else {
-		a.Printer.Println(r.Muted("· Registers the node and auto-assigns it to the selected environment"))
-	}
-	a.Printer.Println(r.Muted("· Installs Docker Engine if absent (auto-install: Ubuntu 22.04/24.04 only)"))
-	a.Printer.Println(r.Muted("  └ Other Linux distros: install Docker Engine manually before running"))
-	a.Printer.Println(r.Muted("· Downloads and verifies the devopsellence agent binary"))
-	a.Printer.Println(r.Muted("· Registers and starts a systemd service"))
-	a.Printer.Println(r.Muted("· Requires: Linux x86_64 or arm64, sudo access"))
-	a.Printer.Println("")
-	return nil
 }
 
 func (a *App) createNodeBootstrapToken(ctx context.Context, tokens *auth.Tokens, opts NodeBootstrapOptions, update func(string)) (nodeBootstrapToken, error) {
@@ -1465,40 +1259,16 @@ func (a *App) NodeList(ctx context.Context, opts NodeListOptions) error {
 	if err != nil {
 		return wrapError(err)
 	}
-	if a.Printer.JSON {
-		return a.Printer.PrintJSON(map[string]any{
-			"schema_version": outputSchemaVersion,
-			"organization": map[string]any{
-				"id":   organization.ID,
-				"name": organization.Name,
-			},
-			"nodes": nodes,
-		})
-	}
-	if len(nodes) == 0 {
-		a.Printer.Println("No nodes.")
-		return nil
-	}
-	for _, node := range nodes {
-		var assignment string
-		if strings.TrimSpace(node.RevokedAt) != "" {
-			assignment = " [revoked]"
-		} else {
-			envName := nestedString(node.Environment, "name")
-			projectName := nestedString(node.Environment, "project_name")
-			if envName != "" {
-				if projectName != "" {
-					assignment = " project=" + projectName + " env=" + envName
-				} else {
-					assignment = " env=" + envName
-				}
-			} else {
-				assignment = " [unassigned]"
-			}
-		}
-		a.Printer.Println(fmt.Sprintf("node #%d  %s  labels=%s%s", node.ID, firstNonEmpty(node.Name, "(unnamed)"), strings.Join(node.Labels, ","), assignment))
-	}
-	return nil
+
+	return a.Printer.PrintJSON(map[string]any{
+		"schema_version": outputSchemaVersion,
+		"organization": map[string]any{
+			"id":   organization.ID,
+			"name": organization.Name,
+		},
+		"nodes": nodes,
+	})
+
 }
 
 func (a *App) NodeAssign(ctx context.Context, opts NodeAssignOptions) error {
@@ -1514,26 +1284,15 @@ func (a *App) NodeAssign(ctx context.Context, opts NodeAssignOptions) error {
 		return err
 	}
 	var onProgress func(string)
-	if !a.Printer.JSON {
-		onProgress = func(msg string) { a.Printer.Println(msg) }
-	}
+
 	result, err := a.API.CreateEnvironmentAssignment(ctx, tokens.AccessToken, workspace.Environment.ID, opts.NodeID, onProgress)
 	if err != nil {
 		return wrapError(err)
 	}
 	result["schema_version"] = outputSchemaVersion
-	if a.Printer.JSON {
-		return a.Printer.PrintJSON(result)
-	}
-	if workspace.Discovery.AppType == config.AppTypeRails && workspace.Discovery.FallbackUsed {
-		a.Printer.Errorln("Could not infer Rails module name; using directory name", fmt.Sprintf("%q.", workspace.Discovery.ProjectName))
-	}
-	a.Printer.Println(
-		"Assigned node #" + strconv.Itoa(intFromMap(result, "node_id")) +
-			" to env #" + strconv.Itoa(intFromMap(result, "environment_id")) +
-			" (desired state: " + stringFromMap(result, "desired_state_uri") + ").",
-	)
-	return nil
+
+	return a.Printer.PrintJSON(result)
+
 }
 
 func (a *App) NodeUnassign(ctx context.Context, opts NodeUnassignOptions) error {
@@ -1549,16 +1308,9 @@ func (a *App) NodeUnassign(ctx context.Context, opts NodeUnassignOptions) error 
 		return wrapError(err)
 	}
 	result["schema_version"] = outputSchemaVersion
-	if a.Printer.JSON {
-		return a.Printer.PrintJSON(result)
-	}
-	if managed, _ := result["managed"].(bool); managed {
-		a.Printer.Println("Unassigned managed node #" + strconv.Itoa(intFromMap(result, "id")) + "; server scheduled for delete.")
-		return nil
-	}
-	a.Printer.Println("Unassigned node #" + strconv.Itoa(intFromMap(result, "id")) + " from env #" + strconv.Itoa(intFromMap(result, "environment_id")) + ".")
-	a.Printer.Println("Next step: run `devopsellence-agent uninstall --purge-runtime` on the node when you are ready to remove it.")
-	return nil
+
+	return a.Printer.PrintJSON(result)
+
 }
 
 func (a *App) NodeDelete(ctx context.Context, opts NodeDeleteOptions) error {
@@ -1574,16 +1326,9 @@ func (a *App) NodeDelete(ctx context.Context, opts NodeDeleteOptions) error {
 		return wrapError(err)
 	}
 	result["schema_version"] = outputSchemaVersion
-	if a.Printer.JSON {
-		return a.Printer.PrintJSON(result)
-	}
-	if managed, _ := result["managed"].(bool); managed {
-		a.Printer.Println("Delete requested for managed node #" + strconv.Itoa(intFromMap(result, "id")) + "; server scheduled for delete.")
-		return nil
-	}
-	a.Printer.Println("Removed node #" + strconv.Itoa(intFromMap(result, "id")) + ".")
-	a.Printer.Println("If the agent is still installed, run `devopsellence-agent uninstall --purge-runtime` on the machine to clean it up.")
-	return nil
+
+	return a.Printer.PrintJSON(result)
+
 }
 
 func (a *App) NodeLabelSet(ctx context.Context, opts NodeLabelSetOptions) error {
@@ -1602,11 +1347,9 @@ func (a *App) NodeLabelSet(ctx context.Context, opts NodeLabelSetOptions) error 
 		return wrapError(err)
 	}
 	result["schema_version"] = outputSchemaVersion
-	if a.Printer.JSON {
-		return a.Printer.PrintJSON(result)
-	}
-	a.Printer.Println("Updated node #"+strconv.Itoa(intFromMap(result, "id"))+" labels:", strings.Join(stringSlice(result["labels"]), ","))
-	return nil
+
+	return a.Printer.PrintJSON(result)
+
 }
 
 func (a *App) NodeDiagnose(ctx context.Context, opts NodeDiagnoseOptions) error {
@@ -1648,18 +1391,11 @@ func (a *App) NodeDiagnose(ctx context.Context, opts NodeDiagnoseOptions) error 
 		}
 	}
 
-	if a.Printer.JSON {
-		return a.Printer.PrintJSON(map[string]any{
-			"schema_version": outputSchemaVersion,
-			"request":        request,
-		})
-	}
+	return a.Printer.PrintJSON(map[string]any{
+		"schema_version": outputSchemaVersion,
+		"request":        request,
+	})
 
-	a.printNodeDiagnose(request)
-	if request.Status == "failed" {
-		return ExitError{Code: 1, Err: errors.New(firstNonEmpty(request.ErrorMessage, "node diagnose failed"))}
-	}
-	return nil
 }
 
 func (a *App) SecretSet(ctx context.Context, opts SecretSetOptions) error {
@@ -1689,14 +1425,11 @@ func (a *App) SecretSet(ctx context.Context, opts SecretSetOptions) error {
 	if err != nil {
 		return wrapError(err)
 	}
-	configUpdated := false
 	configUpdateErr := ""
 	if ref := stringFromMap(result, "secret_ref"); ref != "" {
 		updated, err := a.upsertWorkspaceSecretRef(workspace.Discovery.WorkspaceRoot, serviceName, config.SecretRef{Name: opts.Name, Secret: ref})
 		if err != nil {
 			configUpdateErr = err.Error()
-		} else {
-			configUpdated = updated
 		}
 		result["config_updated"] = updated
 		result["config_path"] = a.ConfigStore.PathFor(workspace.Discovery.WorkspaceRoot)
@@ -1705,26 +1438,12 @@ func (a *App) SecretSet(ctx context.Context, opts SecretSetOptions) error {
 		}
 	}
 	result["schema_version"] = outputSchemaVersion
-	if a.Printer.JSON {
-		if err := a.Printer.PrintJSON(result); err != nil {
-			return err
-		}
-		if configUpdateErr != "" {
-			return ExitError{Code: 1, Err: fmt.Errorf("secret saved, but devopsellence.yml was not updated: %s", configUpdateErr)}
-		}
-		return nil
+
+	if err := a.Printer.PrintJSON(result); err != nil {
+		return err
 	}
-	if workspace.Discovery.AppType == config.AppTypeRails && workspace.Discovery.FallbackUsed {
-		a.Printer.Errorln("Could not infer Rails module name; using directory name", fmt.Sprintf("%q.", workspace.Discovery.ProjectName))
-	}
-	a.Printer.Println("Saved secret", stringFromMap(result, "name"), "for", stringFromMap(result, "service_name")+".")
-	a.Printer.Println("Ref:", stringFromMap(result, "secret_ref"))
 	if configUpdateErr != "" {
-		a.Printer.Errorln("Secret saved, but devopsellence.yml was not updated:", configUpdateErr)
 		return ExitError{Code: 1, Err: fmt.Errorf("secret saved, but devopsellence.yml was not updated: %s", configUpdateErr)}
-	}
-	if configUpdated {
-		a.Printer.Println("Updated:", a.ConfigStore.PathFor(workspace.Discovery.WorkspaceRoot))
 	}
 	return nil
 }
@@ -1746,23 +1465,12 @@ func (a *App) SecretList(ctx context.Context, opts SecretListOptions) error {
 	if err != nil {
 		return err
 	}
-	if a.Printer.JSON {
-		return a.Printer.PrintJSON(map[string]any{
-			"schema_version": outputSchemaVersion,
-			"secrets":        items,
-		})
-	}
-	if workspace.Discovery.AppType == config.AppTypeRails && workspace.Discovery.FallbackUsed {
-		a.Printer.Errorln("Could not infer Rails module name; using directory name", fmt.Sprintf("%q.", workspace.Discovery.ProjectName))
-	}
-	if len(items) == 0 {
-		a.Printer.Println("No secrets configured.")
-		return nil
-	}
-	for _, item := range items {
-		a.Printer.Println(formatListedSecret(item))
-	}
-	return nil
+
+	return a.Printer.PrintJSON(map[string]any{
+		"schema_version": outputSchemaVersion,
+		"secrets":        items,
+	})
+
 }
 
 func (a *App) SecretDelete(ctx context.Context, opts SecretDeleteOptions) error {
@@ -1800,25 +1508,12 @@ func (a *App) SecretDelete(ctx context.Context, opts SecretDeleteOptions) error 
 		result["config_error"] = configUpdateErr
 	}
 	result["schema_version"] = outputSchemaVersion
-	if a.Printer.JSON {
-		if err := a.Printer.PrintJSON(result); err != nil {
-			return err
-		}
-		if configUpdateErr != "" {
-			return ExitError{Code: 1, Err: fmt.Errorf("secret deleted, but devopsellence.yml was not updated: %s", configUpdateErr)}
-		}
-		return nil
+
+	if err := a.Printer.PrintJSON(result); err != nil {
+		return err
 	}
-	if workspace.Discovery.AppType == config.AppTypeRails && workspace.Discovery.FallbackUsed {
-		a.Printer.Errorln("Could not infer Rails module name; using directory name", fmt.Sprintf("%q.", workspace.Discovery.ProjectName))
-	}
-	a.Printer.Println("Deleted secret", stringFromMap(result, "name"), "for", stringFromMap(result, "service_name")+".")
 	if configUpdateErr != "" {
-		a.Printer.Errorln("Secret deleted, but devopsellence.yml was not updated:", configUpdateErr)
 		return ExitError{Code: 1, Err: fmt.Errorf("secret deleted, but devopsellence.yml was not updated: %s", configUpdateErr)}
-	}
-	if configUpdated {
-		a.Printer.Println("Updated:", a.ConfigStore.PathFor(workspace.Discovery.WorkspaceRoot))
 	}
 	return nil
 }
@@ -2013,11 +1708,9 @@ func (a *App) Claim(ctx context.Context, opts ClaimOptions) error {
 		return wrapError(err)
 	}
 	result["schema_version"] = outputSchemaVersion
-	if a.Printer.JSON {
-		return a.Printer.PrintJSON(result)
-	}
-	a.Printer.Println("Claim email sent to", stringFromMap(result, "email")+".")
-	return nil
+
+	return a.Printer.PrintJSON(result)
+
 }
 
 func (a *App) TokenCreate(ctx context.Context, opts TokenCreateOptions) error {
@@ -2030,18 +1723,14 @@ func (a *App) TokenCreate(ctx context.Context, opts TokenCreateOptions) error {
 	if err != nil {
 		return wrapError(err)
 	}
-	if a.Printer.JSON {
-		return a.Printer.PrintJSON(map[string]any{
-			"schema_version": outputSchemaVersion,
-			"token":          result.Token,
-			"name":           result.Name,
-			"created_at":     result.CreatedAt,
-		})
-	}
-	a.Printer.Println("Token:", result.Token)
-	a.Printer.Println("Name:", result.Name)
-	a.Printer.Errorln("Save this token — it will not be shown again.")
-	return nil
+
+	return a.Printer.PrintJSON(map[string]any{
+		"schema_version": outputSchemaVersion,
+		"token":          result.Token,
+		"name":           result.Name,
+		"created_at":     result.CreatedAt,
+	})
+
 }
 
 func (a *App) TokenList(ctx context.Context, _ TokenListOptions) error {
@@ -2053,35 +1742,13 @@ func (a *App) TokenList(ctx context.Context, _ TokenListOptions) error {
 	if err != nil {
 		return wrapError(err)
 	}
-	if a.Printer.JSON {
-		return a.Printer.PrintJSON(map[string]any{
-			"schema_version": outputSchemaVersion,
-			"ok":             true,
-			"tokens":         result,
-		})
-	}
-	if len(result) == 0 {
-		a.Printer.Println("No tokens.")
-		return nil
-	}
-	for _, token := range result {
-		notes := []string{}
-		if token.Current {
-			notes = append(notes, "current")
-		}
-		if strings.TrimSpace(token.RevokedAt) != "" {
-			notes = append(notes, "revoked")
-		}
-		if strings.TrimSpace(token.LastUsedAt) != "" {
-			notes = append(notes, "last_used="+token.LastUsedAt)
-		}
-		suffix := ""
-		if len(notes) > 0 {
-			suffix = " [" + strings.Join(notes, ", ") + "]"
-		}
-		a.Printer.Println(fmt.Sprintf("#%d  %s  created=%s%s", token.ID, token.Name, token.CreatedAt, suffix))
-	}
-	return nil
+
+	return a.Printer.PrintJSON(map[string]any{
+		"schema_version": outputSchemaVersion,
+		"ok":             true,
+		"tokens":         result,
+	})
+
 }
 
 func (a *App) TokenRevoke(ctx context.Context, opts TokenRevokeOptions) error {
@@ -2096,15 +1763,13 @@ func (a *App) TokenRevoke(ctx context.Context, opts TokenRevokeOptions) error {
 	if err != nil {
 		return wrapError(err)
 	}
-	if a.Printer.JSON {
-		return a.Printer.PrintJSON(map[string]any{
-			"schema_version": outputSchemaVersion,
-			"ok":             true,
-			"token":          result,
-		})
-	}
-	a.Printer.Println(fmt.Sprintf("Revoked token #%d %s.", result.ID, result.Name))
-	return nil
+
+	return a.Printer.PrintJSON(map[string]any{
+		"schema_version": outputSchemaVersion,
+		"ok":             true,
+		"token":          result,
+	})
+
 }
 
 func (a *App) OrganizationList(ctx context.Context, _ OrganizationListOptions) error {
@@ -2116,28 +1781,13 @@ func (a *App) OrganizationList(ctx context.Context, _ OrganizationListOptions) e
 	if err != nil {
 		return wrapError(err)
 	}
-	if a.Printer.JSON {
-		return a.Printer.PrintJSON(map[string]any{
-			"schema_version": outputSchemaVersion,
-			"ok":             true,
-			"organizations":  organizations,
-		})
-	}
-	if len(organizations) == 0 {
-		a.Printer.Println("No organizations.")
-		return nil
-	}
-	for _, organization := range organizations {
-		parts := []string{organization.Name}
-		if strings.TrimSpace(organization.Role) != "" {
-			parts = append(parts, "role="+organization.Role)
-		}
-		if strings.TrimSpace(organization.PlanTier) != "" {
-			parts = append(parts, "plan="+organization.PlanTier)
-		}
-		a.Printer.Println(strings.Join(parts, "  "))
-	}
-	return nil
+
+	return a.Printer.PrintJSON(map[string]any{
+		"schema_version": outputSchemaVersion,
+		"ok":             true,
+		"organizations":  organizations,
+	})
+
 }
 
 func (a *App) OrganizationUse(ctx context.Context, opts OrganizationUseOptions) error {
@@ -2158,19 +1808,17 @@ func (a *App) OrganizationUse(ctx context.Context, opts OrganizationUseOptions) 
 		return wrapError(err)
 	}
 	_ = a.rememberOrganization(organization.ID)
-	if a.Printer.JSON {
-		return a.Printer.PrintJSON(map[string]any{
-			"schema_version": outputSchemaVersion,
-			"ok":             true,
-			"organization": map[string]any{
-				"id":   organization.ID,
-				"name": organization.Name,
-			},
-			"config_path": a.ConfigStore.PathFor(discovered.WorkspaceRoot),
-		})
-	}
-	a.Printer.Println("Using organization", organization.Name+".")
-	return nil
+
+	return a.Printer.PrintJSON(map[string]any{
+		"schema_version": outputSchemaVersion,
+		"ok":             true,
+		"organization": map[string]any{
+			"id":   organization.ID,
+			"name": organization.Name,
+		},
+		"config_path": a.ConfigStore.PathFor(discovered.WorkspaceRoot),
+	})
+
 }
 
 func (a *App) OrganizationRegistryShow(ctx context.Context, opts OrganizationRegistryShowOptions) error {
@@ -2187,25 +1835,14 @@ func (a *App) OrganizationRegistryShow(ctx context.Context, opts OrganizationReg
 	if err != nil {
 		return wrapError(err)
 	}
-	if a.Printer.JSON {
-		return a.Printer.PrintJSON(map[string]any{
-			"schema_version": outputSchemaVersion,
-			"ok":             true,
-			"organization":   organization,
-			"registry":       registryConfig,
-		})
-	}
-	if !registryConfig.Configured {
-		a.Printer.Println("Registry not configured for", organization.Name+".")
-		return nil
-	}
-	a.Printer.Println("Registry host:", registryConfig.RegistryHost)
-	a.Printer.Println("Namespace:", registryConfig.RepositoryNamespace)
-	a.Printer.Println("Username:", registryConfig.Username)
-	if strings.TrimSpace(registryConfig.ExpiresAt) != "" {
-		a.Printer.Println("Expires at:", registryConfig.ExpiresAt)
-	}
-	return nil
+
+	return a.Printer.PrintJSON(map[string]any{
+		"schema_version": outputSchemaVersion,
+		"ok":             true,
+		"organization":   organization,
+		"registry":       registryConfig,
+	})
+
 }
 
 func (a *App) OrganizationRegistrySet(ctx context.Context, opts OrganizationRegistrySetOptions) error {
@@ -2246,16 +1883,14 @@ func (a *App) OrganizationRegistrySet(ctx context.Context, opts OrganizationRegi
 	if err != nil {
 		return wrapError(err)
 	}
-	if a.Printer.JSON {
-		return a.Printer.PrintJSON(map[string]any{
-			"schema_version": outputSchemaVersion,
-			"ok":             true,
-			"organization":   organization,
-			"registry":       registryConfig,
-		})
-	}
-	a.Printer.Println("Updated registry config for", organization.Name+".")
-	return nil
+
+	return a.Printer.PrintJSON(map[string]any{
+		"schema_version": outputSchemaVersion,
+		"ok":             true,
+		"organization":   organization,
+		"registry":       registryConfig,
+	})
+
 }
 
 func (a *App) ProjectList(ctx context.Context, opts ProjectListOptions) error {
@@ -2272,22 +1907,14 @@ func (a *App) ProjectList(ctx context.Context, opts ProjectListOptions) error {
 	if err != nil {
 		return wrapError(err)
 	}
-	if a.Printer.JSON {
-		return a.Printer.PrintJSON(map[string]any{
-			"schema_version": outputSchemaVersion,
-			"ok":             true,
-			"organization":   organization,
-			"projects":       projects,
-		})
-	}
-	if len(projects) == 0 {
-		a.Printer.Println("No projects.")
-		return nil
-	}
-	for _, project := range projects {
-		a.Printer.Println(project.Name)
-	}
-	return nil
+
+	return a.Printer.PrintJSON(map[string]any{
+		"schema_version": outputSchemaVersion,
+		"ok":             true,
+		"organization":   organization,
+		"projects":       projects,
+	})
+
 }
 
 func (a *App) ProjectCreate(ctx context.Context, opts ProjectCreateOptions) error {
@@ -2307,16 +1934,14 @@ func (a *App) ProjectCreate(ctx context.Context, opts ProjectCreateOptions) erro
 	if err != nil {
 		return wrapError(err)
 	}
-	if a.Printer.JSON {
-		return a.Printer.PrintJSON(map[string]any{
-			"schema_version": outputSchemaVersion,
-			"ok":             true,
-			"organization":   organization,
-			"project":        project,
-		})
-	}
-	a.Printer.Println("Created project", project.Name+".")
-	return nil
+
+	return a.Printer.PrintJSON(map[string]any{
+		"schema_version": outputSchemaVersion,
+		"ok":             true,
+		"organization":   organization,
+		"project":        project,
+	})
+
 }
 
 func (a *App) ProjectDelete(ctx context.Context, opts ProjectDeleteOptions) error {
@@ -2342,11 +1967,9 @@ func (a *App) ProjectDelete(ctx context.Context, opts ProjectDeleteOptions) erro
 	}
 	result["schema_version"] = outputSchemaVersion
 	result["organization"] = organization
-	if a.Printer.JSON {
-		return a.Printer.PrintJSON(result)
-	}
-	a.Printer.Println("Deleted project", project.Name+".")
-	return nil
+
+	return a.Printer.PrintJSON(result)
+
 }
 
 func (a *App) ProjectUse(ctx context.Context, opts ProjectUseOptions) error {
@@ -2375,17 +1998,15 @@ func (a *App) ProjectUse(ctx context.Context, opts ProjectUseOptions) error {
 		return wrapError(err)
 	}
 	_ = a.rememberOrganization(organization.ID)
-	if a.Printer.JSON {
-		return a.Printer.PrintJSON(map[string]any{
-			"schema_version": outputSchemaVersion,
-			"ok":             true,
-			"organization":   organization,
-			"project":        project,
-			"config_path":    a.ConfigStore.PathFor(discovered.WorkspaceRoot),
-		})
-	}
-	a.Printer.Println("Using project", project.Name+".")
-	return nil
+
+	return a.Printer.PrintJSON(map[string]any{
+		"schema_version": outputSchemaVersion,
+		"ok":             true,
+		"organization":   organization,
+		"project":        project,
+		"config_path":    a.ConfigStore.PathFor(discovered.WorkspaceRoot),
+	})
+
 }
 
 func (a *App) EnvironmentList(ctx context.Context, opts EnvironmentListOptions) error {
@@ -2402,23 +2023,15 @@ func (a *App) EnvironmentList(ctx context.Context, opts EnvironmentListOptions) 
 	if err != nil {
 		return wrapError(err)
 	}
-	if a.Printer.JSON {
-		return a.Printer.PrintJSON(map[string]any{
-			"schema_version": outputSchemaVersion,
-			"ok":             true,
-			"organization":   organization,
-			"project":        project,
-			"environments":   environments,
-		})
-	}
-	if len(environments) == 0 {
-		a.Printer.Println("No environments.")
-		return nil
-	}
-	for _, environment := range environments {
-		a.Printer.Println(environment.Name)
-	}
-	return nil
+
+	return a.Printer.PrintJSON(map[string]any{
+		"schema_version": outputSchemaVersion,
+		"ok":             true,
+		"organization":   organization,
+		"project":        project,
+		"environments":   environments,
+	})
+
 }
 
 func (a *App) EnvironmentCreate(ctx context.Context, opts EnvironmentCreateOptions) error {
@@ -2442,21 +2055,15 @@ func (a *App) EnvironmentCreate(ctx context.Context, opts EnvironmentCreateOptio
 	if err != nil {
 		return wrapError(err)
 	}
-	if a.Printer.JSON {
-		return a.Printer.PrintJSON(map[string]any{
-			"schema_version": outputSchemaVersion,
-			"ok":             true,
-			"organization":   organization,
-			"project":        project,
-			"environment":    environment,
-		})
-	}
-	if environment.IngressStrategy != "" {
-		a.Printer.Println("Created environment", environment.Name+" with ingress", environment.IngressStrategy+".")
-		return nil
-	}
-	a.Printer.Println("Created environment", environment.Name+".")
-	return nil
+
+	return a.Printer.PrintJSON(map[string]any{
+		"schema_version": outputSchemaVersion,
+		"ok":             true,
+		"organization":   organization,
+		"project":        project,
+		"environment":    environment,
+	})
+
 }
 
 func (a *App) EnvironmentIngress(ctx context.Context, opts EnvironmentIngressOptions) error {
@@ -2476,17 +2083,15 @@ func (a *App) EnvironmentIngress(ctx context.Context, opts EnvironmentIngressOpt
 	if err != nil {
 		return wrapError(err)
 	}
-	if a.Printer.JSON {
-		return a.Printer.PrintJSON(map[string]any{
-			"schema_version": outputSchemaVersion,
-			"ok":             true,
-			"organization":   workspace.Organization,
-			"project":        workspace.Project,
-			"environment":    environment,
-		})
-	}
-	a.Printer.Println("Updated environment", environment.Name, "ingress to", environment.IngressStrategy+".")
-	return nil
+
+	return a.Printer.PrintJSON(map[string]any{
+		"schema_version": outputSchemaVersion,
+		"ok":             true,
+		"organization":   workspace.Organization,
+		"project":        workspace.Project,
+		"environment":    environment,
+	})
+
 }
 
 func (a *App) EnvironmentUse(ctx context.Context, opts EnvironmentUseOptions) error {
@@ -2513,19 +2118,17 @@ func (a *App) EnvironmentUse(ctx context.Context, opts EnvironmentUseOptions) er
 		return wrapError(err)
 	}
 	_ = a.rememberOrganization(organization.ID)
-	if a.Printer.JSON {
-		return a.Printer.PrintJSON(map[string]any{
-			"schema_version":      outputSchemaVersion,
-			"ok":                  true,
-			"organization":        organization,
-			"project":             project,
-			"environment":         environment,
-			"workspace_key":       a.modeWorkspaceKey(),
-			"default_environment": cfg.DefaultEnvironment,
-		})
-	}
-	a.Printer.Println("Using environment", environment.Name+".")
-	return nil
+
+	return a.Printer.PrintJSON(map[string]any{
+		"schema_version":      outputSchemaVersion,
+		"ok":                  true,
+		"organization":        organization,
+		"project":             project,
+		"environment":         environment,
+		"workspace_key":       a.modeWorkspaceKey(),
+		"default_environment": cfg.DefaultEnvironment,
+	})
+
 }
 
 func (a *App) EnvironmentOpen(ctx context.Context, opts EnvironmentOpenOptions) error {
@@ -2545,21 +2148,16 @@ func (a *App) EnvironmentOpen(ctx context.Context, opts EnvironmentOpenOptions) 
 	if strings.TrimSpace(publicURL) == "" {
 		return ExitError{Code: 1, Err: errors.New("environment has no public URL")}
 	}
-	if a.Printer.JSON {
-		return a.Printer.PrintJSON(map[string]any{
-			"schema_version": outputSchemaVersion,
-			"ok":             true,
-			"url":            publicURL,
-			"organization":   workspace.Organization,
-			"project":        workspace.Project,
-			"environment":    workspace.Environment,
-		})
-	}
-	if err := a.Auth.OpenURL(publicURL); err != nil {
-		return wrapError(err)
-	}
-	a.Printer.Println("Opened", publicURL)
-	return nil
+
+	return a.Printer.PrintJSON(map[string]any{
+		"schema_version": outputSchemaVersion,
+		"ok":             true,
+		"url":            publicURL,
+		"organization":   workspace.Organization,
+		"project":        workspace.Project,
+		"environment":    workspace.Environment,
+	})
+
 }
 
 func (a *App) ensureAuth(ctx context.Context, allowAnonymousCreate bool) (auth.Tokens, error) {
@@ -4079,63 +3677,4 @@ func nodeDiagnosePending(status string) bool {
 	default:
 		return false
 	}
-}
-
-func (a *App) printNodeDiagnose(request api.NodeDiagnoseRequest) {
-	a.Printer.Println("Node diagnose #" + strconv.Itoa(request.ID) + " for node #" + strconv.Itoa(request.Node.ID) + " (" + firstNonEmpty(request.Node.Name, "unnamed") + ")")
-	a.Printer.Println("Status:", request.Status)
-	if request.CompletedAt != "" {
-		a.Printer.Println("Completed:", request.CompletedAt)
-	}
-	if request.ErrorMessage != "" {
-		a.Printer.Println("Error:", request.ErrorMessage)
-	}
-	if request.Result == nil {
-		return
-	}
-
-	result := request.Result
-	a.Printer.Println("Collected:", result.CollectedAt)
-	a.Printer.Println("Agent:", result.AgentVersion)
-	a.Printer.Println(
-		"Summary:",
-		fmt.Sprintf("status=%s total=%d running=%d stopped=%d unhealthy=%d logs=%d",
-			result.Summary.Status,
-			result.Summary.Total,
-			result.Summary.Running,
-			result.Summary.Stopped,
-			result.Summary.Unhealthy,
-			result.Summary.LogsIncluded,
-		),
-	)
-
-	for _, container := range result.Containers {
-		name := firstNonEmpty(container.Service, container.System, container.Name)
-		line := name + " container=" + container.Name + " running=" + strconv.FormatBool(container.Running)
-		if container.Health != "" {
-			line += " health=" + container.Health
-		}
-		if container.Hash != "" {
-			line += " hash=" + container.Hash
-		}
-		a.Printer.Println(line)
-		if container.LogTail != "" {
-			for _, logLine := range strings.Split(strings.TrimRight(container.LogTail, "\n"), "\n") {
-				a.Printer.Println("  " + logLine)
-			}
-		}
-	}
-}
-
-func (a *App) warnAboutPrebuiltImageConfig(opts DeployOptions, cfg config.ProjectConfig) {
-	if strings.TrimSpace(opts.Image) == "" || a.Printer.JSON {
-		return
-	}
-	if cfg.App.Type != config.AppTypeRails {
-		return
-	}
-
-	a.Printer.Errorln("Using --image skips the local build.")
-	a.Printer.Errorln("Deploy will still use devopsellence.yml for port and healthcheck settings.")
-	a.Printer.Errorln("If this image is not a Rails image, update devopsellence.yml before deploy.")
 }

--- a/cli/internal/workflow/install_logs.go
+++ b/cli/internal/workflow/install_logs.go
@@ -9,14 +9,16 @@ import (
 
 type soloInstallReporter struct {
 	progress func(string)
-	stream   io.Writer
+	stdout   io.Writer
+	stderr   io.Writer
 	close    func()
 }
 
 func newSoloInstallReporter(_ context.Context, _ output.Printer, _ string) soloInstallReporter {
 	return soloInstallReporter{
 		progress: func(string) {},
-		stream:   io.Discard,
+		stdout:   newTailBuffer(sshOutputTailLimit),
+		stderr:   newTailBuffer(sshOutputTailLimit),
 		close:    func() {},
 	}
 }
@@ -27,11 +29,41 @@ func (r soloInstallReporter) Progress(message string) {
 	}
 }
 
-func (r soloInstallReporter) Stream() io.Writer {
-	if r.stream == nil {
+func (r soloInstallReporter) Stdout() io.Writer {
+	if r.stdout == nil {
 		return io.Discard
 	}
-	return r.stream
+	return r.stdout
+}
+
+func (r soloInstallReporter) Stderr() io.Writer {
+	if r.stderr == nil {
+		return io.Discard
+	}
+	return r.stderr
+}
+
+func (r soloInstallReporter) Stream() io.Writer {
+	return r.Stdout()
+}
+
+func (r soloInstallReporter) CapturedStdout() string {
+	return capturedInstallOutput(r.stdout)
+}
+
+func (r soloInstallReporter) CapturedStderr() string {
+	return capturedInstallOutput(r.stderr)
+}
+
+func capturedInstallOutput(writer io.Writer) string {
+	if writer == nil {
+		return ""
+	}
+	stringer, ok := writer.(interface{ String() string })
+	if !ok {
+		return ""
+	}
+	return stringer.String()
 }
 
 func (r soloInstallReporter) Close() {

--- a/cli/internal/workflow/install_logs.go
+++ b/cli/internal/workflow/install_logs.go
@@ -13,7 +13,7 @@ type soloInstallReporter struct {
 	close    func()
 }
 
-func newSoloInstallReporter(_ context.Context, printer output.Printer, nodeName string) soloInstallReporter {
+func newSoloInstallReporter(_ context.Context, _ output.Printer, _ string) soloInstallReporter {
 	return soloInstallReporter{
 		progress: func(string) {},
 		stream:   io.Discard,

--- a/cli/internal/workflow/install_logs.go
+++ b/cli/internal/workflow/install_logs.go
@@ -3,7 +3,6 @@ package workflow
 import (
 	"context"
 	"io"
-	"strings"
 
 	"github.com/devopsellence/cli/internal/output"
 )
@@ -15,22 +14,10 @@ type soloInstallReporter struct {
 }
 
 func newSoloInstallReporter(_ context.Context, printer output.Printer, nodeName string) soloInstallReporter {
-	if printer.JSON {
-		return soloInstallReporter{
-			progress: func(string) {},
-			stream:   io.Discard,
-			close:    func() {},
-		}
-	}
-
-	progress := func(message string) {
-		printer.Println("[" + nodeName + "] " + strings.TrimSpace(message))
-	}
-	writer := &lineProgressWriter{progress: progress}
 	return soloInstallReporter{
-		progress: progress,
-		stream:   writer,
-		close:    writer.Flush,
+		progress: func(string) {},
+		stream:   io.Discard,
+		close:    func() {},
 	}
 }
 

--- a/cli/internal/workflow/install_logs_test.go
+++ b/cli/internal/workflow/install_logs_test.go
@@ -7,17 +7,26 @@ import (
 	"github.com/devopsellence/cli/internal/output"
 )
 
-func TestNewSoloInstallReporterDiscardsInstallNoise(t *testing.T) {
+func TestNewSoloInstallReporterCapturesInstallNoiseWithoutPrinting(t *testing.T) {
 	var out bytes.Buffer
 	reporter := newSoloInstallReporter(t.Context(), output.Printer{Out: &out}, "prod-2")
 
 	reporter.Progress("Installing Docker, agent, and systemd service...")
-	if _, err := reporter.Stream().Write([]byte("progress: downloading agent binary\nplain log\npartial")); err != nil {
+	if _, err := reporter.Stdout().Write([]byte("progress: downloading agent binary\nplain log\npartial")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := reporter.Stderr().Write([]byte("stderr: package install failed")); err != nil {
 		t.Fatal(err)
 	}
 	reporter.Close()
 
 	if got := out.String(); got != "" {
 		t.Fatalf("reporter output = %q, want no unstructured output", got)
+	}
+	if got := reporter.CapturedStdout(); got != "progress: downloading agent binary\nplain log\npartial" {
+		t.Fatalf("captured stdout = %q", got)
+	}
+	if got := reporter.CapturedStderr(); got != "stderr: package install failed" {
+		t.Fatalf("captured stderr = %q", got)
 	}
 }

--- a/cli/internal/workflow/install_logs_test.go
+++ b/cli/internal/workflow/install_logs_test.go
@@ -2,28 +2,12 @@ package workflow
 
 import (
 	"bytes"
-	"strings"
 	"testing"
 
 	"github.com/devopsellence/cli/internal/output"
 )
 
-func TestNewSoloInstallReporterJSONDiscardsInstallNoise(t *testing.T) {
-	var out bytes.Buffer
-	reporter := newSoloInstallReporter(t.Context(), output.Printer{Out: &out, JSON: true}, "prod-2")
-
-	reporter.Progress("Installing Docker, agent, and systemd service...")
-	if _, err := reporter.Stream().Write([]byte("progress: downloading agent binary\nplain log\npartial")); err != nil {
-		t.Fatal(err)
-	}
-	reporter.Close()
-
-	if got := out.String(); got != "" {
-		t.Fatalf("reporter output = %q, want no unstructured output in JSON mode", got)
-	}
-}
-
-func TestNewSoloInstallReporterPlainLinesWhenJSONDisabled(t *testing.T) {
+func TestNewSoloInstallReporterDiscardsInstallNoise(t *testing.T) {
 	var out bytes.Buffer
 	reporter := newSoloInstallReporter(t.Context(), output.Printer{Out: &out}, "prod-2")
 
@@ -33,18 +17,7 @@ func TestNewSoloInstallReporterPlainLinesWhenJSONDisabled(t *testing.T) {
 	}
 	reporter.Close()
 
-	text := out.String()
-	for _, fragment := range []string{
-		"[prod-2] Installing Docker, agent, and systemd service...",
-		"[prod-2] downloading agent binary",
-		"[prod-2] plain log",
-		"[prod-2] partial",
-	} {
-		if !strings.Contains(text, fragment) {
-			t.Fatalf("reporter output = %q, want fragment %q", text, fragment)
-		}
-	}
-	if strings.Contains(text, "\x1b[") {
-		t.Fatalf("reporter output = %q, want no ANSI redraw codes", text)
+	if got := out.String(); got != "" {
+		t.Fatalf("reporter output = %q, want no unstructured output", got)
 	}
 }

--- a/cli/internal/workflow/management_test.go
+++ b/cli/internal/workflow/management_test.go
@@ -282,7 +282,6 @@ func TestContextShowJSONIncludesWorkspaceContext(t *testing.T) {
 
 	var stdout bytes.Buffer
 	app.Printer.Out = &stdout
-	app.Printer.JSON = true
 
 	if err := app.ContextShow(); err != nil {
 		t.Fatalf("ContextShow() error = %v", err)
@@ -503,7 +502,6 @@ func TestConfigResolvePrintsResolvedEnvironmentConfig(t *testing.T) {
 
 	var stdout bytes.Buffer
 	app.Printer.Out = &stdout
-	app.Printer.JSON = true
 
 	if err := app.ConfigResolve(ConfigResolveOptions{Environment: "staging"}); err != nil {
 		t.Fatalf("ConfigResolve() error = %v", err)
@@ -568,7 +566,6 @@ func TestStatusUsesSavedWorkspaceEnvironment(t *testing.T) {
 
 	var stdout bytes.Buffer
 	app.Printer.Out = &stdout
-	app.Printer.JSON = true
 
 	if err := app.Status(context.Background(), StatusOptions{}); err != nil {
 		t.Fatalf("Status() error = %v", err)
@@ -3056,27 +3053,6 @@ func TestDeployFailsWhenExistingConfigIsUncommitted(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "git add "+config.GenericFilePath) {
 		t.Fatalf("Deploy() error = %v", err)
-	}
-}
-
-func TestWarnAboutPrebuiltImageConfigForRails(t *testing.T) {
-	t.Parallel()
-
-	root := makeRailsRoot(t, "ShopApp")
-	app := newTestApp(t, root, roundTripFunc(func(r *http.Request) (*http.Response, error) {
-		t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
-		return nil, nil
-	}))
-	var stderr bytes.Buffer
-	app.Printer = output.New(io.Discard, &stderr)
-
-	cfg := config.DefaultProjectConfig("default", "ShopApp", "production")
-	app.warnAboutPrebuiltImageConfig(DeployOptions{
-		Image: "docker.io/mccutchen/go-httpbin@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-	}, cfg)
-
-	if stderr.String() != "" {
-		t.Fatalf("warning output = %q, want no unstructured warning output in JSON mode", stderr.String())
 	}
 }
 

--- a/cli/internal/workflow/management_test.go
+++ b/cli/internal/workflow/management_test.go
@@ -1321,6 +1321,44 @@ func TestNodeDiagnose(t *testing.T) {
 	}
 }
 
+func TestNodeDiagnoseFailedStatusReturnsExitErrorAfterPrintingJSON(t *testing.T) {
+	t.Parallel()
+
+	root := makeRailsRoot(t, "ShopApp")
+	var stdout bytes.Buffer
+	app := newTestApp(t, root, roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/cli/nodes/8/diagnose_requests":
+			return jsonResponseWithStatus(t, http.StatusAccepted, map[string]any{
+				"id":            42,
+				"status":        "failed",
+				"requested_at":  "2026-03-29T20:00:00Z",
+				"completed_at":  "2026-03-29T20:00:02Z",
+				"error_message": "docker unavailable",
+				"node":          map[string]any{"id": 8, "name": "node-a", "organization_id": 7},
+			}), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+			return nil, nil
+		}
+	}))
+	app.Printer.Out = &stdout
+
+	err := app.NodeDiagnose(context.Background(), NodeDiagnoseOptions{NodeID: 8, Wait: 2 * time.Second})
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 1 {
+		t.Fatalf("NodeDiagnose() error = %#v, want ExitError code 1", err)
+	}
+	if !strings.Contains(err.Error(), "docker unavailable") {
+		t.Fatalf("NodeDiagnose() error = %v, want request error message", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	request := jsonMapFromAny(t, payload["request"])
+	if intValueAny(request["id"]) != 42 || request["status"] != "failed" {
+		t.Fatalf("request = %#v, want failed request #42", request)
+	}
+}
+
 func TestDeployWaitsForRolloutProgress(t *testing.T) {
 	t.Parallel()
 

--- a/cli/internal/workflow/mode.go
+++ b/cli/internal/workflow/mode.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/devopsellence/cli/internal/discovery"
 	"github.com/devopsellence/cli/internal/solo"
-	"github.com/devopsellence/cli/internal/ui"
 	"github.com/devopsellence/devopsellence/deployment-core/pkg/deploycore/config"
 )
 
@@ -192,26 +191,17 @@ func (a *App) ModeShow() error {
 	if err != nil {
 		return ExitError{Code: 1, Err: err}
 	}
-	if a.Printer.JSON {
-		payload := map[string]any{
-			"schema_version": outputSchemaVersion,
-			"workspace_key":  a.modeWorkspaceKey(),
-			"set":            ok,
-		}
-		if ok {
-			payload["mode"] = string(mode)
-		}
-		return a.Printer.PrintJSON(payload)
+
+	payload := map[string]any{
+		"schema_version": outputSchemaVersion,
+		"workspace_key":  a.modeWorkspaceKey(),
+		"set":            ok,
 	}
-	if !ok {
-		a.Printer.Println("Mode: not set")
-		a.Printer.Println("Workspace:", a.modeWorkspaceKey())
-		a.Printer.Println("Next step: run `devopsellence mode use solo|shared`.")
-		return nil
+	if ok {
+		payload["mode"] = string(mode)
 	}
-	a.Printer.Println("Mode:", mode)
-	a.Printer.Println("Workspace:", a.modeWorkspaceKey())
-	return nil
+	return a.Printer.PrintJSON(payload)
+
 }
 
 func (a *App) ContextShow() error {
@@ -241,20 +231,7 @@ func (a *App) ContextShow() error {
 	selectedEnvironment := a.effectiveEnvironment("", cfg)
 	result["environment"] = selectedEnvironment
 	result["selected_environment"] = selectedEnvironment
-	if a.Printer.JSON {
-		return a.Printer.PrintJSON(result)
-	}
-	rows := []ui.Row{
-		{Label: "Workspace", Value: firstNonEmpty(discovered.WorkspaceRoot, a.modeWorkspaceKey())},
-		{Label: "Mode", Value: firstNonEmpty(string(mode), "not set")},
-		{Label: "Organization", Value: safeConfigValue(cfg, func(value *config.ProjectConfig) string { return value.Organization })},
-		{Label: "Project", Value: safeConfigValue(cfg, func(value *config.ProjectConfig) string { return value.Project })},
-		{Label: "Default Env", Value: safeConfigValue(cfg, func(value *config.ProjectConfig) string { return value.DefaultEnvironment })},
-		{Label: "Selected Env", Value: selectedEnvironment},
-	}
-	a.Printer.Println(ui.RenderCard(ui.Card{Title: "Context", Rows: rows}))
-	if !ok {
-		a.Printer.Println("Next step: run `devopsellence mode use solo|shared`.")
-	}
-	return nil
+
+	return a.Printer.PrintJSON(result)
+
 }

--- a/cli/internal/workflow/provider.go
+++ b/cli/internal/workflow/provider.go
@@ -46,25 +46,21 @@ func (a *App) ProviderLogin(ctx context.Context, opts ProviderLoginOptions) erro
 	if err != nil {
 		return err
 	}
-	if !a.Printer.JSON {
-		a.Printer.Println("Validating " + providerSlug + " token...")
-	}
+
 	if err := provider.Validate(ctx); err != nil {
 		return err
 	}
 	if err := saveProviderToken(a.ProviderState, providerSlug, token); err != nil {
 		return err
 	}
-	if a.Printer.JSON {
-		return a.Printer.PrintJSON(map[string]any{
-			"schema_version": outputSchemaVersion,
-			"provider":       providerSlug,
-			"configured":     true,
-			"source":         "state",
-		})
-	}
-	a.Printer.Println("Saved " + providerSlug + " provider token.")
-	return nil
+
+	return a.Printer.PrintJSON(map[string]any{
+		"schema_version": outputSchemaVersion,
+		"provider":       providerSlug,
+		"configured":     true,
+		"source":         "state",
+	})
+
 }
 
 func (a *App) ProviderStatus(ctx context.Context, opts ProviderStatusOptions) error {
@@ -77,15 +73,13 @@ func (a *App) ProviderStatus(ctx context.Context, opts ProviderStatusOptions) er
 		return err
 	}
 	if strings.TrimSpace(token) == "" {
-		if a.Printer.JSON {
-			return a.Printer.PrintJSON(map[string]any{
-				"schema_version": outputSchemaVersion,
-				"provider":       providerSlug,
-				"configured":     false,
-			})
-		}
-		a.Printer.Println(providerSlug + " provider is not configured.")
-		return nil
+
+		return a.Printer.PrintJSON(map[string]any{
+			"schema_version": outputSchemaVersion,
+			"provider":       providerSlug,
+			"configured":     false,
+		})
+
 	}
 	provider, err := providers.ResolveWithToken(providerSlug, token)
 	if err != nil {
@@ -94,16 +88,14 @@ func (a *App) ProviderStatus(ctx context.Context, opts ProviderStatusOptions) er
 	if err := provider.Validate(ctx); err != nil {
 		return err
 	}
-	if a.Printer.JSON {
-		return a.Printer.PrintJSON(map[string]any{
-			"schema_version": outputSchemaVersion,
-			"provider":       providerSlug,
-			"configured":     true,
-			"source":         source,
-		})
-	}
-	a.Printer.Println(providerSlug + " provider is configured (" + source + ").")
-	return nil
+
+	return a.Printer.PrintJSON(map[string]any{
+		"schema_version": outputSchemaVersion,
+		"provider":       providerSlug,
+		"configured":     true,
+		"source":         source,
+	})
+
 }
 
 func (a *App) ProviderLogout(_ context.Context, opts ProviderLogoutOptions) error {
@@ -115,19 +107,13 @@ func (a *App) ProviderLogout(_ context.Context, opts ProviderLogoutOptions) erro
 	if err != nil {
 		return err
 	}
-	if a.Printer.JSON {
-		return a.Printer.PrintJSON(map[string]any{
-			"schema_version": outputSchemaVersion,
-			"provider":       providerSlug,
-			"deleted":        deleted,
-		})
-	}
-	if deleted {
-		a.Printer.Println("Removed " + providerSlug + " provider token.")
-	} else {
-		a.Printer.Println(providerSlug + " provider token was not stored.")
-	}
-	return nil
+
+	return a.Printer.PrintJSON(map[string]any{
+		"schema_version": outputSchemaVersion,
+		"provider":       providerSlug,
+		"deleted":        deleted,
+	})
+
 }
 
 func (a *App) resolveSoloProvider(providerSlug string) (providers.Provider, error) {

--- a/cli/internal/workflow/root.go
+++ b/cli/internal/workflow/root.go
@@ -91,22 +91,15 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 		}, "\n"),
 		SilenceErrors: true,
 		SilenceUsage:  true,
-		PersistentPreRun: func(_ *cobra.Command, _ []string) {
-			app.Printer.JSON = true
-		},
 	}
 	root.AddCommand(&cobra.Command{
 		Use:   "version",
 		Short: "Print the CLI version",
 		RunE: func(_ *cobra.Command, _ []string) error {
-			if app.Printer.JSON {
-				return app.Printer.PrintJSON(map[string]any{
-					"schema_version": outputSchemaVersion,
-					"version":        version.String(),
-				})
-			}
-			app.Printer.Println(version.String())
-			return nil
+			return app.Printer.PrintJSON(map[string]any{
+				"schema_version": outputSchemaVersion,
+				"version":        version.String(),
+			})
 		},
 	})
 
@@ -133,16 +126,11 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 			if err := app.SetMode(mode); err != nil {
 				return ExitError{Code: 1, Err: err}
 			}
-			if app.Printer.JSON {
-				return app.Printer.PrintJSON(map[string]any{
-					"schema_version": outputSchemaVersion,
-					"mode":           string(mode),
-					"workspace_key":  app.modeWorkspaceKey(),
-				})
-			}
-			app.Printer.Println("Mode:", mode)
-			app.Printer.Println("Workspace:", app.modeWorkspaceKey())
-			return nil
+			return app.Printer.PrintJSON(map[string]any{
+				"schema_version": outputSchemaVersion,
+				"mode":           string(mode),
+				"workspace_key":  app.modeWorkspaceKey(),
+			})
 		},
 	})
 	root.AddCommand(modeCommand)

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1773,8 +1773,10 @@ func (a *App) SharedSoloNodeCreate(ctx context.Context, opts SharedSoloNodeCreat
 		return err
 	}
 
-	if err := solo.RunSSHInteractive(ctx, created.Node, installCommand, io.Discard, io.Discard); err != nil {
-		return err
+	var sshStdout bytes.Buffer
+	var sshStderr bytes.Buffer
+	if err := solo.RunSSHInteractive(ctx, created.Node, installCommand, &sshStdout, &sshStderr); err != nil {
+		return sshInteractiveError("failed to run install command over SSH", err, sshStdout.String(), sshStderr.String())
 	}
 
 	result := map[string]any{
@@ -1798,6 +1800,22 @@ func (a *App) SharedSoloNodeCreate(ctx context.Context, opts SharedSoloNodeCreat
 	}
 	return a.Printer.PrintJSON(result)
 
+}
+
+func sshInteractiveError(prefix string, err error, stdout string, stderr string) error {
+	stdout = strings.TrimSpace(stdout)
+	stderr = strings.TrimSpace(stderr)
+
+	switch {
+	case stderr != "" && stdout != "":
+		return fmt.Errorf("%s: %w; stderr: %s; stdout: %s", prefix, err, stderr, stdout)
+	case stderr != "":
+		return fmt.Errorf("%s: %w; stderr: %s", prefix, err, stderr)
+	case stdout != "":
+		return fmt.Errorf("%s: %w; stdout: %s", prefix, err, stdout)
+	default:
+		return fmt.Errorf("%s: %w", prefix, err)
+	}
 }
 
 func (a *App) SoloNodeRemove(ctx context.Context, opts SoloNodeRemoveOptions) error {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1823,8 +1823,10 @@ func (b *tailBuffer) Write(p []byte) (int, error) {
 		return n, nil
 	}
 	if len(p) >= b.limit {
+		if len(p) > b.limit || len(b.buf) > 0 {
+			b.truncated = true
+		}
 		b.buf = append(b.buf[:0], p[len(p)-b.limit:]...)
-		b.truncated = true
 		return n, nil
 	}
 	if overflow := len(b.buf) + len(p) - b.limit; overflow > 0 {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1773,11 +1773,7 @@ func (a *App) SharedSoloNodeCreate(ctx context.Context, opts SharedSoloNodeCreat
 		return err
 	}
 
-	stdout, stderr := a.Printer.Out, a.Printer.Err
-
-	stdout, stderr = io.Discard, io.Discard
-
-	if err := solo.RunSSHInteractive(ctx, created.Node, installCommand, stdout, stderr); err != nil {
+	if err := solo.RunSSHInteractive(ctx, created.Node, installCommand, io.Discard, io.Discard); err != nil {
 		return err
 	}
 

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1773,9 +1773,9 @@ func (a *App) SharedSoloNodeCreate(ctx context.Context, opts SharedSoloNodeCreat
 		return err
 	}
 
-	var sshStdout bytes.Buffer
-	var sshStderr bytes.Buffer
-	if err := solo.RunSSHInteractive(ctx, created.Node, installCommand, &sshStdout, &sshStderr); err != nil {
+	sshStdout := newTailBuffer(sshOutputTailLimit)
+	sshStderr := newTailBuffer(sshOutputTailLimit)
+	if err := solo.RunSSHInteractive(ctx, created.Node, installCommand, sshStdout, sshStderr); err != nil {
 		return sshInteractiveError("failed to run install command over SSH", err, sshStdout.String(), sshStderr.String())
 	}
 
@@ -1800,6 +1800,47 @@ func (a *App) SharedSoloNodeCreate(ctx context.Context, opts SharedSoloNodeCreat
 	}
 	return a.Printer.PrintJSON(result)
 
+}
+
+const sshOutputTailLimit = 64 * 1024
+
+type tailBuffer struct {
+	limit     int
+	buf       []byte
+	truncated bool
+}
+
+func newTailBuffer(limit int) *tailBuffer {
+	return &tailBuffer{limit: limit}
+}
+
+func (b *tailBuffer) Write(p []byte) (int, error) {
+	n := len(p)
+	if b.limit <= 0 {
+		if n > 0 {
+			b.truncated = true
+		}
+		return n, nil
+	}
+	if len(p) >= b.limit {
+		b.buf = append(b.buf[:0], p[len(p)-b.limit:]...)
+		b.truncated = true
+		return n, nil
+	}
+	if overflow := len(b.buf) + len(p) - b.limit; overflow > 0 {
+		copy(b.buf, b.buf[overflow:])
+		b.buf = b.buf[:len(b.buf)-overflow]
+		b.truncated = true
+	}
+	b.buf = append(b.buf, p...)
+	return n, nil
+}
+
+func (b *tailBuffer) String() string {
+	if !b.truncated {
+		return string(b.buf)
+	}
+	return "[truncated]\n" + string(b.buf)
 }
 
 func sshInteractiveError(prefix string, err error, stdout string, stderr string) error {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/devopsellence/cli/internal/api"
 	"github.com/devopsellence/cli/internal/discovery"
-	"github.com/devopsellence/cli/internal/output"
 	"github.com/devopsellence/cli/internal/solo"
 	"github.com/devopsellence/cli/internal/solo/providers"
 	cliversion "github.com/devopsellence/cli/internal/version"
@@ -188,9 +187,7 @@ func (a *App) createProviderNode(ctx context.Context, opts SoloNodeCreateOptions
 	if err != nil {
 		return providerNodeCreateResult{}, err
 	}
-	if !a.Printer.JSON {
-		a.Printer.Println("Creating " + providerSlug + " server " + opts.Name + "...")
-	}
+
 	providerLabels := map[string]string{}
 	if strings.TrimSpace(projectName) != "" {
 		providerLabels["devopsellence_project"] = discovery.Slugify(projectName)
@@ -276,9 +273,7 @@ func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 		shortSHA = shortSHA[:7]
 	}
 	imageTag := soloImageTag(cfg.Project, shortSHA)
-	if !a.Printer.JSON {
-		a.Printer.Println("Building image " + imageTag + " ...")
-	}
+
 	buildCtx := filepath.Join(workspaceRoot, cfg.Build.Context)
 	dockerfile := filepath.Join(workspaceRoot, cfg.Build.Dockerfile)
 	if err := dockerBuild(ctx, buildCtx, dockerfile, imageTag, cfg.Build.Platforms); err != nil {
@@ -310,18 +305,15 @@ func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 		return err
 	}
 
-	if a.Printer.JSON {
-		return a.Printer.PrintJSON(map[string]any{
-			"schema_version":          outputSchemaVersion,
-			"workload_revision":       shortSHA,
-			"desired_state_revisions": desiredStateRevisions,
-			"image":                   imageTag,
-			"environment":             environmentName,
-			"nodes":                   sortedNodeNames(nodes),
-		})
-	}
-	a.Printer.Println(fmt.Sprintf("Deployed revision %s to %d node(s)", shortSHA, len(nodes)))
-	return nil
+	return a.Printer.PrintJSON(map[string]any{
+		"schema_version":          outputSchemaVersion,
+		"workload_revision":       shortSHA,
+		"desired_state_revisions": desiredStateRevisions,
+		"image":                   imageTag,
+		"environment":             environmentName,
+		"nodes":                   sortedNodeNames(nodes),
+	})
+
 }
 
 func validateNodeSchedule(cfg *config.ProjectConfig, nodes map[string]config.Node) (string, error) {
@@ -435,7 +427,6 @@ func (a *App) waitForSoloRollout(ctx context.Context, nodes map[string]config.No
 	rolloutCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	lastSummary := ""
 	latestSummary := "rollout pending"
 	nodeNames := sortedNodeNames(nodes)
 	for {
@@ -483,10 +474,7 @@ func (a *App) waitForSoloRollout(ctx context.Context, nodes map[string]config.No
 		if len(details) > 0 {
 			latestSummary += " - " + strings.Join(details, ", ")
 		}
-		if !a.Printer.JSON && latestSummary != lastSummary {
-			a.Printer.Println(latestSummary)
-			lastSummary = latestSummary
-		}
+
 		if pendingCount == 0 && reconcilingCount == 0 {
 			return nil
 		}
@@ -617,10 +605,7 @@ func (a *App) republishNodes(ctx context.Context, current solo.State, nodeNames 
 					mu.Unlock()
 					return
 				}
-				if !a.Printer.JSON {
-					a.Printer.Println(fmt.Sprintf("[%s] Transferring image %s...", name, image))
-				}
-				if err := transferImage(ctx, node, image, a.soloProgress(name)); err != nil {
+				if err := transferImage(ctx, node, image, func(string) {}); err != nil {
 					mu.Lock()
 					errs = append(errs, fmt.Sprintf("[%s] image transfer: %s", name, err))
 					mu.Unlock()
@@ -641,9 +626,6 @@ func (a *App) republishNodes(ctx context.Context, current solo.State, nodeNames 
 				return
 			}
 			desiredStateJSON := publication.DesiredStateJSON
-			if !a.Printer.JSON {
-				a.Printer.Println(fmt.Sprintf("[%s] Writing desired state...", name))
-			}
 			overridePath := desiredStateOverridePath(node)
 			cmd := remoteDesiredStateOverrideCommand(overridePath)
 			if _, err := solo.RunSSH(ctx, node, cmd, strings.NewReader(string(desiredStateJSON))); err != nil {
@@ -1034,58 +1016,36 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 		result, err := readNodeStatus(ctx, node)
 		if err != nil {
 			readErrors++
-			if a.Printer.JSON {
-				jsonResults = append(jsonResults, map[string]any{
-					"node":  name,
-					"error": err.Error(),
-				})
-			} else {
-				a.Printer.Printf("[%s] error: %s\n", name, err)
-			}
+
+			jsonResults = append(jsonResults, map[string]any{
+				"node":  name,
+				"error": err.Error(),
+			})
+
 			continue
 		}
 
 		if result.Missing {
 			message := "no deploy status yet; run `devopsellence deploy`"
-			if a.Printer.JSON {
-				jsonResults = append(jsonResults, map[string]any{
-					"node":    name,
-					"status":  nil,
-					"message": message,
-				})
-			} else {
-				a.Printer.Printf("[%s] status=missing message=%s\n", name, message)
-			}
+
+			jsonResults = append(jsonResults, map[string]any{
+				"node":    name,
+				"status":  nil,
+				"message": message,
+			})
+
 			continue
 		}
 
-		if a.Printer.JSON {
-			jsonResults = append(jsonResults, map[string]any{
-				"node":   name,
-				"status": result.Raw,
-			})
-		} else {
-			line := fmt.Sprintf("[%s] phase=%s revision=%s", name, result.Status.Phase, result.Status.Revision)
-			if result.Status.Error != "" {
-				line += " error=" + result.Status.Error
-			}
-			for _, environment := range result.Status.Environments {
-				for _, service := range environment.Services {
-					line += fmt.Sprintf(" %s/%s=%s", environment.Name, service.Name, service.State)
-				}
-			}
-			a.Printer.Println(line)
-		}
+		jsonResults = append(jsonResults, map[string]any{
+			"node":   name,
+			"status": result.Raw,
+		})
+
 	}
 
-	if a.Printer.JSON {
-		if err := a.Printer.PrintJSON(map[string]any{"nodes": jsonResults}); err != nil {
-			return err
-		}
-		if readErrors > 0 {
-			return ExitError{Code: 1, Err: RenderedError{Err: fmt.Errorf("status failed for %d node(s)", readErrors)}}
-		}
-		return nil
+	if err := a.Printer.PrintJSON(map[string]any{"nodes": jsonResults}); err != nil {
+		return err
 	}
 	if readErrors > 0 {
 		return ExitError{Code: 1, Err: RenderedError{Err: fmt.Errorf("status failed for %d node(s)", readErrors)}}
@@ -1151,18 +1111,9 @@ func (a *App) SoloSecretsSet(_ context.Context, opts SoloSecretsSetOptions) erro
 			return fmt.Errorf("secret saved locally but update devopsellence.yml failed: %w", err)
 		}
 	}
-	if a.Printer.JSON {
-		return a.Printer.PrintJSON(map[string]any{"key": record.Name, "service_name": record.ServiceName, "environment": record.Environment, "store": record.Store, "reference": record.Reference, "config_updated": configUpdated, "config_path": a.ConfigStore.PathFor(workspaceRoot), "action": "saved"})
-	}
-	if record.Store == solo.SecretStoreOnePassword {
-		a.Printer.Println(fmt.Sprintf("Secret %q saved for %s in %s from 1Password", record.Name, record.ServiceName, record.Environment))
-	} else {
-		a.Printer.Println(fmt.Sprintf("Secret %q saved for %s in %s", record.Name, record.ServiceName, record.Environment))
-	}
-	if configUpdated {
-		a.Printer.Println("Updated:", a.ConfigStore.PathFor(workspaceRoot))
-	}
-	return nil
+
+	return a.Printer.PrintJSON(map[string]any{"key": record.Name, "service_name": record.ServiceName, "environment": record.Environment, "store": record.Store, "reference": record.Reference, "config_updated": configUpdated, "config_path": a.ConfigStore.PathFor(workspaceRoot), "action": "saved"})
+
 }
 
 func soloSecretStore(opts SoloSecretsSetOptions) (string, error) {
@@ -1294,17 +1245,9 @@ func (a *App) SoloSecretsList(_ context.Context, opts SoloSecretsListOptions) er
 		return err
 	}
 	items := soloSecretListItems(cfg, secrets, opts.ServiceName)
-	if a.Printer.JSON {
-		return a.Printer.PrintJSON(map[string]any{"schema_version": outputSchemaVersion, "environment": environmentName, "secrets": items})
-	}
-	if len(items) == 0 {
-		a.Printer.Println("No secrets configured")
-		return nil
-	}
-	for _, item := range items {
-		a.Printer.Println(formatListedSecret(item))
-	}
-	return nil
+
+	return a.Printer.PrintJSON(map[string]any{"schema_version": outputSchemaVersion, "environment": environmentName, "secrets": items})
+
 }
 
 func soloSecretListItems(cfg *config.ProjectConfig, secrets []solo.SecretRecord, serviceFilter string) []listedSecret {
@@ -1384,25 +1327,13 @@ func (a *App) SoloNodeList(_ context.Context, _ SoloNodeListOptions) error {
 			CurrentEnvironmentBound: bound,
 		})
 	}
-	if a.Printer.JSON {
-		return a.Printer.PrintJSON(map[string]any{
-			"schema_version": outputSchemaVersion,
-			"nodes":          current.Nodes,
-			"node_items":     items,
-		})
-	}
-	if len(items) == 0 {
-		a.Printer.Println("No nodes.")
-		return nil
-	}
-	for _, item := range items {
-		line := fmt.Sprintf("%s  host=%s  labels=%s  attachments=%d", item.Name, item.Node.Host, strings.Join(item.Node.Labels, ","), len(item.Attachments))
-		if item.CurrentEnvironmentBound {
-			line += "  current=yes"
-		}
-		a.Printer.Println(line)
-	}
-	return nil
+
+	return a.Printer.PrintJSON(map[string]any{
+		"schema_version": outputSchemaVersion,
+		"nodes":          current.Nodes,
+		"node_items":     items,
+	})
+
 }
 
 func (a *App) SoloNodeAttach(ctx context.Context, opts SoloNodeAttachOptions) error {
@@ -1427,19 +1358,13 @@ func (a *App) SoloNodeAttach(ctx context.Context, opts SoloNodeAttachOptions) er
 			return err
 		}
 	}
-	if a.Printer.JSON {
-		return a.Printer.PrintJSON(map[string]any{
-			"node":        opts.Node,
-			"environment": environmentName,
-			"changed":     changed,
-		})
-	}
-	if changed {
-		a.Printer.Println("Attached solo node " + opts.Node + " to " + environmentName)
-	} else {
-		a.Printer.Println("Solo node " + opts.Node + " already attached to " + environmentName)
-	}
-	return nil
+
+	return a.Printer.PrintJSON(map[string]any{
+		"node":        opts.Node,
+		"environment": environmentName,
+		"changed":     changed,
+	})
+
 }
 
 func (a *App) runSoloNodeAttach(ctx context.Context, opts SoloNodeAttachOptions) error {
@@ -1479,15 +1404,13 @@ func (a *App) SoloNodeDetach(ctx context.Context, opts SoloNodeDetachOptions) er
 	if _, err := a.republishNodes(ctx, current, affectedNodeNames); err != nil {
 		return err
 	}
-	if a.Printer.JSON {
-		return a.Printer.PrintJSON(map[string]any{
-			"node":        opts.Node,
-			"environment": environmentName,
-			"changed":     true,
-		})
-	}
-	a.Printer.Println("Detached solo node " + opts.Node + " from " + environmentName)
-	return nil
+
+	return a.Printer.PrintJSON(map[string]any{
+		"node":        opts.Node,
+		"environment": environmentName,
+		"changed":     true,
+	})
+
 }
 
 func (a *App) SoloSecretsDelete(_ context.Context, opts SoloSecretsDeleteOptions) error {
@@ -1520,14 +1443,9 @@ func (a *App) SoloSecretsDelete(_ context.Context, opts SoloSecretsDeleteOptions
 			return fmt.Errorf("secret deleted locally but update devopsellence.yml failed: %w", err)
 		}
 	}
-	if a.Printer.JSON {
-		return a.Printer.PrintJSON(map[string]any{"key": record.Name, "service_name": record.ServiceName, "environment": record.Environment, "config_updated": configUpdated, "config_path": a.ConfigStore.PathFor(workspaceRoot), "action": "deleted"})
-	}
-	a.Printer.Println(fmt.Sprintf("Secret %q deleted for %s in %s", record.Name, record.ServiceName, record.Environment))
-	if configUpdated {
-		a.Printer.Println("Updated:", a.ConfigStore.PathFor(workspaceRoot))
-	}
-	return nil
+
+	return a.Printer.PrintJSON(map[string]any{"key": record.Name, "service_name": record.ServiceName, "environment": record.Environment, "config_updated": configUpdated, "config_path": a.ConfigStore.PathFor(workspaceRoot), "action": "deleted"})
+
 }
 
 func (a *App) SoloLogs(ctx context.Context, opts SoloLogsOptions) error {
@@ -1576,14 +1494,12 @@ func (a *App) SoloNodeLabelSet(ctx context.Context, opts SoloNodeLabelSetOptions
 	if _, err := a.republishNodes(ctx, current, soloAffectedNodesForNode(current, opts.Node)); err != nil {
 		return err
 	}
-	if a.Printer.JSON {
-		return a.Printer.PrintJSON(map[string]any{
-			"node":   opts.Node,
-			"labels": labels,
-		})
-	}
-	a.Printer.Println("Updated solo node " + opts.Node + " labels: " + strings.Join(labels, ","))
-	return nil
+
+	return a.Printer.PrintJSON(map[string]any{
+		"node":   opts.Node,
+		"labels": labels,
+	})
+
 }
 
 func (a *App) SoloAgentInstall(ctx context.Context, opts SoloAgentInstallOptions) error {
@@ -1595,17 +1511,13 @@ func (a *App) SoloAgentInstall(ctx context.Context, opts SoloAgentInstallOptions
 	if !ok {
 		return fmt.Errorf("node %q not found", opts.Node)
 	}
-	if !a.Printer.JSON {
-		a.Printer.Println("Installing solo agent on " + opts.Node + "...")
-	}
+
 	if err := a.installSoloAgent(ctx, opts.Node, node, opts); err != nil {
 		return err
 	}
-	if a.Printer.JSON {
-		return a.Printer.PrintJSON(map[string]any{"node": opts.Node, "action": "installed"})
-	}
-	a.Printer.Println("Installed solo agent on " + opts.Node)
-	return nil
+
+	return a.Printer.PrintJSON(map[string]any{"node": opts.Node, "action": "installed"})
+
 }
 
 func (a *App) SoloRuntimeDoctor(ctx context.Context, opts SoloDoctorOptions) error {
@@ -1636,23 +1548,12 @@ func (a *App) SoloRuntimeDoctor(ctx context.Context, opts SoloDoctorOptions) err
 				failed = true
 			}
 			results = append(results, map[string]any{"node": name, "check": check.name, "ok": ok})
-			if !a.Printer.JSON {
-				state := "ok"
-				if !ok {
-					state = "fail"
-				}
-				a.Printer.Println(fmt.Sprintf("[%s] %s=%s", name, check.name, state))
-			}
+
 		}
 	}
-	if a.Printer.JSON {
-		if err := a.Printer.PrintJSON(map[string]any{"checks": results}); err != nil {
-			return err
-		}
-		if failed {
-			return ExitError{Code: 1, Err: fmt.Errorf("solo doctor failed")}
-		}
-		return nil
+
+	if err := a.Printer.PrintJSON(map[string]any{"checks": results}); err != nil {
+		return err
 	}
 	if failed {
 		return ExitError{Code: 1, Err: fmt.Errorf("solo doctor failed")}
@@ -1741,24 +1642,12 @@ func (a *App) SoloDoctor(ctx context.Context) error {
 		}
 	}
 
-	if a.Printer.JSON {
-		return a.Printer.PrintJSON(map[string]any{
-			"schema_version": outputSchemaVersion,
-			"ok":             ok,
-			"checks":         checks,
-		})
-	}
-	for _, check := range checks {
-		prefix := "FAIL"
-		if check["ok"] == true {
-			prefix = "OK"
-		}
-		a.Printer.Println(prefix, fmt.Sprintf("%v:", check["name"]), check["detail"])
-	}
-	if ok && len(current.Nodes) > 0 {
-		return a.SoloRuntimeDoctor(ctx, SoloDoctorOptions{})
-	}
-	return nil
+	return a.Printer.PrintJSON(map[string]any{
+		"schema_version": outputSchemaVersion,
+		"ok":             ok,
+		"checks":         checks,
+	})
+
 }
 
 func (a *App) SoloNodeCreate(ctx context.Context, opts SoloNodeCreateOptions) error {
@@ -1790,9 +1679,7 @@ func (a *App) SoloNodeCreate(ctx context.Context, opts SoloNodeCreateOptions) er
 		return err
 	}
 	if !opts.NoInstall {
-		if !a.Printer.JSON {
-			a.Printer.Println("Waiting for SSH on " + opts.Name + "...")
-		}
+
 		if err := waitForSoloSSH(ctx, created.Node, 3*time.Minute); err != nil {
 			return err
 		}
@@ -1800,18 +1687,16 @@ func (a *App) SoloNodeCreate(ctx context.Context, opts SoloNodeCreateOptions) er
 			return err
 		}
 	}
-	if a.Printer.JSON {
-		return a.Printer.PrintJSON(map[string]any{
-			"node":               opts.Name,
-			"host":               created.Node.Host,
-			"labels":             created.Labels,
-			"provider":           created.ProviderSlug,
-			"provider_server_id": created.Server.ID,
-			"config_path":        a.ConfigStore.PathFor(workspaceRoot),
-		})
-	}
-	a.Printer.Println("Created solo node " + opts.Name + " at " + created.Node.Host)
-	return nil
+
+	return a.Printer.PrintJSON(map[string]any{
+		"node":               opts.Name,
+		"host":               created.Node.Host,
+		"labels":             created.Labels,
+		"provider":           created.ProviderSlug,
+		"provider_server_id": created.Server.ID,
+		"config_path":        a.ConfigStore.PathFor(workspaceRoot),
+	})
+
 }
 
 func (a *App) runSoloNodeCreate(ctx context.Context, opts SoloNodeCreateOptions) error {
@@ -1833,13 +1718,7 @@ func (a *App) ensureSoloNodeCreateSSHPublicKey(opts *SoloNodeCreateOptions, work
 		return err
 	}
 	opts.SSHPublicKey = generatedKey.PublicKeyPath
-	if !a.Printer.JSON {
-		action := "Reusing"
-		if generatedKey.Generated {
-			action = "Generated"
-		}
-		a.Printer.Println(fmt.Sprintf("%s workspace SSH key %s (%s)", action, generatedKey.PrivateKeyPath, generatedKey.Fingerprint))
-	}
+
 	return nil
 }
 
@@ -1872,66 +1751,57 @@ func (a *App) SharedSoloNodeCreate(ctx context.Context, opts SharedSoloNodeCreat
 		return err
 	}
 	if opts.NoInstall {
-		if a.Printer.JSON {
-			return a.Printer.PrintJSON(map[string]any{
-				"schema_version":     outputSchemaVersion,
-				"node":               opts.Name,
-				"host":               created.Node.Host,
-				"labels":             created.Labels,
-				"provider":           created.ProviderSlug,
-				"provider_server_id": created.Server.ID,
-				"registered":         false,
-			})
-		}
-		a.Printer.Println("Created shared node " + opts.Name + " at " + created.Node.Host + " without installing the agent")
-		return nil
-	}
 
-	installCommand := strings.TrimSpace(stringFromMap(bootstrap.Result, "install_command"))
-	if installCommand == "" {
-		return fmt.Errorf("node bootstrap response did not include install_command")
-	}
-	if !a.Printer.JSON {
-		a.Printer.Println("Waiting for SSH on " + opts.Name + "...")
-	}
-	if err := waitForSoloSSH(ctx, created.Node, 3*time.Minute); err != nil {
-		return err
-	}
-	if !a.Printer.JSON {
-		a.Printer.Println("Installing and registering devopsellence agent on " + opts.Name + "...")
-	}
-	stdout, stderr := a.Printer.Out, a.Printer.Err
-	if a.Printer.JSON {
-		stdout, stderr = io.Discard, io.Discard
-	}
-	if err := solo.RunSSHInteractive(ctx, created.Node, installCommand, stdout, stderr); err != nil {
-		return err
-	}
-
-	if a.Printer.JSON {
-		result := map[string]any{
+		return a.Printer.PrintJSON(map[string]any{
 			"schema_version":     outputSchemaVersion,
 			"node":               opts.Name,
 			"host":               created.Node.Host,
 			"labels":             created.Labels,
 			"provider":           created.ProviderSlug,
 			"provider_server_id": created.Server.ID,
-			"organization_id":    bootstrap.Organization.ID,
-			"organization_name":  bootstrap.Organization.Name,
-			"registered":         true,
-		}
-		if opts.Unassigned {
-			result["assignment_mode"] = "unassigned"
-		} else {
-			result["assignment_mode"] = firstNonEmpty(stringFromMap(bootstrap.Result, "assignment_mode"), "environment")
-			result["project_name"] = bootstrap.Workspace.Project.Name
-			result["environment_id"] = bootstrap.Workspace.Environment.ID
-			result["environment_name"] = bootstrap.Workspace.Environment.Name
-		}
-		return a.Printer.PrintJSON(result)
+			"registered":         false,
+		})
+
 	}
-	a.Printer.Println("Created shared node " + opts.Name + " at " + created.Node.Host)
-	return nil
+
+	installCommand := strings.TrimSpace(stringFromMap(bootstrap.Result, "install_command"))
+	if installCommand == "" {
+		return fmt.Errorf("node bootstrap response did not include install_command")
+	}
+
+	if err := waitForSoloSSH(ctx, created.Node, 3*time.Minute); err != nil {
+		return err
+	}
+
+	stdout, stderr := a.Printer.Out, a.Printer.Err
+
+	stdout, stderr = io.Discard, io.Discard
+
+	if err := solo.RunSSHInteractive(ctx, created.Node, installCommand, stdout, stderr); err != nil {
+		return err
+	}
+
+	result := map[string]any{
+		"schema_version":     outputSchemaVersion,
+		"node":               opts.Name,
+		"host":               created.Node.Host,
+		"labels":             created.Labels,
+		"provider":           created.ProviderSlug,
+		"provider_server_id": created.Server.ID,
+		"organization_id":    bootstrap.Organization.ID,
+		"organization_name":  bootstrap.Organization.Name,
+		"registered":         true,
+	}
+	if opts.Unassigned {
+		result["assignment_mode"] = "unassigned"
+	} else {
+		result["assignment_mode"] = firstNonEmpty(stringFromMap(bootstrap.Result, "assignment_mode"), "environment")
+		result["project_name"] = bootstrap.Workspace.Project.Name
+		result["environment_id"] = bootstrap.Workspace.Environment.ID
+		result["environment_name"] = bootstrap.Workspace.Environment.Name
+	}
+	return a.Printer.PrintJSON(result)
+
 }
 
 func (a *App) SoloNodeRemove(ctx context.Context, opts SoloNodeRemoveOptions) error {
@@ -1956,11 +1826,9 @@ func (a *App) SoloNodeRemove(ctx context.Context, opts SoloNodeRemoveOptions) er
 		if err := a.writeSoloState(current); err != nil {
 			return err
 		}
-		if a.Printer.JSON {
-			return a.Printer.PrintJSON(map[string]any{"node": opts.Name, "action": "forgotten"})
-		}
-		a.Printer.Println("Removed solo node " + opts.Name + " from local state")
-		return nil
+
+		return a.Printer.PrintJSON(map[string]any{"node": opts.Name, "action": "forgotten"})
+
 	}
 	if provider == "" || providerServerID == "" {
 		return fmt.Errorf("node %q has incomplete provider metadata; refusing provider delete", opts.Name)
@@ -1976,11 +1844,9 @@ func (a *App) SoloNodeRemove(ctx context.Context, opts SoloNodeRemoveOptions) er
 	if err := a.writeSoloState(current); err != nil {
 		return err
 	}
-	if a.Printer.JSON {
-		return a.Printer.PrintJSON(map[string]any{"node": opts.Name, "action": "deleted"})
-	}
-	a.Printer.Println("Removed solo node " + opts.Name)
-	return nil
+
+	return a.Printer.PrintJSON(map[string]any{"node": opts.Name, "action": "deleted"})
+
 }
 
 func (a *App) SoloSetup(context.Context, SoloSetupOptions) error {
@@ -2068,17 +1934,13 @@ func (a *App) IngressSet(_ context.Context, opts IngressSetOptions) error {
 	if err != nil {
 		return err
 	}
-	if a.Printer.JSON {
-		return a.Printer.PrintJSON(map[string]any{
-			"schema_version": outputSchemaVersion,
-			"ingress":        written.Ingress,
-			"config_path":    a.ConfigStore.PathFor(discovered.WorkspaceRoot),
-		})
-	}
-	a.Printer.Println("Ingress hosts:", strings.Join(written.Ingress.Hosts, ","))
-	a.Printer.Println("TLS:", written.Ingress.TLS.Mode)
-	a.Printer.Println("Config:", a.ConfigStore.PathFor(discovered.WorkspaceRoot))
-	return nil
+
+	return a.Printer.PrintJSON(map[string]any{
+		"schema_version": outputSchemaVersion,
+		"ingress":        written.Ingress,
+		"config_path":    a.ConfigStore.PathFor(discovered.WorkspaceRoot),
+	})
+
 }
 
 func (a *App) IngressCheck(ctx context.Context, opts IngressCheckOptions) error {
@@ -2108,13 +1970,11 @@ func (a *App) IngressCheck(ctx context.Context, opts IngressCheckOptions) error 
 			return err
 		}
 		if report.OK || opts.Wait <= 0 || time.Now().After(deadline) {
-			if a.Printer.JSON {
-				if err := a.Printer.PrintJSON(report); err != nil {
-					return err
-				}
-			} else {
-				printIngressDNSReport(a.Printer, report)
+
+			if err := a.Printer.PrintJSON(report); err != nil {
+				return err
 			}
+
 			if !report.OK {
 				return ExitError{Code: 1, Err: fmt.Errorf("ingress DNS is not ready")}
 			}
@@ -2125,15 +1985,6 @@ func (a *App) IngressCheck(ctx context.Context, opts IngressCheckOptions) error 
 			return ctx.Err()
 		case <-time.After(5 * time.Second):
 		}
-	}
-}
-
-func (a *App) soloProgress(nodeName string) func(string) {
-	if a.Printer.JSON {
-		return func(string) {}
-	}
-	return func(message string) {
-		a.Printer.Println("[" + nodeName + "] " + message)
 	}
 }
 
@@ -2274,9 +2125,7 @@ func (a *App) checkIngressBeforeDeploy(ctx context.Context, cfg *config.ProjectC
 	if report.OK {
 		return nil
 	}
-	if !a.Printer.JSON {
-		printIngressDNSReport(a.Printer, report)
-	}
+
 	return fmt.Errorf("ingress DNS is not ready; update DNS or pass --skip-dns-check")
 }
 
@@ -2313,27 +2162,6 @@ func ingressDNSReport(ctx context.Context, cfg *config.ProjectConfig, selected m
 		report.Hosts = append(report.Hosts, result)
 	}
 	return report, nil
-}
-
-func printIngressDNSReport(printer output.Printer, report ingressDNSReportResult) {
-	printer.Println("Expected IPs:", strings.Join(report.ExpectedIPs, ","))
-	for _, host := range report.Hosts {
-		state := "ok"
-		if !host.OK {
-			state = "fail"
-		}
-		line := fmt.Sprintf("%s  %s", state, host.Host)
-		if len(host.Resolved) > 0 {
-			line += " resolved=" + strings.Join(host.Resolved, ",")
-		}
-		if len(host.Missing) > 0 {
-			line += " missing=" + strings.Join(host.Missing, ",")
-		}
-		if host.Error != "" {
-			line += " error=" + host.Error
-		}
-		printer.Println(line)
-	}
 }
 
 func webNodeIPs(cfg *config.ProjectConfig, selected map[string]config.Node) []string {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1521,15 +1521,30 @@ func (a *App) SoloAgentInstall(ctx context.Context, opts SoloAgentInstallOptions
 }
 
 func (a *App) SoloRuntimeDoctor(ctx context.Context, opts SoloDoctorOptions) error {
-	current, err := a.readSoloState()
+	results, failed, err := a.soloRuntimeDoctorChecks(ctx, opts)
 	if err != nil {
 		return err
+	}
+
+	if err := a.Printer.PrintJSON(map[string]any{"checks": results}); err != nil {
+		return err
+	}
+	if failed {
+		return ExitError{Code: 1, Err: fmt.Errorf("solo doctor failed")}
+	}
+	return nil
+}
+
+func (a *App) soloRuntimeDoctorChecks(ctx context.Context, opts SoloDoctorOptions) ([]map[string]any, bool, error) {
+	current, err := a.readSoloState()
+	if err != nil {
+		return nil, false, err
 	}
 	nodes, err := a.resolveNodes(current, opts.Nodes)
 	if err != nil {
-		return err
+		return nil, false, err
 	}
-	results := make([]map[string]any, 0, len(nodes))
+	results := make([]map[string]any, 0, len(nodes)*3)
 	failed := false
 	for _, name := range sortedNodeNames(nodes) {
 		node := nodes[name]
@@ -1548,17 +1563,9 @@ func (a *App) SoloRuntimeDoctor(ctx context.Context, opts SoloDoctorOptions) err
 				failed = true
 			}
 			results = append(results, map[string]any{"node": name, "check": check.name, "ok": ok})
-
 		}
 	}
-
-	if err := a.Printer.PrintJSON(map[string]any{"checks": results}); err != nil {
-		return err
-	}
-	if failed {
-		return ExitError{Code: 1, Err: fmt.Errorf("solo doctor failed")}
-	}
-	return nil
+	return results, failed, nil
 }
 
 func (a *App) runSoloRuntimeDoctor(ctx context.Context, opts SoloDoctorOptions) error {
@@ -1642,11 +1649,28 @@ func (a *App) SoloDoctor(ctx context.Context) error {
 		}
 	}
 
-	return a.Printer.PrintJSON(map[string]any{
+	payload := map[string]any{
 		"schema_version": outputSchemaVersion,
 		"ok":             ok,
 		"checks":         checks,
-	})
+	}
+	if ok && len(current.Nodes) > 0 {
+		runtimeChecks, runtimeFailed, err := a.soloRuntimeDoctorChecks(ctx, SoloDoctorOptions{})
+		if err != nil {
+			return err
+		}
+		payload["runtime_checks"] = runtimeChecks
+		payload["ok"] = !runtimeFailed
+		if err := a.Printer.PrintJSON(payload); err != nil {
+			return err
+		}
+		if runtimeFailed {
+			return ExitError{Code: 1, Err: fmt.Errorf("solo doctor failed")}
+		}
+		return nil
+	}
+
+	return a.Printer.PrintJSON(payload)
 
 }
 
@@ -2360,8 +2384,11 @@ func installSoloAgent(ctx context.Context, node config.Node, opts SoloAgentInsta
 }
 
 func runSoloAgentInstallScript(ctx context.Context, node config.Node, script string, reporter soloInstallReporter) error {
-	writer := reporter.Stream()
-	return solo.RunSSHInteractiveWithStdin(ctx, node, "bash -s", strings.NewReader(script), writer, writer)
+	err := solo.RunSSHInteractiveWithStdin(ctx, node, "bash -s", strings.NewReader(script), reporter.Stdout(), reporter.Stderr())
+	if err != nil {
+		return sshInteractiveError("failed to run install script over SSH", err, reporter.CapturedStdout(), reporter.CapturedStderr())
+	}
+	return nil
 }
 
 type soloAgentInstallScriptOptions struct {

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -50,6 +50,39 @@ func TestDockerBuildArgsRejectsMultiplePlatforms(t *testing.T) {
 	}
 }
 
+func TestTailBufferExactLimitWriteIsNotTruncated(t *testing.T) {
+	buf := newTailBuffer(5)
+
+	n, err := buf.Write([]byte("abcde"))
+	if err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	if n != 5 {
+		t.Fatalf("Write() n = %d, want 5", n)
+	}
+	if got := buf.String(); got != "abcde" {
+		t.Fatalf("String() = %q, want %q", got, "abcde")
+	}
+}
+
+func TestTailBufferExactLimitWriteAfterExistingDataIsTruncated(t *testing.T) {
+	buf := newTailBuffer(5)
+	if _, err := buf.Write([]byte("ab")); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+
+	n, err := buf.Write([]byte("cdefg"))
+	if err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	if n != 5 {
+		t.Fatalf("Write() n = %d, want 5", n)
+	}
+	if got := buf.String(); got != "[truncated]\ncdefg" {
+		t.Fatalf("String() = %q, want bounded tail", got)
+	}
+}
+
 func TestTailBufferKeepsOnlyBoundedTail(t *testing.T) {
 	buf := newTailBuffer(10)
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -50,6 +50,47 @@ func TestDockerBuildArgsRejectsMultiplePlatforms(t *testing.T) {
 	}
 }
 
+func TestTailBufferKeepsOnlyBoundedTail(t *testing.T) {
+	buf := newTailBuffer(10)
+
+	n, err := buf.Write([]byte("abcdef"))
+	if err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	if n != 6 {
+		t.Fatalf("Write() n = %d, want 6", n)
+	}
+	if got := buf.String(); got != "abcdef" {
+		t.Fatalf("String() = %q, want %q", got, "abcdef")
+	}
+
+	n, err = buf.Write([]byte("ghijklmnop"))
+	if err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	if n != 10 {
+		t.Fatalf("Write() n = %d, want 10", n)
+	}
+	if got := buf.String(); got != "[truncated]\nghijklmnop" {
+		t.Fatalf("String() = %q, want bounded tail", got)
+	}
+}
+
+func TestTailBufferLargeWriteKeepsOnlyBoundedTail(t *testing.T) {
+	buf := newTailBuffer(5)
+
+	n, err := buf.Write([]byte("abcdefghijklmnopqrstuvwxyz"))
+	if err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	if n != 26 {
+		t.Fatalf("Write() n = %d, want 26", n)
+	}
+	if got := buf.String(); got != "[truncated]\nvwxyz" {
+		t.Fatalf("String() = %q, want bounded tail", got)
+	}
+}
+
 func TestSSHInteractiveErrorIncludesCapturedOutput(t *testing.T) {
 	err := errors.New("exit status 1")
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -50,6 +50,50 @@ func TestDockerBuildArgsRejectsMultiplePlatforms(t *testing.T) {
 	}
 }
 
+func TestSSHInteractiveErrorIncludesCapturedOutput(t *testing.T) {
+	err := errors.New("exit status 1")
+
+	cases := []struct {
+		name   string
+		stdout string
+		stderr string
+		want   string
+	}{
+		{
+			name:   "stderr and stdout",
+			stdout: "  boot failed\n",
+			stderr: "  permission denied\n",
+			want:   "failed to run install command over SSH: exit status 1; stderr: permission denied; stdout: boot failed",
+		},
+		{
+			name:   "stderr only",
+			stderr: "  permission denied\n",
+			want:   "failed to run install command over SSH: exit status 1; stderr: permission denied",
+		},
+		{
+			name:   "stdout only",
+			stdout: "  boot failed\n",
+			want:   "failed to run install command over SSH: exit status 1; stdout: boot failed",
+		},
+		{
+			name: "no captured output",
+			want: "failed to run install command over SSH: exit status 1",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sshInteractiveError("failed to run install command over SSH", err, tc.stdout, tc.stderr)
+			if got.Error() != tc.want {
+				t.Fatalf("error = %q, want %q", got.Error(), tc.want)
+			}
+			if !errors.Is(got, err) {
+				t.Fatalf("error does not wrap original error")
+			}
+		})
+	}
+}
+
 func TestSoloDefaultProjectConfigBootstrapsExplicitCatchAllIngress(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Remove the internal `Printer.JSON` mode switch now that the CLI is JSON-only.
- Make command result rendering call `PrintJSON` directly instead of branching between JSON and human output.
- Drop legacy human-output helpers and discard solo install/progress noise unconditionally.
- Update tests that previously toggled JSON mode directly.

## Validation

- `cd cli && mise run test`
- `cd cli && mise run build`
- `git diff --check`
- independent pre-commit review found no blocking issues
