### PR TITLE
Revise CLI init and node create flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ devopsellence is agent-first. The installer prints the agent skill command; to i
 curl -fsSL https://www.devopsellence.com/lfg.sh | bash -s -- --install-agent-skill
 ```
 
-Choose the workspace mode once:
+Initialize the workspace:
 
 ```bash
-devopsellence mode use solo
+devopsellence init --mode solo
 ```
 
 Check local tooling:
@@ -47,21 +47,22 @@ Check local tooling:
 devopsellence doctor
 ```
 
-Prepare the app, connect a node, and install the agent:
+Register an existing SSH-accessible VM, install the agent, and attach it to the current environment:
 
 ```bash
-devopsellence provider login hetzner
-devopsellence setup
+devopsellence node create prod-1 --host 203.0.113.10 --user root --ssh-key ~/.ssh/id_ed25519
+devopsellence agent install prod-1
+devopsellence node attach prod-1
 ```
-
-For provider-created solo nodes, `devopsellence setup` and `devopsellence node create` can generate a workspace-scoped SSH keypair under `$XDG_STATE_HOME/devopsellence/solo/keys/` (default: `~/.local/state/devopsellence/solo/keys/`) and reuse it for later node creation from the same workspace.
 
 Or create a Hetzner-backed node from the provider:
 
 ```bash
-devopsellence node create prod-1 --provider hetzner
-devopsellence node attach prod-1
+devopsellence provider login hetzner --token "$HCLOUD_TOKEN"
+devopsellence node create prod-1 --provider hetzner --install --attach
 ```
+
+For provider-created solo nodes, `devopsellence node create` can generate a workspace-scoped SSH keypair under `$XDG_STATE_HOME/devopsellence/solo/keys/` (default: `~/.local/state/devopsellence/solo/keys/`) and reuse it for later node creation from the same workspace.
 
 Deploy over SSH:
 
@@ -83,7 +84,7 @@ devopsellence deploy
 Store solo-mode deploy secrets locally:
 
 ```bash
-printf '%s' "$RAILS_MASTER_KEY" | devopsellence secret set RAILS_MASTER_KEY --stdin
+printf '%s' "$RAILS_MASTER_KEY" | devopsellence secret set RAILS_MASTER_KEY --service web --stdin
 devopsellence secret list
 ```
 
@@ -94,9 +95,8 @@ Solo mode keeps app config workload-only. Solo nodes, local environment attachme
 When you want sign-in, teams, org/project/env context, hosted deploy APIs, or managed node workflows:
 
 ```bash
-devopsellence mode use shared
-devopsellence setup
-devopsellence provider login hetzner
+devopsellence init --mode shared
+devopsellence provider login hetzner --token "$HCLOUD_TOKEN"
 devopsellence node create prod-1 --provider hetzner
 devopsellence deploy
 devopsellence status
@@ -209,7 +209,7 @@ The product layering is deliberate:
 - shared mode when coordination matters.
 - hosted or self-hosted depending on how much convenience you want.
 
-When you outgrow solo, `devopsellence mode use shared` switches to control-plane workflows. Same config, same agent, same deploy verbs.
+When you outgrow solo, `devopsellence init --mode shared` switches to control-plane workflows. Same config, same agent, same deploy verbs.
 
 The design rationale lives in [`docs/vision.md`](docs/vision.md). The explicit ingress-rules + generic-services schema change is documented in [`docs/specs/2026-04-24-explicit-ingress-rules-and-generic-services.md`](docs/specs/2026-04-24-explicit-ingress-rules-and-generic-services.md).
 

--- a/cli/internal/workflow/app.go
+++ b/cli/internal/workflow/app.go
@@ -502,6 +502,7 @@ func (a *App) Init(ctx context.Context, opts InitOptions) error {
 		}
 		result = map[string]any{
 			"schema_version":       outputSchemaVersion,
+			"mode":                 string(ModeShared),
 			"organization_id":      initialized.Organization.ID,
 			"organization_name":    initialized.Organization.Name,
 			"organization_created": initialized.CreatedOrg,
@@ -917,7 +918,7 @@ func initGeneratedFilesCommitMessage(discovered discovery.Result, entries []stri
 			paths = append(paths, path)
 		}
 	}
-	return "workspace contains devopsellence setup files that are not committed yet. commit them before deploy:\n\n  git add " + strings.Join(paths, " ") + "\n  git commit -m \"Set up devopsellence\""
+	return "workspace contains devopsellence init files that are not committed yet. commit them before deploy:\n\n  git add " + strings.Join(paths, " ") + "\n  git commit -m \"Initialize devopsellence\""
 }
 
 func deployDirtyIgnorePaths(store config.Store, discovered discovery.Result, existing *config.ProjectConfig) []string {
@@ -1625,7 +1626,7 @@ func (a *App) requireConfiguredService(workspaceRoot, serviceName string) error 
 		return wrapError(err)
 	}
 	if cfg == nil {
-		return ExitError{Code: 2, Err: errors.New("missing devopsellence.yml; run `devopsellence setup` first")}
+		return ExitError{Code: 2, Err: errors.New("missing devopsellence.yml; run `devopsellence init --mode shared` first")}
 	}
 	if _, ok := cfg.Services[serviceName]; !ok {
 		return ExitError{Code: 2, Err: fmt.Errorf("service %q not found in devopsellence.yml", serviceName)}
@@ -1640,7 +1641,7 @@ func (a *App) requireConfigurableSecretRef(workspaceRoot, serviceName, name stri
 		return wrapError(err)
 	}
 	if cfg == nil {
-		return ExitError{Code: 2, Err: errors.New("missing devopsellence.yml; run `devopsellence setup` first")}
+		return ExitError{Code: 2, Err: errors.New("missing devopsellence.yml; run `devopsellence init --mode shared` first")}
 	}
 	service, ok := cfg.Services[serviceName]
 	if !ok {
@@ -1659,7 +1660,7 @@ func (a *App) upsertWorkspaceSecretRef(workspaceRoot, serviceName string, ref co
 		return false, wrapError(err)
 	}
 	if cfg == nil {
-		return false, ExitError{Code: 2, Err: errors.New("missing devopsellence.yml; run `devopsellence setup` first")}
+		return false, ExitError{Code: 2, Err: errors.New("missing devopsellence.yml; run `devopsellence init --mode shared` first")}
 	}
 	if _, ok := cfg.Services[serviceName]; !ok {
 		return false, ExitError{Code: 2, Err: fmt.Errorf("service %q not found in devopsellence.yml", serviceName)}
@@ -1684,7 +1685,7 @@ func (a *App) removeWorkspaceSecretRef(workspaceRoot, serviceName, name string) 
 		return false, wrapError(err)
 	}
 	if cfg == nil {
-		return false, ExitError{Code: 2, Err: errors.New("missing devopsellence.yml; run `devopsellence setup` first")}
+		return false, ExitError{Code: 2, Err: errors.New("missing devopsellence.yml; run `devopsellence init --mode shared` first")}
 	}
 	if _, ok := cfg.Services[serviceName]; !ok {
 		return false, ExitError{Code: 2, Err: fmt.Errorf("service %q not found in devopsellence.yml", serviceName)}
@@ -2585,7 +2586,7 @@ func (a *App) resolveOrganizationReadOnly(ctx context.Context, token, input stri
 		return match, nil
 	}
 	if len(orgs) == 0 {
-		return api.Organization{}, ExitError{Code: 2, Err: errors.New("no organizations found. run `devopsellence setup --mode shared` first")}
+		return api.Organization{}, ExitError{Code: 2, Err: errors.New("no organizations found. run `devopsellence init --mode shared` first")}
 	}
 	if len(orgs) == 1 {
 		_ = a.rememberOrganization(orgs[0].ID)
@@ -3031,7 +3032,7 @@ func (a *App) requiredWorkspaceConfig() (discovery.Result, config.ProjectConfig,
 		return discovery.Result{}, config.ProjectConfig{}, err
 	}
 	if loaded == nil {
-		return discovery.Result{}, config.ProjectConfig{}, errors.New("project not initialized. run `devopsellence setup` first")
+		return discovery.Result{}, config.ProjectConfig{}, errors.New("project not initialized. run `devopsellence init --mode shared` first")
 	}
 	return discovered, *loaded, nil
 }
@@ -3042,7 +3043,7 @@ func (a *App) resolvedWorkspaceConfig(explicitEnvironment string) (discovery.Res
 		return discovery.Result{}, config.ProjectConfig{}, "", err
 	}
 	if loaded == nil {
-		return discovery.Result{}, config.ProjectConfig{}, "", errors.New("project not initialized. run `devopsellence setup` first")
+		return discovery.Result{}, config.ProjectConfig{}, "", errors.New("project not initialized. run `devopsellence init --mode shared` first")
 	}
 	selectedEnvironment := a.effectiveEnvironment(explicitEnvironment, loaded)
 	resolved, err := config.ResolveEnvironmentConfig(*loaded, selectedEnvironment)

--- a/cli/internal/workflow/management_test.go
+++ b/cli/internal/workflow/management_test.go
@@ -1882,7 +1882,7 @@ func TestDeployReportsManagedCapacityFallback(t *testing.T) {
 	}
 	commitAll(t, root, "add config")
 
-	const capacityError = "No managed server capacity is available in ash/cpx11 right now. Retry in a few minutes, or use your own VM/server with `devopsellence mode use solo` and `devopsellence setup`."
+	const capacityError = "No managed server capacity is available in ash/cpx11 right now. Retry in a few minutes, or use your own VM/server with `devopsellence init --mode solo`."
 
 	var stdout bytes.Buffer
 	app := newTestApp(t, root, roundTripFunc(func(r *http.Request) (*http.Response, error) {
@@ -3086,7 +3086,7 @@ func TestDeployFailsWhenExistingConfigIsUncommitted(t *testing.T) {
 	if err == nil {
 		t.Fatal("Deploy() error = nil, want dirty-worktree failure")
 	}
-	if !strings.Contains(err.Error(), "workspace contains devopsellence setup files that are not committed yet") {
+	if !strings.Contains(err.Error(), "workspace contains devopsellence init files that are not committed yet") {
 		t.Fatalf("Deploy() error = %v", err)
 	}
 	if !strings.Contains(err.Error(), "git add "+config.GenericFilePath) {

--- a/cli/internal/workflow/mode.go
+++ b/cli/internal/workflow/mode.go
@@ -19,7 +19,7 @@ const (
 	ModeShared Mode = "shared"
 )
 
-const modeUnsetError = "workspace mode is not set. Run `devopsellence mode use solo|shared`."
+const modeUnsetError = "workspace mode is not set. Run `devopsellence init --mode solo|shared` or `devopsellence mode use solo|shared`."
 
 func normalizeMode(value string) (Mode, error) {
 	switch strings.TrimSpace(strings.ToLower(value)) {
@@ -172,7 +172,7 @@ func (a *App) ResolveMode() (Mode, error) {
 	return "", ExitError{Code: 2, Err: errors.New(modeUnsetError)}
 }
 
-func (a *App) ResolveSetupMode(explicit string) (Mode, error) {
+func (a *App) ResolveInitMode(explicit string) (Mode, error) {
 	if strings.TrimSpace(explicit) == "" {
 		return a.ResolveMode()
 	}

--- a/cli/internal/workflow/root.go
+++ b/cli/internal/workflow/root.go
@@ -51,7 +51,7 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 					return modeErr
 				}
 				if mode != ModeSolo {
-					return ExitError{Code: 2, Err: fmt.Errorf("%s is only available in solo mode; run `devopsellence mode use solo`", name)}
+					return ExitError{Code: 2, Err: fmt.Errorf("%s is only available in solo mode; run `devopsellence init --mode solo`", name)}
 				}
 				return run(ctx)
 			})
@@ -66,7 +66,7 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 					return modeErr
 				}
 				if mode != ModeShared {
-					return ExitError{Code: 2, Err: fmt.Errorf("%s is only available in shared mode; run `devopsellence mode use shared`", name)}
+					return ExitError{Code: 2, Err: fmt.Errorf("%s is only available in shared mode; run `devopsellence init --mode shared`", name)}
 				}
 				return run(ctx)
 			})
@@ -81,13 +81,14 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 			"Commands emit structured JSON by default and avoid terminal-only interaction.",
 			"Use explicit flags, stdin, plans, and desired-state operations instead of prompts.",
 			"",
-			"Pick a workspace mode once with `devopsellence mode use solo|shared`.",
+			"Initialize a workspace with `devopsellence init --mode solo|shared`.",
 		}, "\n"),
 		Example: strings.Join([]string{
-			"  devopsellence mode use solo",
-			"  devopsellence setup",
+			"  devopsellence init --mode solo",
+			"  devopsellence node create prod-1 --host 203.0.113.10 --user root --ssh-key ~/.ssh/id_ed25519",
+			"  devopsellence agent install prod-1",
+			"  devopsellence node attach prod-1",
 			"  devopsellence deploy",
-			"  devopsellence context show",
 		}, "\n"),
 		SilenceErrors: true,
 		SilenceUsage:  true,
@@ -485,39 +486,39 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 	})
 	root.AddCommand(aliasCommand)
 
-	var setupSharedOpts InitOptions
-	var setupMode string
-	setupCommand := &cobra.Command{
-		Use:   "setup",
-		Short: "Prepare the current workspace for its selected mode",
+	var initSharedOpts InitOptions
+	var initMode string
+	initCommand := &cobra.Command{
+		Use:   "init",
+		Short: "Initialize workspace config for solo or shared mode",
 		Long: strings.Join([]string{
-			"Mode-driven workspace setup.",
-			"  solo   - initialize config if needed, register or create a node, attach it, and install the agent",
-			"  shared - sign in, create/select org/project/env, and write workspace config",
+			"Initialize the current workspace for a selected mode.",
+			"  solo   - write devopsellence.yml if missing and validate it if present",
+			"  shared - sign in, create/select org/project/env, and write devopsellence.yml",
 		}, "\n"),
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runWithTimeout(cmd, func(ctx context.Context) error {
-				mode, modeErr := app.ResolveSetupMode(setupMode)
+				mode, modeErr := app.ResolveInitMode(initMode)
 				if modeErr != nil {
 					return modeErr
 				}
 				switch mode {
 				case ModeSolo:
-					return app.SoloSetup(ctx, SoloSetupOptions{})
+					return app.SoloInit(ctx, SoloInitOptions{})
 				case ModeShared:
-					return app.Init(ctx, setupSharedOpts)
+					return app.Init(ctx, initSharedOpts)
 				default:
 					return ExitError{Code: 2, Err: fmt.Errorf("unsupported mode %q", mode)}
 				}
 			})
 		},
 	}
-	setupCommand.Flags().StringVar(&setupMode, "mode", "", "Set and use workspace mode for setup (solo or shared)")
-	setupCommand.Flags().StringVar(&setupSharedOpts.Organization, "org", "", "Organization name override (shared mode)")
-	setupCommand.Flags().StringVar(&setupSharedOpts.ProjectName, "project", "", "Project name override (shared mode)")
-	setupCommand.Flags().StringVar(&setupSharedOpts.Environment, "env", "", "Environment name override (shared mode)")
-	setupCommand.Flags().BoolVar(&setupSharedOpts.NonInteractive, "non-interactive", false, "Fail instead of prompting for missing values in shared mode")
-	root.AddCommand(setupCommand)
+	initCommand.Flags().StringVar(&initMode, "mode", "", "Set and use workspace mode for init (solo or shared)")
+	initCommand.Flags().StringVar(&initSharedOpts.Organization, "org", "", "Organization name override (shared mode)")
+	initCommand.Flags().StringVar(&initSharedOpts.ProjectName, "project", "", "Project name override (shared mode)")
+	initCommand.Flags().StringVar(&initSharedOpts.Environment, "env", "", "Environment name override (shared mode)")
+	initCommand.Flags().BoolVar(&initSharedOpts.NonInteractive, "non-interactive", false, "Fail instead of prompting for missing values in shared mode")
+	root.AddCommand(initCommand)
 
 	var deploySharedOpts DeployOptions
 	var deploySoloOpts SoloDeployOptions
@@ -758,7 +759,7 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 	nodeRegisterCommand.Flags().BoolVar(&nodeRegisterOpts.Unassigned, "unassigned", false, "Register the node without auto-attaching it to the current environment")
 	nodeCreateCommand := &cobra.Command{
 		Use:   "create <name>",
-		Short: "Create a provider-managed node",
+		Short: "Create or register a node",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			nodeCreateOpts.Name = args[0]
@@ -772,13 +773,18 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 			})(cmd, args)
 		},
 	}
-	nodeCreateCommand.Flags().StringVar(&nodeCreateOpts.Provider, "provider", "hetzner", "Provider")
+	nodeCreateCommand.Flags().StringVar(&nodeCreateOpts.Provider, "provider", "", "Provider for provisioning a new node, for example hetzner")
+	nodeCreateCommand.Flags().StringVar(&nodeCreateOpts.Host, "host", "", "Existing SSH host or IP address (solo mode)")
+	nodeCreateCommand.Flags().StringVar(&nodeCreateOpts.User, "user", "root", "SSH user for an existing node (solo mode)")
+	nodeCreateCommand.Flags().IntVar(&nodeCreateOpts.Port, "port", 22, "SSH port for an existing node (solo mode)")
+	nodeCreateCommand.Flags().StringVar(&nodeCreateOpts.SSHKey, "ssh-key", "", "SSH private key path for an existing node (solo mode)")
 	nodeCreateCommand.Flags().StringVar(&nodeCreateOpts.Region, "region", defaultHetznerRegion, "Provider region")
 	nodeCreateCommand.Flags().StringVar(&nodeCreateOpts.Size, "size", defaultHetznerSize, "Provider machine size")
 	nodeCreateCommand.Flags().StringVar(&nodeCreateOpts.Image, "image", "", "Provider image")
 	nodeCreateCommand.Flags().StringVar(&nodeCreateOpts.Labels, "labels", "", "Comma-separated labels")
-	nodeCreateCommand.Flags().StringVar(&nodeCreateOpts.SSHPublicKey, "ssh-public-key", "", "SSH public key path")
-	nodeCreateCommand.Flags().BoolVar(&nodeCreateOpts.NoInstall, "no-install", false, "Create the provider machine without installing the agent")
+	nodeCreateCommand.Flags().StringVar(&nodeCreateOpts.SSHPublicKey, "ssh-public-key", "", "SSH public key path for provider provisioning")
+	nodeCreateCommand.Flags().BoolVar(&nodeCreateOpts.Install, "install", false, "Install the solo agent after creating the node (solo mode)")
+	nodeCreateCommand.Flags().BoolVar(&nodeCreateOpts.Attach, "attach", false, "Attach the created solo node to the current environment (solo mode)")
 	nodeCreateCommand.Flags().StringVar(&nodeCreateBootstrapOpts.Organization, "org", "", "Shared-mode organization name override")
 	nodeCreateCommand.Flags().StringVar(&nodeCreateBootstrapOpts.Project, "project", "", "Shared-mode project name override")
 	nodeCreateCommand.Flags().StringVar(&nodeCreateBootstrapOpts.Environment, "env", "", "Shared-mode environment name override")

--- a/cli/internal/workflow/root_test.go
+++ b/cli/internal/workflow/root_test.go
@@ -2,7 +2,6 @@ package workflow
 
 import (
 	"bytes"
-	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -51,7 +50,7 @@ func TestRootModeFlagIsNotGlobal(t *testing.T) {
 	}
 }
 
-func TestSetupModeFlagPersistsWorkspaceMode(t *testing.T) {
+func TestInitModeFlagPersistsWorkspaceModeAndWritesConfig(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	cwd := t.TempDir()
 
@@ -59,18 +58,10 @@ func TestSetupModeFlagPersistsWorkspaceMode(t *testing.T) {
 	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, cwd)
 	cmd.SetOut(&stdout)
 	cmd.SetErr(&stdout)
-	cmd.SetArgs([]string{"setup", "--mode", "solo"})
+	cmd.SetArgs([]string{"init", "--mode", "solo"})
 
-	err := cmd.Execute()
-	if err == nil {
-		t.Fatal("Execute() error = nil, want solo setup to require explicit inputs")
-	}
-	if !strings.Contains(err.Error(), "solo setup requires explicit inputs") {
-		t.Fatalf("error = %v, want explicit input setup path", err)
-	}
-	var exitErr ExitError
-	if !errors.As(err, &exitErr) || exitErr.Code != 2 {
-		t.Fatalf("error = %#v, want ExitError code 2", err)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
 	}
 
 	app := NewApp(bytes.NewBuffer(nil), &stdout, &stdout, cwd)
@@ -80,6 +71,9 @@ func TestSetupModeFlagPersistsWorkspaceMode(t *testing.T) {
 	}
 	if !ok || mode != ModeSolo {
 		t.Fatalf("saved mode = %q, %v; want solo, true", mode, ok)
+	}
+	if _, err := config.LoadFromRoot(cwd); err != nil {
+		t.Fatal(err)
 	}
 }
 
@@ -261,10 +255,13 @@ func TestRootHelpShowsModeFirstFlows(t *testing.T) {
 	}
 	text := stdout.String()
 	for _, snippet := range []string{
-		"devopsellence mode use solo",
-		"devopsellence setup",
+		"devopsellence init --mode solo",
+		"devopsellence node create prod-1 --host 203.0.113.10 --user root --ssh-key ~/.ssh/id_ed25519",
+		"devopsellence agent install prod-1",
+		"devopsellence node attach prod-1",
 		"devopsellence deploy",
 		"context",
+		"init",
 		"mode",
 		"node",
 		"provider",
@@ -275,7 +272,7 @@ func TestRootHelpShowsModeFirstFlows(t *testing.T) {
 		}
 	}
 	for _, hidden := range []string{
-		"init",
+		"setup",
 		"direct",
 		"project     ",
 		"org         ",

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -91,12 +91,17 @@ type SoloDoctorOptions struct {
 type SoloNodeCreateOptions struct {
 	Name         string
 	Provider     string
+	Host         string
+	User         string
+	Port         int
+	SSHKey       string
 	Region       string
 	Size         string
 	Image        string
 	Labels       string
 	SSHPublicKey string
-	NoInstall    bool
+	Install      bool
+	Attach       bool
 }
 
 type SoloNodeRemoveOptions struct {
@@ -116,7 +121,7 @@ type providerNodeCreateResult struct {
 	ProviderSlug string
 }
 
-type SoloSetupOptions struct{}
+type SoloInitOptions struct{}
 
 type IngressSetOptions struct {
 	Hosts               []string
@@ -163,7 +168,10 @@ func (a *App) createProviderNode(ctx context.Context, opts SoloNodeCreateOptions
 	if err != nil {
 		return providerNodeCreateResult{}, err
 	}
-	providerSlug, err := normalizeProvider(firstNonEmpty(opts.Provider, providerHetzner))
+	if strings.TrimSpace(opts.Provider) == "" {
+		return providerNodeCreateResult{}, ExitError{Code: 2, Err: fmt.Errorf("node create requires --provider")}
+	}
+	providerSlug, err := normalizeProvider(opts.Provider)
 	if err != nil {
 		return providerNodeCreateResult{}, err
 	}
@@ -234,6 +242,63 @@ func (a *App) createProviderNode(ctx context.Context, opts SoloNodeCreateOptions
 		Labels:       labels,
 		ProviderSlug: providerSlug,
 	}, nil
+}
+
+func existingSSHNodeFromCreateOptions(opts SoloNodeCreateOptions) (config.Node, []string, error) {
+	labels, err := parseSoloLabels(firstNonEmpty(opts.Labels, strings.Join(config.DefaultNodeLabels, ",")))
+	if err != nil {
+		return config.Node{}, nil, err
+	}
+	user := strings.TrimSpace(opts.User)
+	if user == "" {
+		user = "root"
+	}
+	sshKey, err := expandSoloSSHKeyPath(opts.SSHKey)
+	if err != nil {
+		return config.Node{}, nil, err
+	}
+	port := opts.Port
+	if port < 1 || port > 65535 {
+		return config.Node{}, nil, ExitError{Code: 2, Err: fmt.Errorf("ssh port must be between 1 and 65535")}
+	}
+	node := config.Node{
+		Host:          strings.TrimSpace(opts.Host),
+		User:          user,
+		Port:          port,
+		SSHKey:        sshKey,
+		AgentStateDir: "/var/lib/devopsellence",
+		Labels:        labels,
+	}
+	return node, labels, nil
+}
+
+func expandSoloSSHKeyPath(path string) (string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "", nil
+	}
+	if path == "~" {
+		return "", fmt.Errorf("ssh key path %q must reference a private key file, not the home directory", path)
+	}
+	if strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("expand ssh key path: %w", err)
+		}
+		path = filepath.Join(home, strings.TrimPrefix(path, "~/"))
+	}
+	path = filepath.Clean(path)
+	info, err := os.Stat(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", fmt.Errorf("ssh key path %q does not exist", path)
+		}
+		return "", fmt.Errorf("stat ssh key path %q: %w", path, err)
+	}
+	if info.IsDir() {
+		return "", fmt.Errorf("ssh key path %q must be a file, not a directory", path)
+	}
+	return path, nil
 }
 
 func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
@@ -1624,7 +1689,7 @@ func (a *App) SoloDoctor(ctx context.Context) error {
 			return "", err
 		}
 		if cfg == nil {
-			return "", errors.New("No config found. Run `devopsellence setup`.")
+			return "", errors.New("No config found. Run `devopsellence init --mode solo`.")
 		}
 		return a.ConfigStore.PathFor(discovered.WorkspaceRoot), nil
 	})
@@ -1636,7 +1701,7 @@ func (a *App) SoloDoctor(ctx context.Context) error {
 			return "", err
 		}
 		if len(current.Nodes) == 0 {
-			return "", errors.New("No solo nodes registered yet. Run `devopsellence node create` or `devopsellence setup`.")
+			return "", errors.New("No solo nodes registered yet. Run `devopsellence node create`.")
 		}
 		return fmt.Sprintf("%d node(s) registered", len(current.Nodes)), nil
 	})
@@ -1675,7 +1740,7 @@ func (a *App) SoloDoctor(ctx context.Context) error {
 }
 
 func (a *App) SoloNodeCreate(ctx context.Context, opts SoloNodeCreateOptions) error {
-	cfg, workspaceRoot, err := a.loadProjectConfigForSoloUpdate()
+	cfg, workspaceRoot, err := a.loadSoloProjectConfig()
 	if err != nil {
 		return err
 	}
@@ -1683,43 +1748,92 @@ func (a *App) SoloNodeCreate(ctx context.Context, opts SoloNodeCreateOptions) er
 	if err != nil {
 		return err
 	}
-	if opts.Name == "" {
+	nodeName := strings.TrimSpace(opts.Name)
+	if nodeName == "" {
 		return fmt.Errorf("node name is required")
 	}
-	if _, ok := current.Nodes[opts.Name]; ok {
-		return fmt.Errorf("solo node %q already exists", opts.Name)
+	opts.Name = nodeName
+	if _, ok := current.Nodes[nodeName]; ok {
+		return fmt.Errorf("solo node %q already exists", nodeName)
 	}
-	if err := a.ensureSoloNodeCreateSSHPublicKey(&opts, workspaceRoot); err != nil {
+	hasProvider := strings.TrimSpace(opts.Provider) != ""
+	hasHost := strings.TrimSpace(opts.Host) != ""
+	if hasProvider == hasHost {
+		if hasProvider {
+			return ExitError{Code: 2, Err: fmt.Errorf("node create accepts either --provider or --host, not both")}
+		}
+		return ExitError{Code: 2, Err: fmt.Errorf("node create requires --provider or --host")}
+	}
+
+	var node config.Node
+	var labels []string
+	result := map[string]any{
+		"schema_version": outputSchemaVersion,
+		"node":           nodeName,
+		"config_path":    a.ConfigStore.PathFor(workspaceRoot),
+	}
+	if hasHost {
+		node, labels, err = existingSSHNodeFromCreateOptions(opts)
+		if err != nil {
+			return err
+		}
+		result["source"] = "existing_ssh"
+	} else {
+		if err := a.ensureSoloNodeCreateSSHPublicKey(&opts, workspaceRoot); err != nil {
+			return err
+		}
+		created, createErr := a.createProviderNode(ctx, opts, cfg.Project)
+		if createErr != nil {
+			return createErr
+		}
+		node = created.Node
+		labels = created.Labels
+		result["source"] = "provider"
+		result["provider"] = created.ProviderSlug
+		result["provider_server_id"] = created.Server.ID
+	}
+	if err := current.SetNode(nodeName, node); err != nil {
 		return err
 	}
-	created, err := a.createProviderNode(ctx, opts, cfg.Project)
-	if err != nil {
-		return err
-	}
-	if err := current.SetNode(opts.Name, created.Node); err != nil {
-		return err
+	attached := false
+	var attachment solo.AttachmentRecord
+	if opts.Attach {
+		environmentName := soloEnvironmentName(cfg, "")
+		var attachErr error
+		attachment, _, attachErr = a.attachNode(&current, workspaceRoot, environmentName, nodeName)
+		if attachErr != nil {
+			return attachErr
+		}
+		attached = true
+		result["environment"] = environmentName
 	}
 	if err := a.writeSoloState(current); err != nil {
 		return err
 	}
-	if !opts.NoInstall {
-
-		if err := waitForSoloSSH(ctx, created.Node, 3*time.Minute); err != nil {
+	installed := false
+	if opts.Install {
+		if err := waitForSoloSSH(ctx, node, 3*time.Minute); err != nil {
 			return err
 		}
-		if err := a.installSoloAgent(ctx, opts.Name, created.Node, SoloAgentInstallOptions{}); err != nil {
+		if err := a.installSoloAgent(ctx, nodeName, node, SoloAgentInstallOptions{}); err != nil {
 			return err
+		}
+		installed = true
+	}
+
+	if attached {
+		if _, ok := current.Snapshots[attachment.WorkspaceKey+"\n"+attachment.Environment]; ok {
+			if _, err := a.republishNodes(ctx, current, attachment.NodeNames); err != nil {
+				return err
+			}
 		}
 	}
 
-	return a.Printer.PrintJSON(map[string]any{
-		"node":               opts.Name,
-		"host":               created.Node.Host,
-		"labels":             created.Labels,
-		"provider":           created.ProviderSlug,
-		"provider_server_id": created.Server.ID,
-		"config_path":        a.ConfigStore.PathFor(workspaceRoot),
-	})
+	result["host"] = node.Host
+	result["labels"] = labels
+	result["agent_installed"] = installed
+	result["attached"] = attached
+	return a.Printer.PrintJSON(result)
 
 }
 
@@ -1750,42 +1864,45 @@ func (a *App) SharedSoloNodeCreate(ctx context.Context, opts SharedSoloNodeCreat
 	if opts.Name == "" {
 		return fmt.Errorf("node name is required")
 	}
+	if strings.TrimSpace(opts.Host) != "" {
+		return ExitError{Code: 2, Err: fmt.Errorf("node create --host is only available in solo mode")}
+	}
+	if strings.TrimSpace(opts.SSHKey) != "" {
+		return ExitError{Code: 2, Err: fmt.Errorf("node create --ssh-key is only available in solo mode")}
+	}
+	if opts.Install {
+		return ExitError{Code: 2, Err: fmt.Errorf("node create --install is only available in solo mode")}
+	}
+	if opts.Attach {
+		return ExitError{Code: 2, Err: fmt.Errorf("node create --attach is only available in solo mode")}
+	}
+	if strings.TrimSpace(opts.Provider) == "" {
+		return ExitError{Code: 2, Err: fmt.Errorf("node create requires --provider in shared mode")}
+	}
+	tokens, err := a.ensureAuth(ctx, false)
+	if err != nil {
+		return err
+	}
 	var bootstrap nodeBootstrapToken
-	if !opts.NoInstall {
-		tokens, err := a.ensureAuth(ctx, false)
-		if err != nil {
-			return err
-		}
-		run := func(ctx context.Context, update, _ func(string)) error {
-			var err error
-			bootstrap, err = a.createNodeBootstrapToken(ctx, &tokens, opts.NodeBootstrapOptions, update)
-			return err
-		}
-		if err := run(ctx, func(string) {}, func(string) {}); err != nil {
-			return err
-		}
+	run := func(ctx context.Context, update, _ func(string)) error {
+		var err error
+		bootstrap, err = a.createNodeBootstrapToken(ctx, &tokens, opts.NodeBootstrapOptions, update)
+		return err
+	}
+	if err := run(ctx, func(string) {}, func(string) {}); err != nil {
+		return err
 	}
 
 	projectName := opts.Project
 	if !opts.Unassigned && bootstrap.Workspace.Project.Name != "" {
 		projectName = bootstrap.Workspace.Project.Name
 	}
+	if err := a.ensureSoloNodeCreateSSHPublicKey(&opts.SoloNodeCreateOptions, bootstrap.Workspace.Discovery.WorkspaceRoot); err != nil {
+		return err
+	}
 	created, err := a.createProviderNode(ctx, opts.SoloNodeCreateOptions, projectName)
 	if err != nil {
 		return err
-	}
-	if opts.NoInstall {
-
-		return a.Printer.PrintJSON(map[string]any{
-			"schema_version":     outputSchemaVersion,
-			"node":               opts.Name,
-			"host":               created.Node.Host,
-			"labels":             created.Labels,
-			"provider":           created.ProviderSlug,
-			"provider_server_id": created.Server.ID,
-			"registered":         false,
-		})
-
 	}
 
 	installCommand := strings.TrimSpace(stringFromMap(bootstrap.Result, "install_command"))
@@ -1930,28 +2047,66 @@ func (a *App) SoloNodeRemove(ctx context.Context, opts SoloNodeRemoveOptions) er
 
 }
 
-func (a *App) SoloSetup(context.Context, SoloSetupOptions) error {
-	return ExitError{Code: 2, Err: fmt.Errorf("solo setup requires explicit inputs; use `devopsellence node create <name> --provider hetzner` for provider-managed nodes or `devopsellence node attach <name> --host <host> --user <user> --ssh-key <path>` for existing nodes")}
-}
-
-func (a *App) ensureSoloProjectConfig() (*config.ProjectConfig, string, error) {
+func (a *App) SoloInit(context.Context, SoloInitOptions) error {
 	discovered, err := discovery.Discover(a.Cwd)
 	if err != nil {
-		return nil, "", err
+		return err
 	}
 	cfg, err := a.ConfigStore.Read(discovered.WorkspaceRoot)
 	if err != nil {
-		return nil, "", err
+		return err
 	}
-	if cfg != nil {
-		return cfg, discovered.WorkspaceRoot, nil
+	created := false
+	if cfg == nil {
+		cfg = soloDefaultProjectConfig(discovered)
+		written, writeErr := a.ConfigStore.Write(discovered.WorkspaceRoot, *cfg)
+		if writeErr != nil {
+			return writeErr
+		}
+		cfg = &written
+		created = true
 	}
-	defaultCfg := soloDefaultProjectConfig(discovered)
-	written, err := a.ConfigStore.Write(discovered.WorkspaceRoot, *defaultCfg)
-	if err != nil {
-		return nil, "", err
+	configPath := a.ConfigStore.PathFor(discovered.WorkspaceRoot)
+	environmentName := soloEnvironmentName(cfg, "")
+	ready := false
+	if a.SoloState != nil {
+		current, stateErr := a.readSoloState()
+		if stateErr != nil {
+			return stateErr
+		}
+		attached, attachErr := current.AttachedNodeNames(discovered.WorkspaceRoot, environmentName)
+		if attachErr != nil {
+			return attachErr
+		}
+		ready = len(attached) > 0
 	}
-	return &written, discovered.WorkspaceRoot, nil
+	missing := []string{}
+	if !ready {
+		missing = append(missing, "node")
+	}
+	return a.Printer.PrintJSON(map[string]any{
+		"schema_version": outputSchemaVersion,
+		"mode":           string(ModeSolo),
+		"workspace_root": discovered.WorkspaceRoot,
+		"project_slug":   discovered.ProjectSlug,
+		"app_type":       discovered.AppType,
+		"fallback_used":  discovered.FallbackUsed,
+		"config": map[string]any{
+			"path":           configPath,
+			"created":        created,
+			"valid":          true,
+			"schema_version": cfg.SchemaVersion,
+		},
+		"environment": environmentName,
+		"ready":       ready,
+		"missing":     missing,
+		"next_steps": []string{
+			"devopsellence node create prod-1 --host <host> --user root --ssh-key <path>",
+			"devopsellence agent install prod-1",
+			"devopsellence node attach prod-1",
+			"devopsellence deploy",
+		},
+	})
 }
 
 func (a *App) IngressSet(_ context.Context, opts IngressSetOptions) error {
@@ -2086,24 +2241,9 @@ func (a *App) loadSoloProjectConfig() (*config.ProjectConfig, string, error) {
 		return nil, "", err
 	}
 	if cfg == nil {
-		return nil, "", fmt.Errorf("no devopsellence.yml found; run `devopsellence setup --mode solo`")
+		return nil, "", fmt.Errorf("no devopsellence.yml found; run `devopsellence init --mode solo`")
 	}
 	return cfg, workspaceRoot, nil
-}
-
-func (a *App) loadProjectConfigForSoloUpdate() (*config.ProjectConfig, string, error) {
-	discovered, err := discovery.Discover(a.Cwd)
-	if err != nil {
-		return nil, "", err
-	}
-	cfg, err := a.ConfigStore.Read(discovered.WorkspaceRoot)
-	if err != nil {
-		return nil, "", err
-	}
-	if cfg == nil {
-		cfg = soloDefaultProjectConfig(discovered)
-	}
-	return cfg, discovered.WorkspaceRoot, nil
 }
 
 func soloEnvironmentName(cfg *config.ProjectConfig, override string) string {

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -428,6 +428,86 @@ func TestCreateProviderNodeNormalizesHetznerProviderBeforeValidation(t *testing.
 	}
 }
 
+func TestSoloNodeCreateRejectsDuplicateAfterTrimmingName(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{Nodes: map[string]config.Node{"prod-1": {Host: "203.0.113.10", User: "root"}}}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+	app := &App{Printer: output.New(io.Discard, io.Discard), SoloState: soloState, ConfigStore: config.NewStore(), Cwd: workspaceRoot}
+
+	err := app.SoloNodeCreate(context.Background(), SoloNodeCreateOptions{Name: " prod-1 ", Host: "203.0.113.11", User: "root"})
+	if err == nil || !strings.Contains(err.Error(), `solo node "prod-1" already exists`) {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestSoloNodeCreateRegistersExistingSSHNode(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	wantKey := filepath.Join(home, ".ssh", "id_ed25519")
+	if err := os.MkdirAll(filepath.Dir(wantKey), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(wantKey, []byte("private key"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	if err := soloState.Write(solo.State{}); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{
+		Printer:     output.New(&stdout, io.Discard),
+		SoloState:   soloState,
+		ConfigStore: config.NewStore(),
+		Cwd:         workspaceRoot,
+	}
+	err := app.SoloNodeCreate(context.Background(), SoloNodeCreateOptions{
+		Name:   "prod-1",
+		Host:   "203.0.113.10",
+		User:   "deploy",
+		Port:   2222,
+		SSHKey: "~/.ssh/id_ed25519",
+		Labels: "web,worker",
+		Attach: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	current, err := soloState.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+	node := current.Nodes["prod-1"]
+	if node.Host != "203.0.113.10" || node.User != "deploy" || node.Port != 2222 || node.SSHKey != wantKey {
+		t.Fatalf("node = %#v, want ssh key %q", node, wantKey)
+	}
+	attached, err := current.AttachedNodeNames(workspaceRoot, "production")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(attached, []string{"prod-1"}) {
+		t.Fatalf("attached nodes = %#v", attached)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	if payload["source"] != "existing_ssh" || payload["attached"] != true || payload["agent_installed"] != false {
+		t.Fatalf("payload = %#v", payload)
+	}
+}
+
 func TestReleaseNodeForSnapshotSelectsSortedEligibleNode(t *testing.T) {
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")
 	cfg.Tasks.Release = &config.TaskConfig{Service: "web", Command: []string{"bin/rails", "db:migrate"}}
@@ -785,37 +865,6 @@ func TestDesiredStateRevisionReadsRevision(t *testing.T) {
 	}
 	if revision != "abc123" {
 		t.Fatalf("revision = %q, want abc123", revision)
-	}
-}
-
-func TestEnsureSoloProjectConfigWritesDefaultConfig(t *testing.T) {
-	t.Parallel()
-
-	workspaceRoot := t.TempDir()
-	if err := os.WriteFile(filepath.Join(workspaceRoot, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	app := &App{
-		ConfigStore: config.NewStore(),
-		Cwd:         workspaceRoot,
-	}
-
-	cfg, gotRoot, err := app.ensureSoloProjectConfig()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if gotRoot != workspaceRoot {
-		t.Fatalf("workspace root = %q, want %q", gotRoot, workspaceRoot)
-	}
-	if cfg == nil {
-		t.Fatal("config is nil")
-	}
-	if cfg.Organization != "solo" {
-		t.Fatalf("organization = %q, want solo", cfg.Organization)
-	}
-	if _, err := os.Stat(filepath.Join(workspaceRoot, "devopsellence.yml")); err != nil {
-		t.Fatalf("expected config file: %v", err)
 	}
 }
 
@@ -1539,15 +1588,54 @@ func TestEnsureNodeCreateSSHPublicKeyKeepsExplicitKey(t *testing.T) {
 	}
 }
 
-func TestSoloSetupRequiresExplicitInputs(t *testing.T) {
-	app := &App{Printer: output.New(io.Discard, io.Discard)}
-
-	err := app.SoloSetup(context.Background(), SoloSetupOptions{})
-	if err == nil {
-		t.Fatal("SoloSetup() error = nil, want explicit input error")
+func TestSoloInitCreatesWorkspaceConfig(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	var stdout bytes.Buffer
+	app := &App{
+		Printer:     output.New(&stdout, io.Discard),
+		ConfigStore: config.NewStore(),
+		Cwd:         workspaceRoot,
 	}
-	if !strings.Contains(err.Error(), "solo setup requires explicit inputs") {
-		t.Fatalf("SoloSetup() error = %v", err)
+
+	if err := app.SoloInit(context.Background(), SoloInitOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := config.LoadFromRoot(workspaceRoot); err != nil {
+		t.Fatal(err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	configPayload := jsonMapFromAny(t, payload["config"])
+	if configPayload["created"] != true || configPayload["valid"] != true {
+		t.Fatalf("config payload = %#v", configPayload)
+	}
+}
+
+func TestSoloInitReportsReadyWhenNodeAttached(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{Nodes: map[string]config.Node{"prod-1": {Host: "203.0.113.10", User: "root"}}}
+	if _, _, err := current.AttachNode(workspaceRoot, "production", "prod-1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState, ConfigStore: config.NewStore(), Cwd: workspaceRoot}
+	if err := app.SoloInit(context.Background(), SoloInitOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	if payload["ready"] != true {
+		t.Fatalf("payload = %#v", payload)
+	}
+	if missing := jsonArrayFromMap(t, payload, "missing"); len(missing) != 0 {
+		t.Fatalf("missing = %#v, want empty", missing)
 	}
 }
 

--- a/control-plane/app/services/managed_nodes/provisioner.rb
+++ b/control-plane/app/services/managed_nodes/provisioner.rb
@@ -148,7 +148,7 @@ module ManagedNodes
       return error.message unless retryable_placement_error?(error)
 
       pools = pool_candidates.map { |candidate| "#{candidate.fetch(:region)}/#{candidate.fetch(:size_slug)}" }.join(", ")
-      "No managed server capacity is available in #{pools} right now. Retry in a few minutes, or use your own VM/server with `devopsellence mode use solo` and `devopsellence setup`."
+      "No managed server capacity is available in #{pools} right now. Retry in a few minutes, or use your own VM/server with `devopsellence init --mode solo`."
     end
   end
 end

--- a/control-plane/app/views/marketing/docs.html.erb
+++ b/control-plane/app/views/marketing/docs.html.erb
@@ -175,13 +175,13 @@
       </div>
       <div class="terminal-body">
         <div class="tl"><span class="tp">$</span> cd my-app</div>
-        <div class="tl"><span class="tp">$</span> devopsellence mode use solo</div>
-        <div class="tl tl-muted"># Use `shared` instead when you want sign-in, org/project/env context, and team workflows.</div>
+        <div class="tl"><span class="tp">$</span> devopsellence init --mode solo</div>
+        <div class="tl tl-muted"># Use `--mode shared` instead when you want sign-in, org/project/env context, and team workflows.</div>
       </div>
     </div>
-    <p>Mode is saved per workspace. You can switch later with <code>devopsellence mode use shared</code> or override a single command with <code>--mode</code>.</p>
+    <p>Mode is saved per workspace. You can switch later with <code>devopsellence init --mode shared</code> or override individual shared commands with explicit context flags.</p>
 
-    <h3>3. Set up the workspace</h3>
+    <h3>3. Add a node</h3>
     <div class="terminal">
       <div class="terminal-bar">
         <span class="dot dot-red"></span>
@@ -189,9 +189,9 @@
         <span class="dot dot-green"></span>
       </div>
       <div class="terminal-body">
-        <div class="tl"><span class="tp">$</span> devopsellence setup</div>
-        <div class="tl tl-muted"># solo: initialize config if needed, register or create a node, attach it, and install the agent.</div>
-        <div class="tl tl-muted"># shared: sign in, create or select org/project/env, and write workspace config.</div>
+        <div class="tl"><span class="tp">$</span> devopsellence node create prod-1 --host 203.0.113.10 --user root --ssh-key ~/.ssh/id_ed25519</div>
+        <div class="tl"><span class="tp">$</span> devopsellence agent install prod-1</div>
+        <div class="tl"><span class="tp">$</span> devopsellence node attach prod-1</div>
       </div>
     </div>
     <p>The root verbs stay the same across modes. The selected mode decides whether the CLI runs the solo SSH workflow or the shared control-plane workflow.</p>
@@ -307,7 +307,7 @@
     <p>Public ingress uses Envoy in solo and shared mode. Add hostnames with <code>devopsellence ingress set</code>; pass <code>--service</code> when the target web service is not already obvious. The agent answers HTTP-01 challenges and keeps HTTPS certificates on the node.</p>
 
     <h3>Set up a node</h3>
-    <p>Use the setup wizard for an existing SSH node or a Hetzner node created by the CLI:</p>
+    <p>Initialize the workspace, then register an existing SSH node or create a Hetzner node with the CLI:</p>
     <div class="terminal">
       <div class="terminal-bar">
         <span class="dot dot-red"></span>
@@ -315,13 +315,13 @@
         <span class="dot dot-green"></span>
       </div>
       <div class="terminal-body">
-        <div class="tl"><span class="tp">$</span> devopsellence mode use solo</div>
-        <div class="tl"><span class="tp">$</span> devopsellence setup</div>
-        <div class="tl tl-muted"># Existing node: prompts for host, user, labels, and SSH private key path.</div>
-        <div class="tl tl-muted"># Hetzner: prompts for region, size, labels, and defaults to a workspace-scoped generated SSH key.</div>
+        <div class="tl"><span class="tp">$</span> devopsellence init --mode solo</div>
+        <div class="tl"><span class="tp">$</span> devopsellence node create prod-1 --host 203.0.113.10 --user root --ssh-key ~/.ssh/id_ed25519</div>
+        <div class="tl"><span class="tp">$</span> devopsellence agent install prod-1</div>
+        <div class="tl"><span class="tp">$</span> devopsellence node attach prod-1</div>
       </div>
     </div>
-    <p>The wizard creates <code>devopsellence.yml</code> when needed, records the node and attachment in local solo state, installs Docker when supported, installs <code>devopsellence-agent</code>, starts the <code>devopsellence-agent</code> systemd service, and runs <code>doctor</code>. For provider-created solo nodes it can generate and reuse a workspace-scoped SSH keypair under local state instead of requiring a pre-existing SSH public key path.</p>
+    <p><code>devopsellence init --mode solo</code> creates <code>devopsellence.yml</code> when needed. Node commands record node inventory and environment attachments in local solo state. <code>devopsellence agent install</code> installs Docker when supported, installs <code>devopsellence-agent</code>, and starts the systemd service. For provider-created solo nodes, <code>node create</code> can generate and reuse a workspace-scoped SSH keypair under local state instead of requiring a pre-existing SSH public key path.</p>
 
     <h3>Create a Hetzner node</h3>
     <p>Provider tokens stay outside the config file. Save a Hetzner token locally, or set <code>DEVOPSELLENCE_HETZNER_API_TOKEN</code> or <code>HCLOUD_TOKEN</code>:</p>
@@ -847,16 +847,20 @@ tasks:
     <h3>Core</h3>
     <dl class="docs-fields">
       <div class="docs-field">
+        <dt><code>devopsellence init --mode solo|shared</code></dt>
+        <dd>Set the workspace mode and initialize the current checkout for that mode. In solo mode this can create <code>devopsellence.yml</code>; in shared mode this can sign in, create or select org/project/env context, and write <code>devopsellence.yml</code>.</dd>
+      </div>
+      <div class="docs-field">
         <dt><code>devopsellence mode use solo|shared</code></dt>
-        <dd>Persist the workspace mode for this checkout.</dd>
+        <dd>Persist only the workspace mode for this checkout.</dd>
       </div>
       <div class="docs-field">
         <dt><code>devopsellence mode show</code></dt>
         <dd>Show the current workspace mode.</dd>
       </div>
       <div class="docs-field">
-        <dt><code>devopsellence setup</code></dt>
-        <dd>Prepare the current workspace for its selected mode.</dd>
+        <dt><code>devopsellence init</code></dt>
+        <dd>Initialize the current workspace using its saved mode.</dd>
       </div>
       <div class="docs-field">
         <dt><code>devopsellence deploy</code></dt>
@@ -955,8 +959,8 @@ tasks:
     <h3>Solo mode</h3>
     <dl class="docs-fields">
       <div class="docs-field">
-        <dt><code>devopsellence setup</code></dt>
-        <dd>In solo mode, configure a node, write local node inventory, install the agent over SSH, and run diagnostics.</dd>
+        <dt><code>devopsellence init</code></dt>
+        <dd>In solo mode, ensure or validate <code>devopsellence.yml</code> and report readiness based on whether a node is attached. To prepare a node, use <code>devopsellence node create</code>, <code>devopsellence agent install</code>, and <code>devopsellence node attach</code>.</dd>
       </div>
       <div class="docs-field">
         <dt><code>devopsellence deploy</code></dt>
@@ -1107,7 +1111,7 @@ tasks:
 
     <h3>What changes</h3>
     <ul>
-      <li><strong>Mode</strong> &mdash; run <code>devopsellence mode use shared</code>, then <code>devopsellence setup</code> to sign in and create org/project/env context.</li>
+      <li><strong>Mode</strong> &mdash; run <code>devopsellence init --mode shared</code> to sign in and create org/project/env context.</li>
       <li><strong>Nodes</strong> &mdash; register your existing servers with <code>devopsellence node register</code> and run the install command on each server. The agent switches from file-watching to control-plane polling.</li>
       <li><strong>Images</strong> &mdash; instead of streaming over SSH, images are pushed to a container registry. The control plane handles registry credentials.</li>
       <li><strong>Secrets</strong> &mdash; re-create secrets with <code>devopsellence secret set &lt;name&gt; --service web --stdin</code>. They move from your local <code>.env</code> to encrypted server-side storage.</li>

--- a/control-plane/app/views/marketing/index.html.erb
+++ b/control-plane/app/views/marketing/index.html.erb
@@ -28,9 +28,8 @@
           <span class="dot dot-green"></span>
         </div>
         <div class="terminal-body">
-          <div class="tl"><span class="tp">$</span> devopsellence mode use solo</div>
-          <div class="tl"><span class="tp">$</span> devopsellence setup</div>
-          <div class="tl tl-muted">Connect an existing VM or let the CLI provision one.</div>
+          <div class="tl"><span class="tp">$</span> devopsellence init --mode solo</div>
+          <div class="tl"><span class="tp">$</span> devopsellence node create prod-1 --provider hetzner --install --attach</div>
           <div class="tl"><span class="tp">$</span> devopsellence deploy</div>
           <div class="tl tl-muted">Building...</div>
           <div class="tl tl-muted">Transferring image...</div>

--- a/control-plane/test/services/managed_nodes/provisioner_test.rb
+++ b/control-plane/test/services/managed_nodes/provisioner_test.rb
@@ -121,7 +121,7 @@ module ManagedNodes
         ).call(node_name: "pool-node")
       end
 
-      assert_equal "No managed server capacity is available in ash/cpx11 right now. Retry in a few minutes, or use your own VM/server with `devopsellence mode use solo` and `devopsellence setup`.", error.message
+      assert_equal "No managed server capacity is available in ash/cpx11 right now. Retry in a few minutes, or use your own VM/server with `devopsellence init --mode solo`.", error.message
       assert_equal 3, provider.attempts
       assert NodeBootstrapToken.order(:id).last.consumed_at.present?
     end
@@ -150,7 +150,7 @@ module ManagedNodes
         ).call(node_name: "pool-node")
       end
 
-      assert_equal "No managed server capacity is available in ash/cpx11, hil/cpx11 right now. Retry in a few minutes, or use your own VM/server with `devopsellence mode use solo` and `devopsellence setup`.", error.message
+      assert_equal "No managed server capacity is available in ash/cpx11, hil/cpx11 right now. Retry in a few minutes, or use your own VM/server with `devopsellence init --mode solo`.", error.message
       assert_equal 3, primary.attempts
       assert_equal 3, secondary.attempts
     end

--- a/deployment-core/pkg/deploycore/config/config.go
+++ b/deployment-core/pkg/deploycore/config/config.go
@@ -226,7 +226,7 @@ func Load(path string) (*ProjectConfig, error) {
 		cfg.App.Type = AppTypeGeneric
 	}
 	if cfg.SchemaVersion == 0 {
-		return nil, fmt.Errorf("invalid %s in %s: schema_version must be %d; re-run `devopsellence setup`", filepath.Base(path), path, SchemaVersion)
+		return nil, fmt.Errorf("invalid %s in %s: schema_version must be %d; re-run `devopsellence init --mode solo|shared`", filepath.Base(path), path, SchemaVersion)
 	}
 	applyDefaults(&cfg)
 	if err := Validate(&cfg); err != nil {
@@ -265,7 +265,7 @@ func (s Store) Fetch(workspaceRoot string) (ProjectConfig, error) {
 		return ProjectConfig{}, err
 	}
 	if cfg == nil {
-		return ProjectConfig{}, fmt.Errorf("project not initialized. run `devopsellence setup` from %s", workspaceRoot)
+		return ProjectConfig{}, fmt.Errorf("project not initialized. run `devopsellence init --mode solo|shared` from %s", workspaceRoot)
 	}
 	return *cfg, nil
 }
@@ -342,7 +342,7 @@ func Validate(cfg *ProjectConfig) error {
 		return errors.New("config is required")
 	}
 	if cfg.SchemaVersion != SchemaVersion {
-		return fmt.Errorf("schema_version must be %d; re-run `devopsellence setup`", SchemaVersion)
+		return fmt.Errorf("schema_version must be %d; re-run `devopsellence init --mode solo|shared`", SchemaVersion)
 	}
 	if cfg.App.Type != AppTypeRails && cfg.App.Type != AppTypeGeneric {
 		return fmt.Errorf("app.type must be %q or %q", AppTypeRails, AppTypeGeneric)

--- a/skills/devopsellence/SKILL.md
+++ b/skills/devopsellence/SKILL.md
@@ -25,23 +25,16 @@ If the command is missing, tell the user the devopsellence CLI is required and p
 devopsellence doctor
 ```
 
-4. Choose the workspace mode before the first setup:
+4. Initialize the workspace before the first deploy:
 
 ```sh
-devopsellence mode use shared
-```
-
-Then prepare the project:
-
-```sh
-devopsellence setup
+devopsellence init --mode shared
 ```
 
 If the user already knows the target workspace values, prefer explicit flags:
 
 ```sh
-devopsellence mode use shared
-devopsellence setup --org acme --project shop --env staging
+devopsellence init --mode shared --org acme --project shop --env staging
 ```
 
 5. Deploy the app:
@@ -59,7 +52,7 @@ devopsellence deploy --image docker.io/example/app@sha256:...
 6. Verify the result:
 
 ```sh
-devopsellence status --json
+devopsellence status
 ```
 
 ## Secrets
@@ -75,26 +68,30 @@ devopsellence secret delete NAME --service web
 
 ## Bring your own node
 
-Use these in shared mode when the user wants to run on their own machine or VM:
+Use these in shared mode for a provider-created node:
 
 ```sh
-devopsellence mode use shared
-devopsellence provider login hetzner
-devopsellence node create prod-1
-devopsellence node register
-devopsellence node list --json
+devopsellence init --mode shared
+devopsellence provider login hetzner --token "$HCLOUD_TOKEN"
+devopsellence node create prod-1 --provider hetzner
+devopsellence node list
 devopsellence node attach <id>
 devopsellence node detach <id>
 devopsellence node remove <id>
 ```
 
+Use this in shared mode for an existing server that you will install manually:
+
+```sh
+devopsellence node register
+```
+
 Use these in solo mode when the user wants SSH-first workflows without the control plane:
 
 ```sh
-devopsellence mode use solo
-devopsellence provider login hetzner
-devopsellence node create prod-1
-devopsellence setup
+devopsellence init --mode solo
+devopsellence provider login hetzner --token "$HCLOUD_TOKEN"
+devopsellence node create prod-1 --provider hetzner --install --attach
 devopsellence deploy
 devopsellence node logs <name> --follow
 ```

--- a/test/e2e/e2e.rb
+++ b/test/e2e/e2e.rb
@@ -657,9 +657,9 @@ class E2E
     def scaffold_app!(plain_env_value, release_marker_value:)
       FileUtils.mkdir_p(@app_dir)
       init_git_repo!
-      set_workspace_mode!
       run!(
-        cli_binary.to_s, "setup",
+        cli_binary.to_s, "init",
+        "--mode", "shared",
         "--non-interactive",
         "--project", @project_name,
         "--env", @environment_name,
@@ -671,17 +671,6 @@ class E2E
       build_app_server_binary!
       update_app_config!(plain_env_value, release_marker_value:)
       commit_all!("Initialize e2e app")
-    end
-
-    def set_workspace_mode!
-      output = run!(
-        cli_binary.to_s, "mode", "use", "shared",
-        chdir: @app_dir.to_s,
-        timeout: 30,
-        env: cli_env
-      )
-      result = parse_json_output(output)
-      raise "mode use shared did not confirm shared mode" unless result["mode"] == "shared"
     end
 
     def write_app_files!


### PR DESCRIPTION
## Summary
- replace the ambiguous setup command with explicit init for solo/shared workspace initialization
- make solo node create register existing SSH nodes and keep provider provisioning on the same verb
- update CLI help, docs, skill guidance, e2e bootstrap, and related error copy

## Verification
- mise run test:cli
- cd deployment-core && go test ./...
- ruby -c test/e2e/e2e.rb
- ruby -c test/e2e/solo_e2e.rb
- ruby -c control-plane/app/services/managed_nodes/provisioner.rb
- ruby -c control-plane/test/services/managed_nodes/provisioner_test.rb
- ruby -rerb -e 'ARGV.each { |p| ERB.new(File.read(p)).src; puts "OK #{p}" }' control-plane/app/views/marketing/index.html.erb control-plane/app/views/marketing/docs.html.erb\n\nNote: `mise run test:core` is blocked locally because deployment-core/mise.toml is not trusted; direct `go test ./...` in deployment-core passes.