### PR TITLE
Clarify solo secret output

### DIFF
--- a/cli/internal/workflow/app.go
+++ b/cli/internal/workflow/app.go
@@ -303,7 +303,7 @@ type listedSecret struct {
 	Reference   string `json:"reference,omitempty"`
 	Configured  bool   `json:"configured"`
 	Stored      bool   `json:"stored"`
-	Exposed     bool   `json:"exposed"`
+	Exposed     bool   `json:"available_to_service"`
 }
 
 type TokenCreateOptions struct {
@@ -1602,7 +1602,7 @@ func formatListedSecret(item listedSecret) string {
 	parts := []string{
 		item.ServiceName,
 		item.Name,
-		"exposed=" + yesNo(item.Exposed),
+		"available_to_service=" + yesNo(item.Exposed),
 		"configured=" + yesNo(item.Configured),
 		"stored=" + yesNo(item.Stored),
 	}

--- a/cli/internal/workflow/app.go
+++ b/cli/internal/workflow/app.go
@@ -296,14 +296,14 @@ type SecretDeleteOptions struct {
 }
 
 type listedSecret struct {
-	ServiceName string `json:"service_name"`
-	Name        string `json:"name"`
-	SecretRef   string `json:"secret_ref,omitempty"`
-	Store       string `json:"store,omitempty"`
-	Reference   string `json:"reference,omitempty"`
-	Configured  bool   `json:"configured"`
-	Stored      bool   `json:"stored"`
-	Exposed     bool   `json:"available_to_service"`
+	ServiceName        string `json:"service_name"`
+	Name               string `json:"name"`
+	SecretRef          string `json:"secret_ref,omitempty"`
+	Store              string `json:"store,omitempty"`
+	Reference          string `json:"reference,omitempty"`
+	Configured         bool   `json:"configured"`
+	Stored             bool   `json:"stored"`
+	AvailableToService bool   `json:"available_to_service"`
 }
 
 type TokenCreateOptions struct {
@@ -1539,12 +1539,12 @@ func (a *App) sharedSecretListItems(workspaceRoot string, secrets []api.Environm
 			for _, ref := range cfg.Services[serviceName].SecretRefs {
 				key := secretListKey(serviceName, ref.Name)
 				items[key] = listedSecret{
-					ServiceName: serviceName,
-					Name:        ref.Name,
-					SecretRef:   strings.TrimSpace(ref.Secret),
-					Store:       secretListStore(strings.TrimSpace(ref.Secret), "managed"),
-					Configured:  true,
-					Exposed:     true,
+					ServiceName:        serviceName,
+					Name:               ref.Name,
+					SecretRef:          strings.TrimSpace(ref.Secret),
+					Store:              secretListStore(strings.TrimSpace(ref.Secret), "managed"),
+					Configured:         true,
+					AvailableToService: true,
 				}
 			}
 		}
@@ -1602,7 +1602,7 @@ func formatListedSecret(item listedSecret) string {
 	parts := []string{
 		item.ServiceName,
 		item.Name,
-		"available_to_service=" + yesNo(item.Exposed),
+		"available_to_service=" + yesNo(item.AvailableToService),
 		"configured=" + yesNo(item.Configured),
 		"stored=" + yesNo(item.Stored),
 	}

--- a/cli/internal/workflow/management_test.go
+++ b/cli/internal/workflow/management_test.go
@@ -1047,9 +1047,9 @@ func TestSecretListUsesWorkspaceEnvironment(t *testing.T) {
 		seen[stringValueAny(item["name"])] = item
 	}
 	for name, want := range map[string]map[string]any{
-		"SECRET_KEY_BASE":  {"configured": true, "stored": true, "exposed": true, "store": "managed"},
-		"ONLY_IN_CONFIG":   {"configured": true, "stored": false, "exposed": true, "store": "managed"},
-		"RAILS_MASTER_KEY": {"configured": false, "stored": true, "exposed": false, "store": "managed"},
+		"SECRET_KEY_BASE":  {"configured": true, "stored": true, "available_to_service": true, "store": "managed"},
+		"ONLY_IN_CONFIG":   {"configured": true, "stored": false, "available_to_service": true, "store": "managed"},
+		"RAILS_MASTER_KEY": {"configured": false, "stored": true, "available_to_service": false, "store": "managed"},
 	} {
 		item := seen[name]
 		if item == nil {

--- a/cli/internal/workflow/root_test.go
+++ b/cli/internal/workflow/root_test.go
@@ -112,6 +112,16 @@ func TestRootSoloSecretSetHonorsEnvironmentAndService(t *testing.T) {
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
+	setPayload := decodeJSONOutput(t, &stdout)
+	if setPayload["secret_ref"] != "devopsellence://plaintext/DATABASE_URL" {
+		t.Fatalf("secret_ref = %#v, want plaintext config ref", setPayload["secret_ref"])
+	}
+	if setPayload["reference"] != nil {
+		t.Fatalf("reference = %#v, want omitted for plaintext secret", setPayload["reference"])
+	}
+	if setPayload["state_path"] != solo.DefaultStatePath() {
+		t.Fatalf("state_path = %#v, want solo state path", setPayload["state_path"])
+	}
 
 	current, err := solo.NewStateStore(solo.DefaultStatePath()).Read()
 	if err != nil {
@@ -168,9 +178,9 @@ func TestRootSoloSecretSetHonorsEnvironmentAndService(t *testing.T) {
 		seen[stringValueAny(item["name"])] = item
 	}
 	for name, want := range map[string]map[string]any{
-		"DATABASE_URL":   {"configured": true, "stored": true, "exposed": true, "store": "plaintext"},
-		"ONLY_IN_CONFIG": {"configured": true, "stored": false, "exposed": true, "store": "plaintext"},
-		"ONLY_IN_STORE":  {"configured": false, "stored": true, "exposed": false, "store": "plaintext"},
+		"DATABASE_URL":   {"configured": true, "stored": true, "available_to_service": true, "store": "plaintext"},
+		"ONLY_IN_CONFIG": {"configured": true, "stored": false, "available_to_service": true, "store": "plaintext"},
+		"ONLY_IN_STORE":  {"configured": false, "stored": true, "available_to_service": false, "store": "plaintext"},
 	} {
 		item := seen[name]
 		if item == nil {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1537,12 +1537,12 @@ func soloSecretListItems(cfg *config.ProjectConfig, secrets []solo.SecretRecord,
 				key := secretListKey(serviceName, ref.Name)
 				secretRef := strings.TrimSpace(ref.Secret)
 				items[key] = listedSecret{
-					ServiceName: serviceName,
-					Name:        ref.Name,
-					SecretRef:   secretRef,
-					Store:       secretListStore(secretRef, "configured"),
-					Configured:  true,
-					Exposed:     true,
+					ServiceName:        serviceName,
+					Name:               ref.Name,
+					SecretRef:          secretRef,
+					Store:              secretListStore(secretRef, "configured"),
+					Configured:         true,
+					AvailableToService: true,
 				}
 			}
 		}

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1371,7 +1371,23 @@ func (a *App) SoloSecretsSet(_ context.Context, opts SoloSecretsSetOptions) erro
 		}
 	}
 
-	return a.Printer.PrintJSON(map[string]any{"key": record.Name, "service_name": record.ServiceName, "environment": record.Environment, "store": record.Store, "reference": record.Reference, "config_updated": configUpdated, "config_path": a.ConfigStore.PathFor(workspaceRoot), "action": "saved"})
+	payload := map[string]any{
+		"key":            record.Name,
+		"service_name":   record.ServiceName,
+		"environment":    record.Environment,
+		"store":          record.Store,
+		"secret_ref":     soloSecretConfigRef(record).Secret,
+		"config_updated": configUpdated,
+		"config_path":    a.ConfigStore.PathFor(workspaceRoot),
+		"action":         "saved",
+	}
+	if strings.TrimSpace(record.Reference) != "" {
+		payload["reference"] = record.Reference
+	}
+	if a.SoloState != nil && strings.TrimSpace(a.SoloState.Path) != "" {
+		payload["state_path"] = a.SoloState.Path
+	}
+	return a.Printer.PrintJSON(payload)
 
 }
 


### PR DESCRIPTION
## Summary
- include the generated secret_ref and solo state_path in solo secret set output
- omit empty reference for plaintext secrets
- rename secret list JSON/text from exposed to available_to_service

## Dogfood
- /tmp/devopsellence-dogfood/20260427T153042671952Z-existing-app-deploy-with-secrets

## Tests
- cd cli && mise run test
- mise run build:cli
