### PR TITLE
Refine dogfood skill for agent-mediated QA

### DIFF
--- a/.agents/skills/dogfood/SKILL.md
+++ b/.agents/skills/dogfood/SKILL.md
@@ -63,22 +63,9 @@ Evaluate whether the AI coding/operator agent can:
 
 ## Command Logging
 
-Keep `commands.log` as you go. For each meaningful step, record:
+Keep `commands.log` as you go. Use the exact step format in `references/commands-log-template.md`; the `new_run.rb` helper copies that template into each run artifact.
 
-```text
-## <ISO-8601 timestamp> <short step name>
-cwd: <working directory>
-AI agent intent: <why the AI agent is doing this>
-user approval: <not needed | requested | granted | denied>
-command: <command with secrets redacted>
-exit: <exit code>
-output excerpt:
-<minimal stdout/stderr or JSON proving the result>
-AI agent interpretation:
-<what the AI agent concluded and next action>
-```
-
-Use placeholders such as `$TOKEN`, `<redacted>`, or `<private-host>` instead of secret values or private identifiers.
+For each meaningful step, capture the timestamp, working directory, AI agent intent, user approval state, redacted command, exit code, minimal output/JSON evidence, and AI agent interpretation. Use placeholders such as `$TOKEN`, `<redacted>`, or `<private-host>` instead of secret values or private identifiers.
 
 ## Workflow
 

--- a/.agents/skills/dogfood/SKILL.md
+++ b/.agents/skills/dogfood/SKILL.md
@@ -1,36 +1,88 @@
 ---
 name: dogfood
-description: Use when asked to dogfood devopsellence, run manual product QA, test DevX, simulate a new user journey, evaluate product completeness, or produce a dogfood report. The skill guides blind-pass and expert-pass testing with evidence, scenarios, rubrics, and repeatable run artifacts.
+description: Use when asked to dogfood devopsellence from an agent-mediated perspective: an AI/operator agent acting for a user who delegates deployment, diagnosis, cleanup, and reporting. The skill guides blind-pass and expert-pass testing with evidence, agent-centric scenarios, rubrics, and repeatable run artifacts.
 ---
 
 # Dogfood
 
 ## Purpose
 
-Run devopsellence like a real user would. Find bugs, edge cases, product gaps, confusing language, missing docs, and DevX friction.
+Run devopsellence as an AI/operator agent acting on behalf of a user. Find bugs, product gaps, confusing contracts, missing docs, unsafe workflows, and DevX friction that prevent an agent from deploying, observing, diagnosing, recovering, and explaining devopsellence operations.
 
-Dogfood is not only e2e. It asks: can a target user complete the job, understand what happened, recover from failure, and trust the product?
+Dogfood is not direct human CLI QA. It asks: can a user safely delegate the job to an agent, can the agent determine the right operations, can the agent execute them non-interactively where appropriate, can it understand what happened from structured/inspectable outputs, can it recover from failure, and can it explain the result back to the user?
+
+Direct human UX matters only when it affects agent-mediated use, for example approval boundaries, docs the agent must read, terminal-only flows the agent cannot automate, ambiguous output the agent must parse, or messages the agent must relay to a user.
 
 ## Core Rules
 
 - Write `devopsellence` lowercase.
+- Evaluate from the agent-mediated perspective by default: the agent receives a user goal, operates devopsellence, asks the user for approvals or missing facts, and reports back with evidence.
+- Do not score direct human terminal ergonomics as the primary product experience unless the user explicitly asks for human-direct QA.
 - Prefer fresh temp apps and fresh state.
-- For ordinary solo-mode node tests, prefer `zirk` VMs when available instead of provider-created nodes. Use `zirk health`, `zirk flavors`, `zirk create <name> --flavor <flavor>`, `zirk show <name>`, and `zirk exec <name> ...` as user-facing setup evidence.
-- Also QA the Hetzner provider-created VM path for solo first-deploy/provider scenarios. Retrieve the Hetzner API token from 1Password item `hetzner-devopsellence-solo` with `op`, export it as `HCLOUD_TOKEN` or pass it to `devopsellence provider login hetzner --token "$HCLOUD_TOKEN"`, and never log the token value.
+- For ordinary solo-mode node tests, prefer `zirk` VMs when available. Use `zirk health`, `zirk flavors`, `zirk create <run-scoped-name> --flavor <flavor>`, `zirk show <run-scoped-name>`, and `zirk exec <run-scoped-name> ...` as setup evidence.
+- Use run-scoped names for external resources, for example `dogfood-<timestamp>` or the run slug. Do not use generic production-like names unless the scenario specifically requires testing that name.
 - Start with a blind pass unless the user explicitly asks for code review first.
-- During blind pass, use only public/user-facing context: README, docs, CLI help, web UI, generated errors, logs surfaced by the product.
+- During blind pass, use only context an external agent could use: public website docs, README/docs that match the target version when available, installed CLI help, API/JSON output, web UI state when unavoidable, generated errors, logs surfaced by the product, and ordinary tools exposed to the operator.
+- If versioned public docs are unavailable, record the docs source used and treat any version mismatch as a finding instead of silently mixing sources.
 - Do not read implementation source during blind pass.
 - After blind pass, run expert pass: inspect source, logs, DB, tests, and root causes.
-- Capture evidence: exact commands, key output excerpts, paths, screenshots when UI matters, and time-to-first-success.
-- Separate product gaps from bugs. Product completeness and DevX count even when code works.
-- Do not hide setup pain. Record confusing prompts, missing next steps, slow feedback, scary output, and cleanup uncertainty.
+- Capture evidence: exact commands, key output excerpts, machine-readable payload excerpts, paths, screenshots when UI matters, user approval points, and time-to-first-agent-confidence.
+- Separate product gaps from bugs. Product completeness and agent DevX count even when code works.
+- Do not hide setup pain. Record missing machine-readable affordances, unclear next actions, prompts that block automation, slow feedback, scary output, and cleanup uncertainty.
 - Keep secrets and private identifiers out of reports.
+
+## Agent-Mediated Evaluation Frame
+
+For every run, model three roles:
+
+- Delegating user: owns the goal, constraints, approvals, and risk tolerance.
+- Operator agent: reads docs/help/output, executes commands, interprets state, asks for approval when needed, and explains results.
+- devopsellence: product under test.
+
+Evaluate whether the operator agent can:
+
+- discover the correct workflow without source inspection;
+- run it non-interactively or identify explicit approval boundaries;
+- get structured output (`--json` or equivalent) for plans, status, errors, logs, cleanup, and diagnostics where possible;
+- rely on deterministic exit codes and stable error categories;
+- understand intended state vs observed state without scraping styled terminal output;
+- detect secrets/private identifiers and avoid leaking them;
+- produce a concise, trustworthy report for the delegating user;
+- recover or safely stop when information, credentials, approvals, or infrastructure are missing.
+
+## Safety and Cleanup
+
+- Before creating any VM, cloud resource, or long-lived local state, record the expected resource name, owner, approval requirement, and cleanup command in `commands.log`.
+- Prefer ephemeral local or zirk-backed resources for routine dogfood runs.
+- Avoid provider-created resources unless the scenario explicitly requires them and the user has approved the cost/blast radius.
+- Always perform cleanup or document why cleanup was not possible.
+- Verify cleanup with agent-usable commands, for example status/list commands, `zirk show`, or cloud/provider CLIs when used.
+- If cleanup fails, mark the run as needing follow-up and include exact remaining resource identifiers after redaction.
+
+## Command Logging
+
+Keep `commands.log` as you go. For each meaningful step, record:
+
+```text
+## <ISO-8601 timestamp> <short step name>
+cwd: <working directory>
+agent intent: <why the agent is doing this>
+user approval: <not needed | requested | granted | denied>
+command: <command with secrets redacted>
+exit: <exit code>
+output excerpt:
+<minimal stdout/stderr or JSON proving the result>
+agent interpretation:
+<what the agent concluded and next action>
+```
+
+Use placeholders such as `$TOKEN`, `<redacted>`, or `<private-host>` instead of secret values or private identifiers.
 
 ## Workflow
 
 1. Pick scenario.
    - If the user names one, use it.
-   - Otherwise choose the smallest scenario that answers the request.
+   - Otherwise choose the smallest agent-mediated scenario that answers the request.
    - Read `references/scenarios.md` only when scenario detail is needed.
 
 2. Create run artifact.
@@ -38,69 +90,89 @@ Dogfood is not only e2e. It asks: can a target user complete the job, understand
    - If the user names a devopsellence version, pass `--version <version>`.
    - If no version is named, omit `--version` and dogfood the default stable installer/control-plane version.
    - Use the temp run path printed by the helper unless the user asks for repo-tracked reports.
-   - Keep `commands.log` as you go.
+   - Keep `commands.log` as described above.
 
 3. Blind pass.
-   - Use docs, CLI help, UI, and terminal feedback.
+   - Act as the operator agent, not as a direct human user.
+   - Use docs, CLI help, structured output, UI when unavoidable, ordinary tools, and terminal feedback.
    - Do not inspect source.
-   - Install the requested target from `commands.log`: preview versions use `curl -fsSL https://www.devopsellence.com/lfg.sh?version=<version> | bash`; default stable uses `curl -fsSL https://www.devopsellence.com/lfg.sh | bash`.
-   - For solo first-deploy scenarios, if `zirk` is installed and healthy, create a fresh VM and use it as the existing SSH node. Record `zirk` commands in `commands.log`. Prefer the smallest flavor that can run Docker builds/deploys reliably.
-   - For Hetzner provider QA, create a fresh provider node with `devopsellence provider login hetzner --token "$HCLOUD_TOKEN"` and `devopsellence node create prod-1 --provider hetzner --install --attach`. Use the default region/size unless the scenario asks otherwise. Record commands with `$HCLOUD_TOKEN` redacted, then verify deploy, status, logs/diagnose, detach, and provider-backed `devopsellence node remove prod-1 --yes` cleanup.
-   - Work from user goals, not privileged steps.
-   - Stop only for hard blockers; otherwise recover like a user would.
+   - Install the target recorded in the run artifact: preview versions use `curl -fsSL https://www.devopsellence.com/lfg.sh?version=<version> | bash`; default stable uses `curl -fsSL https://www.devopsellence.com/lfg.sh | bash`.
+   - For solo first-deploy scenarios, if `zirk` is installed and healthy, create a fresh run-scoped VM and use it as the existing SSH node. Record `zirk` commands in `commands.log`. Prefer the smallest flavor that can run Docker builds/deploys reliably.
+   - Work from the delegating user's goal, constraints, and approvals; do not use privileged implementation knowledge.
+   - Stop for missing approval, unsafe ambiguity, or hard blockers; otherwise recover like a competent operator agent would.
 
-4. Expert pass.
+4. Agent-primary checks.
+   - Probe whether the workflow can run non-interactively after required user approvals are known.
+   - Prefer structured output when available, especially `--json` or equivalent.
+   - Record whether errors include stable codes, machine-readable fields, suggested next actions, and deterministic exit codes.
+   - Note any flow that requires scraping styled terminal text, prompts, spinners, browser-only state, or implicit TTY behavior.
+   - Check whether the agent can produce a correct user-facing summary without guessing.
+
+5. Expert pass.
    - Inspect implementation only after blind evidence is recorded.
    - Root-cause failures and confusing behavior.
    - Check whether existing tests cover the risk.
 
-5. Score and report.
+6. Score and report.
    - Read `references/rubric.md` for scoring when needed.
    - Use `references/report-template.md` for final structure.
-   - Lead with outcome, top fixes, and evidence.
+   - Lead with outcome, top fixes, and evidence from the agent-mediated run.
 
-6. Optional fixes.
+7. Optional fixes.
    - If user asks to fix findings, make small reviewable changes.
    - Preserve unrelated worktree changes.
    - Re-run the relevant scenario or narrower verification.
 
 ## Scenario Defaults
 
-Use these default personas:
+Use these default delegating-user personas:
 
-- Solo founder: wants one containerized app live on one VM with ordinary tools.
-- Rails developer: understands app code, not infra details.
-- Infra-aware skeptic: checks logs, rollback/delete, status, and escape hatches.
-- Tired maintainer: bad input, broken deploy, needs clear recovery.
+- Solo founder delegating deployment: wants one containerized app live on one VM and expects the agent to handle operational details safely.
+- Rails developer delegating production config: understands app code, asks the agent to wire secrets/deploy/redeploy without leaking values.
+- Infra-aware skeptic supervising an agent: checks plans, logs, rollback/delete, status, and escape hatches before approving risky actions.
+- Tired maintainer delegating incident recovery: gives the agent a broken deploy and needs clear diagnosis, recovery, and stop/ask behavior.
 
 Good default devopsellence journeys:
 
-- Solo first deploy for a fresh Rails app.
-- Solo first deploy with a Hetzner provider-created VM.
-- Existing app deploy with secrets.
-- Failed deploy diagnosis and recovery.
-- Status/log inspection after deploy.
-- Delete/cleanup after experiment.
-- Shared flow: connect node, deploy app, inspect status.
+- Agent-mediated solo first deploy for a fresh Rails app.
+- Agent-mediated existing app deploy with secrets.
+- Agent-mediated failed deploy diagnosis and recovery.
+- Agent-mediated status/log inspection and user summary after deploy.
+- Agent-mediated delete/cleanup after experiment.
+- Agent-mediated shared flow: connect node, deploy app, inspect status.
+- Non-interactive deploy/status/log workflow with structured output.
 
 ## Evidence Standard
 
 For each important claim, include one of:
 
 - Command and output excerpt.
+- JSON/API payload excerpt or schema shape.
 - File path and line reference.
-- UI screenshot or described visual state.
+- UI screenshot or described visual state when UI is unavoidable.
 - Log line with timestamp when available.
-- Reproduction steps in user-facing terms.
+- Reproduction steps in agent-facing terms.
+- User approval point and resulting agent action.
 
 Do not over-quote logs. Keep enough to prove the point.
+
+## Finding Standard
+
+For each top finding, include:
+
+- Severity: blocker, high, medium, low.
+- Surface: docs, CLI, API, control plane, agent, deploy core, installer, cleanup, or observability.
+- Expected agent-mediated behavior.
+- Actual behavior.
+- Reproduction evidence.
+- Suggested fix.
 
 ## Output Shape
 
 Final response should be short unless user asks for the full report inline:
 
 - run path
-- outcome
+- outcome from the agent-mediated perspective
 - top 3 findings
 - validation done
 - next suggested fix batch

--- a/.agents/skills/dogfood/SKILL.md
+++ b/.agents/skills/dogfood/SKILL.md
@@ -1,45 +1,47 @@
 ---
 name: dogfood
-description: Use when asked to dogfood devopsellence from an agent-mediated perspective: an AI/operator agent acting for a user who delegates deployment, diagnosis, cleanup, and reporting. The skill guides blind-pass and expert-pass testing with evidence, agent-centric scenarios, rubrics, and repeatable run artifacts.
+description: Use when asked to dogfood devopsellence from an AI-agent-mediated perspective: an AI coding/operator agent acting for a user who delegates deployment, diagnosis, cleanup, and reporting. The skill guides blind-pass and expert-pass testing with evidence, AI-agent-centric scenarios, rubrics, and repeatable run artifacts.
 ---
 
 # Dogfood
 
 ## Purpose
 
-Run devopsellence as an AI/operator agent acting on behalf of a user. Find bugs, product gaps, confusing contracts, missing docs, unsafe workflows, and DevX friction that prevent an agent from deploying, observing, diagnosing, recovering, and explaining devopsellence operations.
+Run devopsellence as an AI coding/operator agent acting on behalf of a user. Find bugs, product gaps, confusing contracts, missing docs, unsafe workflows, and DevX friction that prevent an AI agent from deploying, observing, diagnosing, recovering, and explaining devopsellence operations.
 
-Dogfood is not direct human CLI QA. It asks: can a user safely delegate the job to an agent, can the agent determine the right operations, can the agent execute them non-interactively where appropriate, can it understand what happened from structured/inspectable outputs, can it recover from failure, and can it explain the result back to the user?
+Dogfood is not direct human CLI QA. It asks: can a user safely delegate the job to an AI coding/operator agent, can the AI agent determine the right operations, can the AI agent execute them non-interactively where appropriate, can it understand what happened from structured/inspectable outputs, can it recover from failure, and can it explain the result back to the user?
 
-Direct human UX matters only when it affects agent-mediated use, for example approval boundaries, docs the agent must read, terminal-only flows the agent cannot automate, ambiguous output the agent must parse, or messages the agent must relay to a user.
+Terminology: in this skill, "AI agent" means an AI coding/operator agent acting on behalf of a delegating user. "devopsellence node agent" means the runtime reconciler on the VM. Use the explicit term when both meanings could be confused.
+
+Direct human UX matters only when it affects AI-agent-mediated use, for example approval boundaries, docs the AI agent must read, terminal-only flows the AI agent cannot automate, ambiguous output the AI agent must parse, or messages the AI agent must relay to a user.
 
 ## Core Rules
 
 - Write `devopsellence` lowercase.
-- Evaluate from the agent-mediated perspective by default: the agent receives a user goal, operates devopsellence, asks the user for approvals or missing facts, and reports back with evidence.
+- Evaluate from the AI-agent-mediated perspective by default: the AI coding/operator agent receives a user goal, operates devopsellence, asks the user for approvals or missing facts, and reports back with evidence.
 - Do not score direct human terminal ergonomics as the primary product experience unless the user explicitly asks for human-direct QA.
 - Prefer fresh temp apps and fresh state.
 - For ordinary solo-mode node tests, prefer `zirk` VMs when available. Use `zirk health`, `zirk flavors`, `zirk create <run-scoped-name> --flavor <flavor>`, `zirk show <run-scoped-name>`, and `zirk exec <run-scoped-name> ...` as setup evidence.
 - Use run-scoped names for external resources, for example `dogfood-<timestamp>` or the run slug. Do not use generic production-like names unless the scenario specifically requires testing that name.
 - Start with a blind pass unless the user explicitly asks for code review first.
-- During blind pass, use only context an external agent could use: public website docs, README/docs that match the target version when available, installed CLI help, API/JSON output, web UI state when unavoidable, generated errors, logs surfaced by the product, and ordinary tools exposed to the operator.
+- During blind pass, use only context an external AI coding/operator agent could use: public website docs, README/docs that match the target version when available, installed CLI help, API/JSON output, web UI state when unavoidable, generated errors, logs surfaced by the product, and ordinary tools exposed to the operator.
 - If versioned public docs are unavailable, record the docs source used and treat any version mismatch as a finding instead of silently mixing sources.
 - Do not read implementation source during blind pass.
 - After blind pass, run expert pass: inspect source, logs, DB, tests, and root causes.
 - Capture evidence: exact commands, key output excerpts, machine-readable payload excerpts, paths, screenshots when UI matters, user approval points, and time-to-first-agent-confidence.
-- Separate product gaps from bugs. Product completeness and agent DevX count even when code works.
+- Separate product gaps from bugs. Product completeness and AI agent DevX count even when code works.
 - Do not hide setup pain. Record missing machine-readable affordances, unclear next actions, prompts that block automation, slow feedback, scary output, and cleanup uncertainty.
 - Keep secrets and private identifiers out of reports.
 
-## Agent-Mediated Evaluation Frame
+## AI-Agent-Mediated Evaluation Frame
 
 For every run, model three roles:
 
 - Delegating user: owns the goal, constraints, approvals, and risk tolerance.
-- Operator agent: reads docs/help/output, executes commands, interprets state, asks for approval when needed, and explains results.
+- AI coding/operator agent: reads docs/help/output, executes commands, interprets state, asks for approval when needed, and explains results.
 - devopsellence: product under test.
 
-Evaluate whether the operator agent can:
+Evaluate whether the AI coding/operator agent can:
 
 - discover the correct workflow without source inspection;
 - run it non-interactively or identify explicit approval boundaries;
@@ -56,7 +58,7 @@ Evaluate whether the operator agent can:
 - Prefer ephemeral local or zirk-backed resources for routine dogfood runs.
 - Avoid provider-created resources unless the scenario explicitly requires them and the user has approved the cost/blast radius.
 - Always perform cleanup or document why cleanup was not possible.
-- Verify cleanup with agent-usable commands, for example status/list commands, `zirk show`, or cloud/provider CLIs when used.
+- Verify cleanup with AI-agent-usable commands, for example status/list commands, `zirk show`, or cloud/provider CLIs when used.
 - If cleanup fails, mark the run as needing follow-up and include exact remaining resource identifiers after redaction.
 
 ## Command Logging
@@ -66,14 +68,14 @@ Keep `commands.log` as you go. For each meaningful step, record:
 ```text
 ## <ISO-8601 timestamp> <short step name>
 cwd: <working directory>
-agent intent: <why the agent is doing this>
+AI agent intent: <why the AI agent is doing this>
 user approval: <not needed | requested | granted | denied>
 command: <command with secrets redacted>
 exit: <exit code>
 output excerpt:
 <minimal stdout/stderr or JSON proving the result>
-agent interpretation:
-<what the agent concluded and next action>
+AI agent interpretation:
+<what the AI agent concluded and next action>
 ```
 
 Use placeholders such as `$TOKEN`, `<redacted>`, or `<private-host>` instead of secret values or private identifiers.
@@ -82,7 +84,7 @@ Use placeholders such as `$TOKEN`, `<redacted>`, or `<private-host>` instead of 
 
 1. Pick scenario.
    - If the user names one, use it.
-   - Otherwise choose the smallest agent-mediated scenario that answers the request.
+   - Otherwise choose the smallest AI-agent-mediated scenario that answers the request.
    - Read `references/scenarios.md` only when scenario detail is needed.
 
 2. Create run artifact.
@@ -93,20 +95,20 @@ Use placeholders such as `$TOKEN`, `<redacted>`, or `<private-host>` instead of 
    - Keep `commands.log` as described above.
 
 3. Blind pass.
-   - Act as the operator agent, not as a direct human user.
+   - Act as the AI coding/operator agent, not as a direct human user.
    - Use docs, CLI help, structured output, UI when unavoidable, ordinary tools, and terminal feedback.
    - Do not inspect source.
    - Install the target recorded in the run artifact: preview versions use `curl -fsSL https://www.devopsellence.com/lfg.sh?version=<version> | bash`; default stable uses `curl -fsSL https://www.devopsellence.com/lfg.sh | bash`.
    - For solo first-deploy scenarios, if `zirk` is installed and healthy, create a fresh run-scoped VM and use it as the existing SSH node. Record `zirk` commands in `commands.log`. Prefer the smallest flavor that can run Docker builds/deploys reliably.
    - Work from the delegating user's goal, constraints, and approvals; do not use privileged implementation knowledge.
-   - Stop for missing approval, unsafe ambiguity, or hard blockers; otherwise recover like a competent operator agent would.
+   - Stop for missing approval, unsafe ambiguity, or hard blockers; otherwise recover like a competent AI coding/operator agent would.
 
-4. Agent-primary checks.
+4. AI-agent-primary checks.
    - Probe whether the workflow can run non-interactively after required user approvals are known.
    - Prefer structured output when available, especially `--json` or equivalent.
    - Record whether errors include stable codes, machine-readable fields, suggested next actions, and deterministic exit codes.
    - Note any flow that requires scraping styled terminal text, prompts, spinners, browser-only state, or implicit TTY behavior.
-   - Check whether the agent can produce a correct user-facing summary without guessing.
+   - Check whether the AI agent can produce a correct user-facing summary without guessing.
 
 5. Expert pass.
    - Inspect implementation only after blind evidence is recorded.
@@ -116,7 +118,7 @@ Use placeholders such as `$TOKEN`, `<redacted>`, or `<private-host>` instead of 
 6. Score and report.
    - Read `references/rubric.md` for scoring when needed.
    - Use `references/report-template.md` for final structure.
-   - Lead with outcome, top fixes, and evidence from the agent-mediated run.
+   - Lead with outcome, top fixes, and evidence from the AI-agent-mediated run.
 
 7. Optional fixes.
    - If user asks to fix findings, make small reviewable changes.
@@ -127,19 +129,19 @@ Use placeholders such as `$TOKEN`, `<redacted>`, or `<private-host>` instead of 
 
 Use these default delegating-user personas:
 
-- Solo founder delegating deployment: wants one containerized app live on one VM and expects the agent to handle operational details safely.
-- Rails developer delegating production config: understands app code, asks the agent to wire secrets/deploy/redeploy without leaking values.
-- Infra-aware skeptic supervising an agent: checks plans, logs, rollback/delete, status, and escape hatches before approving risky actions.
-- Tired maintainer delegating incident recovery: gives the agent a broken deploy and needs clear diagnosis, recovery, and stop/ask behavior.
+- Solo founder delegating deployment: wants one containerized app live on one VM and expects the AI agent to handle operational details safely.
+- Rails developer delegating production config: understands app code, asks the AI agent to wire secrets/deploy/redeploy without leaking values.
+- Infra-aware skeptic supervising an AI agent: checks plans, logs, rollback/delete, status, and escape hatches before approving risky actions.
+- Tired maintainer delegating incident recovery: gives the AI agent a broken deploy and needs clear diagnosis, recovery, and stop/ask behavior.
 
 Good default devopsellence journeys:
 
-- Agent-mediated solo first deploy for a fresh Rails app.
-- Agent-mediated existing app deploy with secrets.
-- Agent-mediated failed deploy diagnosis and recovery.
-- Agent-mediated status/log inspection and user summary after deploy.
-- Agent-mediated delete/cleanup after experiment.
-- Agent-mediated shared flow: connect node, deploy app, inspect status.
+- AI-agent-mediated solo first deploy for a fresh Rails app.
+- AI-agent-mediated existing app deploy with secrets.
+- AI-agent-mediated failed deploy diagnosis and recovery.
+- AI-agent-mediated status/log inspection and user summary after deploy.
+- AI-agent-mediated delete/cleanup after experiment.
+- AI-agent-mediated shared flow: connect node, deploy app, inspect status.
 - Non-interactive deploy/status/log workflow with structured output.
 
 ## Evidence Standard
@@ -151,8 +153,8 @@ For each important claim, include one of:
 - File path and line reference.
 - UI screenshot or described visual state when UI is unavoidable.
 - Log line with timestamp when available.
-- Reproduction steps in agent-facing terms.
-- User approval point and resulting agent action.
+- Reproduction steps in AI-agent-facing terms.
+- User approval point and resulting AI agent action.
 
 Do not over-quote logs. Keep enough to prove the point.
 
@@ -161,8 +163,8 @@ Do not over-quote logs. Keep enough to prove the point.
 For each top finding, include:
 
 - Severity: blocker, high, medium, low.
-- Surface: docs, CLI, API, control plane, agent, deploy core, installer, cleanup, or observability.
-- Expected agent-mediated behavior.
+- Surface: docs, CLI, API, control plane, AI coding/operator agent, devopsellence node agent, deploy core, installer, cleanup, or observability.
+- Expected AI-agent-mediated behavior.
 - Actual behavior.
 - Reproduction evidence.
 - Suggested fix.
@@ -172,7 +174,7 @@ For each top finding, include:
 Final response should be short unless user asks for the full report inline:
 
 - run path
-- outcome from the agent-mediated perspective
+- outcome from the AI-agent-mediated perspective
 - top 3 findings
 - validation done
 - next suggested fix batch

--- a/.agents/skills/dogfood/agents/openai.yaml
+++ b/.agents/skills/dogfood/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Dogfood"
-  short_description: "Repeatable devopsellence dogfooding runs"
-  default_prompt: "Dogfood devopsellence: pick a scenario, run a blind pass, then an expert pass, and write a report."
+  short_description: "Agent-mediated devopsellence dogfooding runs"
+  default_prompt: "Dogfood devopsellence from the perspective of an operator agent acting for a delegating user: run a blind pass, then an expert pass, and write an evidence-backed report."

--- a/.agents/skills/dogfood/agents/openai.yaml
+++ b/.agents/skills/dogfood/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Dogfood"
   short_description: "AI-agent-mediated devopsellence dogfooding runs"
-  default_prompt: "Dogfood devopsellence from the perspective of an AI coding/operator agent acting for a delegating user: run a blind pass, then an expert pass, and write an evidence-backed report."
+  default_prompt: "Dogfood devopsellence from the perspective of an AI coding/operator agent acting for a delegating user: run a blind pass, perform AI-agent-primary non-interactive/structured-output checks, capture approval and cleanup evidence, then run an expert pass and write an evidence-backed report."

--- a/.agents/skills/dogfood/agents/openai.yaml
+++ b/.agents/skills/dogfood/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Dogfood"
-  short_description: "Agent-mediated devopsellence dogfooding runs"
-  default_prompt: "Dogfood devopsellence from the perspective of an operator agent acting for a delegating user: run a blind pass, then an expert pass, and write an evidence-backed report."
+  short_description: "AI-agent-mediated devopsellence dogfooding runs"
+  default_prompt: "Dogfood devopsellence from the perspective of an AI coding/operator agent acting for a delegating user: run a blind pass, then an expert pass, and write an evidence-backed report."

--- a/.agents/skills/dogfood/references/commands-log-template.md
+++ b/.agents/skills/dogfood/references/commands-log-template.md
@@ -1,0 +1,19 @@
+# Commands for {{scenario}}
+# Target version: {{target_version}}
+# Install command:
+{{install_command}}
+
+# Record each meaningful step in this format:
+#
+# ## <ISO-8601 timestamp> <short step name>
+# cwd: <working directory>
+# AI agent intent: <why the AI agent is doing this>
+# user approval: <not needed | requested | granted | denied>
+# command: <command with secrets redacted>
+# exit: <exit code>
+# output excerpt:
+# <minimal stdout/stderr or JSON proving the result>
+# AI agent interpretation:
+# <what the AI agent concluded and next action>
+#
+# Use placeholders such as $TOKEN, <redacted>, or <private-host> instead of secret values or private identifiers.

--- a/.agents/skills/dogfood/references/report-template.md
+++ b/.agents/skills/dogfood/references/report-template.md
@@ -32,12 +32,12 @@ Trustworthy user summary possible:
 
 ## Scores
 
-AI-agent-mediated product completeness:
-AI agent DevX:
-AI agent observability:
+AI-Agent-Mediated Product Completeness:
+AI Agent DevX:
+AI Agent Observability:
 Docs and Machine Contracts:
-Delegation trust:
-AI-agent-primary operability:
+Delegation Trust:
+AI-Agent-Primary Operability:
 
 ## Commands
 

--- a/.agents/skills/dogfood/references/report-template.md
+++ b/.agents/skills/dogfood/references/report-template.md
@@ -2,7 +2,7 @@
 
 Scenario:
 Delegating user:
-Operator agent role:
+AI coding/operator agent role:
 Target version:
 Install command:
 Date:
@@ -17,8 +17,8 @@ Cleanup plan:
 
 ## Outcome
 
-Result from agent-mediated perspective:
-Time to first useful agent confidence:
+Result from AI-agent-mediated perspective:
+Time to first useful AI agent confidence:
 Time to first verified success:
 Blocking issue:
 Cleanup result:
@@ -32,12 +32,12 @@ Trustworthy user summary possible:
 
 ## Scores
 
-Agent-mediated product completeness:
-Agent DevX:
-Agent observability:
-Docs and machine contracts:
+AI-agent-mediated product completeness:
+AI agent DevX:
+AI agent observability:
+Docs and Machine Contracts:
 Delegation trust:
-Agent-primary operability:
+AI-agent-primary operability:
 
 ## Commands
 
@@ -49,7 +49,7 @@ See `commands.log`.
 
 Severity:
 Surface:
-Expected agent-mediated behavior:
+Expected AI-agent-mediated behavior:
 Actual behavior:
 Reproduction evidence:
 Suggested fix:
@@ -60,29 +60,29 @@ Suggested fix:
 
 Severity:
 Surface:
-Expected agent-mediated behavior:
+Expected AI-agent-mediated behavior:
 Actual behavior:
 Reproduction evidence:
 Suggested fix:
 
-## Agent DevX Gaps
+## AI Agent DevX Gaps
 
 ### Finding: <title>
 
 Severity:
 Surface:
-Expected agent-mediated behavior:
+Expected AI-agent-mediated behavior:
 Actual behavior:
 Reproduction evidence:
 Suggested fix:
 
-## Agent-Primary Gaps
+## AI-Agent-Primary Gaps
 
 ### Finding: <title>
 
 Severity:
 Surface:
-Expected agent-mediated behavior:
+Expected AI-agent-mediated behavior:
 Actual behavior:
 Reproduction evidence:
 Suggested fix:
@@ -93,7 +93,7 @@ Suggested fix:
 
 Severity:
 Surface:
-Expected agent-mediated behavior:
+Expected AI-agent-mediated behavior:
 Actual behavior:
 Reproduction evidence:
 Suggested fix:
@@ -104,12 +104,12 @@ Suggested fix:
 
 Severity:
 Surface:
-Expected agent-mediated behavior:
+Expected AI-agent-mediated behavior:
 Actual behavior:
 Reproduction evidence:
 Suggested fix:
 
-## Confusing or Ambiguous Agent Inputs
+## Confusing or Ambiguous AI Agent Inputs
 
 - 
 

--- a/.agents/skills/dogfood/references/report-template.md
+++ b/.agents/skills/dogfood/references/report-template.md
@@ -54,7 +54,7 @@ Actual behavior:
 Reproduction evidence:
 Suggested fix:
 
-## Product Completeness Gaps
+## AI-Agent-Mediated Product Completeness Gaps
 
 ### Finding: <title>
 

--- a/.agents/skills/dogfood/references/report-template.md
+++ b/.agents/skills/dogfood/references/report-template.md
@@ -1,21 +1,28 @@
 # Dogfood Run
 
 Scenario:
-Persona:
+Delegating user:
+Operator agent role:
 Target version:
 Install command:
 Date:
 Commit:
 Run path:
 Allowed blind-pass context:
+Docs source:
 Environment:
+Resource plan:
+Human approval points:
+Cleanup plan:
 
 ## Outcome
 
-Result:
-Time to first useful feedback:
-Time to first success:
+Result from agent-mediated perspective:
+Time to first useful agent confidence:
+Time to first verified success:
 Blocking issue:
+Cleanup result:
+Could the agent report a trustworthy summary to the user?:
 
 ## Top Fixes
 
@@ -25,11 +32,12 @@ Blocking issue:
 
 ## Scores
 
-Product completeness:
-DevX:
-Observability:
-Docs and language:
-Trust:
+Agent-mediated product completeness:
+Agent DevX:
+Agent observability:
+Docs and machine contracts:
+Delegation trust:
+Agent-primary operability:
 
 ## Commands
 
@@ -37,21 +45,71 @@ See `commands.log`.
 
 ## Bugs
 
-- 
+### Finding: <title>
+
+Severity:
+Surface:
+Expected agent-mediated behavior:
+Actual behavior:
+Reproduction evidence:
+Suggested fix:
 
 ## Product Completeness Gaps
 
-- 
+### Finding: <title>
 
-## DevX Gaps
+Severity:
+Surface:
+Expected agent-mediated behavior:
+Actual behavior:
+Reproduction evidence:
+Suggested fix:
 
-- 
+## Agent DevX Gaps
 
-## Docs Gaps
+### Finding: <title>
 
-- 
+Severity:
+Surface:
+Expected agent-mediated behavior:
+Actual behavior:
+Reproduction evidence:
+Suggested fix:
 
-## Confusing Language
+## Agent-Primary Gaps
+
+### Finding: <title>
+
+Severity:
+Surface:
+Expected agent-mediated behavior:
+Actual behavior:
+Reproduction evidence:
+Suggested fix:
+
+## Docs and Machine Contract Gaps
+
+### Finding: <title>
+
+Severity:
+Surface:
+Expected agent-mediated behavior:
+Actual behavior:
+Reproduction evidence:
+Suggested fix:
+
+## Delegation Trust Gaps
+
+### Finding: <title>
+
+Severity:
+Surface:
+Expected agent-mediated behavior:
+Actual behavior:
+Reproduction evidence:
+Suggested fix:
+
+## Confusing or Ambiguous Agent Inputs
 
 - 
 
@@ -64,6 +122,14 @@ See `commands.log`.
 - 
 
 ## Verification
+
+- 
+
+## Cleanup Evidence
+
+- 
+
+## Final User-Facing Summary Draft
 
 - 
 

--- a/.agents/skills/dogfood/references/report-template.md
+++ b/.agents/skills/dogfood/references/report-template.md
@@ -76,7 +76,18 @@ Actual behavior:
 Reproduction evidence:
 Suggested fix:
 
-## AI-Agent-Primary Gaps
+## AI Agent Observability Gaps
+
+### Finding: <title>
+
+Severity:
+Surface:
+Expected AI-agent-mediated behavior:
+Actual behavior:
+Reproduction evidence:
+Suggested fix:
+
+## AI-Agent-Primary Operability Gaps
 
 ### Finding: <title>
 

--- a/.agents/skills/dogfood/references/report-template.md
+++ b/.agents/skills/dogfood/references/report-template.md
@@ -22,7 +22,7 @@ Time to first useful agent confidence:
 Time to first verified success:
 Blocking issue:
 Cleanup result:
-Could the agent report a trustworthy summary to the user?:
+Trustworthy user summary possible:
 
 ## Top Fixes
 
@@ -87,7 +87,7 @@ Actual behavior:
 Reproduction evidence:
 Suggested fix:
 
-## Docs and Machine Contract Gaps
+## Docs and Machine Contracts Gaps
 
 ### Finding: <title>
 

--- a/.agents/skills/dogfood/references/rubric.md
+++ b/.agents/skills/dogfood/references/rubric.md
@@ -1,43 +1,51 @@
 # Dogfood Rubric
 
-Score each area 1-5. Use plain evidence, not vibes.
+Score each area 1-5 from the agent-mediated perspective. Use plain evidence, not vibes. The question is not “would a human enjoy using this directly?” The question is “can a user safely delegate this devopsellence task to an operator agent?”
 
-## Product Completeness
+## Agent-Mediated Product Completeness
 
-1. Cannot complete core goal.
-2. Goal possible only with privileged knowledge or manual hacks.
-3. Happy path works, important lifecycle gaps remain.
-4. Main lifecycle works with understandable recovery.
-5. Goal, recovery, cleanup, and confidence paths are complete.
+1. Agent cannot complete the delegated core goal.
+2. Goal possible only with source inspection, privileged knowledge, or unsafe manual hacks.
+3. Happy path works, but important lifecycle gaps remain for agent operation.
+4. Main lifecycle works with understandable recovery and cleanup.
+5. Goal, recovery, cleanup, approval boundaries, and user reporting are complete.
 
-## DevX
+## Agent DevX
 
-1. Setup or first command blocks progress.
-2. Frequent confusion; errors lack next steps.
+1. Setup or first command blocks the agent.
+2. Frequent ambiguity; errors lack next steps or require terminal-text guessing.
 3. Usable but requires persistence and inference.
-4. Mostly clear; friction is localized.
-5. Fast, predictable, and confidence-building.
+4. Mostly clear; friction is localized and reportable.
+5. Fast, predictable, structured, and confidence-building for agent operation.
 
-## Observability
+## Agent Observability
 
-1. User cannot tell what happened.
-2. Logs/status exist but are hard to find or interpret.
+1. Agent cannot tell what happened.
+2. Logs/status exist but are hard to find, parse, or tie to intended state.
 3. Basic status works; root cause still takes guessing.
 4. Failures point to likely cause and next command.
-5. State, logs, revisions, and recovery are obvious.
+5. Intended state, observed state, revisions, logs, and recovery are obvious and explainable.
 
-## Docs and Language
+## Docs and Machine Contracts
 
-1. Docs mislead or omit essential setup.
-2. User must search source or infer model.
-3. Docs cover happy path but not recovery.
-4. Docs explain model and common failure paths.
-5. Docs, CLI help, and product language reinforce each other.
+1. Docs/help mislead or omit essential setup and no machine-readable contract compensates.
+2. Agent must search source or infer the model.
+3. Docs/help cover happy path but not recovery or automation.
+4. Docs, CLI help, JSON/API shapes, and errors explain model and common failure paths.
+5. Docs, CLI help, schemas, structured output, and product language reinforce each other.
 
-## Trust
+## Delegation Trust
 
-1. User fears data loss, secret leaks, or unknown infrastructure changes.
-2. Product hides important actions.
-3. Actions are visible but not fully explainable.
-4. Changes and blast radius are clear.
-5. Product feels boring, reversible, and inspectable.
+1. User would fear data loss, secret leaks, cost leaks, or unknown infrastructure changes from delegating to the agent.
+2. Product hides important actions, approval boundaries, or cleanup uncertainty.
+3. Actions are visible but not fully explainable by the agent.
+4. Changes, blast radius, approval needs, and cleanup path are clear.
+5. Product feels boring, reversible, auditable, and safe to delegate.
+
+## Agent-Primary Operability
+
+1. Workflow requires prompts, browser-only interactions, TTY behavior, or terminal-text scraping.
+2. Some commands can be automated, but key actions lack structured output or deterministic errors.
+3. Basic non-interactive operation works, but status/errors require inference.
+4. Most operations support structured output, meaningful exit codes, and clear next actions.
+5. Inspect, validate/plan, deploy, observe, explain, and recover are deterministic and machine-readable.

--- a/.agents/skills/dogfood/references/rubric.md
+++ b/.agents/skills/dogfood/references/rubric.md
@@ -1,26 +1,28 @@
 # Dogfood Rubric
 
-Score each area 1-5 from the agent-mediated perspective. Use plain evidence, not vibes. The question is not “would a human enjoy using this directly?” The question is “can a user safely delegate this devopsellence task to an operator agent?”
+Score each area 1-5 from the AI-agent-mediated perspective. Use plain evidence, not vibes. The question is not “would a human enjoy using this directly?” The question is “can a user safely delegate this devopsellence task to an AI coding/operator agent?”
 
-## Agent-Mediated Product Completeness
+Terminology: "AI agent" means the AI coding/operator agent doing the dogfood run. "devopsellence node agent" means the runtime reconciler on the VM.
 
-1. Agent cannot complete the delegated core goal.
+## AI-Agent-Mediated Product Completeness
+
+1. AI agent cannot complete the delegated core goal.
 2. Goal possible only with source inspection, privileged knowledge, or unsafe manual hacks.
-3. Happy path works, but important lifecycle gaps remain for agent operation.
+3. Happy path works, but important lifecycle gaps remain for AI agent operation.
 4. Main lifecycle works with understandable recovery and cleanup.
 5. Goal, recovery, cleanup, approval boundaries, and user reporting are complete.
 
-## Agent DevX
+## AI Agent DevX
 
-1. Setup or first command blocks the agent.
+1. Setup or first command blocks the AI agent.
 2. Frequent ambiguity; errors lack next steps or require terminal-text guessing.
 3. Usable but requires persistence and inference.
 4. Mostly clear; friction is localized and reportable.
-5. Fast, predictable, structured, and confidence-building for agent operation.
+5. Fast, predictable, structured, and confidence-building for AI agent operation.
 
-## Agent Observability
+## AI Agent Observability
 
-1. Agent cannot tell what happened.
+1. AI agent cannot tell what happened.
 2. Logs/status exist but are hard to find, parse, or tie to intended state.
 3. Basic status works; root cause still takes guessing.
 4. Failures point to likely cause and next command.
@@ -29,20 +31,20 @@ Score each area 1-5 from the agent-mediated perspective. Use plain evidence, not
 ## Docs and Machine Contracts
 
 1. Docs/help mislead or omit essential setup and no machine-readable contract compensates.
-2. Agent must search source or infer the model.
+2. AI agent must search source or infer the model.
 3. Docs/help cover happy path but not recovery or automation.
 4. Docs, CLI help, JSON/API shapes, and errors explain model and common failure paths.
 5. Docs, CLI help, schemas, structured output, and product language reinforce each other.
 
 ## Delegation Trust
 
-1. User would fear data loss, secret leaks, cost leaks, or unknown infrastructure changes from delegating to the agent.
+1. User would fear data loss, secret leaks, cost leaks, or unknown infrastructure changes from delegating to the AI agent.
 2. Product hides important actions, approval boundaries, or cleanup uncertainty.
-3. Actions are visible but not fully explainable by the agent.
+3. Actions are visible but not fully explainable by the AI agent.
 4. Changes, blast radius, approval needs, and cleanup path are clear.
 5. Product feels boring, reversible, auditable, and safe to delegate.
 
-## Agent-Primary Operability
+## AI-Agent-Primary Operability
 
 1. Workflow requires prompts, browser-only interactions, TTY behavior, or terminal-text scraping.
 2. Some commands can be automated, but key actions lack structured output or deterministic errors.

--- a/.agents/skills/dogfood/references/scenarios.md
+++ b/.agents/skills/dogfood/references/scenarios.md
@@ -15,8 +15,9 @@ Allowed blind-pass context: public website docs, README/docs that match the targ
 Setup:
 
 - Use a fresh app and fresh devopsellence state.
-- If `zirk` is installed and healthy, create a run-scoped VM name such as `dogfood-<timestamp>` and use it as the existing SSH node.
-- Record expected resource creation, required user approval, and cleanup before creating the node.
+- If `zirk` is installed and healthy, create a run-scoped VM named `dogfood-<timestamp>` and use it as the existing SSH node.
+- If `zirk` is not installed or not healthy, the AI coding/operator agent must either use a user-provided existing reachable SSH node or follow a documented provider/node provisioning path discoverable from allowed docs/CLI output. If neither is available, stop and ask the user to provide a reachable SSH node or approve a documented provisioning path before continuing.
+- Record expected resource creation, whether the AI agent will create a node or adopt an existing host, required user approval, and cleanup before taking action.
 
 Success:
 

--- a/.agents/skills/dogfood/references/scenarios.md
+++ b/.agents/skills/dogfood/references/scenarios.md
@@ -1,84 +1,71 @@
 # Dogfood Scenarios
 
-## solo-rails-first-deploy
+All scenarios are agent-mediated by default. The primary actor is an operator agent acting on behalf of a delegating user. Do not evaluate devopsellence as direct human CLI UX unless the scenario explicitly asks for that.
 
-Persona: solo Rails founder, infra-aware but impatient.
+## agent-mediated-solo-rails-first-deploy
 
-Goal: deploy a fresh Rails app with devopsellence solo.
+Delegating user: solo Rails founder, infra-aware but impatient.
 
-Allowed blind-pass context: README, docs, CLI help, command output, product logs/status surfaced by commands.
+Operator agent goal: deploy a fresh Rails app with devopsellence solo, ask for approval before creating resources, verify the app, summarize what changed, and clean up if this is an experiment.
 
-Success:
-
-- App reachable.
-- Deploy status understandable.
-- Secret path discoverable.
-- Logs/status path discoverable.
-- Delete or cleanup path clear.
-
-Probe:
-
-- Install/setup friction.
-- First command discoverability.
-- Error recovery.
-- Time to first useful feedback.
-- Confidence after deploy.
-
-## solo-hetzner-provider-first-deploy
-
-Persona: solo founder who wants devopsellence to create the VM.
-
-Goal: deploy a fresh app with devopsellence solo using a Hetzner-created VM.
-
-Allowed blind-pass context: README, docs, CLI help, command output, product logs/status surfaced by commands, and `op` for retrieving the Hetzner token.
+Allowed blind-pass context: public website docs, README/docs that match the target version when available, CLI help, JSON/API output, command output, product logs/status surfaced by commands, ordinary SSH/Docker/file tools when exposed by the workflow.
 
 Setup:
 
-- Retrieve the API token from 1Password item `hetzner-devopsellence-solo` with `op`.
-- Export the token as `HCLOUD_TOKEN` or pass it to `devopsellence provider login hetzner --token "$HCLOUD_TOKEN"`.
-- Do not record the token value, raw `op` output, or raw item JSON in `commands.log` or reports.
-- Create the node with `devopsellence node create prod-1 --provider hetzner --install --attach`.
+- Use a fresh app and fresh devopsellence state.
+- If `zirk` is installed and healthy, create a run-scoped VM name such as `dogfood-<timestamp>` and use it as the existing SSH node.
+- Record expected resource creation, required user approval, and cleanup before creating the node.
 
 Success:
 
-- Provider login is discoverable and token errors are clear.
-- Hetzner server creation returns usable node metadata.
-- Agent install reaches a usable SSH/Docker/node-agent state.
-- Deploy status and public URL are understandable.
-- Cleanup deletes the provider VM and local node state after detach.
+- The agent can discover the deployment workflow without source inspection.
+- The agent can install/setup/deploy with clear approval boundaries.
+- App reachability can be verified with evidence.
+- Deploy status is machine-readable or inspectable enough for the agent to explain.
+- Secret path is discoverable without leaking values.
+- Logs/status path is discoverable.
+- Delete or cleanup path is clear and verified.
 
 Probe:
 
-- 1Password token retrieval friction.
-- Default Hetzner region/size clarity.
-- SSH key generation/reuse messaging.
-- Provider API error quality.
-- Cleanup confidence and cost-leak risk.
+- Whether the first deploy can be run non-interactively after approvals are known.
+- Whether plan/apply/status/logs have structured output.
+- Whether errors tell the agent the next safe action.
+- Time to first useful agent confidence.
+- Confidence of the final user-facing summary.
 
-## existing-app-secrets-redeploy
+## agent-mediated-existing-app-secrets-redeploy
 
-Persona: Rails developer adding production-like config.
+Delegating user: Rails developer adding production-like config.
 
-Goal: deploy an existing app, add a secret, redeploy, verify status.
+Operator agent goal: deploy an existing app, add or update a secret, redeploy, verify status, and report back without exposing the secret.
+
+Allowed blind-pass context: public website docs, README/docs that match the target version when available, CLI help, JSON/API output, command output, product logs/status surfaced by commands.
 
 Success:
 
-- Secret command or workflow is discoverable.
-- Secret value does not leak in output/report.
-- Redeploy makes state understandable.
-- Failed secret usage has clear recovery.
+- Secret command or workflow is discoverable by the agent.
+- The agent can determine required scope: app, environment, node, or service.
+- Secret value does not leak in commands, logs, reports, or output excerpts.
+- Redeploy makes intended vs active state understandable.
+- Failed secret usage has clear machine-readable or clearly parseable recovery.
+- Status identifies the active revision/config when available.
 
 Probe:
 
 - Naming of app/environment/secret scopes.
-- Whether local and remote state are easy to distinguish.
+- Whether local and remote state are easy for the agent to distinguish.
 - Whether status explains which revision/config is active.
+- Whether secret workflows work non-interactively without leaking values.
+- Whether the agent knows when to ask the user for a secret vs guessing.
 
-## failed-deploy-recovery
+## agent-mediated-failed-deploy-recovery
 
-Persona: tired maintainer at night.
+Delegating user: tired maintainer at night.
 
-Goal: diagnose and recover from a broken deploy.
+Operator agent goal: diagnose and recover from a broken deploy, or stop safely with a clear request for missing approval/information.
+
+Allowed blind-pass context: public website docs, README/docs that match the target version when available, CLI help, JSON/API output, command output, product logs/status surfaced by commands.
 
 Failure seeds:
 
@@ -91,31 +78,67 @@ Failure seeds:
 Success:
 
 - Failure is surfaced without source inspection.
-- Next step is obvious.
-- Logs are reachable.
-- Retrying after fix is boring.
+- The agent can distinguish intended state from observed state.
+- Next safe action is obvious or explicitly asks for user approval.
+- Logs are reachable with bounded, relevant output.
+- Retrying after fix is deterministic.
+- Exit codes and structured errors are deterministic enough for automation.
+- The final report explains cause, action taken, residual risk, and verification.
 
 Probe:
 
-- Error specificity.
+- Error specificity and stable categories.
 - Whether failed desired state is visible.
 - Whether rollback/delete/cleanup is understandable.
+- Whether JSON or other structured output avoids terminal-text scraping.
+- Whether the agent avoids unsafe repair attempts without approval.
 
-## shared-node-connect-deploy
+## agent-mediated-shared-node-connect-deploy
 
-Persona: user evaluating hosted/shared control plane.
+Delegating user: user evaluating hosted/shared control plane.
 
-Goal: connect a node, deploy app, inspect status.
+Operator agent goal: connect a node, deploy an app, inspect status, and explain hosted vs local responsibilities.
+
+Allowed blind-pass context: public website docs, hosted UI when required, CLI help, JSON/API output, command output, product logs/status surfaced by commands.
 
 Success:
 
-- Node enrollment is understandable.
-- Hosted vs local responsibilities are clear.
-- Status reflects node/app state.
+- Node enrollment is understandable to the agent.
+- Hosted vs local responsibilities are clear enough to explain.
+- Status reflects node/app state in an agent-readable way.
 - Escape hatches remain ordinary: SSH, Docker, logs, JSON.
+- Cleanup/de-enrollment path is clear and verified.
+- Browser-only or UI-only state does not block agent operation, or is reported as a gap.
 
 Probe:
 
 - Account/environment naming.
 - Agent reconciliation mental model.
 - Trust boundary clarity.
+- Structured operations for autonomous agents.
+- Approval boundaries for enrollment, deploy, and cleanup.
+
+## non-interactive-agent-workflow
+
+Delegating user: human operator asking an automation agent to manage devopsellence.
+
+Operator agent goal: inspect, validate/plan or dry-run when available, deploy/apply when approved, read status/logs, and recommend recovery using deterministic commands.
+
+Allowed blind-pass context: public website docs, CLI help, JSON/API output, command output, product logs/status surfaced by commands.
+
+Success:
+
+- Workflow can run without prompts or TTY-only behavior after approvals are known.
+- Commands provide structured output suitable for parsing.
+- Errors include stable codes or machine-readable categories when available.
+- Exit codes are meaningful and deterministic.
+- The agent can explain intended state, observed state, and next action without scraping styled text.
+- The agent can produce a concise user report with evidence and residual risks.
+
+Probe:
+
+- `--json` or equivalent coverage.
+- Non-interactive flags and defaults.
+- Dry-run/plan/apply boundary clarity.
+- Stable operation names and error shapes.
+- Whether UI-only functionality has an API/CLI equivalent.

--- a/.agents/skills/dogfood/references/scenarios.md
+++ b/.agents/skills/dogfood/references/scenarios.md
@@ -1,12 +1,14 @@
 # Dogfood Scenarios
 
-All scenarios are agent-mediated by default. The primary actor is an operator agent acting on behalf of a delegating user. Do not evaluate devopsellence as direct human CLI UX unless the scenario explicitly asks for that.
+All scenarios are AI-agent-mediated by default. The primary actor is an AI coding/operator agent acting on behalf of a delegating user. Do not evaluate devopsellence as direct human CLI UX unless the scenario explicitly asks for that.
 
-## agent-mediated-solo-rails-first-deploy
+Terminology: "AI agent" means the AI coding/operator agent doing the dogfood run. "devopsellence node agent" means the runtime reconciler on the VM.
+
+## ai-agent-mediated-solo-rails-first-deploy
 
 Delegating user: solo Rails founder, infra-aware but impatient.
 
-Operator agent goal: deploy a fresh Rails app with devopsellence solo, ask for approval before creating resources, verify the app, summarize what changed, and clean up if this is an experiment.
+AI coding/operator agent goal: deploy a fresh Rails app with devopsellence solo, ask for approval before creating resources, verify the app, summarize what changed, and clean up if this is an experiment.
 
 Allowed blind-pass context: public website docs, README/docs that match the target version when available, CLI help, JSON/API output, command output, product logs/status surfaced by commands, ordinary SSH/Docker/file tools when exposed by the workflow.
 
@@ -18,10 +20,10 @@ Setup:
 
 Success:
 
-- The agent can discover the deployment workflow without source inspection.
-- The agent can install/setup/deploy with clear approval boundaries.
+- The AI agent can discover the deployment workflow without source inspection.
+- The AI agent can install/setup/deploy with clear approval boundaries.
 - App reachability can be verified with evidence.
-- Deploy status is machine-readable or inspectable enough for the agent to explain.
+- Deploy status is machine-readable or inspectable enough for the AI agent to explain.
 - Secret path is discoverable without leaking values.
 - Logs/status path is discoverable.
 - Delete or cleanup path is clear and verified.
@@ -30,22 +32,22 @@ Probe:
 
 - Whether the first deploy can be run non-interactively after approvals are known.
 - Whether plan/apply/status/logs have structured output.
-- Whether errors tell the agent the next safe action.
-- Time to first useful agent confidence.
+- Whether errors tell the AI agent the next safe action.
+- Time to first useful AI agent confidence.
 - Confidence of the final user-facing summary.
 
-## agent-mediated-existing-app-secrets-redeploy
+## ai-agent-mediated-existing-app-secrets-redeploy
 
 Delegating user: Rails developer adding production-like config.
 
-Operator agent goal: deploy an existing app, add or update a secret, redeploy, verify status, and report back without exposing the secret.
+AI coding/operator agent goal: deploy an existing app, add or update a secret, redeploy, verify status, and report back without exposing the secret.
 
 Allowed blind-pass context: public website docs, README/docs that match the target version when available, CLI help, JSON/API output, command output, product logs/status surfaced by commands.
 
 Success:
 
-- Secret command or workflow is discoverable by the agent.
-- The agent can determine required scope: app, environment, node, or service.
+- Secret command or workflow is discoverable by the AI agent.
+- The AI agent can determine required scope: app, environment, node, or service.
 - Secret value does not leak in commands, logs, reports, or output excerpts.
 - Redeploy makes intended vs active state understandable.
 - Failed secret usage has clear machine-readable or clearly parseable recovery.
@@ -54,16 +56,16 @@ Success:
 Probe:
 
 - Naming of app/environment/secret scopes.
-- Whether local and remote state are easy for the agent to distinguish.
+- Whether local and remote state are easy for the AI agent to distinguish.
 - Whether status explains which revision/config is active.
 - Whether secret workflows work non-interactively without leaking values.
-- Whether the agent knows when to ask the user for a secret vs guessing.
+- Whether the AI agent knows when to ask the user for a secret vs guessing.
 
-## agent-mediated-failed-deploy-recovery
+## ai-agent-mediated-failed-deploy-recovery
 
 Delegating user: tired maintainer at night.
 
-Operator agent goal: diagnose and recover from a broken deploy, or stop safely with a clear request for missing approval/information.
+AI coding/operator agent goal: diagnose and recover from a broken deploy, or stop safely with a clear request for missing approval/information.
 
 Allowed blind-pass context: public website docs, README/docs that match the target version when available, CLI help, JSON/API output, command output, product logs/status surfaced by commands.
 
@@ -78,7 +80,7 @@ Failure seeds:
 Success:
 
 - Failure is surfaced without source inspection.
-- The agent can distinguish intended state from observed state.
+- The AI agent can distinguish intended state from observed state.
 - Next safe action is obvious or explicitly asks for user approval.
 - Logs are reachable with bounded, relevant output.
 - Retrying after fix is deterministic.
@@ -91,38 +93,38 @@ Probe:
 - Whether failed desired state is visible.
 - Whether rollback/delete/cleanup is understandable.
 - Whether JSON or other structured output avoids terminal-text scraping.
-- Whether the agent avoids unsafe repair attempts without approval.
+- Whether the AI agent avoids unsafe repair attempts without approval.
 
-## agent-mediated-shared-node-connect-deploy
+## ai-agent-mediated-shared-node-connect-deploy
 
 Delegating user: user evaluating hosted/shared control plane.
 
-Operator agent goal: connect a node, deploy an app, inspect status, and explain hosted vs local responsibilities.
+AI coding/operator agent goal: connect a node, deploy an app, inspect status, and explain hosted vs local responsibilities.
 
 Allowed blind-pass context: public website docs, hosted UI when required, CLI help, JSON/API output, command output, product logs/status surfaced by commands.
 
 Success:
 
-- Node enrollment is understandable to the agent.
+- Node enrollment is understandable to the AI agent.
 - Hosted vs local responsibilities are clear enough to explain.
-- Status reflects node/app state in an agent-readable way.
+- Status reflects node/app state in an AI-agent-readable way.
 - Escape hatches remain ordinary: SSH, Docker, logs, JSON.
 - Cleanup/de-enrollment path is clear and verified.
-- Browser-only or UI-only state does not block agent operation, or is reported as a gap.
+- Browser-only or UI-only state does not block AI agent operation, or is reported as a gap.
 
 Probe:
 
 - Account/environment naming.
-- Agent reconciliation mental model.
+- devopsellence node agent reconciliation mental model.
 - Trust boundary clarity.
 - Structured operations for autonomous agents.
 - Approval boundaries for enrollment, deploy, and cleanup.
 
 ## non-interactive-agent-workflow
 
-Delegating user: human operator asking an automation agent to manage devopsellence.
+Delegating user: human operator asking an AI coding/operator agent to manage devopsellence.
 
-Operator agent goal: inspect, validate/plan or dry-run when available, deploy/apply when approved, read status/logs, and recommend recovery using deterministic commands.
+AI coding/operator agent goal: inspect, validate/plan or dry-run when available, deploy/apply when approved, read status/logs, and recommend recovery using deterministic commands.
 
 Allowed blind-pass context: public website docs, CLI help, JSON/API output, command output, product logs/status surfaced by commands.
 
@@ -132,8 +134,8 @@ Success:
 - Commands provide structured output suitable for parsing.
 - Errors include stable codes or machine-readable categories when available.
 - Exit codes are meaningful and deterministic.
-- The agent can explain intended state, observed state, and next action without scraping styled text.
-- The agent can produce a concise user report with evidence and residual risks.
+- The AI agent can explain intended state, observed state, and next action without scraping styled text.
+- The AI agent can produce a concise user report with evidence and residual risks.
 
 Probe:
 

--- a/.agents/skills/dogfood/scripts/new_run.rb
+++ b/.agents/skills/dogfood/scripts/new_run.rb
@@ -154,7 +154,7 @@ commands_template = <<~LOG
   # agent interpretation:
   # <what the agent concluded and next action>
   #
-  # Use placeholders such as $TOKEN, <redacted>, or <private-host> instead of secret values or private identifiers.
+  # Use placeholders such as \$TOKEN, <redacted>, or <private-host> instead of secret values or private identifiers.
 LOG
 
 begin

--- a/.agents/skills/dogfood/scripts/new_run.rb
+++ b/.agents/skills/dogfood/scripts/new_run.rb
@@ -145,14 +145,14 @@ commands_template = <<~LOG
   #
   # ## <ISO-8601 timestamp> <short step name>
   # cwd: <working directory>
-  # agent intent: <why the agent is doing this>
+  # AI agent intent: <why the AI agent is doing this>
   # user approval: <not needed | requested | granted | denied>
   # command: <command with secrets redacted>
   # exit: <exit code>
   # output excerpt:
   # <minimal stdout/stderr or JSON proving the result>
-  # agent interpretation:
-  # <what the agent concluded and next action>
+  # AI agent interpretation:
+  # <what the AI agent concluded and next action>
   #
   # Use placeholders such as \$TOKEN, <redacted>, or <private-host> instead of secret values or private identifiers.
 LOG

--- a/.agents/skills/dogfood/scripts/new_run.rb
+++ b/.agents/skills/dogfood/scripts/new_run.rb
@@ -135,30 +135,19 @@ rescue SystemCallError => e
   exit_filesystem_error("failed to write", report_path, e)
 end
 
-commands_template = <<~LOG
-  # Commands for #{scenario}
-  # Target version: #{target_version}
-  # Install command:
-  #{install_command}
-
-  # Record each meaningful step in this format:
-  #
-  # ## <ISO-8601 timestamp> <short step name>
-  # cwd: <working directory>
-  # AI agent intent: <why the AI agent is doing this>
-  # user approval: <not needed | requested | granted | denied>
-  # command: <command with secrets redacted>
-  # exit: <exit code>
-  # output excerpt:
-  # <minimal stdout/stderr or JSON proving the result>
-  # AI agent interpretation:
-  # <what the AI agent concluded and next action>
-  #
-  # Use placeholders such as \$TOKEN, <redacted>, or <private-host> instead of secret values or private identifiers.
-LOG
+commands_template_path = File.expand_path("../references/commands-log-template.md", __dir__)
+begin
+  commands_template = File.read(commands_template_path)
+rescue SystemCallError => e
+  exit_filesystem_error("failed to read", commands_template_path, e)
+end
+commands_log = commands_template
+  .gsub("{{scenario}}", scenario)
+  .gsub("{{target_version}}", target_version)
+  .gsub("{{install_command}}", install_command)
 
 begin
-  File.write(commands_path, commands_template)
+  File.write(commands_path, commands_log)
 rescue SystemCallError => e
   exit_filesystem_error("failed to write", commands_path, e)
 end

--- a/.agents/skills/dogfood/scripts/new_run.rb
+++ b/.agents/skills/dogfood/scripts/new_run.rb
@@ -135,8 +135,30 @@ rescue SystemCallError => e
   exit_filesystem_error("failed to write", report_path, e)
 end
 
+commands_template = <<~LOG
+  # Commands for #{scenario}
+  # Target version: #{target_version}
+  # Install command:
+  #{install_command}
+
+  # Record each meaningful step in this format:
+  #
+  # ## <ISO-8601 timestamp> <short step name>
+  # cwd: <working directory>
+  # agent intent: <why the agent is doing this>
+  # user approval: <not needed | requested | granted | denied>
+  # command: <command with secrets redacted>
+  # exit: <exit code>
+  # output excerpt:
+  # <minimal stdout/stderr or JSON proving the result>
+  # agent interpretation:
+  # <what the agent concluded and next action>
+  #
+  # Use placeholders such as $TOKEN, <redacted>, or <private-host> instead of secret values or private identifiers.
+LOG
+
 begin
-  File.write(commands_path, "# Commands for #{scenario}\n# Target version: #{target_version}\n# Install command:\n#{install_command}\n")
+  File.write(commands_path, commands_template)
 rescue SystemCallError => e
   exit_filesystem_error("failed to write", commands_path, e)
 end


### PR DESCRIPTION
## Summary
- reframe the dogfood skill around agent-mediated devopsellence evaluation instead of direct human CLI QA
- update scenarios, rubric, and report template for delegating-user/operator-agent workflows
- improve command logging, cleanup, structured-output, and approval-boundary evidence capture

## Validation
- ruby -c .agents/skills/dogfood/scripts/new_run.rb
- ruby .agents/skills/dogfood/scripts/new_run.rb agent-mediated-sample --out /tmp/devopsellence-dogfood-test