### PR TITLE
Improve failed solo deploy diagnostics

### DIFF
--- a/cli/cmd/devopsellence/main.go
+++ b/cli/cmd/devopsellence/main.go
@@ -45,9 +45,17 @@ func writeError(operation string, exitCode int, err error) {
 		"message":   err.Error(),
 		"exit_code": exitCode,
 	}
+	reservedErrorKeys := map[string]struct{}{
+		"code":      {},
+		"message":   {},
+		"exit_code": {},
+	}
 	var structured workflow.StructuredError
 	if errors.As(err, &structured) {
 		for key, value := range structured.ErrorFields() {
+			if _, reserved := reservedErrorKeys[key]; reserved {
+				continue
+			}
 			errorObject[key] = value
 		}
 	}

--- a/cli/cmd/devopsellence/main.go
+++ b/cli/cmd/devopsellence/main.go
@@ -40,15 +40,22 @@ func main() {
 }
 
 func writeError(operation string, exitCode int, err error) {
+	errorObject := map[string]any{
+		"code":      "command_failed",
+		"message":   err.Error(),
+		"exit_code": exitCode,
+	}
+	var structured workflow.StructuredError
+	if errors.As(err, &structured) {
+		for key, value := range structured.ErrorFields() {
+			errorObject[key] = value
+		}
+	}
 	payload := map[string]any{
 		"ok":             false,
 		"schema_version": workflow.OutputSchemaVersion,
 		"operation":      operation,
-		"error": map[string]any{
-			"code":      "command_failed",
-			"message":   err.Error(),
-			"exit_code": exitCode,
-		},
+		"error":          errorObject,
 	}
 	encoder := json.NewEncoder(os.Stderr)
 	encoder.SetIndent("", "  ")

--- a/cli/cmd/devopsellence/main_test.go
+++ b/cli/cmd/devopsellence/main_test.go
@@ -1,11 +1,46 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
+	"os"
 	"testing"
 
 	"github.com/devopsellence/cli/internal/workflow"
 )
+
+type structuredTestError struct{}
+
+func (structuredTestError) Error() string { return "structured failure" }
+
+func (structuredTestError) ErrorFields() map[string]any {
+	return map[string]any{"next_steps": []string{"devopsellence status"}}
+}
+
+func TestWriteErrorIncludesStructuredFields(t *testing.T) {
+	originalStderr := os.Stderr
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Stderr = originalStderr })
+	os.Stderr = writer
+
+	writeError("devopsellence deploy", 1, structuredTestError{})
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	var payload map[string]any
+	if err := json.NewDecoder(reader).Decode(&payload); err != nil {
+		t.Fatal(err)
+	}
+	errorPayload := payload["error"].(map[string]any)
+	steps := errorPayload["next_steps"].([]any)
+	if len(steps) != 1 || steps[0] != "devopsellence status" {
+		t.Fatalf("next_steps = %#v, want structured field", steps)
+	}
+}
 
 func TestRenderedErrorDoesNotNeedExtraPrint(t *testing.T) {
 	err := workflow.ExitError{

--- a/cli/cmd/devopsellence/main_test.go
+++ b/cli/cmd/devopsellence/main_test.go
@@ -26,7 +26,11 @@ func TestWriteErrorIncludesStructuredFields(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { os.Stderr = originalStderr })
+	t.Cleanup(func() {
+		os.Stderr = originalStderr
+		_ = reader.Close()
+		_ = writer.Close()
+	})
 	os.Stderr = writer
 
 	writeError("devopsellence deploy", 1, structuredTestError{})

--- a/cli/cmd/devopsellence/main_test.go
+++ b/cli/cmd/devopsellence/main_test.go
@@ -14,7 +14,10 @@ type structuredTestError struct{}
 func (structuredTestError) Error() string { return "structured failure" }
 
 func (structuredTestError) ErrorFields() map[string]any {
-	return map[string]any{"next_steps": []string{"devopsellence status"}}
+	return map[string]any{
+		"message":    "do not override standard message",
+		"next_steps": []string{"devopsellence status"},
+	}
 }
 
 func TestWriteErrorIncludesStructuredFields(t *testing.T) {
@@ -36,6 +39,9 @@ func TestWriteErrorIncludesStructuredFields(t *testing.T) {
 		t.Fatal(err)
 	}
 	errorPayload := payload["error"].(map[string]any)
+	if errorPayload["message"] != "structured failure" {
+		t.Fatalf("message = %#v, want standard error message", errorPayload["message"])
+	}
 	steps := errorPayload["next_steps"].([]any)
 	if len(steps) != 1 || steps[0] != "devopsellence status" {
 		t.Fatalf("next_steps = %#v, want structured field", steps)

--- a/cli/internal/workflow/app.go
+++ b/cli/internal/workflow/app.go
@@ -54,6 +54,10 @@ func (e ExitError) Error() string {
 	return e.Err.Error()
 }
 
+func (e ExitError) Unwrap() error {
+	return e.Err
+}
+
 type App struct {
 	In                  io.Reader
 	Printer             output.Printer

--- a/cli/internal/workflow/rendered_error.go
+++ b/cli/internal/workflow/rendered_error.go
@@ -4,6 +4,12 @@ type RenderedError struct {
 	Err error
 }
 
+// StructuredError lets command errors add machine-readable fields to the
+// standard JSON error object rendered by the CLI entrypoint.
+type StructuredError interface {
+	ErrorFields() map[string]any
+}
+
 func (e RenderedError) Error() string {
 	if e.Err == nil {
 		return ""

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -2265,7 +2265,7 @@ func (a *App) SoloNodeRemove(ctx context.Context, opts SoloNodeRemoveOptions) er
 		return a.Printer.PrintJSON(map[string]any{
 			"node":   opts.Name,
 			"action": "forgotten",
-			"note":   "node remove only forgot local state; remote cleanup, if needed, should be handled by `devopsellence agent uninstall <name> --yes` before running `node remove`",
+			"note":   fmt.Sprintf("node removed from local state only; if remote cleanup is still needed, run `devopsellence agent uninstall %s --yes`", opts.Name),
 		})
 
 	}

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -519,7 +519,7 @@ func (e *soloRolloutError) ErrorFields() map[string]any {
 		"node": e.Node,
 		"next_steps": []string{
 			"devopsellence status",
-			"devopsellence node logs " + e.Node + " --lines 100",
+			"devopsellence node logs " + shellQuote(e.Node) + " --lines 100",
 		},
 	}
 	if len(e.Healthchecks) > 0 {
@@ -2265,7 +2265,7 @@ func (a *App) SoloNodeRemove(ctx context.Context, opts SoloNodeRemoveOptions) er
 		return a.Printer.PrintJSON(map[string]any{
 			"node":   opts.Name,
 			"action": "forgotten",
-			"note":   fmt.Sprintf("node removed from local state only; if remote cleanup is still needed, run `devopsellence agent uninstall %s --yes`", opts.Name),
+			"note":   fmt.Sprintf("node removed from local state only; if remote cleanup is still needed, run `devopsellence agent uninstall %s --yes`", shellQuote(opts.Name)),
 		})
 
 	}

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -373,6 +373,11 @@ func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 		return err
 	}
 	if err := a.waitForSoloRollout(ctx, nodes, desiredStateRevisions); err != nil {
+		var rolloutErr *soloRolloutError
+		if errors.As(err, &rolloutErr) {
+			rolloutErr.Healthchecks = soloDeployHealthcheckDetails(cfg)
+			return ExitError{Code: 1, Err: rolloutErr}
+		}
 		return err
 	}
 
@@ -493,6 +498,52 @@ func readNodeStatus(ctx context.Context, node config.Node) (soloNodeStatusResult
 	}, nil
 }
 
+type soloRolloutError struct {
+	Node         string
+	Message      string
+	Healthchecks []map[string]any
+}
+
+func (e *soloRolloutError) Error() string {
+	if e == nil {
+		return "rollout failed"
+	}
+	return fmt.Sprintf("rollout failed on %s: %s", e.Node, e.Message)
+}
+
+func (e *soloRolloutError) ErrorFields() map[string]any {
+	fields := map[string]any{
+		"node": e.Node,
+		"next_steps": []string{
+			"devopsellence status",
+			"devopsellence node logs " + e.Node + " --lines 100",
+		},
+	}
+	if len(e.Healthchecks) > 0 {
+		fields["healthchecks"] = e.Healthchecks
+	}
+	return fields
+}
+
+func soloDeployHealthcheckDetails(cfg *config.ProjectConfig) []map[string]any {
+	if cfg == nil {
+		return nil
+	}
+	details := []map[string]any{}
+	for _, serviceName := range cfg.ServiceNames() {
+		service := cfg.Services[serviceName]
+		if service.Healthcheck == nil {
+			continue
+		}
+		details = append(details, map[string]any{
+			"service_name": serviceName,
+			"path":         service.Healthcheck.Path,
+			"port":         service.Healthcheck.Port,
+		})
+	}
+	return details
+}
+
 func (a *App) waitForSoloRollout(ctx context.Context, nodes map[string]config.Node, expectedRevisions map[string]string) error {
 	timeout := a.DeployTimeout
 	if timeout <= 0 {
@@ -541,7 +592,7 @@ func (a *App) waitForSoloRollout(ctx context.Context, nodes map[string]config.No
 					settledCount++
 				case "error":
 					message := firstNonEmpty(strings.TrimSpace(result.Status.Error), "node reported phase=error")
-					return ExitError{Code: 1, Err: fmt.Errorf("rollout failed on %s: %s", name, message)}
+					return ExitError{Code: 1, Err: &soloRolloutError{Node: name, Message: message}}
 				default:
 					reconcilingCount++
 					details = append(details, fmt.Sprintf("%s=%s", name, firstNonEmpty(strings.TrimSpace(result.Status.Phase), "reconciling")))
@@ -1119,11 +1170,13 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 
 	var jsonResults []map[string]any
 	readErrors := 0
+	allSettled := true
 
 	for name, node := range nodes {
 		result, err := readNodeStatus(ctx, node)
 		if err != nil {
 			readErrors++
+			allSettled = false
 
 			jsonResults = append(jsonResults, map[string]any{
 				"node":  name,
@@ -1134,6 +1187,7 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 		}
 
 		if result.Missing {
+			allSettled = false
 			message := "no deploy status yet; run `devopsellence deploy`"
 
 			jsonResults = append(jsonResults, map[string]any{
@@ -1145,6 +1199,9 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 			continue
 		}
 
+		if strings.TrimSpace(result.Status.Phase) != "settled" {
+			allSettled = false
+		}
 		jsonResults = append(jsonResults, map[string]any{
 			"node":   name,
 			"status": result.Raw,
@@ -1154,7 +1211,12 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 
 	payload := map[string]any{"nodes": jsonResults}
 	if urls := soloStatusPublicURLs(cfg, nodes); len(urls) > 0 {
-		payload["public_urls"] = urls
+		if allSettled {
+			payload["public_urls"] = urls
+		} else {
+			payload["configured_public_urls"] = urls
+			payload["warnings"] = []string{"public URLs are configured, but one or more nodes are not settled; check node status before testing reachability"}
+		}
 	}
 	if err := a.Printer.PrintJSON(payload); err != nil {
 		return err
@@ -2200,7 +2262,7 @@ func (a *App) SoloNodeRemove(ctx context.Context, opts SoloNodeRemoveOptions) er
 		return a.Printer.PrintJSON(map[string]any{
 			"node":   opts.Name,
 			"action": "forgotten",
-			"note":   "existing SSH node removed from local state only; remote VM resources were not changed",
+			"note":   "node remove only forgot local state; remote cleanup, if needed, is handled by `devopsellence agent uninstall <name> --yes` before forgetting the node",
 		})
 
 	}

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -378,6 +378,11 @@ func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 			rolloutErr.Healthchecks = soloDeployHealthcheckDetails(cfg)
 			return ExitError{Code: 1, Err: rolloutErr}
 		}
+		var timeoutErr *soloRolloutTimeoutError
+		if errors.As(err, &timeoutErr) {
+			timeoutErr.Healthchecks = soloDeployHealthcheckDetails(cfg)
+			return ExitError{Code: 1, Err: timeoutErr}
+		}
 		return err
 	}
 
@@ -528,6 +533,34 @@ func (e *soloRolloutError) ErrorFields() map[string]any {
 	return fields
 }
 
+type soloRolloutTimeoutError struct {
+	Summary      string
+	Nodes        []string
+	Healthchecks []map[string]any
+}
+
+func (e *soloRolloutTimeoutError) Error() string {
+	if e == nil {
+		return "timed out waiting for solo rollout"
+	}
+	return "timed out waiting for solo rollout: " + e.Summary
+}
+
+func (e *soloRolloutTimeoutError) ErrorFields() map[string]any {
+	if e == nil {
+		return map[string]any{}
+	}
+	steps := []string{"devopsellence status"}
+	for _, node := range e.Nodes {
+		steps = append(steps, "devopsellence node logs "+shellQuote(node)+" --lines 100")
+	}
+	fields := map[string]any{"next_steps": steps}
+	if len(e.Healthchecks) > 0 {
+		fields["healthchecks"] = e.Healthchecks
+	}
+	return fields
+}
+
 func soloDeployHealthcheckDetails(cfg *config.ProjectConfig) []map[string]any {
 	if cfg == nil {
 		return nil
@@ -577,7 +610,7 @@ func (a *App) waitForSoloRollout(ctx context.Context, nodes map[string]config.No
 			result, err := readNodeStatus(rolloutCtx, nodes[name])
 			if err != nil {
 				if errors.Is(rolloutCtx.Err(), context.DeadlineExceeded) {
-					return ExitError{Code: 1, Err: fmt.Errorf("timed out waiting for solo rollout: %s", latestSummary)}
+					return ExitError{Code: 1, Err: &soloRolloutTimeoutError{Summary: latestSummary, Nodes: nodeNames}}
 				}
 				return fmt.Errorf("[%s] read status: %w", name, err)
 			}
@@ -617,7 +650,7 @@ func (a *App) waitForSoloRollout(ctx context.Context, nodes map[string]config.No
 		case <-rolloutCtx.Done():
 			timer.Stop()
 			if errors.Is(rolloutCtx.Err(), context.DeadlineExceeded) {
-				return ExitError{Code: 1, Err: fmt.Errorf("timed out waiting for solo rollout: %s", latestSummary)}
+				return ExitError{Code: 1, Err: &soloRolloutTimeoutError{Summary: latestSummary, Nodes: nodeNames}}
 			}
 			return rolloutCtx.Err()
 		case <-timer.C:

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -512,6 +512,9 @@ func (e *soloRolloutError) Error() string {
 }
 
 func (e *soloRolloutError) ErrorFields() map[string]any {
+	if e == nil {
+		return map[string]any{}
+	}
 	fields := map[string]any{
 		"node": e.Node,
 		"next_steps": []string{
@@ -2262,7 +2265,7 @@ func (a *App) SoloNodeRemove(ctx context.Context, opts SoloNodeRemoveOptions) er
 		return a.Printer.PrintJSON(map[string]any{
 			"node":   opts.Name,
 			"action": "forgotten",
-			"note":   "node remove only forgot local state; remote cleanup, if needed, is handled by `devopsellence agent uninstall <name> --yes` before forgetting the node",
+			"note":   "node remove only forgot local state; remote cleanup, if needed, should be handled by `devopsellence agent uninstall <name> --yes` before running `node remove`",
 		})
 
 	}

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -1487,6 +1487,15 @@ func TestWaitForSoloRolloutTimesOutWhenExpectedRevisionNeverSettles(t *testing.T
 	if !strings.Contains(err.Error(), "timed out waiting for solo rollout") {
 		t.Fatalf("error = %v", err)
 	}
+	var timeoutErr *soloRolloutTimeoutError
+	if !errors.As(err, &timeoutErr) {
+		t.Fatalf("error = %T %v, want soloRolloutTimeoutError", err, err)
+	}
+	fields := timeoutErr.ErrorFields()
+	steps := fields["next_steps"].([]string)
+	if len(steps) != 2 || steps[1] != "devopsellence node logs 'node-a' --lines 100" {
+		t.Fatalf("next_steps = %#v, want status and node logs commands", steps)
+	}
 }
 
 func TestWaitForSoloRolloutFailsClearlyOnStatusReadAndParseErrors(t *testing.T) {

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -1338,6 +1338,60 @@ func TestSoloDeployWaitsForSettledStatusBeforeSuccess(t *testing.T) {
 	}
 }
 
+func TestSoloDeployRolloutFailureIncludesHealthcheckContext(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(workspaceRoot, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	commitTestRepo(t, workspaceRoot)
+
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.Node{
+			"node-a": {Host: "203.0.113.10", User: "root", Port: 22, AgentStateDir: "/var/lib/devopsellence", Labels: []string{config.DefaultWebRole}},
+		},
+		Attachments: map[string]solo.AttachmentRecord{},
+		Snapshots:   map[string]desiredstate.DeploySnapshot{},
+	}
+	if _, _, err := current.AttachNode(workspaceRoot, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+	installFakeSoloCommands(t, []fakeSSHResponse{{stdout: `{"revision":"__REVISION__","phase":"error","error":"healthcheck failed"}` + "\n"}})
+
+	var stdout bytes.Buffer
+	app := &App{
+		Printer:            output.New(&stdout, io.Discard),
+		SoloState:          soloState,
+		ConfigStore:        config.NewStore(),
+		Git:                git.Client{},
+		Cwd:                workspaceRoot,
+		DeployPollInterval: 5 * time.Millisecond,
+		DeployTimeout:      time.Second,
+	}
+
+	err := app.SoloDeploy(context.Background(), SoloDeployOptions{})
+	if err == nil {
+		t.Fatal("expected deploy failure")
+	}
+	var rolloutErr *soloRolloutError
+	if !errors.As(err, &rolloutErr) {
+		t.Fatalf("error = %T %v, want soloRolloutError", err, err)
+	}
+	fields := rolloutErr.ErrorFields()
+	healthchecks := fields["healthchecks"].([]map[string]any)
+	if len(healthchecks) != 1 || healthchecks[0]["service_name"] != config.DefaultWebServiceName || healthchecks[0]["path"] != config.DefaultHealthcheckPath {
+		t.Fatalf("healthchecks = %#v, want web healthcheck context", healthchecks)
+	}
+}
+
 func TestWaitForSoloRolloutIgnoresMissingAndStaleStatusUntilExpectedRevisionSettles(t *testing.T) {
 	statusCountPath := installFakeSoloCommands(t, []fakeSSHResponse{
 		{stdout: soloStatusMissingSentinel + "\n"},

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -1451,7 +1451,7 @@ func TestWaitForSoloRolloutFailsOnExpectedRevisionErrorPhase(t *testing.T) {
 	}
 	fields := rolloutErr.ErrorFields()
 	steps := fields["next_steps"].([]string)
-	if len(steps) != 2 || steps[1] != "devopsellence node logs node-a --lines 100" {
+	if len(steps) != 2 || steps[1] != "devopsellence node logs 'node-a' --lines 100" {
 		t.Fatalf("next_steps = %#v, want status and node logs commands", steps)
 	}
 }

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -616,6 +616,64 @@ func TestSoloStatusIncludesPublicURLs(t *testing.T) {
 	}
 }
 
+func TestSoloStatusUsesConfiguredPublicURLsWhenNodeIsNotSettled(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	cfg.Ingress = &config.IngressConfig{
+		Hosts: []string{"*"},
+		Rules: []config.IngressRuleConfig{{
+			Match:  config.IngressMatchConfig{Host: "*", PathPrefix: "/"},
+			Target: config.IngressTargetConfig{Service: config.DefaultWebServiceName, Port: "http"},
+		}},
+		TLS: config.IngressTLSConfig{Mode: "off"},
+	}
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	installFakeSoloCommands(t, []fakeSSHResponse{{stdout: `{"revision":"rev","phase":"error","error":"healthcheck failed"}` + "\n"}})
+
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.Node{
+			"node-a": {Host: "203.0.113.10", User: "root", Labels: []string{config.DefaultWebRole}},
+		},
+		Attachments: map[string]solo.AttachmentRecord{
+			workspaceRoot + "\nproduction": {
+				WorkspaceRoot: workspaceRoot,
+				WorkspaceKey:  workspaceRoot,
+				Environment:   "production",
+				NodeNames:     []string{"node-a"},
+			},
+		},
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{
+		Printer:     output.New(&stdout, io.Discard),
+		SoloState:   soloState,
+		ConfigStore: config.NewStore(),
+		Cwd:         workspaceRoot,
+	}
+	if err := app.SoloStatus(context.Background(), SoloStatusOptions{Nodes: []string{"node-a"}}); err != nil {
+		t.Fatalf("SoloStatus() error = %v", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	if _, ok := payload["public_urls"]; ok {
+		t.Fatalf("payload = %#v, did not expect public_urls while node is errored", payload)
+	}
+	urls := jsonArrayFromMap(t, payload, "configured_public_urls")
+	if len(urls) != 1 || urls[0] != "http://203.0.113.10/" {
+		t.Fatalf("configured_public_urls = %#v, want node URL", urls)
+	}
+	warnings := jsonArrayFromMap(t, payload, "warnings")
+	if len(warnings) != 1 || !strings.Contains(warnings[0].(string), "not settled") {
+		t.Fatalf("warnings = %#v, want not-settled warning", warnings)
+	}
+}
+
 func TestSoloStatusPublicURLsUseHTTPSForManualTLS(t *testing.T) {
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")
 	cfg.Ingress = &config.IngressConfig{
@@ -1332,6 +1390,15 @@ func TestWaitForSoloRolloutFailsOnExpectedRevisionErrorPhase(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "rollout failed on node-a: image pull failed") {
 		t.Fatalf("error = %v", err)
+	}
+	var rolloutErr *soloRolloutError
+	if !errors.As(err, &rolloutErr) {
+		t.Fatalf("error = %T %v, want soloRolloutError", err, err)
+	}
+	fields := rolloutErr.ErrorFields()
+	steps := fields["next_steps"].([]string)
+	if len(steps) != 2 || steps[1] != "devopsellence node logs node-a --lines 100" {
+		t.Fatalf("next_steps = %#v, want status and node logs commands", steps)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add structured error fields so failed solo deploys can include next steps and healthcheck context
- enrich solo rollout failures with node log/status commands and configured service healthchecks
- distinguish configured public URLs from reachable public URLs in status when nodes are not settled
- clarify existing-SSH node remove note after cleanup

## Dogfood
- /tmp/devopsellence-dogfood/20260427T141512956478Z-failed-deploy-diagnosis-and-recovery

## Tests
- cd cli && mise run test
- mise run build:cli
