### PR TITLE
Improve solo deploy feedback and cleanup UX

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,7 @@ cd control-plane && mise run test -- test/path/file_test.rb
 ## Review Handling
 
 - Explicit user product direction overrides reviewer suggestions.
-- If user says no legacy / no backward compat / clean slate, do not add backfills, shims, compat code, or rejection guards just to preserve or explicitly refute removed behavior; remove the deleted surface cleanly and simplify the codepath instead.
+- The default product stance is clean slate: no legacy behavior and no backward-compatibility promises unless explicitly requested. Do not add backfills, shims, compat code, or rejection guards just to preserve or explicitly refute removed behavior; remove deleted surfaces cleanly and simplify the codepath instead.
 - Open PRs as ready for review, not draft, unless the user explicitly asks for a draft.
 - After addressing a PR review thread, resolve the thread in GitHub so only remaining actionable feedback stays open.
 - Right after each PR is opened or updated with pushed fixes, request a fresh Copilot review with `gh pr edit <pr-number> --add-reviewer copilot-pull-request-reviewer`.

--- a/README.md
+++ b/README.md
@@ -94,11 +94,11 @@ printf '%s' "$RAILS_MASTER_KEY" | devopsellence secret set RAILS_MASTER_KEY --se
 devopsellence secret list
 ```
 
-To clean up a solo experiment on an existing SSH node, uninstall the agent and remove devopsellence-managed runtime resources before forgetting the node locally:
+To clean up a solo experiment on an existing SSH node, first detach the node from the environment, then uninstall the agent and remove devopsellence-managed runtime resources before forgetting the node locally:
 
 ```bash
-devopsellence agent uninstall prod-1 --yes
 devopsellence node detach prod-1
+devopsellence agent uninstall prod-1 --yes
 devopsellence node remove prod-1 --yes
 ```
 

--- a/cli/internal/solo/ssh.go
+++ b/cli/internal/solo/ssh.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -42,6 +43,44 @@ func managedKnownHostsPath(node config.Node) string {
 	return filepath.Join(state.DefaultPath(filepath.Join("devopsellence", "ssh_known_hosts")), filename)
 }
 
+// SSHError preserves the underlying ssh process error and captured stderr.
+// Callers that need to branch on remote command failures can inspect ExitCode
+// without parsing the rendered error string.
+type SSHError struct {
+	User   string
+	Host   string
+	Err    error
+	Stderr string
+}
+
+func (e *SSHError) Error() string {
+	if e == nil {
+		return "ssh error"
+	}
+	if e.Stderr != "" {
+		return fmt.Sprintf("ssh %s@%s: %v: %s", e.User, e.Host, e.Err, e.Stderr)
+	}
+	return fmt.Sprintf("ssh %s@%s: %v", e.User, e.Host, e.Err)
+}
+
+func (e *SSHError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+func (e *SSHError) ExitCode() (int, bool) {
+	if e == nil {
+		return 0, false
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(e.Err, &exitErr) {
+		return 0, false
+	}
+	return exitErr.ExitCode(), true
+}
+
 func prepareSSH(node config.Node) error {
 	knownHostsPath := managedKnownHostsPath(node)
 	if knownHostsPath == "" {
@@ -71,7 +110,7 @@ func RunSSH(ctx context.Context, node config.Node, command string, stdin io.Read
 	cmd.Stderr = &stderr
 
 	if err := cmd.Run(); err != nil {
-		return "", fmt.Errorf("ssh %s@%s: %w: %s", node.User, node.Host, err, stderr.String())
+		return "", &SSHError{User: node.User, Host: node.Host, Err: err, Stderr: stderr.String()}
 	}
 	return stdout.String(), nil
 }
@@ -88,7 +127,7 @@ func RunSSHInteractive(ctx context.Context, node config.Node, command string, st
 	cmd.Stderr = stderr
 
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("ssh %s@%s: %w", node.User, node.Host, err)
+		return &SSHError{User: node.User, Host: node.Host, Err: err}
 	}
 	return nil
 }
@@ -103,7 +142,7 @@ func RunSSHInteractiveWithStdin(ctx context.Context, node config.Node, command s
 	cmd.Stderr = stderr
 
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("ssh %s@%s: %w", node.User, node.Host, err)
+		return &SSHError{User: node.User, Host: node.Host, Err: err}
 	}
 	return nil
 }
@@ -122,7 +161,7 @@ func RunSSHStream(ctx context.Context, node config.Node, command string, stdin i
 	cmd.Stderr = &stderr
 
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("ssh %s@%s: %w: %s", node.User, node.Host, err, stderr.String())
+		return &SSHError{User: node.User, Host: node.Host, Err: err, Stderr: stderr.String()}
 	}
 	return nil
 }

--- a/cli/internal/workflow/root.go
+++ b/cli/internal/workflow/root.go
@@ -858,7 +858,7 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 		Short: "Remove a node",
 		Long: strings.Join([]string{
 			"Remove a node from devopsellence state.",
-			"For solo existing-SSH nodes this only forgets the node locally; run `devopsellence agent uninstall <name> --yes` first to clean the remote VM.",
+			"For solo existing-SSH nodes this only forgets the node locally; detach the node, then run `devopsellence agent uninstall <name> --yes` before removal to clean the remote VM.",
 			"For provider-managed solo nodes and shared nodes, removal deletes the provider/control-plane node where supported.",
 		}, "\n"),
 		Args: cobra.ExactArgs(1),

--- a/cli/internal/workflow/root.go
+++ b/cli/internal/workflow/root.go
@@ -918,8 +918,12 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 	nodeDiagnoseCommand.Flags().DurationVar(&nodeDiagnoseOpts.Wait, "wait", defaultNodeDiagnoseWaitTimeout, "How long to wait for the node snapshot")
 	nodeLogsCommand := &cobra.Command{
 		Use:   "logs <name>",
-		Short: "Tail agent logs from a solo node over SSH",
-		Args:  cobra.ExactArgs(1),
+		Short: "Show recent agent logs from a solo node over SSH",
+		Long: strings.Join([]string{
+			"Show recent devopsellence agent journal lines from a solo node over SSH.",
+			"The CLI returns a bounded JSON snapshot; use SSH and journalctl directly when you need an interactive follow stream.",
+		}, "\n"),
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			nodeLogsOpts.Node = args[0]
 			return runSoloOnly("node logs", func(ctx context.Context) error {
@@ -927,7 +931,6 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 			})(cmd, args)
 		},
 	}
-	nodeLogsCommand.Flags().BoolVarP(&nodeLogsOpts.Follow, "follow", "f", false, "Follow log output")
 	nodeLogsCommand.Flags().IntVar(&nodeLogsOpts.Lines, "lines", soloLogsDefaultLines, fmt.Sprintf("Number of recent log lines to return, 1-%d", soloLogsMaxLines))
 	nodeCommand.AddCommand(nodeRegisterCommand, nodeCreateCommand, nodeListCommand, nodeAttachCommand, nodeDetachCommand, nodeRemoveCommand, nodeLabelCommand, nodeDiagnoseCommand, nodeLogsCommand)
 	root.AddCommand(nodeCommand)

--- a/cli/internal/workflow/root_test.go
+++ b/cli/internal/workflow/root_test.go
@@ -391,6 +391,29 @@ func TestNodeHelpShowsSharedAndSoloActions(t *testing.T) {
 	}
 }
 
+func TestNodeLogsHelpDocumentsBoundedJSONSnapshot(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, t.TempDir())
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{"node", "logs", "--help"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	output := stdout.String()
+	for _, snippet := range []string{"bounded JSON snapshot", "--lines"} {
+		if !strings.Contains(output, snippet) {
+			t.Fatalf("help output = %q, want %q", output, snippet)
+		}
+	}
+	if strings.Contains(output, "--follow") {
+		t.Fatalf("help output = %q, did not expect --follow", output)
+	}
+}
+
 func TestNodeCreateHelpUsesCurrentHetznerDefaults(t *testing.T) {
 	t.Parallel()
 

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -69,9 +69,8 @@ type SoloNodeDetachOptions struct {
 }
 
 type SoloLogsOptions struct {
-	Node   string
-	Follow bool
-	Lines  int
+	Node  string
+	Lines int
 }
 
 type SoloNodeLabelSetOptions struct {
@@ -377,14 +376,22 @@ func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 		return err
 	}
 
-	return a.Printer.PrintJSON(map[string]any{
+	payload := map[string]any{
 		"schema_version":          outputSchemaVersion,
 		"workload_revision":       shortSHA,
 		"desired_state_revisions": desiredStateRevisions,
 		"image":                   imageTag,
 		"environment":             environmentName,
 		"nodes":                   sortedNodeNames(nodes),
-	})
+		"phase":                   "settled",
+	}
+	if urls := soloStatusPublicURLs(cfg, nodes); len(urls) > 0 {
+		payload["public_urls"] = urls
+		payload["next_steps"] = []string{"devopsellence status", "curl " + urls[0]}
+	} else {
+		payload["next_steps"] = []string{"devopsellence status"}
+	}
+	return a.Printer.PrintJSON(payload)
 
 }
 
@@ -1521,21 +1528,44 @@ func (a *App) SoloNodeDetach(ctx context.Context, opts SoloNodeDetachOptions) er
 	} else if !changed {
 		return fmt.Errorf("node %q is not attached to %s", opts.Node, environmentName)
 	}
-	affectedNodeNames := append([]string{opts.Node}, nodeNamesBefore...)
-	affectedNodeNames = normalizeSoloNames(affectedNodeNames)
+	remainingNodeNames := make([]string, 0, len(nodeNamesBefore))
+	for _, name := range nodeNamesBefore {
+		if name != opts.Node {
+			remainingNodeNames = append(remainingNodeNames, name)
+		}
+	}
+	remainingNodeNames = normalizeSoloNames(remainingNodeNames)
 	if err := a.writeSoloState(current); err != nil {
 		return err
 	}
-	if _, err := a.republishNodes(ctx, current, affectedNodeNames); err != nil {
+	if _, err := a.republishNodes(ctx, current, remainingNodeNames); err != nil {
 		return err
 	}
+	warnings := []string{}
+	if _, err := a.republishNodes(ctx, current, []string{opts.Node}); err != nil {
+		if current.NodeHasAttachments(opts.Node) || !soloRepublishMissingAgentError(err) {
+			return err
+		}
+		warnings = append(warnings, "remote desired state was not cleared because the agent is already uninstalled on the node")
+	}
 
-	return a.Printer.PrintJSON(map[string]any{
+	payload := map[string]any{
 		"node":        opts.Node,
 		"environment": environmentName,
 		"changed":     true,
-	})
+	}
+	if len(warnings) > 0 {
+		payload["warnings"] = warnings
+	}
+	return a.Printer.PrintJSON(payload)
 
+}
+
+func soloRepublishMissingAgentError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "devopsellence agent binary not found")
 }
 
 func (a *App) SoloSecretsDelete(_ context.Context, opts SoloSecretsDeleteOptions) error {
@@ -1583,9 +1613,6 @@ func (a *App) SoloLogs(ctx context.Context, opts SoloLogsOptions) error {
 		return fmt.Errorf("node %q not found", opts.Node)
 	}
 
-	if opts.Follow {
-		return ExitError{Code: 2, Err: errors.New("--follow streams raw logs and is not supported by the JSON-only CLI")}
-	}
 	linesLimit := opts.Lines
 	if linesLimit < 1 || linesLimit > soloLogsMaxLines {
 		return ExitError{Code: 2, Err: fmt.Errorf("--lines must be between 1 and %d", soloLogsMaxLines)}

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1565,7 +1565,8 @@ func soloRepublishMissingAgentError(err error) bool {
 	if err == nil {
 		return false
 	}
-	return strings.Contains(err.Error(), "devopsellence agent binary not found")
+	message := err.Error()
+	return strings.Contains(message, soloRemoteAgentBinaryNotFoundMessage) && strings.Contains(message, "exit status 127")
 }
 
 func (a *App) SoloSecretsDelete(_ context.Context, opts SoloSecretsDeleteOptions) error {
@@ -2078,8 +2079,9 @@ func (a *App) SharedSoloNodeCreate(ctx context.Context, opts SharedSoloNodeCreat
 const sshOutputTailLimit = 64 * 1024
 
 const (
-	soloLogsDefaultLines = 100
-	soloLogsMaxLines     = 1000
+	soloLogsDefaultLines                 = 100
+	soloLogsMaxLines                     = 1000
+	soloRemoteAgentBinaryNotFoundMessage = "devopsellence agent binary not found"
 )
 
 type tailBuffer struct {
@@ -3231,7 +3233,7 @@ func desiredStateOverridePath(node config.Node) string {
 
 func remoteDesiredStateOverrideCommand(overridePath string) string {
 	quotedPath := shellQuote(overridePath)
-	return fmt.Sprintf("agent_bin=$(command -v devopsellence-agent || command -v devopsellence || true); if [ -z \"$agent_bin\" ]; then echo 'devopsellence agent binary not found' >&2; exit 127; fi; override_dir=$(dirname -- %[1]s); if [ \"$(id -u)\" = 0 ] || [ -w \"$override_dir\" ]; then exec \"$agent_bin\" desired-state set-override --file - --override-path %[1]s; fi; if command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then exec sudo -n \"$agent_bin\" desired-state set-override --file - --override-path %[1]s; fi; echo 'Cannot write desired state override. Make the SSH user able to write the agent state directory or enable passwordless sudo.' >&2; exit 1", quotedPath)
+	return fmt.Sprintf("agent_bin=$(command -v devopsellence-agent || command -v devopsellence || true); if [ -z \"$agent_bin\" ]; then echo %[2]s >&2; exit 127; fi; override_dir=$(dirname -- %[1]s); if [ \"$(id -u)\" = 0 ] || [ -w \"$override_dir\" ]; then exec \"$agent_bin\" desired-state set-override --file - --override-path %[1]s; fi; if command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then exec sudo -n \"$agent_bin\" desired-state set-override --file - --override-path %[1]s; fi; echo 'Cannot write desired state override. Make the SSH user able to write the agent state directory or enable passwordless sudo.' >&2; exit 1", quotedPath, shellQuote(soloRemoteAgentBinaryNotFoundMessage))
 }
 
 type progressReader struct {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -608,6 +608,49 @@ func (a *App) resolveNodes(current solo.State, names []string) (map[string]confi
 	return result, nil
 }
 
+type soloRepublishErrorEntry struct {
+	node      string
+	operation string
+	err       error
+}
+
+func (e soloRepublishErrorEntry) Error() string {
+	return fmt.Sprintf("[%s] %s: %s", e.node, e.operation, e.err)
+}
+
+func (e soloRepublishErrorEntry) Unwrap() error {
+	return e.err
+}
+
+type soloRepublishError struct {
+	entries []soloRepublishErrorEntry
+}
+
+func (e *soloRepublishError) Error() string {
+	parts := make([]string, 0, len(e.entries))
+	for _, entry := range e.entries {
+		parts = append(parts, entry.Error())
+	}
+	return fmt.Sprintf("republish errors:\n  %s", strings.Join(parts, "\n  "))
+}
+
+func (e *soloRepublishError) Unwrap() []error {
+	wrapped := make([]error, 0, len(e.entries))
+	for _, entry := range e.entries {
+		wrapped = append(wrapped, entry)
+	}
+	return wrapped
+}
+
+func appendSoloRepublishError(mu *sync.Mutex, errs *[]soloRepublishErrorEntry, node, operation string, err error) {
+	if err == nil {
+		return
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	*errs = append(*errs, soloRepublishErrorEntry{node: node, operation: operation, err: err})
+}
+
 func (a *App) republishNodes(ctx context.Context, current solo.State, nodeNames []string) (map[string]string, error) {
 	if len(nodeNames) == 0 {
 		return map[string]string{}, nil
@@ -623,7 +666,7 @@ func (a *App) republishNodes(ctx context.Context, current solo.State, nodeNames 
 		err  error
 	}
 	var mu sync.Mutex
-	var errs []string
+	var errs []soloRepublishErrorEntry
 	revisions := map[string]string{}
 	var wg sync.WaitGroup
 
@@ -651,18 +694,14 @@ func (a *App) republishNodes(ctx context.Context, current solo.State, nodeNames 
 			defer wg.Done()
 			if len(inputs.images) > 0 {
 				if _, err := solo.RunSSH(ctx, node, remoteDockerCheckCommand(), nil); err != nil {
-					mu.Lock()
-					errs = append(errs, fmt.Sprintf("[%s] remote docker check: %s", name, err))
-					mu.Unlock()
+					appendSoloRepublishError(&mu, &errs, name, "remote docker check", err)
 					return
 				}
 			}
 			for _, image := range inputs.images {
 				present, err := remoteNodeHasImage(ctx, node, image)
 				if err != nil {
-					mu.Lock()
-					errs = append(errs, fmt.Sprintf("[%s] remote image check: %s", name, err))
-					mu.Unlock()
+					appendSoloRepublishError(&mu, &errs, name, "remote image check", err)
 					return
 				}
 				if present {
@@ -679,15 +718,11 @@ func (a *App) republishNodes(ctx context.Context, current solo.State, nodeNames 
 					check.err = a.ensureLocalSoloSnapshotImage(ctx, image)
 				})
 				if check.err != nil {
-					mu.Lock()
-					errs = append(errs, fmt.Sprintf("[%s] local image precheck: %s", name, check.err))
-					mu.Unlock()
+					appendSoloRepublishError(&mu, &errs, name, "local image precheck", check.err)
 					return
 				}
 				if err := transferImage(ctx, node, image, func(string) {}); err != nil {
-					mu.Lock()
-					errs = append(errs, fmt.Sprintf("[%s] image transfer: %s", name, err))
-					mu.Unlock()
+					appendSoloRepublishError(&mu, &errs, name, "image transfer", err)
 					return
 				}
 			}
@@ -699,25 +734,19 @@ func (a *App) republishNodes(ctx context.Context, current solo.State, nodeNames 
 				NodePeers:    inputs.peers,
 			})
 			if err != nil {
-				mu.Lock()
-				errs = append(errs, fmt.Sprintf("[%s] build desired state: %s", name, err))
-				mu.Unlock()
+				appendSoloRepublishError(&mu, &errs, name, "build desired state", err)
 				return
 			}
 			desiredStateJSON := publication.DesiredStateJSON
 			overridePath := desiredStateOverridePath(node)
 			cmd := remoteDesiredStateOverrideCommand(overridePath)
 			if _, err := solo.RunSSH(ctx, node, cmd, strings.NewReader(string(desiredStateJSON))); err != nil {
-				mu.Lock()
-				errs = append(errs, fmt.Sprintf("[%s] write desired state: %s", name, err))
-				mu.Unlock()
+				appendSoloRepublishError(&mu, &errs, name, "write desired state", err)
 				return
 			}
 			revision, err := desiredStateRevision(desiredStateJSON)
 			if err != nil {
-				mu.Lock()
-				errs = append(errs, fmt.Sprintf("[%s] parse desired state revision: %s", name, err))
-				mu.Unlock()
+				appendSoloRepublishError(&mu, &errs, name, "parse desired state revision", err)
 				return
 			}
 			mu.Lock()
@@ -727,7 +756,7 @@ func (a *App) republishNodes(ctx context.Context, current solo.State, nodeNames 
 	}
 	wg.Wait()
 	if len(errs) > 0 {
-		return nil, fmt.Errorf("republish errors:\n  %s", strings.Join(errs, "\n  "))
+		return nil, &soloRepublishError{entries: errs}
 	}
 	return revisions, nil
 }
@@ -1565,8 +1594,12 @@ func soloRepublishMissingAgentError(err error) bool {
 	if err == nil {
 		return false
 	}
-	message := err.Error()
-	return strings.Contains(message, soloRemoteAgentBinaryNotFoundMessage) && strings.Contains(message, "exit status 127")
+	var sshErr *solo.SSHError
+	if !errors.As(err, &sshErr) {
+		return false
+	}
+	exitCode, ok := sshErr.ExitCode()
+	return ok && exitCode == 127 && strings.Contains(sshErr.Stderr, soloRemoteAgentBinaryNotFoundMessage)
 }
 
 func (a *App) SoloSecretsDelete(_ context.Context, opts SoloSecretsDeleteOptions) error {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -615,7 +615,7 @@ type soloRepublishErrorEntry struct {
 }
 
 func (e soloRepublishErrorEntry) Error() string {
-	return fmt.Sprintf("[%s] %s: %s", e.node, e.operation, e.err)
+	return fmt.Sprintf("[%s] %s: %v", e.node, e.operation, e.err)
 }
 
 func (e soloRepublishErrorEntry) Unwrap() error {
@@ -2200,7 +2200,7 @@ func (a *App) SoloNodeRemove(ctx context.Context, opts SoloNodeRemoveOptions) er
 		return a.Printer.PrintJSON(map[string]any{
 			"node":   opts.Name,
 			"action": "forgotten",
-			"note":   "existing SSH node removed from local state only; detach the node, then run `devopsellence agent uninstall <name> --yes` before removal to clean the remote VM",
+			"note":   "existing SSH node removed from local state only; remote VM resources were not changed",
 		})
 
 	}

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -2167,7 +2167,7 @@ func (a *App) SoloNodeRemove(ctx context.Context, opts SoloNodeRemoveOptions) er
 		return a.Printer.PrintJSON(map[string]any{
 			"node":   opts.Name,
 			"action": "forgotten",
-			"note":   "existing SSH node removed from local state only; run `devopsellence agent uninstall <name> --yes` before removal to clean the remote VM",
+			"note":   "existing SSH node removed from local state only; detach the node, then run `devopsellence agent uninstall <name> --yes` before removal to clean the remote VM",
 		})
 
 	}

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -1007,6 +1007,66 @@ func TestRepublishNodesReportsRemoteDockerCheck(t *testing.T) {
 	}
 }
 
+func TestSoloNodeDetachSucceedsWhenAgentAlreadyUninstalled(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.Node{
+			"prod-1": {Host: "203.0.113.10", User: "root", Labels: []string{config.DefaultWebRole}},
+		},
+		Attachments: map[string]solo.AttachmentRecord{},
+		Snapshots:   map[string]desiredstate.DeploySnapshot{},
+	}
+	if _, _, err := current.AttachNode(workspaceRoot, "production", "prod-1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	binDir := t.TempDir()
+	writeExecutable(t, filepath.Join(binDir, "ssh"), `#!/usr/bin/env bash
+set -euo pipefail
+command="${!#}"
+if [[ "$command" == *"desired-state set-override"* ]]; then
+  echo 'devopsellence agent binary not found' >&2
+  exit 127
+fi
+echo "unexpected ssh command: $command" >&2
+exit 1
+`)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	var stdout bytes.Buffer
+	app := &App{
+		Printer:     output.New(&stdout, io.Discard),
+		SoloState:   soloState,
+		ConfigStore: config.NewStore(),
+		Cwd:         workspaceRoot,
+	}
+
+	if err := app.SoloNodeDetach(context.Background(), SoloNodeDetachOptions{Node: "prod-1"}); err != nil {
+		t.Fatal(err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	warnings := jsonArrayFromMap(t, payload, "warnings")
+	if len(warnings) != 1 || !strings.Contains(warnings[0].(string), "agent is already uninstalled") {
+		t.Fatalf("warnings = %#v, want already-uninstalled warning", warnings)
+	}
+	loaded, err := soloState.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.NodeHasAttachments("prod-1") {
+		t.Fatalf("prod-1 still attached after detach: %#v", loaded.Attachments)
+	}
+}
+
 func TestNodeRemoveForManualNodeForgetsLocalState(t *testing.T) {
 	t.Parallel()
 
@@ -1150,6 +1210,14 @@ func TestSoloDeployWaitsForSettledStatusBeforeSuccess(t *testing.T) {
 	}
 
 	cfg := config.DefaultProjectConfigForType("solo", "demo", "production", config.AppTypeGeneric)
+	cfg.Ingress = &config.IngressConfig{
+		Hosts: []string{"*"},
+		Rules: []config.IngressRuleConfig{{
+			Match:  config.IngressMatchConfig{Host: "*", PathPrefix: "/"},
+			Target: config.IngressTargetConfig{Service: config.DefaultWebServiceName, Port: "http"},
+		}},
+		TLS: config.IngressTLSConfig{Mode: "off"},
+	}
 	if _, err := config.Write(workspaceRoot, cfg); err != nil {
 		t.Fatal(err)
 	}
@@ -1195,12 +1263,20 @@ func TestSoloDeployWaitsForSettledStatusBeforeSuccess(t *testing.T) {
 		t.Fatalf("status poll count = %d, want 3", got)
 	}
 	payload := decodeJSONOutput(t, &stdout)
-	if payload["environment"] != "production" || payload["workload_revision"] == "" {
-		t.Fatalf("payload = %#v, want deploy JSON", payload)
+	if payload["environment"] != "production" || payload["workload_revision"] == "" || payload["phase"] != "settled" {
+		t.Fatalf("payload = %#v, want settled deploy JSON", payload)
 	}
 	revisions := jsonMapFromAny(t, payload["desired_state_revisions"])
 	if revisions["node-a"] == "" {
 		t.Fatalf("desired_state_revisions = %#v, want node revision", revisions)
+	}
+	urls := jsonArrayFromMap(t, payload, "public_urls")
+	if len(urls) != 1 || urls[0] != "http://203.0.113.10/" {
+		t.Fatalf("public_urls = %#v, want node URL", urls)
+	}
+	nextSteps := jsonArrayFromMap(t, payload, "next_steps")
+	if len(nextSteps) != 2 || nextSteps[0] != "devopsellence status" || nextSteps[1] != "curl http://203.0.113.10/" {
+		t.Fatalf("next_steps = %#v, want status and curl commands", nextSteps)
 	}
 }
 

--- a/skills/devopsellence/SKILL.md
+++ b/skills/devopsellence/SKILL.md
@@ -93,7 +93,7 @@ devopsellence init --mode solo
 devopsellence provider login hetzner --token "$HCLOUD_TOKEN"
 devopsellence node create prod-1 --provider hetzner --install --attach
 devopsellence deploy
-devopsellence node logs <name> --follow
+devopsellence node logs <name> --lines 100
 ```
 
 ## Lifecycle hooks


### PR DESCRIPTION
## Summary
- include settled phase, public URLs, and next steps in solo deploy success output
- remove unsupported node logs --follow flag and document bounded JSON log snapshots
- fix solo cleanup docs/order and tolerate already-uninstalled agents during detach recovery
- record clean-slate/no-back-compat project direction in AGENTS.md

## Dogfood
- /tmp/devopsellence-dogfood/20260427T122612047555Z-solo-first-deploy
- /tmp/devopsellence-dogfood/20260427T124320222556Z-solo-no-expose

## Tests
- cd cli && mise run test
- mise run build:cli
