### PR TITLE
Address solo dogfood findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Initialize the workspace:
 devopsellence init --mode solo
 ```
 
+Start from an app that already has a Dockerfile. devopsellence does not install language toolchains or generate Rails/Node/etc. projects for you; create the app with your normal framework tools first, then let devopsellence deploy the container.
+
 Commit the app before the first deploy. devopsellence uses the current git commit as the workload revision and image tag:
 
 ```bash
@@ -58,6 +60,21 @@ devopsellence node attach prod-1
 devopsellence doctor
 ```
 
+Existing SSH node prerequisites:
+
+- the host must accept key-based SSH for the selected `--user` and `--ssh-key`;
+- devopsellence stores SSH host keys in its own state directory and uses OpenSSH `StrictHostKeyChecking=accept-new`, so first contact does not write to your global `~/.ssh/known_hosts`;
+- Docker must be reachable by the SSH user, or the SSH user must have passwordless sudo for Docker. On supported Ubuntu VMs, `devopsellence agent install` can install Docker when it is missing;
+- `agent install` writes `/usr/local/bin/devopsellence-agent`, creates a `devopsellence-agent` systemd service, and uses `/var/lib/devopsellence` for node state by default.
+
+If remote checks fail, start with:
+
+```bash
+devopsellence doctor
+devopsellence node diagnose prod-1
+devopsellence node logs prod-1 --lines 100
+```
+
 Or create a Hetzner-backed node from the provider:
 
 ```bash
@@ -73,6 +90,7 @@ Deploy over SSH:
 ```bash
 devopsellence deploy
 devopsellence status
+devopsellence node logs prod-1 --lines 100
 ```
 
 `devopsellence status` includes `public_urls` when it can infer where the app should be reachable. For default solo HTTP ingress, try the node URL it prints.

--- a/cli/internal/output/output.go
+++ b/cli/internal/output/output.go
@@ -5,6 +5,8 @@ import (
 	"io"
 )
 
+const SchemaVersion = 1
+
 // Printer writes command results. The CLI is agent-primary: final command
 // results are JSON on stdout, and progress events are structured JSON on stderr.
 type Printer struct {
@@ -31,7 +33,7 @@ func (p Printer) PrintEvent(event string, fields map[string]any) error {
 		return nil
 	}
 	payload := map[string]any{
-		"schema_version": 1,
+		"schema_version": SchemaVersion,
 		"event":          event,
 	}
 	for key, value := range fields {

--- a/cli/internal/output/output.go
+++ b/cli/internal/output/output.go
@@ -38,6 +38,9 @@ func (p Printer) PrintEvent(event string, fields map[string]any) error {
 	}
 	payload := map[string]any{}
 	for key, value := range fields {
+		if key == "schema_version" || key == "event" {
+			continue
+		}
 		payload[key] = value
 	}
 	payload["schema_version"] = SchemaVersion

--- a/cli/internal/output/output.go
+++ b/cli/internal/output/output.go
@@ -5,8 +5,8 @@ import (
 	"io"
 )
 
-// Printer writes command results. The CLI is agent-primary and emits JSON-only
-// output so automation can consume every command safely.
+// Printer writes command results. The CLI is agent-primary: final command
+// results are JSON on stdout, and progress events are structured JSON on stderr.
 type Printer struct {
 	Out io.Writer
 	Err io.Writer
@@ -24,4 +24,20 @@ func (p Printer) PrintJSON(value any) error {
 	encoder.SetIndent("", "  ")
 	encoder.SetEscapeHTML(false)
 	return encoder.Encode(value)
+}
+
+func (p Printer) PrintEvent(event string, fields map[string]any) error {
+	if p.Err == nil {
+		return nil
+	}
+	payload := map[string]any{
+		"schema_version": 1,
+		"event":          event,
+	}
+	for key, value := range fields {
+		payload[key] = value
+	}
+	encoder := json.NewEncoder(p.Err)
+	encoder.SetEscapeHTML(false)
+	return encoder.Encode(payload)
 }

--- a/cli/internal/output/output.go
+++ b/cli/internal/output/output.go
@@ -32,13 +32,12 @@ func (p Printer) PrintEvent(event string, fields map[string]any) error {
 	if p.Err == nil {
 		return nil
 	}
-	payload := map[string]any{
-		"schema_version": SchemaVersion,
-		"event":          event,
-	}
+	payload := map[string]any{}
 	for key, value := range fields {
 		payload[key] = value
 	}
+	payload["schema_version"] = SchemaVersion
+	payload["event"] = event
 	data, err := json.Marshal(payload)
 	if err != nil {
 		return err

--- a/cli/internal/output/output.go
+++ b/cli/internal/output/output.go
@@ -1,6 +1,7 @@
 package output
 
 import (
+	"bytes"
 	"encoding/json"
 	"io"
 )
@@ -38,11 +39,12 @@ func (p Printer) PrintEvent(event string, fields map[string]any) error {
 	}
 	payload["schema_version"] = SchemaVersion
 	payload["event"] = event
-	data, err := json.Marshal(payload)
-	if err != nil {
+	var buf bytes.Buffer
+	encoder := json.NewEncoder(&buf)
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(payload); err != nil {
 		return err
 	}
-	data = append(data, '\n')
-	_, err = p.Err.Write(data)
+	_, err := p.Err.Write(buf.Bytes())
 	return err
 }

--- a/cli/internal/output/output.go
+++ b/cli/internal/output/output.go
@@ -39,7 +39,11 @@ func (p Printer) PrintEvent(event string, fields map[string]any) error {
 	for key, value := range fields {
 		payload[key] = value
 	}
-	encoder := json.NewEncoder(p.Err)
-	encoder.SetEscapeHTML(false)
-	return encoder.Encode(payload)
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	_, err = p.Err.Write(data)
+	return err
 }

--- a/cli/internal/output/output.go
+++ b/cli/internal/output/output.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
+	"sync"
 )
 
 const SchemaVersion = 1
@@ -13,12 +14,14 @@ const SchemaVersion = 1
 type Printer struct {
 	Out io.Writer
 	Err io.Writer
+	mu  *sync.Mutex
 }
 
 func New(out, err io.Writer) Printer {
 	return Printer{
 		Out: out,
 		Err: err,
+		mu:  &sync.Mutex{},
 	}
 }
 
@@ -44,6 +47,10 @@ func (p Printer) PrintEvent(event string, fields map[string]any) error {
 	encoder.SetEscapeHTML(false)
 	if err := encoder.Encode(payload); err != nil {
 		return err
+	}
+	if p.mu != nil {
+		p.mu.Lock()
+		defer p.mu.Unlock()
 	}
 	_, err := p.Err.Write(buf.Bytes())
 	return err

--- a/cli/internal/solo/ssh.go
+++ b/cli/internal/solo/ssh.go
@@ -46,6 +46,19 @@ func managedKnownHostsPath(node config.Node) string {
 	return filepath.Join(state.DefaultPath(filepath.Join("devopsellence", "ssh_known_hosts")), filename)
 }
 
+func RemoveKnownHosts(node config.Node) (bool, error) {
+	path := managedKnownHostsPath(node)
+	if path == "" {
+		return false, nil
+	}
+	if err := os.Remove(path); errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	} else if err != nil {
+		return false, fmt.Errorf("remove ssh known_hosts for %s@%s: %w", node.User, node.Host, err)
+	}
+	return true, nil
+}
+
 // SSHError preserves the underlying ssh process error and captured stderr.
 // Callers that need to branch on remote command failures can inspect ExitCode
 // without parsing the rendered error string.

--- a/cli/internal/solo/ssh.go
+++ b/cli/internal/solo/ssh.go
@@ -35,11 +35,14 @@ func sshArgs(node config.Node, command string) []string {
 }
 
 func managedKnownHostsPath(node config.Node) string {
+	identity := node.Provider + "\x00" + node.ProviderServerID
+	prefix := "managed-"
 	if node.Provider == "" || node.ProviderServerID == "" {
-		return ""
+		identity = node.User + "\x00" + node.Host + "\x00" + strconv.Itoa(node.Port)
+		prefix = "existing-"
 	}
-	sum := sha256.Sum256([]byte(node.Provider + "\x00" + node.ProviderServerID))
-	filename := "managed-" + hex.EncodeToString(sum[:])
+	sum := sha256.Sum256([]byte(identity))
+	filename := prefix + hex.EncodeToString(sum[:])
 	return filepath.Join(state.DefaultPath(filepath.Join("devopsellence", "ssh_known_hosts")), filename)
 }
 
@@ -93,8 +96,9 @@ func prepareSSH(node config.Node) error {
 }
 
 // RunSSH executes a command on a remote node via ssh.
-// It inherits the user's SSH config and agent behavior; for provider-managed
-// nodes it uses a devopsellence-managed per-server known_hosts file under state.
+// It inherits the user's SSH config and agent behavior, but stores host keys in
+// a devopsellence-managed known_hosts file under state so node bootstrap does
+// not depend on or mutate the operator's global ~/.ssh/known_hosts.
 // If stdin is non-nil it is piped to the remote command.
 func RunSSH(ctx context.Context, node config.Node, command string, stdin io.Reader) (string, error) {
 	if err := prepareSSH(node); err != nil {

--- a/cli/internal/solo/ssh_test.go
+++ b/cli/internal/solo/ssh_test.go
@@ -8,7 +8,9 @@ import (
 	"github.com/devopsellence/devopsellence/deployment-core/pkg/deploycore/config"
 )
 
-func TestSSHArgsIncludeConnectTimeoutAndKey(t *testing.T) {
+func TestSSHArgsIncludeConnectTimeoutKeyAndManagedKnownHosts(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateDir)
 	node := config.Node{
 		User:   "root",
 		Host:   "203.0.113.10",
@@ -22,6 +24,7 @@ func TestSSHArgsIncludeConnectTimeoutAndKey(t *testing.T) {
 		"-o", "ConnectTimeout=10",
 		"-o", "StrictHostKeyChecking=accept-new",
 		"-p", "22",
+		"-o", "UserKnownHostsFile=" + managedKnownHostsPath(node),
 		"-i", "/tmp/id_ed25519",
 		"root@203.0.113.10",
 		"true",
@@ -59,20 +62,23 @@ func TestSSHArgsUseManagedKnownHostsForProviderNodes(t *testing.T) {
 	}
 }
 
-func TestManagedKnownHostsPathHashesUntrustedServerID(t *testing.T) {
+func TestManagedKnownHostsPathHashesUntrustedIdentity(t *testing.T) {
 	stateDir := t.TempDir()
 	t.Setenv("XDG_STATE_HOME", stateDir)
-	node := config.Node{
-		Provider:         "hetzner",
-		ProviderServerID: "../../escape",
-	}
-
-	path := managedKnownHostsPath(node)
-	base := filepath.Join(stateDir, "devopsellence", "ssh_known_hosts")
-	if filepath.Dir(path) != base {
-		t.Fatalf("managedKnownHostsPath() dir = %q, want %q", filepath.Dir(path), base)
-	}
-	if filepath.Base(path) == node.Provider+"-"+node.ProviderServerID || filepath.Base(path) == "managed-"+node.ProviderServerID {
-		t.Fatalf("managedKnownHostsPath() base = %q, want hashed filename", filepath.Base(path))
+	for _, node := range []config.Node{
+		{Provider: "hetzner", ProviderServerID: "../../escape"},
+		{User: "root", Host: "../../escape", Port: 22},
+	} {
+		node := node
+		t.Run(node.Provider+node.Host, func(t *testing.T) {
+			path := managedKnownHostsPath(node)
+			base := filepath.Join(stateDir, "devopsellence", "ssh_known_hosts")
+			if filepath.Dir(path) != base {
+				t.Fatalf("managedKnownHostsPath() dir = %q, want %q", filepath.Dir(path), base)
+			}
+			if filepath.Base(path) == node.Provider+"-"+node.ProviderServerID || filepath.Base(path) == "managed-"+node.ProviderServerID || filepath.Base(path) == "existing-"+node.Host {
+				t.Fatalf("managedKnownHostsPath() base = %q, want hashed filename", filepath.Base(path))
+			}
+		})
 	}
 }

--- a/cli/internal/solo/ssh_test.go
+++ b/cli/internal/solo/ssh_test.go
@@ -1,6 +1,7 @@
 package solo
 
 import (
+	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -59,6 +60,35 @@ func TestSSHArgsUseManagedKnownHostsForProviderNodes(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("sshArgs() = %#v, want %#v", got, want)
+	}
+}
+
+func TestRemoveKnownHostsDeletesManagedFile(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateDir)
+	node := config.Node{User: "root", Host: "203.0.113.10", Port: 22}
+	path := managedKnownHostsPath(node)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("host key\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	removed, err := RemoveKnownHosts(node)
+	if err != nil {
+		t.Fatalf("RemoveKnownHosts() error = %v", err)
+	}
+	if !removed {
+		t.Fatal("RemoveKnownHosts() removed = false, want true")
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("known_hosts file still exists or unexpected stat error: %v", err)
+	}
+
+	removed, err = RemoveKnownHosts(node)
+	if err != nil || removed {
+		t.Fatalf("RemoveKnownHosts() second call = %v, %v; want false, nil", removed, err)
 	}
 }
 

--- a/cli/internal/workflow/app.go
+++ b/cli/internal/workflow/app.go
@@ -29,7 +29,7 @@ import (
 	"github.com/devopsellence/devopsellence/deployment-core/pkg/deploycore/config"
 )
 
-const OutputSchemaVersion = 1
+const OutputSchemaVersion = output.SchemaVersion
 
 const outputSchemaVersion = OutputSchemaVersion
 

--- a/cli/internal/workflow/install_logs.go
+++ b/cli/internal/workflow/install_logs.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"context"
 	"io"
+	"strings"
 
 	"github.com/devopsellence/cli/internal/output"
 )
@@ -14,12 +15,22 @@ type soloInstallReporter struct {
 	close    func()
 }
 
-func newSoloInstallReporter(_ context.Context, _ output.Printer, _ string) soloInstallReporter {
+func newSoloInstallReporter(_ context.Context, printer output.Printer, node string) soloInstallReporter {
 	return soloInstallReporter{
-		progress: func(string) {},
-		stdout:   newTailBuffer(sshOutputTailLimit),
-		stderr:   newTailBuffer(sshOutputTailLimit),
-		close:    func() {},
+		progress: func(message string) {
+			message = strings.TrimSpace(message)
+			if message == "" {
+				return
+			}
+			_ = printer.PrintEvent("progress", map[string]any{
+				"operation": "devopsellence agent install",
+				"node":      node,
+				"message":   message,
+			})
+		},
+		stdout: newTailBuffer(sshOutputTailLimit),
+		stderr: newTailBuffer(sshOutputTailLimit),
+		close:  func() {},
 	}
 }
 

--- a/cli/internal/workflow/install_logs_test.go
+++ b/cli/internal/workflow/install_logs_test.go
@@ -7,9 +7,10 @@ import (
 	"github.com/devopsellence/cli/internal/output"
 )
 
-func TestNewSoloInstallReporterCapturesInstallNoiseWithoutPrinting(t *testing.T) {
+func TestNewSoloInstallReporterCapturesInstallNoiseAndEmitsStructuredProgress(t *testing.T) {
 	var out bytes.Buffer
-	reporter := newSoloInstallReporter(t.Context(), output.Printer{Out: &out}, "prod-2")
+	var errOut bytes.Buffer
+	reporter := newSoloInstallReporter(t.Context(), output.Printer{Out: &out, Err: &errOut}, "prod-2")
 
 	reporter.Progress("Installing Docker, agent, and systemd service...")
 	if _, err := reporter.Stdout().Write([]byte("progress: downloading agent binary\nplain log\npartial")); err != nil {
@@ -21,7 +22,10 @@ func TestNewSoloInstallReporterCapturesInstallNoiseWithoutPrinting(t *testing.T)
 	reporter.Close()
 
 	if got := out.String(); got != "" {
-		t.Fatalf("reporter output = %q, want no unstructured output", got)
+		t.Fatalf("reporter stdout = %q, want no final output", got)
+	}
+	if got := errOut.String(); !bytes.Contains([]byte(got), []byte(`"event":"progress"`)) || !bytes.Contains([]byte(got), []byte(`"node":"prod-2"`)) {
+		t.Fatalf("progress stderr = %q, want structured progress event", got)
 	}
 	if got := reporter.CapturedStdout(); got != "progress: downloading agent binary\nplain log\npartial" {
 		t.Fatalf("captured stdout = %q", got)

--- a/cli/internal/workflow/root.go
+++ b/cli/internal/workflow/root.go
@@ -118,6 +118,9 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 	modeCommand := &cobra.Command{
 		Use:   "mode",
 		Short: "Select or inspect the current workspace mode",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return app.ModeShow()
+		},
 	}
 	modeCommand.AddCommand(&cobra.Command{
 		Use:   "show",
@@ -750,6 +753,7 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 	var nodeLabelSharedOpts NodeLabelSetOptions
 	var nodeLabelSoloOpts SoloNodeLabelSetOptions
 	var nodeDiagnoseOpts NodeDiagnoseOptions
+	var soloNodeDiagnoseOpts SoloNodeDiagnoseOptions
 	var nodeLogsOpts SoloLogsOptions
 	var nodeLabels string
 	var nodeAttachEnvironment string
@@ -772,7 +776,12 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 	nodeCreateCommand := &cobra.Command{
 		Use:   "create <name>",
 		Short: "Create or register a node",
-		Args:  cobra.ExactArgs(1),
+		Long: strings.Join([]string{
+			"Create or register a node for the selected workspace mode.",
+			"Solo --host nodes must be reachable over SSH with the selected key. devopsellence stores SSH host keys in its own state directory and uses StrictHostKeyChecking=accept-new, so first contact does not write to ~/.ssh/known_hosts.",
+			"The solo agent install can install Docker on supported Ubuntu VMs when Docker is missing; otherwise install Docker yourself or make the SSH user able to run docker via passwordless sudo.",
+		}, "\n"),
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			nodeCreateOpts.Name = args[0]
 			return runByMode(func(ctx context.Context) error {
@@ -901,16 +910,24 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 	nodeLabelCommand := &cobra.Command{Use: "label", Short: "Manage node labels"}
 	nodeLabelCommand.AddCommand(nodeLabelSetCommand)
 	nodeDiagnoseCommand := &cobra.Command{
-		Use:   "diagnose <id>",
-		Short: "Collect a runtime snapshot from a shared node",
-		Args:  cobra.ExactArgs(1),
+		Use:   "diagnose <name|id>",
+		Short: "Collect a runtime snapshot from a node",
+		Long: strings.Join([]string{
+			"Collect a bounded runtime snapshot from a node.",
+			"In solo mode, pass the node name and the CLI collects SSH, Docker, agent, port, status, image, network, and container details over SSH.",
+			"In shared mode, pass the numeric node id and the control plane asks the node for a snapshot.",
+		}, "\n"),
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			id, parseErr := strconv.Atoi(args[0])
-			if parseErr != nil {
-				return ExitError{Code: 2, Err: fmt.Errorf("invalid node id %q: must be a number", args[0])}
-			}
-			nodeDiagnoseOpts.NodeID = id
-			return runSharedOnly("node diagnose", func(ctx context.Context) error {
+			return runByMode(func(ctx context.Context) error {
+				soloNodeDiagnoseOpts.Node = args[0]
+				return app.SoloNodeDiagnose(ctx, soloNodeDiagnoseOpts)
+			}, func(ctx context.Context) error {
+				id, parseErr := strconv.Atoi(args[0])
+				if parseErr != nil {
+					return ExitError{Code: 2, Err: fmt.Errorf("invalid node id %q: must be a number", args[0])}
+				}
+				nodeDiagnoseOpts.NodeID = id
 				return app.NodeDiagnose(ctx, nodeDiagnoseOpts)
 			})(cmd, args)
 		},

--- a/cli/internal/workflow/root_test.go
+++ b/cli/internal/workflow/root_test.go
@@ -84,6 +84,23 @@ func TestInitModeFlagPersistsWorkspaceModeAndWritesConfig(t *testing.T) {
 	}
 }
 
+func TestModeCommandDefaultsToShow(t *testing.T) {
+	var stdout bytes.Buffer
+	cwd := rootTestWorkspaceWithMode(t, ModeSolo)
+	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, cwd)
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{"mode"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	if payload["mode"] != "solo" || payload["set"] != true {
+		t.Fatalf("payload = %#v, want current solo mode", payload)
+	}
+}
+
 func TestRootSecretSetRejectsExplicitEmptyValue(t *testing.T) {
 	var stdout bytes.Buffer
 	cwd := rootTestWorkspaceWithMode(t, ModeShared)
@@ -398,6 +415,31 @@ func TestNodeHelpShowsSharedAndSoloActions(t *testing.T) {
 		if !strings.Contains(stdout.String(), snippet) {
 			t.Fatalf("help output = %q, want %q command", stdout.String(), snippet)
 		}
+	}
+}
+
+func TestNodeDiagnoseAcceptsSoloNodeName(t *testing.T) {
+	cwd := rootTestSoloWorkspace(t)
+	installFakeSoloCommands(t, []fakeSSHResponse{{stdout: `{"revision":"abc","phase":"settled"}` + "\n"}})
+	current := solo.State{Nodes: map[string]config.Node{
+		"node-a": {Host: "203.0.113.10", User: "root", Labels: []string{config.DefaultWebRole}},
+	}}
+	if err := solo.NewStateStore(solo.DefaultStatePath()).Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, cwd)
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{"node", "diagnose", "node-a"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	if payload["node"] != "node-a" {
+		t.Fatalf("payload = %#v, want solo node diagnosis", payload)
 	}
 }
 

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1840,9 +1840,11 @@ func (a *App) SoloNodeDiagnose(ctx context.Context, opts SoloNodeDiagnoseOptions
 	}
 	checks := a.soloDiagnoseChecks(ctx, node)
 	payload["checks"] = checks
+	diagnoseOK := soloChecksOK(checks)
+	payload["ok"] = diagnoseOK
 	if soloCheckFailed(checks, "ssh") {
 		payload["next_steps"] = []string{fmt.Sprintf("ssh -p %d %s true", node.Port, shellQuote(node.User+"@"+node.Host))}
-		return a.Printer.PrintJSON(payload)
+		return a.printSoloDiagnoseResult(payload, diagnoseOK)
 	}
 	payload["agent"] = map[string]any{
 		"active": collectRemoteText(ctx, node, "systemctl is-active devopsellence-agent"),
@@ -1857,6 +1859,8 @@ func (a *App) SoloNodeDiagnose(ctx context.Context, opts SoloNodeDiagnoseOptions
 	statusResult, statusErr := readNodeStatus(ctx, node)
 	if statusErr != nil {
 		payload["status_error"] = statusErr.Error()
+		diagnoseOK = false
+		payload["ok"] = false
 	} else if statusResult.Missing {
 		payload["status_missing"] = true
 	} else {
@@ -1871,7 +1875,21 @@ func (a *App) SoloNodeDiagnose(ctx context.Context, opts SoloNodeDiagnoseOptions
 		"devopsellence status",
 		"devopsellence node logs " + shellQuote(opts.Node) + " --lines 100",
 	}
-	return a.Printer.PrintJSON(payload)
+	return a.printSoloDiagnoseResult(payload, diagnoseOK)
+}
+
+func (a *App) printSoloDiagnoseResult(payload map[string]any, ok bool) error {
+	if err := a.Printer.PrintJSON(payload); err != nil {
+		return err
+	}
+	if !ok {
+		nodeName, _ := payload["node"].(string)
+		if strings.TrimSpace(nodeName) == "" {
+			nodeName = "node"
+		}
+		return ExitError{Code: 1, Err: RenderedError{Err: fmt.Errorf("solo node diagnose failed for %s", nodeName)}}
+	}
+	return nil
 }
 
 func (a *App) soloDiagnoseChecks(ctx context.Context, node config.Node) []map[string]any {
@@ -1895,6 +1913,15 @@ func (a *App) soloDiagnoseChecks(ctx context.Context, node config.Node) []map[st
 		results = append(results, result)
 	}
 	return results
+}
+
+func soloChecksOK(checks []map[string]any) bool {
+	for _, check := range checks {
+		if check["ok"] == false {
+			return false
+		}
+	}
+	return true
 }
 
 func soloCheckFailed(checks []map[string]any, name string) bool {
@@ -2593,15 +2620,20 @@ func (a *App) SoloNodeRemove(ctx context.Context, opts SoloNodeRemoveOptions) er
 	provider := strings.TrimSpace(node.Provider)
 	providerServerID := strings.TrimSpace(node.ProviderServerID)
 	if provider == "" && providerServerID == "" {
+		knownHostsRemoved, err := solo.RemoveKnownHosts(node)
+		if err != nil {
+			return err
+		}
 		current.RemoveNode(opts.Name)
 		if err := a.writeSoloState(current); err != nil {
 			return err
 		}
 
 		return a.Printer.PrintJSON(map[string]any{
-			"node":   opts.Name,
-			"action": "forgotten",
-			"note":   "manual SSH node forgotten locally; this command did not contact the VM",
+			"node":                opts.Name,
+			"action":              "forgotten",
+			"known_hosts_removed": knownHostsRemoved,
+			"note":                "manual SSH node forgotten locally; this command did not contact the VM",
 			"remote_cleanup": map[string]any{
 				"performed": false,
 				"if_needed": fmt.Sprintf("devopsellence agent uninstall %s --yes", shellQuote(opts.Name)),
@@ -2619,12 +2651,16 @@ func (a *App) SoloNodeRemove(ctx context.Context, opts SoloNodeRemoveOptions) er
 	if err := resolvedProvider.DeleteServer(ctx, providerServerID); err != nil {
 		return err
 	}
+	knownHostsRemoved, err := solo.RemoveKnownHosts(node)
+	if err != nil {
+		return err
+	}
 	current.RemoveNode(opts.Name)
 	if err := a.writeSoloState(current); err != nil {
 		return err
 	}
 
-	return a.Printer.PrintJSON(map[string]any{"node": opts.Name, "action": "deleted"})
+	return a.Printer.PrintJSON(map[string]any{"node": opts.Name, "action": "deleted", "known_hosts_removed": knownHostsRemoved})
 
 }
 

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1133,8 +1133,8 @@ func (a *App) soloProgress(operation string, fields map[string]any) func(string)
 
 func soloNodeLogNextSteps(nodes map[string]config.Node) []string {
 	steps := []string{}
-	for _, node := range sortedNodeNames(nodes) {
-		steps = append(steps, "devopsellence node logs "+shellQuote(node)+" --lines 100")
+	for _, nodeName := range sortedNodeNames(nodes) {
+		steps = append(steps, "devopsellence node logs "+shellQuote(nodeName)+" --lines 100")
 	}
 	return steps
 }
@@ -1848,9 +1848,9 @@ func (a *App) SoloNodeDiagnose(ctx context.Context, opts SoloNodeDiagnoseOptions
 		"status": collectRemoteLines(ctx, node, remoteSystemctlStatusCommand("devopsellence-agent", 40)),
 	}
 	payload["docker"] = map[string]any{
-		"containers": collectRemoteJSONLines(ctx, node, remoteDockerPSJSONCommand()),
-		"images":     collectRemoteJSONLines(ctx, node, remoteDockerImagesJSONCommand()),
-		"networks":   collectRemoteJSONLines(ctx, node, remoteDockerNetworksJSONCommand()),
+		"containers": collectRemoteJSONLines(ctx, node, remoteDockerPSJSONCommand(), soloDiagnoseDockerItemLimit),
+		"images":     collectRemoteJSONLines(ctx, node, remoteDockerImagesJSONCommand(), soloDiagnoseDockerItemLimit),
+		"networks":   collectRemoteJSONLines(ctx, node, remoteDockerNetworksJSONCommand(), soloDiagnoseDockerItemLimit),
 	}
 	payload["ports"] = collectRemoteLines(ctx, node, remoteListeningPortsCommand())
 	statusResult, statusErr := readNodeStatus(ctx, node)
@@ -1935,9 +1935,9 @@ func collectRemoteLines(ctx context.Context, node config.Node, command string) m
 	return result
 }
 
-func collectRemoteJSONLines(ctx context.Context, node config.Node, command string) map[string]any {
+func collectRemoteJSONLines(ctx context.Context, node config.Node, command string, limit int) map[string]any {
 	out, err := solo.RunSSH(ctx, node, command, nil)
-	result := map[string]any{"ok": err == nil}
+	result := map[string]any{"ok": err == nil, "limit": limit, "truncated": false}
 	if err != nil {
 		result["error"] = err.Error()
 		return result
@@ -1946,6 +1946,10 @@ func collectRemoteJSONLines(ctx context.Context, node config.Node, command strin
 	for _, line := range splitNonFinalEmptyLines(out) {
 		line = strings.TrimSpace(line)
 		if line == "" {
+			continue
+		}
+		if line == soloDiagnoseTruncatedMarker {
+			result["truncated"] = true
 			continue
 		}
 		var item map[string]any
@@ -2418,6 +2422,8 @@ const sshOutputTailLimit = 64 * 1024
 const (
 	soloLogsDefaultLines                 = 100
 	soloLogsMaxLines                     = 1000
+	soloDiagnoseDockerItemLimit          = 100
+	soloDiagnoseTruncatedMarker          = "__DEVOPSELLENCE_TRUNCATED__"
 	soloRemoteAgentBinaryNotFoundMessage = "devopsellence agent binary not found"
 )
 
@@ -3576,15 +3582,19 @@ func remoteSystemctlStatusCommand(unit string, lines int) string {
 }
 
 func remoteDockerPSJSONCommand() string {
-	return "if docker info >/dev/null 2>&1; then docker ps -a --format '{{json .}}'; elif command -v sudo >/dev/null 2>&1 && sudo -n docker info >/dev/null 2>&1; then sudo -n docker ps -a --format '{{json .}}'; else echo 'Docker is not reachable' >&2; exit 1; fi"
+	return withRemoteLineLimit("if docker info >/dev/null 2>&1; then docker ps -a --format '{{json .}}'; elif command -v sudo >/dev/null 2>&1 && sudo -n docker info >/dev/null 2>&1; then sudo -n docker ps -a --format '{{json .}}'; else echo 'Docker is not reachable' >&2; exit 1; fi", soloDiagnoseDockerItemLimit)
 }
 
 func remoteDockerImagesJSONCommand() string {
-	return "if docker info >/dev/null 2>&1; then docker images --format '{{json .}}'; elif command -v sudo >/dev/null 2>&1 && sudo -n docker info >/dev/null 2>&1; then sudo -n docker images --format '{{json .}}'; else echo 'Docker is not reachable' >&2; exit 1; fi"
+	return withRemoteLineLimit("if docker info >/dev/null 2>&1; then docker images --format '{{json .}}'; elif command -v sudo >/dev/null 2>&1 && sudo -n docker info >/dev/null 2>&1; then sudo -n docker images --format '{{json .}}'; else echo 'Docker is not reachable' >&2; exit 1; fi", soloDiagnoseDockerItemLimit)
 }
 
 func remoteDockerNetworksJSONCommand() string {
-	return "if docker info >/dev/null 2>&1; then docker network ls --format '{{json .}}'; elif command -v sudo >/dev/null 2>&1 && sudo -n docker info >/dev/null 2>&1; then sudo -n docker network ls --format '{{json .}}'; else echo 'Docker is not reachable' >&2; exit 1; fi"
+	return withRemoteLineLimit("if docker info >/dev/null 2>&1; then docker network ls --format '{{json .}}'; elif command -v sudo >/dev/null 2>&1 && sudo -n docker info >/dev/null 2>&1; then sudo -n docker network ls --format '{{json .}}'; else echo 'Docker is not reachable' >&2; exit 1; fi", soloDiagnoseDockerItemLimit)
+}
+
+func withRemoteLineLimit(command string, limit int) string {
+	return fmt.Sprintf("( %s ) | awk 'NR <= %d { print } NR == %d { print %s; exit }'", command, limit, limit+1, shellQuote(soloDiagnoseTruncatedMarker))
 }
 
 func remoteListeningPortsCommand() string {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -3667,7 +3667,7 @@ func remoteDockerNetworksJSONCommand() string {
 }
 
 func withRemoteLineLimit(command string, limit int) string {
-	pipeline := fmt.Sprintf("( %s ) | awk 'NR <= %d { print } NR == %d { print %s; exit }'", command, limit, limit+1, shellQuote(soloDiagnoseTruncatedMarker))
+	pipeline := fmt.Sprintf("( %s ) | awk -v marker=%s 'NR <= %d { print } NR == %d { print marker; exit }'", command, shellQuote(soloDiagnoseTruncatedMarker), limit, limit+1)
 	return "if command -v bash >/dev/null 2>&1; then exec bash -o pipefail -c " + shellQuote(pipeline) + "; fi; echo 'bash is required for bounded diagnostic output' >&2; exit 1"
 }
 

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -1913,37 +1914,109 @@ func splitNonFinalEmptyLines(out string) []string {
 	return lines
 }
 
-func collectRemoteText(ctx context.Context, node config.Node, command string) map[string]any {
-	out, err := solo.RunSSH(ctx, node, command, nil)
-	result := map[string]any{"ok": err == nil}
+type remoteDiagnosticResult struct {
+	ExitCode int
+	Stdout   string
+	Stderr   string
+	Err      error
+}
+
+func runRemoteDiagnostic(ctx context.Context, node config.Node, command string) remoteDiagnosticResult {
+	wrapped := fmt.Sprintf(`stdout_file="$(mktemp)" || exit 1
+stderr_file="$(mktemp)" || { rm -f "$stdout_file"; exit 1; }
+(
+%s
+) >"$stdout_file" 2>"$stderr_file"
+rc=$?
+printf '__DEVOPSELLENCE_EXIT_CODE__%%s\n' "$rc"
+printf '__DEVOPSELLENCE_STDOUT__\n'
+cat "$stdout_file"
+printf '\n__DEVOPSELLENCE_STDERR__\n'
+cat "$stderr_file"
+rm -f "$stdout_file" "$stderr_file"
+exit 0`, command)
+	out, err := solo.RunSSH(ctx, node, wrapped, nil)
 	if err != nil {
-		result["error"] = err.Error()
-	} else {
-		result["value"] = strings.TrimSpace(out)
+		return remoteDiagnosticResult{Err: err}
+	}
+	return parseRemoteDiagnostic(out)
+}
+
+func parseRemoteDiagnostic(out string) remoteDiagnosticResult {
+	const exitPrefix = "__DEVOPSELLENCE_EXIT_CODE__"
+	const stdoutMarker = "\n__DEVOPSELLENCE_STDOUT__\n"
+	const stderrMarker = "\n__DEVOPSELLENCE_STDERR__\n"
+	lineEnd := strings.IndexByte(out, '\n')
+	if lineEnd < 0 || !strings.HasPrefix(out[:lineEnd], exitPrefix) {
+		return remoteDiagnosticResult{ExitCode: 1, Stdout: out, Err: fmt.Errorf("remote diagnostic wrapper returned unexpected output")}
+	}
+	exitCode, err := strconv.Atoi(strings.TrimSpace(strings.TrimPrefix(out[:lineEnd], exitPrefix)))
+	if err != nil {
+		return remoteDiagnosticResult{ExitCode: 1, Stdout: out, Err: fmt.Errorf("parse remote diagnostic exit code: %w", err)}
+	}
+	rest := out[lineEnd:]
+	if !strings.HasPrefix(rest, stdoutMarker) {
+		return remoteDiagnosticResult{ExitCode: exitCode, Stdout: rest, Err: fmt.Errorf("remote diagnostic wrapper missing stdout marker")}
+	}
+	rest = strings.TrimPrefix(rest, stdoutMarker)
+	stderrIndex := strings.LastIndex(rest, stderrMarker)
+	if stderrIndex < 0 {
+		return remoteDiagnosticResult{ExitCode: exitCode, Stdout: rest, Err: fmt.Errorf("remote diagnostic wrapper missing stderr marker")}
+	}
+	return remoteDiagnosticResult{
+		ExitCode: exitCode,
+		Stdout:   strings.TrimSuffix(rest[:stderrIndex], "\n"),
+		Stderr:   rest[stderrIndex+len(stderrMarker):],
+	}
+}
+
+func collectRemoteText(ctx context.Context, node config.Node, command string) map[string]any {
+	diag := runRemoteDiagnostic(ctx, node, command)
+	result := map[string]any{"ok": diag.Err == nil && diag.ExitCode == 0}
+	if diag.Err != nil {
+		result["error"] = diag.Err.Error()
+	} else if diag.ExitCode != 0 {
+		result["exit_code"] = diag.ExitCode
+		result["error"] = strings.TrimSpace(diag.Stderr)
+	}
+	if value := strings.TrimSpace(diag.Stdout); value != "" {
+		result["value"] = value
+	}
+	if stderr := strings.TrimSpace(diag.Stderr); stderr != "" && diag.ExitCode == 0 {
+		result["stderr"] = stderr
 	}
 	return result
 }
 
 func collectRemoteLines(ctx context.Context, node config.Node, command string) map[string]any {
-	out, err := solo.RunSSH(ctx, node, command, nil)
-	result := map[string]any{"ok": err == nil}
-	if err != nil {
-		result["error"] = err.Error()
-	} else {
-		result["lines"] = splitNonFinalEmptyLines(out)
+	diag := runRemoteDiagnostic(ctx, node, command)
+	result := map[string]any{"ok": diag.Err == nil && diag.ExitCode == 0}
+	if diag.Err != nil {
+		result["error"] = diag.Err.Error()
+	} else if diag.ExitCode != 0 {
+		result["exit_code"] = diag.ExitCode
+		result["error"] = strings.TrimSpace(diag.Stderr)
+	}
+	result["lines"] = splitNonFinalEmptyLines(diag.Stdout)
+	if stderr := strings.TrimSpace(diag.Stderr); stderr != "" && diag.ExitCode == 0 {
+		result["stderr"] = stderr
 	}
 	return result
 }
 
 func collectRemoteJSONLines(ctx context.Context, node config.Node, command string, limit int) map[string]any {
-	out, err := solo.RunSSH(ctx, node, command, nil)
-	result := map[string]any{"ok": err == nil, "limit": limit, "truncated": false}
-	if err != nil {
-		result["error"] = err.Error()
+	diag := runRemoteDiagnostic(ctx, node, command)
+	result := map[string]any{"ok": diag.Err == nil && diag.ExitCode == 0, "limit": limit, "truncated": false}
+	if diag.Err != nil {
+		result["error"] = diag.Err.Error()
 		return result
 	}
+	if diag.ExitCode != 0 {
+		result["exit_code"] = diag.ExitCode
+		result["error"] = strings.TrimSpace(diag.Stderr)
+	}
 	items := []any{}
-	for _, line := range splitNonFinalEmptyLines(out) {
+	for _, line := range splitNonFinalEmptyLines(diag.Stdout) {
 		line = strings.TrimSpace(line)
 		if line == "" {
 			continue
@@ -3594,7 +3667,8 @@ func remoteDockerNetworksJSONCommand() string {
 }
 
 func withRemoteLineLimit(command string, limit int) string {
-	return fmt.Sprintf("( %s ) | awk 'NR <= %d { print } NR == %d { print %s; exit }'", command, limit, limit+1, shellQuote(soloDiagnoseTruncatedMarker))
+	pipeline := fmt.Sprintf("( %s ) | awk 'NR <= %d { print } NR == %d { print %s; exit }'", command, limit, limit+1, shellQuote(soloDiagnoseTruncatedMarker))
+	return "if command -v bash >/dev/null 2>&1; then exec bash -o pipefail -c " + shellQuote(pipeline) + "; fi; echo 'bash is required for bounded diagnostic output' >&2; exit 1"
 }
 
 func remoteListeningPortsCommand() string {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -2680,16 +2680,18 @@ func (a *App) SoloNodeRemove(ctx context.Context, opts SoloNodeRemoveOptions) er
 	if err := resolvedProvider.DeleteServer(ctx, providerServerID); err != nil {
 		return err
 	}
-	knownHostsRemoved, err := solo.RemoveKnownHosts(node)
-	if err != nil {
-		return err
-	}
+	knownHostsRemoved, knownHostsErr := solo.RemoveKnownHosts(node)
 	current.RemoveNode(opts.Name)
 	if err := a.writeSoloState(current); err != nil {
 		return err
 	}
 
-	return a.Printer.PrintJSON(map[string]any{"node": opts.Name, "action": "deleted", "known_hosts_removed": knownHostsRemoved})
+	payload := map[string]any{"node": opts.Name, "action": "deleted", "known_hosts_removed": knownHostsRemoved}
+	if knownHostsErr != nil {
+		payload["known_hosts_error"] = knownHostsErr.Error()
+		payload["warnings"] = []string{"provider node deleted and local state removed, but SSH known_hosts cleanup failed"}
+	}
+	return a.Printer.PrintJSON(payload)
 
 }
 
@@ -3751,7 +3753,8 @@ func remoteDockerNetworksJSONCommand() string {
 
 func withRemoteLineLimit(command string, limit int) string {
 	pipeline := fmt.Sprintf("( %s ) | awk -v marker=%s 'NR <= %d { print } NR == %d { print marker; exit }'", command, shellQuote(soloDiagnoseTruncatedMarker), limit, limit+1)
-	return "if command -v bash >/dev/null 2>&1; then exec bash -o pipefail -c " + shellQuote(pipeline) + "; fi; echo 'bash is required for bounded diagnostic output' >&2; exit 1"
+	script := pipeline + `; status=$?; if [ "$status" -eq 0 ] || [ "$status" -eq 141 ]; then exit 0; fi; exit "$status"`
+	return "if command -v bash >/dev/null 2>&1; then exec bash -o pipefail -c " + shellQuote(script) + "; fi; echo 'bash is required for bounded diagnostic output' >&2; exit 1"
 }
 
 func remoteListeningPortsCommand() string {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1853,7 +1853,7 @@ func (a *App) SoloNodeDiagnose(ctx context.Context, opts SoloNodeDiagnoseOptions
 		"images":     collectRemoteJSONLines(ctx, node, remoteDockerImagesJSONCommand(), soloDiagnoseDockerItemLimit),
 		"networks":   collectRemoteJSONLines(ctx, node, remoteDockerNetworksJSONCommand(), soloDiagnoseDockerItemLimit),
 	}
-	payload["ports"] = collectRemoteLines(ctx, node, remoteListeningPortsCommand())
+	payload["ports"] = collectRemoteLimitedLines(ctx, node, remoteListeningPortsCommand(), soloDiagnosePortsLineLimit)
 	statusResult, statusErr := readNodeStatus(ctx, node)
 	if statusErr != nil {
 		payload["status_error"] = statusErr.Error()
@@ -2001,6 +2001,23 @@ func collectRemoteLines(ctx context.Context, node config.Node, command string) m
 	if stderr := strings.TrimSpace(diag.Stderr); stderr != "" && diag.ExitCode == 0 {
 		result["stderr"] = stderr
 	}
+	return result
+}
+
+func collectRemoteLimitedLines(ctx context.Context, node config.Node, command string, limit int) map[string]any {
+	result := collectRemoteLines(ctx, node, command)
+	result["limit"] = limit
+	result["truncated"] = false
+	lines, _ := result["lines"].([]string)
+	filtered := lines[:0]
+	for _, line := range lines {
+		if strings.TrimSpace(line) == soloDiagnoseTruncatedMarker {
+			result["truncated"] = true
+			continue
+		}
+		filtered = append(filtered, line)
+	}
+	result["lines"] = filtered
 	return result
 }
 
@@ -2496,6 +2513,7 @@ const (
 	soloLogsDefaultLines                 = 100
 	soloLogsMaxLines                     = 1000
 	soloDiagnoseDockerItemLimit          = 100
+	soloDiagnosePortsLineLimit           = 200
 	soloDiagnoseTruncatedMarker          = "__DEVOPSELLENCE_TRUNCATED__"
 	soloRemoteAgentBinaryNotFoundMessage = "devopsellence agent binary not found"
 )
@@ -3672,7 +3690,7 @@ func withRemoteLineLimit(command string, limit int) string {
 }
 
 func remoteListeningPortsCommand() string {
-	return "if command -v ss >/dev/null 2>&1; then ss -ltnp || ss -ltn; elif command -v netstat >/dev/null 2>&1; then netstat -ltnp || netstat -ltn; else echo 'no ss or netstat available'; fi"
+	return withRemoteLineLimit("if command -v ss >/dev/null 2>&1; then ss -ltnp || ss -ltn; elif command -v netstat >/dev/null 2>&1; then netstat -ltnp || netstat -ltn; else echo 'no ss or netstat available'; fi", soloDiagnosePortsLineLimit)
 }
 
 func desiredStateOverridePath(node config.Node) string {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1846,16 +1846,23 @@ func (a *App) SoloNodeDiagnose(ctx context.Context, opts SoloNodeDiagnoseOptions
 		payload["next_steps"] = []string{fmt.Sprintf("ssh -p %d %s true", node.Port, shellQuote(node.User+"@"+node.Host))}
 		return a.printSoloDiagnoseResult(payload, diagnoseOK)
 	}
-	payload["agent"] = map[string]any{
+	agent := map[string]any{
 		"active": collectRemoteText(ctx, node, "systemctl is-active devopsellence-agent"),
 		"status": collectRemoteLines(ctx, node, remoteSystemctlStatusCommand("devopsellence-agent", 40)),
 	}
-	payload["docker"] = map[string]any{
+	payload["agent"] = agent
+	dockerSnapshot := map[string]any{
 		"containers": collectRemoteJSONLines(ctx, node, remoteDockerPSJSONCommand(), soloDiagnoseDockerItemLimit),
 		"images":     collectRemoteJSONLines(ctx, node, remoteDockerImagesJSONCommand(), soloDiagnoseDockerItemLimit),
 		"networks":   collectRemoteJSONLines(ctx, node, remoteDockerNetworksJSONCommand(), soloDiagnoseDockerItemLimit),
 	}
-	payload["ports"] = collectRemoteLimitedLines(ctx, node, remoteListeningPortsCommand(), soloDiagnosePortsLineLimit)
+	payload["docker"] = dockerSnapshot
+	ports := collectRemoteLimitedLines(ctx, node, remoteListeningPortsCommand(), soloDiagnosePortsLineLimit)
+	payload["ports"] = ports
+	if !diagnosticSectionsOK(agent, dockerSnapshot, ports) {
+		diagnoseOK = false
+		payload["ok"] = false
+	}
 	statusResult, statusErr := readNodeStatus(ctx, node)
 	if statusErr != nil {
 		payload["status_error"] = statusErr.Error()
@@ -1876,6 +1883,28 @@ func (a *App) SoloNodeDiagnose(ctx context.Context, opts SoloNodeDiagnoseOptions
 		"devopsellence node logs " + shellQuote(opts.Node) + " --lines 100",
 	}
 	return a.printSoloDiagnoseResult(payload, diagnoseOK)
+}
+
+func diagnosticSectionsOK(sections ...map[string]any) bool {
+	for _, section := range sections {
+		if !diagnosticSectionOK(section) {
+			return false
+		}
+	}
+	return true
+}
+
+func diagnosticSectionOK(section map[string]any) bool {
+	if section["ok"] == false {
+		return false
+	}
+	for _, value := range section {
+		child, ok := value.(map[string]any)
+		if ok && !diagnosticSectionOK(child) {
+			return false
+		}
+	}
+	return true
 }
 
 func (a *App) printSoloDiagnoseResult(payload map[string]any, ok bool) error {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1146,7 +1146,7 @@ func soloDoctorNextSteps(nodes map[string]config.Node) []string {
 		steps = append(steps,
 			"devopsellence agent install "+shellQuote(nodeName),
 			"devopsellence node diagnose "+shellQuote(nodeName),
-			fmt.Sprintf("ssh -p %d %s@%s true", node.Port, shellQuote(node.User), shellQuote(node.Host)),
+			fmt.Sprintf("ssh -p %d %s true", node.Port, shellQuote(node.User+"@"+node.Host)),
 		)
 	}
 	return steps
@@ -1840,11 +1840,11 @@ func (a *App) SoloNodeDiagnose(ctx context.Context, opts SoloNodeDiagnoseOptions
 	checks := a.soloDiagnoseChecks(ctx, node)
 	payload["checks"] = checks
 	if soloCheckFailed(checks, "ssh") {
-		payload["next_steps"] = []string{fmt.Sprintf("ssh -p %d %s@%s true", node.Port, shellQuote(node.User), shellQuote(node.Host))}
+		payload["next_steps"] = []string{fmt.Sprintf("ssh -p %d %s true", node.Port, shellQuote(node.User+"@"+node.Host))}
 		return a.Printer.PrintJSON(payload)
 	}
 	payload["agent"] = map[string]any{
-		"active": collectRemoteText(ctx, node, "systemctl is-active devopsellence-agent || true"),
+		"active": collectRemoteText(ctx, node, "systemctl is-active devopsellence-agent"),
 		"status": collectRemoteLines(ctx, node, remoteSystemctlStatusCommand("devopsellence-agent", 40)),
 	}
 	payload["docker"] = map[string]any{
@@ -3572,7 +3572,7 @@ func remoteJournalctlCommand(args string) string {
 
 func remoteSystemctlStatusCommand(unit string, lines int) string {
 	args := fmt.Sprintf("status --no-pager -l -n %d %s", lines, shellQuote(unit))
-	return fmt.Sprintf("if command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then sudo -n systemctl %s || true; else systemctl %s || true; fi", args, args)
+	return fmt.Sprintf("if command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then sudo -n systemctl %s; else systemctl %s; fi", args, args)
 }
 
 func remoteDockerPSJSONCommand() string {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -2026,6 +2026,16 @@ func parseRemoteDiagnostic(out string) remoteDiagnosticResult {
 	}
 }
 
+func diagnosticErrorMessage(diag remoteDiagnosticResult) string {
+	if message := strings.TrimSpace(diag.Stderr); message != "" {
+		return message
+	}
+	if message := strings.TrimSpace(diag.Stdout); message != "" {
+		return message
+	}
+	return fmt.Sprintf("command exited with code %d", diag.ExitCode)
+}
+
 func collectRemoteText(ctx context.Context, node config.Node, command string) map[string]any {
 	diag := runRemoteDiagnostic(ctx, node, command)
 	result := map[string]any{"ok": diag.Err == nil && diag.ExitCode == 0}
@@ -2033,7 +2043,7 @@ func collectRemoteText(ctx context.Context, node config.Node, command string) ma
 		result["error"] = diag.Err.Error()
 	} else if diag.ExitCode != 0 {
 		result["exit_code"] = diag.ExitCode
-		result["error"] = strings.TrimSpace(diag.Stderr)
+		result["error"] = diagnosticErrorMessage(diag)
 	}
 	if value := strings.TrimSpace(diag.Stdout); value != "" {
 		result["value"] = value
@@ -2051,7 +2061,7 @@ func collectRemoteLines(ctx context.Context, node config.Node, command string) m
 		result["error"] = diag.Err.Error()
 	} else if diag.ExitCode != 0 {
 		result["exit_code"] = diag.ExitCode
-		result["error"] = strings.TrimSpace(diag.Stderr)
+		result["error"] = diagnosticErrorMessage(diag)
 	}
 	result["lines"] = splitNonFinalEmptyLines(diag.Stdout)
 	if stderr := strings.TrimSpace(diag.Stderr); stderr != "" && diag.ExitCode == 0 {
@@ -2086,7 +2096,7 @@ func collectRemoteJSONLines(ctx context.Context, node config.Node, command strin
 	}
 	if diag.ExitCode != 0 {
 		result["exit_code"] = diag.ExitCode
-		result["error"] = strings.TrimSpace(diag.Stderr)
+		result["error"] = diagnosticErrorMessage(diag)
 	}
 	items := []any{}
 	for _, line := range splitNonFinalEmptyLines(diag.Stdout) {
@@ -2649,11 +2659,11 @@ func (a *App) SoloNodeRemove(ctx context.Context, opts SoloNodeRemoveOptions) er
 	provider := strings.TrimSpace(node.Provider)
 	providerServerID := strings.TrimSpace(node.ProviderServerID)
 	if provider == "" && providerServerID == "" {
-		knownHostsRemoved, knownHostsErr := solo.RemoveKnownHosts(node)
 		current.RemoveNode(opts.Name)
 		if err := a.writeSoloState(current); err != nil {
 			return err
 		}
+		knownHostsRemoved, knownHostsErr := solo.RemoveKnownHosts(node)
 
 		payload := map[string]any{
 			"node":                opts.Name,
@@ -2682,11 +2692,11 @@ func (a *App) SoloNodeRemove(ctx context.Context, opts SoloNodeRemoveOptions) er
 	if err := resolvedProvider.DeleteServer(ctx, providerServerID); err != nil {
 		return err
 	}
-	knownHostsRemoved, knownHostsErr := solo.RemoveKnownHosts(node)
 	current.RemoveNode(opts.Name)
 	if err := a.writeSoloState(current); err != nil {
 		return err
 	}
+	knownHostsRemoved, knownHostsErr := solo.RemoveKnownHosts(node)
 
 	payload := map[string]any{"node": opts.Name, "action": "deleted", "known_hosts_removed": knownHostsRemoved}
 	if knownHostsErr != nil {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -2649,16 +2649,13 @@ func (a *App) SoloNodeRemove(ctx context.Context, opts SoloNodeRemoveOptions) er
 	provider := strings.TrimSpace(node.Provider)
 	providerServerID := strings.TrimSpace(node.ProviderServerID)
 	if provider == "" && providerServerID == "" {
-		knownHostsRemoved, err := solo.RemoveKnownHosts(node)
-		if err != nil {
-			return err
-		}
+		knownHostsRemoved, knownHostsErr := solo.RemoveKnownHosts(node)
 		current.RemoveNode(opts.Name)
 		if err := a.writeSoloState(current); err != nil {
 			return err
 		}
 
-		return a.Printer.PrintJSON(map[string]any{
+		payload := map[string]any{
 			"node":                opts.Name,
 			"action":              "forgotten",
 			"known_hosts_removed": knownHostsRemoved,
@@ -2667,7 +2664,12 @@ func (a *App) SoloNodeRemove(ctx context.Context, opts SoloNodeRemoveOptions) er
 				"performed": false,
 				"if_needed": fmt.Sprintf("devopsellence agent uninstall %s --yes", shellQuote(opts.Name)),
 			},
-		})
+		}
+		if knownHostsErr != nil {
+			payload["known_hosts_error"] = knownHostsErr.Error()
+			payload["warnings"] = []string{"manual SSH node forgotten locally, but SSH known_hosts cleanup failed"}
+		}
+		return a.Printer.PrintJSON(payload)
 
 	}
 	if provider == "" || providerServerID == "" {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -73,6 +73,10 @@ type SoloLogsOptions struct {
 	Lines int
 }
 
+type SoloNodeDiagnoseOptions struct {
+	Node string
+}
+
 type SoloNodeLabelSetOptions struct {
 	Node   string
 	Labels string
@@ -347,9 +351,12 @@ func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 
 	buildCtx := filepath.Join(workspaceRoot, cfg.Build.Context)
 	dockerfile := filepath.Join(workspaceRoot, cfg.Build.Dockerfile)
+	deployProgress := a.soloProgress("devopsellence deploy", map[string]any{"image": imageTag})
+	deployProgress("Building local Docker image...")
 	if err := dockerBuild(ctx, buildCtx, dockerfile, imageTag, cfg.Build.Platforms); err != nil {
 		return fmt.Errorf("docker build: %w", err)
 	}
+	deployProgress("Local Docker image built.")
 
 	secrets, err := a.resolveSoloSecretValues(ctx, current, workspaceRoot, environmentName, cfg)
 	if err != nil {
@@ -397,9 +404,9 @@ func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 	}
 	if urls := soloStatusPublicURLs(cfg, nodes); len(urls) > 0 {
 		payload["public_urls"] = urls
-		payload["next_steps"] = []string{"devopsellence status", "curl " + urls[0]}
+		payload["next_steps"] = append([]string{"devopsellence status", "curl " + urls[0]}, soloNodeLogNextSteps(nodes)...)
 	} else {
-		payload["next_steps"] = []string{"devopsellence status"}
+		payload["next_steps"] = append([]string{"devopsellence status"}, soloNodeLogNextSteps(nodes)...)
 	}
 	return a.Printer.PrintJSON(payload)
 
@@ -808,7 +815,7 @@ func (a *App) republishNodes(ctx context.Context, current solo.State, nodeNames 
 					appendSoloRepublishError(&mu, &errs, name, "local image precheck", check.err)
 					return
 				}
-				if err := transferImage(ctx, node, image, func(string) {}); err != nil {
+				if err := transferImage(ctx, node, image, a.soloProgress("devopsellence deploy", map[string]any{"node": name, "image": image, "step": "image_transfer"})); err != nil {
 					appendSoloRepublishError(&mu, &errs, name, "image transfer", err)
 					return
 				}
@@ -1105,6 +1112,44 @@ func remoteNodeHasImage(ctx context.Context, node config.Node, imageTag string) 
 		return false, err
 	}
 	return strings.TrimSpace(out) == "present", nil
+}
+
+func (a *App) soloProgress(operation string, fields map[string]any) func(string) {
+	return func(message string) {
+		message = strings.TrimSpace(message)
+		if message == "" {
+			return
+		}
+		payload := map[string]any{
+			"operation": operation,
+			"message":   message,
+		}
+		for key, value := range fields {
+			payload[key] = value
+		}
+		_ = a.Printer.PrintEvent("progress", payload)
+	}
+}
+
+func soloNodeLogNextSteps(nodes map[string]config.Node) []string {
+	steps := []string{}
+	for _, node := range sortedNodeNames(nodes) {
+		steps = append(steps, "devopsellence node logs "+shellQuote(node)+" --lines 100")
+	}
+	return steps
+}
+
+func soloDoctorNextSteps(nodes map[string]config.Node) []string {
+	steps := []string{}
+	for _, nodeName := range sortedNodeNames(nodes) {
+		node := nodes[nodeName]
+		steps = append(steps,
+			"devopsellence agent install "+shellQuote(nodeName),
+			"devopsellence node diagnose "+shellQuote(nodeName),
+			fmt.Sprintf("ssh -p %d %s@%s true", node.Port, shellQuote(node.User), shellQuote(node.Host)),
+		)
+	}
+	return steps
 }
 
 func (a *App) ensureLocalSoloSnapshotImage(ctx context.Context, imageTag string) error {
@@ -1771,11 +1816,147 @@ func (a *App) SoloLogs(ctx context.Context, opts SoloLogsOptions) error {
 	if err != nil {
 		return err
 	}
+	lines := splitNonFinalEmptyLines(out)
+	return a.Printer.PrintJSON(map[string]any{"node": opts.Node, "lines": lines, "limit": linesLimit})
+}
+
+func (a *App) SoloNodeDiagnose(ctx context.Context, opts SoloNodeDiagnoseOptions) error {
+	current, err := a.readSoloState()
+	if err != nil {
+		return err
+	}
+	node, ok := current.Nodes[opts.Node]
+	if !ok {
+		return fmt.Errorf("node %q not found", opts.Node)
+	}
+
+	payload := map[string]any{
+		"schema_version": outputSchemaVersion,
+		"node":           opts.Node,
+		"host":           node.Host,
+		"user":           node.User,
+		"port":           node.Port,
+	}
+	checks := a.soloDiagnoseChecks(ctx, node)
+	payload["checks"] = checks
+	if soloCheckFailed(checks, "ssh") {
+		payload["next_steps"] = []string{fmt.Sprintf("ssh -p %d %s@%s true", node.Port, shellQuote(node.User), shellQuote(node.Host))}
+		return a.Printer.PrintJSON(payload)
+	}
+	payload["agent"] = map[string]any{
+		"active": collectRemoteText(ctx, node, "systemctl is-active devopsellence-agent || true"),
+		"status": collectRemoteLines(ctx, node, remoteSystemctlStatusCommand("devopsellence-agent", 40)),
+	}
+	payload["docker"] = map[string]any{
+		"containers": collectRemoteJSONLines(ctx, node, remoteDockerPSJSONCommand()),
+		"images":     collectRemoteJSONLines(ctx, node, remoteDockerImagesJSONCommand()),
+		"networks":   collectRemoteJSONLines(ctx, node, remoteDockerNetworksJSONCommand()),
+	}
+	payload["ports"] = collectRemoteLines(ctx, node, remoteListeningPortsCommand())
+	statusResult, statusErr := readNodeStatus(ctx, node)
+	if statusErr != nil {
+		payload["status_error"] = statusErr.Error()
+	} else if statusResult.Missing {
+		payload["status_missing"] = true
+	} else {
+		var statusPayload any
+		if err := json.Unmarshal(statusResult.Raw, &statusPayload); err == nil {
+			payload["status"] = statusPayload
+		} else {
+			payload["status"] = string(statusResult.Raw)
+		}
+	}
+	payload["next_steps"] = []string{
+		"devopsellence status",
+		"devopsellence node logs " + shellQuote(opts.Node) + " --lines 100",
+	}
+	return a.Printer.PrintJSON(payload)
+}
+
+func (a *App) soloDiagnoseChecks(ctx context.Context, node config.Node) []map[string]any {
+	checks := []struct {
+		name string
+		cmd  string
+	}{
+		{name: "ssh", cmd: "true"},
+		{name: "docker", cmd: remoteDockerCheckCommand()},
+		{name: "agent", cmd: "systemctl is-active --quiet devopsellence-agent"},
+	}
+	results := make([]map[string]any, 0, len(checks))
+	for _, check := range checks {
+		out, err := solo.RunSSH(ctx, node, check.cmd, nil)
+		result := map[string]any{"check": check.name, "ok": err == nil}
+		if err != nil {
+			result["detail"] = err.Error()
+		} else if detail := strings.TrimSpace(out); detail != "" {
+			result["detail"] = detail
+		}
+		results = append(results, result)
+	}
+	return results
+}
+
+func soloCheckFailed(checks []map[string]any, name string) bool {
+	for _, check := range checks {
+		if check["check"] == name && check["ok"] == false {
+			return true
+		}
+	}
+	return false
+}
+
+func splitNonFinalEmptyLines(out string) []string {
 	lines := strings.Split(out, "\n")
 	if len(lines) > 0 && lines[len(lines)-1] == "" {
 		lines = lines[:len(lines)-1]
 	}
-	return a.Printer.PrintJSON(map[string]any{"node": opts.Node, "lines": lines, "limit": linesLimit})
+	return lines
+}
+
+func collectRemoteText(ctx context.Context, node config.Node, command string) map[string]any {
+	out, err := solo.RunSSH(ctx, node, command, nil)
+	result := map[string]any{"ok": err == nil}
+	if err != nil {
+		result["error"] = err.Error()
+	} else {
+		result["value"] = strings.TrimSpace(out)
+	}
+	return result
+}
+
+func collectRemoteLines(ctx context.Context, node config.Node, command string) map[string]any {
+	out, err := solo.RunSSH(ctx, node, command, nil)
+	result := map[string]any{"ok": err == nil}
+	if err != nil {
+		result["error"] = err.Error()
+	} else {
+		result["lines"] = splitNonFinalEmptyLines(out)
+	}
+	return result
+}
+
+func collectRemoteJSONLines(ctx context.Context, node config.Node, command string) map[string]any {
+	out, err := solo.RunSSH(ctx, node, command, nil)
+	result := map[string]any{"ok": err == nil}
+	if err != nil {
+		result["error"] = err.Error()
+		return result
+	}
+	items := []any{}
+	for _, line := range splitNonFinalEmptyLines(out) {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var item map[string]any
+		if err := json.Unmarshal([]byte(line), &item); err != nil {
+			items = append(items, line)
+		} else {
+			items = append(items, item)
+		}
+	}
+	result["items"] = items
+	return result
 }
 
 func (a *App) SoloNodeLabelSet(ctx context.Context, opts SoloNodeLabelSetOptions) error {
@@ -1896,12 +2077,18 @@ func (a *App) soloRuntimeDoctorChecks(ctx context.Context, opts SoloDoctorOption
 			{name: "agent", cmd: "systemctl is-active --quiet devopsellence-agent"},
 		}
 		for _, check := range checks {
-			err := solo.RunSSHInteractive(ctx, node, check.cmd, io.Discard, io.Discard)
+			out, err := solo.RunSSH(ctx, node, check.cmd, nil)
 			ok := err == nil
-			if !ok {
+			result := map[string]any{"node": name, "check": check.name, "ok": ok}
+			if ok {
+				if detail := strings.TrimSpace(out); detail != "" {
+					result["detail"] = detail
+				}
+			} else {
 				failed = true
+				result["detail"] = strings.TrimSpace(err.Error())
 			}
-			results = append(results, map[string]any{"node": name, "check": check.name, "ok": ok})
+			results = append(results, result)
 		}
 	}
 	return results, failed, nil
@@ -2000,6 +2187,9 @@ func (a *App) SoloDoctor(ctx context.Context) error {
 		}
 		payload["runtime_checks"] = runtimeChecks
 		payload["ok"] = !runtimeFailed
+		if runtimeFailed {
+			payload["next_steps"] = soloDoctorNextSteps(current.Nodes)
+		}
 		if err := a.Printer.PrintJSON(payload); err != nil {
 			return err
 		}
@@ -2314,7 +2504,11 @@ func (a *App) SoloNodeRemove(ctx context.Context, opts SoloNodeRemoveOptions) er
 		return a.Printer.PrintJSON(map[string]any{
 			"node":   opts.Name,
 			"action": "forgotten",
-			"note":   fmt.Sprintf("node removed from local state only; if remote cleanup is still needed, run `devopsellence agent uninstall %s --yes`", shellQuote(opts.Name)),
+			"note":   "manual SSH node forgotten locally; this command did not contact the VM",
+			"remote_cleanup": map[string]any{
+				"performed": false,
+				"if_needed": fmt.Sprintf("devopsellence agent uninstall %s --yes", shellQuote(opts.Name)),
+			},
 		})
 
 	}
@@ -2375,7 +2569,9 @@ func (a *App) SoloInit(context.Context, SoloInitOptions) error {
 		missing = append(missing, "node")
 	}
 	nextSteps := []string{
-		"git init && git add . && git commit -m 'initial deploy' # if this app is not committed yet",
+		"git init # if this app is not already a git checkout",
+		"git add . # include devopsellence.yml and app files",
+		"git commit -m 'initial deploy' # devopsellence deploys the current commit",
 		"devopsellence node create prod-1 --host <host> --user root --ssh-key <path>",
 		"devopsellence agent install prod-1",
 		"devopsellence node attach prod-1",
@@ -3372,6 +3568,27 @@ func remoteReadOptionalFileCommand(path, missingSentinel string) string {
 
 func remoteJournalctlCommand(args string) string {
 	return fmt.Sprintf("if command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then exec sudo -n journalctl %s; fi; exec journalctl %s", args, args)
+}
+
+func remoteSystemctlStatusCommand(unit string, lines int) string {
+	args := fmt.Sprintf("status --no-pager -l -n %d %s", lines, shellQuote(unit))
+	return fmt.Sprintf("if command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then sudo -n systemctl %s || true; else systemctl %s || true; fi", args, args)
+}
+
+func remoteDockerPSJSONCommand() string {
+	return "if docker info >/dev/null 2>&1; then docker ps -a --format '{{json .}}'; elif command -v sudo >/dev/null 2>&1 && sudo -n docker info >/dev/null 2>&1; then sudo -n docker ps -a --format '{{json .}}'; else echo 'Docker is not reachable' >&2; exit 1; fi"
+}
+
+func remoteDockerImagesJSONCommand() string {
+	return "if docker info >/dev/null 2>&1; then docker images --format '{{json .}}'; elif command -v sudo >/dev/null 2>&1 && sudo -n docker info >/dev/null 2>&1; then sudo -n docker images --format '{{json .}}'; else echo 'Docker is not reachable' >&2; exit 1; fi"
+}
+
+func remoteDockerNetworksJSONCommand() string {
+	return "if docker info >/dev/null 2>&1; then docker network ls --format '{{json .}}'; elif command -v sudo >/dev/null 2>&1 && sudo -n docker info >/dev/null 2>&1; then sudo -n docker network ls --format '{{json .}}'; else echo 'Docker is not reachable' >&2; exit 1; fi"
+}
+
+func remoteListeningPortsCommand() string {
+	return "if command -v ss >/dev/null 2>&1; then ss -ltnp || ss -ltn; elif command -v netstat >/dev/null 2>&1; then netstat -ltnp || netstat -ltn; else echo 'no ss or netstat available'; fi"
 }
 
 func desiredStateOverridePath(node config.Node) string {

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -2321,6 +2321,21 @@ if [[ "$command" == *"docker info"* ]]; then
   exit 0
 fi
 
+if [[ "$command" == *"__DEVOPSELLENCE_EXIT_CODE__"* && "$command" == *"systemctl is-active devopsellence-agent"* ]]; then
+  printf '__DEVOPSELLENCE_EXIT_CODE__0\n__DEVOPSELLENCE_STDOUT__\nactive\n__DEVOPSELLENCE_STDERR__\n'
+  exit 0
+fi
+
+if [[ "$command" == *"__DEVOPSELLENCE_EXIT_CODE__"* && "$command" == *"systemctl status"* ]]; then
+  printf '__DEVOPSELLENCE_EXIT_CODE__0\n__DEVOPSELLENCE_STDOUT__\ndevopsellence-agent active\n__DEVOPSELLENCE_STDERR__\n'
+  exit 0
+fi
+
+if [[ "$command" == *"__DEVOPSELLENCE_EXIT_CODE__"* && ( "$command" == *"ss -ltn"* || "$command" == *"netstat -ltn"* ) ]]; then
+  printf '__DEVOPSELLENCE_EXIT_CODE__0\n__DEVOPSELLENCE_STDOUT__\nLISTEN 0 4096 0.0.0.0:80 0.0.0.0:*\n__DEVOPSELLENCE_STDERR__\n'
+  exit 0
+fi
+
 if [[ "$command" == *"systemctl is-active devopsellence-agent"* ]]; then
   printf 'active\n'
   exit 0

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -888,6 +888,48 @@ func TestSoloNodeDiagnoseCollectsRuntimeSnapshot(t *testing.T) {
 	}
 }
 
+func TestSoloNodeDiagnoseReturnsFailureWhenSSHCheckFails(t *testing.T) {
+	binDir := t.TempDir()
+	writeExecutable(t, filepath.Join(binDir, "ssh"), `#!/usr/bin/env bash
+echo "permission denied" >&2
+exit 255
+`)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.Node{
+			"node-a": {Host: "203.0.113.10", User: "root", Port: 22},
+		},
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState}
+	err := app.SoloNodeDiagnose(context.Background(), SoloNodeDiagnoseOptions{Node: "node-a"})
+	if err == nil {
+		t.Fatal("SoloNodeDiagnose() error = nil, want failure")
+	}
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 1 {
+		t.Fatalf("error = %#v, want ExitError code 1", err)
+	}
+	var renderedErr RenderedError
+	if !errors.As(exitErr.Err, &renderedErr) {
+		t.Fatalf("exit error = %#v, want RenderedError", exitErr.Err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	if payload["ok"] != false {
+		t.Fatalf("payload ok = %#v, want false", payload["ok"])
+	}
+	steps := jsonArrayFromMap(t, payload, "next_steps")
+	if len(steps) != 1 || steps[0] != "ssh -p 22 'root@203.0.113.10' true" {
+		t.Fatalf("next_steps = %#v, want SSH recovery command", steps)
+	}
+}
+
 func TestSoloAgentUninstallRequiresConfirmation(t *testing.T) {
 	app := &App{SoloState: solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))}
 	err := app.SoloAgentUninstall(context.Background(), SoloAgentUninstallOptions{Node: "node-a"})

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -2245,6 +2245,21 @@ if [[ "$command" == *"docker image inspect"* ]]; then
   exit 0
 fi
 
+if [[ "$command" == *"__DEVOPSELLENCE_EXIT_CODE__"* && "$command" == *"docker ps -a"* ]]; then
+  printf '__DEVOPSELLENCE_EXIT_CODE__0\n__DEVOPSELLENCE_STDOUT__\n{"Names":"svc-production-web","Image":"demo:abc","Status":"Up 1 minute","Ports":"3000/tcp"}\n__DEVOPSELLENCE_STDERR__\n'
+  exit 0
+fi
+
+if [[ "$command" == *"__DEVOPSELLENCE_EXIT_CODE__"* && "$command" == *"docker images"* ]]; then
+  printf '__DEVOPSELLENCE_EXIT_CODE__0\n__DEVOPSELLENCE_STDOUT__\n{"Repository":"demo","Tag":"abc","ID":"sha256:abc","Size":"1MB"}\n__DEVOPSELLENCE_STDERR__\n'
+  exit 0
+fi
+
+if [[ "$command" == *"__DEVOPSELLENCE_EXIT_CODE__"* && "$command" == *"docker network ls"* ]]; then
+  printf '__DEVOPSELLENCE_EXIT_CODE__0\n__DEVOPSELLENCE_STDOUT__\n{"Name":"devopsellence","Driver":"bridge"}\n__DEVOPSELLENCE_STDERR__\n'
+  exit 0
+fi
+
 if [[ "$command" == *"docker ps -a"* ]]; then
   printf '{"Names":"svc-production-web","Image":"demo:abc","Status":"Up 1 minute","Ports":"3000/tcp"}\n'
   exit 0

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -850,6 +850,44 @@ func TestSoloLogsUsesRequestedLineLimit(t *testing.T) {
 	}
 }
 
+func TestSoloNodeDiagnoseCollectsRuntimeSnapshot(t *testing.T) {
+	installFakeSoloCommands(t, []fakeSSHResponse{{stdout: `{"revision":"abc","phase":"settled"}` + "\n"}})
+
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.Node{
+			"node-a": {Host: "203.0.113.10", User: "root", Labels: []string{config.DefaultWebRole}},
+		},
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState}
+	if err := app.SoloNodeDiagnose(context.Background(), SoloNodeDiagnoseOptions{Node: "node-a"}); err != nil {
+		t.Fatalf("SoloNodeDiagnose() error = %v", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	if payload["node"] != "node-a" || payload["host"] != "203.0.113.10" {
+		t.Fatalf("payload = %#v, want node identity", payload)
+	}
+	checks := jsonArrayFromMap(t, payload, "checks")
+	if len(checks) != 3 {
+		t.Fatalf("checks = %#v, want ssh/docker/agent checks", checks)
+	}
+	dockerPayload := jsonMapFromAny(t, payload["docker"])
+	containers := jsonMapFromAny(t, dockerPayload["containers"])
+	items := jsonArrayFromMap(t, containers, "items")
+	if len(items) != 1 || jsonMapFromAny(t, items[0])["Names"] != "svc-production-web" {
+		t.Fatalf("containers = %#v, want web container", containers)
+	}
+	status := jsonMapFromAny(t, payload["status"])
+	if status["phase"] != "settled" {
+		t.Fatalf("status = %#v, want settled phase", status)
+	}
+}
+
 func TestSoloAgentUninstallRequiresConfirmation(t *testing.T) {
 	app := &App{SoloState: solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))}
 	err := app.SoloAgentUninstall(context.Background(), SoloAgentUninstallOptions{Node: "node-a"})
@@ -1333,8 +1371,8 @@ func TestSoloDeployWaitsForSettledStatusBeforeSuccess(t *testing.T) {
 		t.Fatalf("public_urls = %#v, want node URL", urls)
 	}
 	nextSteps := jsonArrayFromMap(t, payload, "next_steps")
-	if len(nextSteps) != 2 || nextSteps[0] != "devopsellence status" || nextSteps[1] != "curl http://203.0.113.10/" {
-		t.Fatalf("next_steps = %#v, want status and curl commands", nextSteps)
+	if len(nextSteps) != 3 || nextSteps[0] != "devopsellence status" || nextSteps[1] != "curl http://203.0.113.10/" || nextSteps[2] != "devopsellence node logs 'node-a' --lines 100" {
+		t.Fatalf("next_steps = %#v, want status, curl, and logs commands", nextSteps)
 	}
 }
 
@@ -2193,6 +2231,10 @@ func installFakeSoloCommands(t *testing.T, statusResponses []fakeSSHResponse) st
 set -euo pipefail
 command="${!#}"
 
+if [[ "$command" == "true" ]]; then
+  exit 0
+fi
+
 if [[ "$command" == *"desired-state set-override"* ]]; then
   cat >"$DEVOPSELLENCE_FAKE_SSH_REVISION_FILE"
   exit 0
@@ -2203,7 +2245,41 @@ if [[ "$command" == *"docker image inspect"* ]]; then
   exit 0
 fi
 
+if [[ "$command" == *"docker ps -a"* ]]; then
+  printf '{"Names":"svc-production-web","Image":"demo:abc","Status":"Up 1 minute","Ports":"3000/tcp"}\n'
+  exit 0
+fi
+
+if [[ "$command" == *"docker images"* ]]; then
+  printf '{"Repository":"demo","Tag":"abc","ID":"sha256:abc","Size":"1MB"}\n'
+  exit 0
+fi
+
+if [[ "$command" == *"docker network ls"* ]]; then
+  printf '{"Name":"devopsellence","Driver":"bridge"}\n'
+  exit 0
+fi
+
 if [[ "$command" == *"docker info"* ]]; then
+  exit 0
+fi
+
+if [[ "$command" == *"systemctl is-active devopsellence-agent"* ]]; then
+  printf 'active\n'
+  exit 0
+fi
+
+if [[ "$command" == *"systemctl is-active --quiet devopsellence-agent"* ]]; then
+  exit 0
+fi
+
+if [[ "$command" == *"systemctl status"* ]]; then
+  printf 'devopsellence-agent active\n'
+  exit 0
+fi
+
+if [[ "$command" == *"ss -ltn"* ]] || [[ "$command" == *"netstat -ltn"* ]]; then
+  printf 'LISTEN 0 4096 0.0.0.0:80 0.0.0.0:*\n'
   exit 0
 fi
 


### PR DESCRIPTION
## Summary

Addresses the solo first-deploy dogfood findings from:

- `/tmp/devopsellence-dogfood/20260427T163949402250Z-solo-first-deploy/report.md`
- `/tmp/devopsellence-dogfood/20260427T155356923593Z-solo-first-deploy/report.md`

Changes include:

- isolate existing SSH-node host keys in devopsellence-managed known_hosts files
- emit structured progress events on stderr for solo agent install, Docker build, and image transfer
- add solo `node diagnose <name>` snapshots for checks, agent, Docker, ports, and status
- route `node diagnose` by mode before parsing shared numeric node IDs
- include details/next steps in solo doctor runtime failures
- add logs next steps after successful solo deploys
- make `devopsellence mode` show current mode by default
- clarify first-run existing SSH-node docs, Docker expectations, cleanup/recovery commands, and app/toolchain boundaries

## Validation

```sh
cd cli && mise run test
```
