### PR TITLE
[codex] Clarify solo port contract

### DIFF
--- a/.agents/skills/dogfood/SKILL.md
+++ b/.agents/skills/dogfood/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: dogfood
-description: Use when asked to dogfood devopsellence from an AI-agent-mediated perspective: an AI coding/operator agent acting for a user who delegates deployment, diagnosis, cleanup, and reporting. The skill guides blind-pass and expert-pass testing with evidence, AI-agent-centric scenarios, rubrics, and repeatable run artifacts.
+description: >-
+  Use when asked to dogfood devopsellence from an AI-agent-mediated perspective:
+  an AI coding/operator agent acting for a user who delegates deployment,
+  diagnosis, cleanup, and reporting. The skill guides blind-pass and expert-pass
+  testing with evidence, AI-agent-centric scenarios, rubrics, and repeatable run
+  artifacts.
 ---
 
 # Dogfood

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ devopsellence init --mode solo
 
 Start from an app that already has a Dockerfile. devopsellence does not install language toolchains or generate Rails/Node/etc. projects for you; create the app with your normal framework tools first, then let devopsellence deploy the container.
 
-The generated generic config uses the container port from your Dockerfile when it can infer one, for example `EXPOSE 80`. Otherwise it defaults the `web` service and health check to port `3000`. Your container must listen on the port in `devopsellence.yml`; edit `services.web.ports` and `services.web.healthcheck.port` if it listens elsewhere.
+The generated generic config uses the container port from your Dockerfile when it can infer one, for example `EXPOSE 80`. Otherwise it defaults the `web` service and healthcheck to port `3000`. Your container must listen on the port in `devopsellence.yml`; edit `services.web.ports` and `services.web.healthcheck.port` if it listens elsewhere.
 
 Commit the app before the first deploy. devopsellence uses the current git commit as the workload revision and image tag:
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ devopsellence init --mode solo
 
 Start from an app that already has a Dockerfile. devopsellence does not install language toolchains or generate Rails/Node/etc. projects for you; create the app with your normal framework tools first, then let devopsellence deploy the container.
 
+The generated generic config uses the container port from your Dockerfile when it can infer one, for example `EXPOSE 80`. Otherwise it defaults the `web` service and health check to port `3000`. Your container must listen on the port in `devopsellence.yml`; edit `services.web.ports` and `services.web.healthcheck.port` if it listens elsewhere.
+
 Commit the app before the first deploy. devopsellence uses the current git commit as the workload revision and image tag:
 
 ```bash

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -2874,12 +2874,13 @@ func (a *App) SoloInit(context.Context, SoloInitOptions) error {
 		"devopsellence deploy",
 	}
 	return a.Printer.PrintJSON(map[string]any{
-		"schema_version": outputSchemaVersion,
-		"mode":           string(ModeSolo),
-		"workspace_root": discovered.WorkspaceRoot,
-		"project_slug":   discovered.ProjectSlug,
-		"app_type":       discovered.AppType,
-		"fallback_used":  discovered.FallbackUsed,
+		"schema_version":   outputSchemaVersion,
+		"mode":             string(ModeSolo),
+		"workspace_root":   discovered.WorkspaceRoot,
+		"project_slug":     discovered.ProjectSlug,
+		"app_type":         discovered.AppType,
+		"fallback_used":    discovered.FallbackUsed,
+		"runtime_contract": soloInitRuntimeContract(*cfg, discovered),
 		"config": map[string]any{
 			"path":           configPath,
 			"created":        created,
@@ -2891,6 +2892,35 @@ func (a *App) SoloInit(context.Context, SoloInitOptions) error {
 		"missing":     missing,
 		"next_steps":  nextSteps,
 	})
+}
+
+func soloInitRuntimeContract(cfg config.ProjectConfig, discovered discovery.Result) map[string]any {
+	serviceName, ok := cfg.PrimaryWebServiceName()
+	if !ok {
+		return map[string]any{
+			"requirement": "containers must listen on the ports configured in devopsellence.yml",
+		}
+	}
+	service := cfg.Services[serviceName]
+	port := service.HTTPPort(0)
+	source := "default"
+	switch {
+	case discovered.InferredWebPort > 0 && port == discovered.InferredWebPort:
+		source = "dockerfile"
+	case port != config.DefaultWebPort:
+		source = "config"
+	}
+	contract := map[string]any{
+		"service":     serviceName,
+		"port":        port,
+		"port_source": source,
+		"requirement": "the container must listen on this port; add EXPOSE to the Dockerfile or edit devopsellence.yml if it listens elsewhere",
+	}
+	if service.Healthcheck != nil {
+		contract["healthcheck_path"] = service.Healthcheck.Path
+		contract["healthcheck_port"] = service.Healthcheck.Port
+	}
+	return contract
 }
 
 func (a *App) IngressSet(_ context.Context, opts IngressSetOptions) error {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -2880,7 +2880,7 @@ func (a *App) SoloInit(context.Context, SoloInitOptions) error {
 		"project_slug":     discovered.ProjectSlug,
 		"app_type":         discovered.AppType,
 		"fallback_used":    discovered.FallbackUsed,
-		"runtime_contract": soloInitRuntimeContract(*cfg, discovered),
+		"runtime_contract": soloInitRuntimeContract(*cfg, discovered, created),
 		"config": map[string]any{
 			"path":           configPath,
 			"created":        created,
@@ -2894,7 +2894,7 @@ func (a *App) SoloInit(context.Context, SoloInitOptions) error {
 	})
 }
 
-func soloInitRuntimeContract(cfg config.ProjectConfig, discovered discovery.Result) map[string]any {
+func soloInitRuntimeContract(cfg config.ProjectConfig, discovered discovery.Result, created bool) map[string]any {
 	serviceName, ok := cfg.PrimaryWebServiceName()
 	if !ok {
 		return map[string]any{
@@ -2905,6 +2905,8 @@ func soloInitRuntimeContract(cfg config.ProjectConfig, discovered discovery.Resu
 	port := service.HTTPPort(0)
 	source := "default"
 	switch {
+	case !created:
+		source = "config"
 	case discovered.InferredWebPort > 0 && port == discovered.InferredWebPort:
 		source = "dockerfile"
 	case port != config.DefaultWebPort:

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -2898,7 +2898,10 @@ func soloInitRuntimeContract(cfg config.ProjectConfig, discovered discovery.Resu
 	serviceName, ok := cfg.PrimaryWebServiceName()
 	if !ok {
 		return map[string]any{
-			"requirement": "containers must listen on the ports configured in devopsellence.yml",
+			"web_service": false,
+			"port_source": "none",
+			"reason":      "no primary web service detected",
+			"requirement": "no web port contract applies unless a service exposes an http port or healthcheck in devopsellence.yml",
 		}
 	}
 	service := cfg.Services[serviceName]
@@ -2913,6 +2916,7 @@ func soloInitRuntimeContract(cfg config.ProjectConfig, discovered discovery.Resu
 		source = "config"
 	}
 	contract := map[string]any{
+		"web_service": true,
 		"service":     serviceName,
 		"port":        port,
 		"port_source": source,

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -2352,6 +2352,9 @@ func TestSoloInitCreatesWorkspaceConfig(t *testing.T) {
 
 func TestSoloInitReportsConfigPortContract(t *testing.T) {
 	workspaceRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(workspaceRoot, "Dockerfile"), []byte("FROM nginx:1.27-alpine\nEXPOSE 8080\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	cfg := config.DefaultProjectConfigForType("solo", "demo", "production", config.AppTypeGeneric)
 	web := cfg.Services["web"]
 	web.Ports = []config.ServicePort{{Name: "http", Port: 8080}}

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -2341,6 +2341,9 @@ func TestSoloInitCreatesWorkspaceConfig(t *testing.T) {
 	if runtimeContract["service"] != "web" || runtimeContract["port"] != float64(3000) || runtimeContract["port_source"] != "default" {
 		t.Fatalf("runtime_contract = %#v, want default web port contract", runtimeContract)
 	}
+	if runtimeContract["web_service"] != true {
+		t.Fatalf("runtime_contract.web_service = %#v, want true", runtimeContract["web_service"])
+	}
 	if runtimeContract["healthcheck_path"] != "/" || runtimeContract["healthcheck_port"] != float64(3000) {
 		t.Fatalf("runtime_contract healthcheck = %#v, want / on port 3000", runtimeContract)
 	}
@@ -2381,6 +2384,42 @@ func TestSoloInitReportsConfigPortContract(t *testing.T) {
 	}
 	if runtimeContract["healthcheck_path"] != "/health" || runtimeContract["healthcheck_port"] != float64(8080) {
 		t.Fatalf("runtime_contract healthcheck = %#v, want /health on port 8080", runtimeContract)
+	}
+}
+
+func TestSoloInitReportsNoWebServicePortContract(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfigForType("solo", "demo", "production", config.AppTypeGeneric)
+	cfg.Services = map[string]config.ServiceConfig{
+		"worker": {
+			Command: []string{"bin/worker"},
+		},
+	}
+	cfg.Ingress = nil
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{
+		Printer:     output.New(&stdout, io.Discard),
+		ConfigStore: config.NewStore(),
+		Cwd:         workspaceRoot,
+	}
+
+	if err := app.SoloInit(context.Background(), SoloInitOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	runtimeContract := jsonMapFromAny(t, payload["runtime_contract"])
+	if runtimeContract["web_service"] != false || runtimeContract["port_source"] != "none" {
+		t.Fatalf("runtime_contract = %#v, want explicit no-web-service contract", runtimeContract)
+	}
+	if runtimeContract["reason"] != "no primary web service detected" {
+		t.Fatalf("runtime_contract.reason = %#v, want no primary web service detected", runtimeContract["reason"])
+	}
+	if _, ok := runtimeContract["port"]; ok {
+		t.Fatalf("runtime_contract port = %#v, want omitted", runtimeContract["port"])
 	}
 }
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -2341,9 +2341,43 @@ func TestSoloInitCreatesWorkspaceConfig(t *testing.T) {
 	if runtimeContract["service"] != "web" || runtimeContract["port"] != float64(3000) || runtimeContract["port_source"] != "default" {
 		t.Fatalf("runtime_contract = %#v, want default web port contract", runtimeContract)
 	}
+	if runtimeContract["healthcheck_path"] != "/" || runtimeContract["healthcheck_port"] != float64(3000) {
+		t.Fatalf("runtime_contract healthcheck = %#v, want / on port 3000", runtimeContract)
+	}
 	requirement := stringValueAny(runtimeContract["requirement"])
 	if !strings.Contains(requirement, "EXPOSE") || !strings.Contains(requirement, "devopsellence.yml") {
 		t.Fatalf("runtime_contract.requirement = %q, want Dockerfile/config guidance", requirement)
+	}
+}
+
+func TestSoloInitReportsConfigPortContract(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfigForType("solo", "demo", "production", config.AppTypeGeneric)
+	web := cfg.Services["web"]
+	web.Ports = []config.ServicePort{{Name: "http", Port: 8080}}
+	web.Healthcheck = &config.HTTPHealthcheck{Path: "/health", Port: 8080}
+	cfg.Services["web"] = web
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{
+		Printer:     output.New(&stdout, io.Discard),
+		ConfigStore: config.NewStore(),
+		Cwd:         workspaceRoot,
+	}
+
+	if err := app.SoloInit(context.Background(), SoloInitOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	runtimeContract := jsonMapFromAny(t, payload["runtime_contract"])
+	if runtimeContract["service"] != "web" || runtimeContract["port"] != float64(8080) || runtimeContract["port_source"] != "config" {
+		t.Fatalf("runtime_contract = %#v, want configured web port contract", runtimeContract)
+	}
+	if runtimeContract["healthcheck_path"] != "/health" || runtimeContract["healthcheck_port"] != float64(8080) {
+		t.Fatalf("runtime_contract healthcheck = %#v, want /health on port 8080", runtimeContract)
 	}
 }
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -2337,6 +2337,39 @@ func TestSoloInitCreatesWorkspaceConfig(t *testing.T) {
 	if !strings.Contains(nextSteps, "devopsellence node create prod-1 --provider hetzner --install --attach") {
 		t.Fatalf("next_steps = %q, want provider-created node path", nextSteps)
 	}
+	runtimeContract := jsonMapFromAny(t, payload["runtime_contract"])
+	if runtimeContract["service"] != "web" || runtimeContract["port"] != float64(3000) || runtimeContract["port_source"] != "default" {
+		t.Fatalf("runtime_contract = %#v, want default web port contract", runtimeContract)
+	}
+	requirement := stringValueAny(runtimeContract["requirement"])
+	if !strings.Contains(requirement, "EXPOSE") || !strings.Contains(requirement, "devopsellence.yml") {
+		t.Fatalf("runtime_contract.requirement = %q, want Dockerfile/config guidance", requirement)
+	}
+}
+
+func TestSoloInitReportsDockerfileInferredPortContract(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(workspaceRoot, "Dockerfile"), []byte("FROM nginx:1.27-alpine\nEXPOSE 80\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var stdout bytes.Buffer
+	app := &App{
+		Printer:     output.New(&stdout, io.Discard),
+		ConfigStore: config.NewStore(),
+		Cwd:         workspaceRoot,
+	}
+
+	if err := app.SoloInit(context.Background(), SoloInitOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	runtimeContract := jsonMapFromAny(t, payload["runtime_contract"])
+	if runtimeContract["service"] != "web" || runtimeContract["port"] != float64(80) || runtimeContract["port_source"] != "dockerfile" {
+		t.Fatalf("runtime_contract = %#v, want inferred Dockerfile web port contract", runtimeContract)
+	}
+	if runtimeContract["healthcheck_port"] != float64(80) {
+		t.Fatalf("runtime_contract.healthcheck_port = %#v, want 80", runtimeContract["healthcheck_port"])
+	}
 }
 
 func TestSoloInitReportsReadyWhenNodeAttached(t *testing.T) {


### PR DESCRIPTION
## Summary

- add a structured `runtime_contract` object to `devopsellence init --mode solo` output
- document how generic app container ports are inferred from Dockerfile `EXPOSE` or default to port 3000
- cover default and Dockerfile-inferred port contracts in solo init tests

## Why

Dogfood of `v0.2.0-preview` showed the generic first-deploy flow works, but users can miss that their container must listen on the generated `devopsellence.yml` service and healthcheck port. A simple nginx Dockerfile defaults to port 80 while generated generic config defaults to 3000 unless a Dockerfile signal is present.

## Validation

- `mise run test:cli`