### PR TITLE
[codex] Address dogfood findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ In shared mode, `node create` provisions the server and runs the registration in
 `devopsellence` reads `devopsellence.yml` from the app root:
 
 ```yaml
-schema_version: 6
+schema_version: 1
 app:
   type: rails
 organization: solo

--- a/cli/internal/discovery/discovery_test.go
+++ b/cli/internal/discovery/discovery_test.go
@@ -77,7 +77,7 @@ func TestDiscoverFindsGenericWorkspaceFromConfig(t *testing.T) {
 	t.Parallel()
 
 	root := t.TempDir()
-	if err := os.WriteFile(filepath.Join(root, "devopsellence.yml"), []byte("schema_version: 6\norganization: acme\nproject: demo\ndefault_environment: production\nbuild:\n  context: .\n  dockerfile: Dockerfile\nservices:\n  web:\n    ports:\n      - name: http\n        port: 8080\n    healthcheck:\n      path: /\n      port: 8080\n"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(root, "devopsellence.yml"), []byte("schema_version: 1\norganization: acme\nproject: demo\ndefault_environment: production\nbuild:\n  context: .\n  dockerfile: Dockerfile\nservices:\n  web:\n    ports:\n      - name: http\n        port: 8080\n    healthcheck:\n      path: /\n      port: 8080\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	start := filepath.Join(root, "src", "api")

--- a/cli/internal/workflow/root.go
+++ b/cli/internal/workflow/root.go
@@ -821,6 +821,7 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 		}),
 	}
 	nodeListCommand.Flags().StringVar(&nodeListSharedOpts.Organization, "org", "", "Organization name override (shared mode)")
+	nodeListCommand.Flags().BoolVar(&nodeListSoloOpts.All, "all", false, "List all registered solo nodes instead of only the current environment")
 	nodeAttachCommand := &cobra.Command{
 		Use:   "attach <name|id>",
 		Short: "Attach a node to the current environment (solo: name, shared: numeric id)",

--- a/cli/internal/workflow/root_test.go
+++ b/cli/internal/workflow/root_test.go
@@ -378,7 +378,7 @@ func rootTestSoloWorkspace(t *testing.T) string {
 	t.Helper()
 	cwd := rootTestWorkspaceWithMode(t, ModeSolo)
 	if err := os.WriteFile(filepath.Join(cwd, "devopsellence.yml"), []byte(strings.Join([]string{
-		"schema_version: 6",
+		"schema_version: 1",
 		"organization: solo",
 		"project: demo",
 		"default_environment: production",

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -57,7 +57,9 @@ type SoloSecretsDeleteOptions struct {
 	Environment string
 }
 
-type SoloNodeListOptions struct{}
+type SoloNodeListOptions struct {
+	All bool
+}
 
 type SoloNodeAttachOptions struct {
 	Node        string
@@ -722,6 +724,69 @@ func (a *App) resolveNodes(current solo.State, names []string) (map[string]confi
 		return nil, fmt.Errorf("unknown node(s): %s (available: %s)", strings.Join(unknown, ", "), strings.Join(current.NodeNames(), ", "))
 	}
 	return result, nil
+}
+
+func (a *App) currentSoloAttachment(current solo.State) (*config.ProjectConfig, string, string, []string, bool, error) {
+	discovered, cfg, err := a.optionalWorkspaceConfig()
+	if err != nil {
+		return nil, "", "", nil, false, err
+	}
+	if cfg == nil {
+		return nil, discovered.WorkspaceRoot, "", nil, false, nil
+	}
+	environmentName := soloEnvironmentName(cfg, "")
+	nodeNames, err := current.AttachedNodeNames(discovered.WorkspaceRoot, environmentName)
+	if err != nil {
+		return nil, "", "", nil, true, err
+	}
+	return cfg, discovered.WorkspaceRoot, environmentName, nodeNames, true, nil
+}
+
+func soloNodeListNode(node config.Node) map[string]any {
+	item := map[string]any{
+		"host": node.Host,
+		"user": node.User,
+	}
+	if node.Port != 0 {
+		item["port"] = node.Port
+	}
+	if len(node.Labels) > 0 {
+		item["labels"] = node.Labels
+	}
+	if strings.TrimSpace(node.Provider) != "" {
+		item["provider"] = node.Provider
+	}
+	if strings.TrimSpace(node.ProviderRegion) != "" {
+		item["provider_region"] = node.ProviderRegion
+	}
+	if strings.TrimSpace(node.ProviderSize) != "" {
+		item["provider_size"] = node.ProviderSize
+	}
+	if strings.TrimSpace(node.ProviderImage) != "" {
+		item["provider_image"] = node.ProviderImage
+	}
+	if strings.TrimSpace(node.SSHKey) != "" {
+		item["ssh_key_configured"] = true
+	}
+	if strings.TrimSpace(node.ProviderServerID) != "" {
+		item["provider_server_id_configured"] = true
+	}
+	return item
+}
+
+func soloNodeListAttachments(attachments []solo.AttachmentRecord, currentWorkspaceKey, currentEnvironment string) []map[string]any {
+	items := make([]map[string]any, 0, len(attachments))
+	for _, attachment := range attachments {
+		item := map[string]any{
+			"environment": attachment.Environment,
+			"node_names":  attachment.NodeNames,
+		}
+		if attachment.WorkspaceKey == currentWorkspaceKey && attachment.Environment == currentEnvironment {
+			item["current_environment"] = true
+		}
+		items = append(items, item)
+	}
+	return items
 }
 
 type soloRepublishErrorEntry struct {
@@ -1636,25 +1701,50 @@ func soloSecretListItems(cfg *config.ProjectConfig, secrets []solo.SecretRecord,
 	return sortListedSecrets(items)
 }
 
-func (a *App) SoloNodeList(_ context.Context, _ SoloNodeListOptions) error {
+func (a *App) SoloNodeList(_ context.Context, opts SoloNodeListOptions) error {
 	current, err := a.readSoloState()
 	if err != nil {
 		return err
 	}
 	currentWorkspaceKey := ""
 	currentEnvironment := ""
-	if discovered, cfg, cfgErr := a.optionalWorkspaceConfig(); cfgErr == nil && cfg != nil {
-		currentWorkspaceKey, _ = solo.CanonicalWorkspaceKey(discovered.WorkspaceRoot)
-		currentEnvironment = soloEnvironmentName(cfg, "")
+	nodeNames := current.NodeNames()
+	scope := "global"
+	_, workspaceRoot, environmentName, attached, hasWorkspace, cfgErr := a.currentSoloAttachment(current)
+	if cfgErr != nil {
+		if !opts.All {
+			return cfgErr
+		}
+	} else if hasWorkspace {
+		workspaceKey, keyErr := solo.CanonicalWorkspaceKey(workspaceRoot)
+		if keyErr != nil {
+			if !opts.All {
+				return keyErr
+			}
+		} else {
+			currentWorkspaceKey = workspaceKey
+			currentEnvironment = environmentName
+			if !opts.All {
+				nodeNames = attached
+				scope = "current_environment"
+			}
+		}
+	} else if !opts.All && workspaceRoot != "" {
+		return errors.New("Current workspace configuration could not be determined. Run `devopsellence init --mode solo` or use `--all` to list all nodes.")
 	}
 	type nodeListItem struct {
-		Name                    string                  `json:"name"`
-		Node                    config.Node             `json:"node"`
-		Attachments             []solo.AttachmentRecord `json:"attachments,omitempty"`
-		CurrentEnvironmentBound bool                    `json:"current_environment_bound,omitempty"`
+		Name                    string           `json:"name"`
+		Node                    map[string]any   `json:"node"`
+		Attachments             []map[string]any `json:"attachments,omitempty"`
+		CurrentEnvironmentBound bool             `json:"current_environment_bound,omitempty"`
 	}
-	items := make([]nodeListItem, 0, len(current.Nodes))
-	for _, name := range current.NodeNames() {
+	items := make([]nodeListItem, 0, len(nodeNames))
+	nodes := make(map[string]map[string]any, len(nodeNames))
+	for _, name := range nodeNames {
+		node, ok := current.Nodes[name]
+		if !ok {
+			continue
+		}
 		attachments := current.AttachmentsForNode(name)
 		bound := false
 		for _, attachment := range attachments {
@@ -1663,17 +1753,20 @@ func (a *App) SoloNodeList(_ context.Context, _ SoloNodeListOptions) error {
 				break
 			}
 		}
+		listedNode := soloNodeListNode(node)
+		nodes[name] = listedNode
 		items = append(items, nodeListItem{
 			Name:                    name,
-			Node:                    current.Nodes[name],
-			Attachments:             attachments,
+			Node:                    listedNode,
+			Attachments:             soloNodeListAttachments(attachments, currentWorkspaceKey, currentEnvironment),
 			CurrentEnvironmentBound: bound,
 		})
 	}
 
 	return a.Printer.PrintJSON(map[string]any{
 		"schema_version": outputSchemaVersion,
-		"nodes":          current.Nodes,
+		"scope":          scope,
+		"nodes":          nodes,
 		"node_items":     items,
 	})
 
@@ -1878,7 +1971,18 @@ func (a *App) SoloWorkloadLogs(ctx context.Context, opts SoloWorkloadLogsOptions
 			ok = false
 		} else if diag.ExitCode != 0 {
 			entry["exit_code"] = diag.ExitCode
-			entry["error"] = diagnosticErrorMessage(diag)
+			entry["error"] = workloadLogsErrorMessage(diag)
+			if noWorkloadContainers(diag) {
+				fallback := runRemoteDiagnostic(ctx, nodes[nodeName], remoteJournalctlCommand(fmt.Sprintf("-u devopsellence-agent --no-pager -n %d", linesLimit)))
+				entry["fallback"] = "devopsellence_agent_logs"
+				entry["fallback_lines"] = splitNonFinalEmptyLines(fallback.Stdout)
+				if fallback.Err != nil {
+					entry["fallback_error"] = fallback.Err.Error()
+				} else if fallback.ExitCode != 0 {
+					entry["fallback_exit_code"] = fallback.ExitCode
+					entry["fallback_error"] = diagnosticErrorMessage(fallback)
+				}
+			}
 			ok = false
 		}
 		results = append(results, entry)
@@ -2113,6 +2217,27 @@ func diagnosticErrorMessage(diag remoteDiagnosticResult) string {
 		return message
 	}
 	return fmt.Sprintf("command exited with code %d", diag.ExitCode)
+}
+
+func noWorkloadContainers(diag remoteDiagnosticResult) bool {
+	return strings.Contains(diag.Stderr, soloNoWorkloadContainersSentinel)
+}
+
+func workloadLogsErrorMessage(diag remoteDiagnosticResult) string {
+	if !noWorkloadContainers(diag) {
+		return diagnosticErrorMessage(diag)
+	}
+	lines := []string{}
+	for _, line := range splitNonFinalEmptyLines(diag.Stderr) {
+		if strings.TrimSpace(line) == soloNoWorkloadContainersSentinel {
+			continue
+		}
+		lines = append(lines, line)
+	}
+	if len(lines) > 0 {
+		return strings.Join(lines, "\n")
+	}
+	return "No workload containers found"
 }
 
 func collectRemoteText(ctx context.Context, node config.Node, command string) map[string]any {
@@ -2400,10 +2525,20 @@ func (a *App) SoloDoctor(ctx context.Context) error {
 		if err != nil {
 			return "", err
 		}
-		if len(current.Nodes) == 0 {
-			return "", errors.New("No solo nodes registered yet. Run `devopsellence node create`.")
+		if cfg == nil {
+			return "", errors.New("No config found. Run `devopsellence init --mode solo`.")
 		}
-		return fmt.Sprintf("%d node(s) registered", len(current.Nodes)), nil
+		if len(current.Nodes) == 0 {
+			return "", errors.New("No nodes registered in solo state. Run `devopsellence node create <name>`.")
+		}
+		nodeNames, err := current.AttachedNodeNames(discovered.WorkspaceRoot, soloEnvironmentName(cfg, ""))
+		if err != nil {
+			return "", err
+		}
+		if len(nodeNames) == 0 {
+			return "", errors.New("No nodes attached to the current environment. Run `devopsellence node attach <name>`.")
+		}
+		return fmt.Sprintf("%d node(s) attached to %s", len(nodeNames), soloEnvironmentName(cfg, "")), nil
 	})
 
 	ok := true
@@ -2419,15 +2554,23 @@ func (a *App) SoloDoctor(ctx context.Context) error {
 		"ok":             ok,
 		"checks":         checks,
 	}
-	if ok && len(current.Nodes) > 0 {
-		runtimeChecks, runtimeFailed, err := a.soloRuntimeDoctorChecks(ctx, SoloDoctorOptions{})
+	if ok && cfg != nil {
+		nodeNames, err := current.AttachedNodeNames(discovered.WorkspaceRoot, soloEnvironmentName(cfg, ""))
+		if err != nil {
+			return err
+		}
+		runtimeChecks, runtimeFailed, err := a.soloRuntimeDoctorChecks(ctx, SoloDoctorOptions{Nodes: nodeNames})
 		if err != nil {
 			return err
 		}
 		payload["runtime_checks"] = runtimeChecks
 		payload["ok"] = !runtimeFailed
 		if runtimeFailed {
-			payload["next_steps"] = soloDoctorNextSteps(current.Nodes)
+			nodes, err := a.resolveNodes(current, nodeNames)
+			if err != nil {
+				return err
+			}
+			payload["next_steps"] = soloDoctorNextSteps(nodes)
 		}
 		if err := a.Printer.PrintJSON(payload); err != nil {
 			return err
@@ -2681,6 +2824,7 @@ const (
 	soloDiagnoseDockerItemLimit          = 100
 	soloDiagnosePortsLineLimit           = 200
 	soloDiagnoseTruncatedMarker          = "__DEVOPSELLENCE_TRUNCATED__"
+	soloNoWorkloadContainersSentinel     = "__DEVOPSELLENCE_NO_WORKLOAD_CONTAINERS__"
 	soloRemoteAgentBinaryNotFoundMessage = "devopsellence agent binary not found"
 )
 
@@ -3945,7 +4089,7 @@ if [ "$ps_status" -ne 0 ]; then
   exit "$ps_status"
 fi
 ids=$(printf '%%s\n' "$ids" | sed '/^$/d' | head -n %d)
-if [ -z "$ids" ]; then echo "No workload containers found for service %s in environment %s" >&2; exit 1; fi
+if [ -z "$ids" ]; then echo "%s" >&2; echo "No workload containers found for service %s in environment %s" >&2; exit 1; fi
 rc=0
 for id in $ids; do
   name=$($docker_cmd inspect --format '{{.Name}}' "$id" 2>/dev/null | sed 's#^/##')
@@ -3961,7 +4105,7 @@ for id in $ids; do
     rc=$logs_status
   fi
 done
-exit "$rc"`, env, service, service, env, soloWorkloadLogsContainerLimit, service, env, lines)
+exit "$rc"`, env, service, service, env, soloWorkloadLogsContainerLimit, soloNoWorkloadContainersSentinel, service, env, lines)
 }
 
 func withRemoteLineLimit(command string, limit int) string {

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -849,6 +849,61 @@ func TestSoloDoctorReturnsFailureWhenLocalChecksFail(t *testing.T) {
 	if payload["ok"] != false {
 		t.Fatalf("payload ok = %v, want false", payload["ok"])
 	}
+	checks := jsonArrayFromMap(t, payload, "checks")
+	var nodesDetail string
+	for _, item := range checks {
+		check := jsonMapFromAny(t, item)
+		if check["name"] == "nodes" {
+			nodesDetail, _ = check["detail"].(string)
+			break
+		}
+	}
+	if nodesDetail != "No nodes registered in solo state. Run `devopsellence node create <name>`." {
+		t.Fatalf("nodes check detail = %q, want node create guidance", nodesDetail)
+	}
+}
+
+func TestSoloDoctorScopesRuntimeChecksToCurrentEnvironment(t *testing.T) {
+	installFakeSoloCommands(t, nil)
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	commitTestRepo(t, workspaceRoot)
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.Node{
+			"node-a": {Host: "203.0.113.10", User: "root"},
+			"node-b": {Host: "203.0.113.11", User: "root"},
+		},
+	}
+	if _, _, err := current.AttachNode(workspaceRoot, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{
+		Printer:     output.New(&stdout, io.Discard),
+		Docker:      &fakeDocker{},
+		SoloState:   soloState,
+		ConfigStore: config.NewStore(),
+		Cwd:         workspaceRoot,
+	}
+	if err := app.SoloDoctor(context.Background()); err != nil {
+		t.Fatalf("SoloDoctor() error = %v", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	checks := jsonArrayFromMap(t, payload, "runtime_checks")
+	for _, item := range checks {
+		check := jsonMapFromAny(t, item)
+		if check["node"] != "node-a" {
+			t.Fatalf("runtime check node = %v, want only node-a", check["node"])
+		}
+	}
 }
 
 func TestSoloStatusReturnsFailureWhenNodeStatusReadFails(t *testing.T) {
@@ -904,6 +959,115 @@ func TestSoloStatusReturnsFailureWhenNodeStatusReadFails(t *testing.T) {
 	node := jsonMapFromAny(t, nodes[0])
 	if node["node"] != "node-a" || !strings.Contains(stringValueAny(node["error"]), "ssh root@203.0.113.10:") {
 		t.Fatalf("node payload = %#v, want node read error", node)
+	}
+}
+
+func TestSoloNodeListDefaultsToCurrentEnvironmentAndRedactsPrivateFields(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.Node{
+			"node-a": {Host: "203.0.113.10", User: "root", SSHKey: "/secret/key", ProviderServerID: "123", Labels: []string{"web"}},
+			"node-b": {Host: "203.0.113.11", User: "root", SSHKey: "/other/key"},
+		},
+	}
+	if _, _, err := current.AttachNode(workspaceRoot, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState, Cwd: workspaceRoot}
+	if err := app.SoloNodeList(context.Background(), SoloNodeListOptions{}); err != nil {
+		t.Fatalf("SoloNodeList() error = %v", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	if payload["scope"] != "current_environment" {
+		t.Fatalf("scope = %v, want current_environment", payload["scope"])
+	}
+	nodes := jsonMapFromAny(t, payload["nodes"])
+	if _, ok := nodes["node-b"]; ok {
+		t.Fatalf("nodes = %#v, want node-b omitted", nodes)
+	}
+	nodeA := jsonMapFromAny(t, nodes["node-a"])
+	if _, ok := nodeA["ssh_key"]; ok {
+		t.Fatalf("node-a = %#v, want ssh_key redacted", nodeA)
+	}
+	if _, ok := nodeA["provider_server_id"]; ok {
+		t.Fatalf("node-a = %#v, want provider_server_id redacted", nodeA)
+	}
+	if nodeA["ssh_key_configured"] != true || nodeA["provider_server_id_configured"] != true {
+		t.Fatalf("node-a = %#v, want configured booleans", nodeA)
+	}
+	items := jsonArrayFromMap(t, payload, "node_items")
+	item := jsonMapFromAny(t, items[0])
+	attachments := jsonArrayFromMap(t, item, "attachments")
+	attachment := jsonMapFromAny(t, attachments[0])
+	if _, ok := attachment["workspace_root"]; ok {
+		t.Fatalf("attachment = %#v, want workspace_root redacted", attachment)
+	}
+	if _, ok := attachment["workspace_key"]; ok {
+		t.Fatalf("attachment = %#v, want workspace_key redacted", attachment)
+	}
+
+	stdout.Reset()
+	if err := app.SoloNodeList(context.Background(), SoloNodeListOptions{All: true}); err != nil {
+		t.Fatalf("SoloNodeList(--all) error = %v", err)
+	}
+	payload = decodeJSONOutput(t, &stdout)
+	if payload["scope"] != "global" {
+		t.Fatalf("scope = %v, want global", payload["scope"])
+	}
+	items = jsonArrayFromMap(t, payload, "node_items")
+	for _, rawItem := range items {
+		item := jsonMapFromAny(t, rawItem)
+		if item["name"] != "node-a" {
+			continue
+		}
+		if item["current_environment_bound"] != true {
+			t.Fatalf("node-a item = %#v, want current_environment_bound", item)
+		}
+		attachments := jsonArrayFromMap(t, item, "attachments")
+		attachment := jsonMapFromAny(t, attachments[0])
+		if attachment["current_environment"] != true {
+			t.Fatalf("attachment = %#v, want current_environment marker", attachment)
+		}
+		return
+	}
+	t.Fatalf("node_items = %#v, want node-a", items)
+}
+
+func TestSoloNodeListRequiresConfigForDefaultScope(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.Node{
+			"node-a": {Host: "203.0.113.10", User: "root"},
+		},
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState, Cwd: workspaceRoot}
+	err := app.SoloNodeList(context.Background(), SoloNodeListOptions{})
+	if err == nil || !strings.Contains(err.Error(), "use `--all` to list all nodes") {
+		t.Fatalf("SoloNodeList() error = %v, want --all guidance", err)
+	}
+
+	if err := app.SoloNodeList(context.Background(), SoloNodeListOptions{All: true}); err != nil {
+		t.Fatalf("SoloNodeList(--all) error = %v", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	if payload["scope"] != "global" {
+		t.Fatalf("scope = %v, want global", payload["scope"])
 	}
 }
 
@@ -1007,10 +1171,45 @@ func TestSoloWorkloadLogsRequiresWorkspaceConfig(t *testing.T) {
 
 func TestRemoteDockerLogsCommandPreservesPerContainerFailure(t *testing.T) {
 	command := remoteDockerLogsCommand("production", "web", 20)
-	for _, snippet := range []string{`ps_status=$?`, `Failed to list workload containers`, `head -n 20`, `rc=0`, `inspect_status=$?`, `logs_status=$?`, `exit "$rc"`} {
+	for _, snippet := range []string{`ps_status=$?`, `Failed to list workload containers`, `__DEVOPSELLENCE_NO_WORKLOAD_CONTAINERS__`, `head -n 20`, `rc=0`, `inspect_status=$?`, `logs_status=$?`, `exit "$rc"`} {
 		if !strings.Contains(command, snippet) {
 			t.Fatalf("command = %q, want %q", command, snippet)
 		}
+	}
+}
+
+func TestSoloWorkloadLogsFallsBackToAgentLogsWhenContainersMissing(t *testing.T) {
+	t.Setenv("DEVOPSELLENCE_FAKE_SSH_WORKLOAD_LOGS_EMPTY", "1")
+	installFakeSoloCommands(t, nil)
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{Nodes: map[string]config.Node{"node-a": {Host: "203.0.113.10", User: "root"}}}
+	if _, _, err := current.AttachNode(workspaceRoot, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState, ConfigStore: config.NewStore(), Cwd: workspaceRoot}
+	err := app.SoloWorkloadLogs(context.Background(), SoloWorkloadLogsOptions{ServiceName: "web", Lines: 20})
+	if err == nil {
+		t.Fatal("SoloWorkloadLogs() error = nil, want failure with fallback payload")
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	nodes := jsonArrayFromMap(t, payload, "nodes")
+	node := jsonMapFromAny(t, nodes[0])
+	if node["fallback"] != "devopsellence_agent_logs" {
+		t.Fatalf("node payload = %#v, want agent-log fallback", node)
+	}
+	lines := jsonArrayFromMap(t, node, "fallback_lines")
+	if len(lines) == 0 || !strings.Contains(stringValueAny(lines[0]), "agent captured failure") {
+		t.Fatalf("fallback_lines = %#v, want captured failure", lines)
 	}
 }
 
@@ -2615,8 +2814,18 @@ if [[ "$command" == *"docker image inspect"* ]]; then
   exit 0
 fi
 
+if [[ "$command" == *" logs --tail "* && -n "${DEVOPSELLENCE_FAKE_SSH_WORKLOAD_LOGS_EMPTY:-}" ]]; then
+  printf '__DEVOPSELLENCE_EXIT_CODE__1\n__DEVOPSELLENCE_STDOUT__\n\n__DEVOPSELLENCE_STDERR__\n__DEVOPSELLENCE_NO_WORKLOAD_CONTAINERS__\nNo workload containers found for service web in environment production\n'
+  exit 0
+fi
+
 if [[ "$command" == *" logs --tail "* ]]; then
   printf '__DEVOPSELLENCE_EXIT_CODE__0\n__DEVOPSELLENCE_STDOUT__\n==> svc-production-web <==\napp line one\napp line two\n__DEVOPSELLENCE_STDERR__\n'
+  exit 0
+fi
+
+if [[ "$command" == *"__DEVOPSELLENCE_EXIT_CODE__"* && "$command" == *"journalctl"* ]]; then
+  printf '__DEVOPSELLENCE_EXIT_CODE__0\n__DEVOPSELLENCE_STDOUT__\nagent captured failure\n__DEVOPSELLENCE_STDERR__\n'
   exit 0
 fi
 

--- a/control-plane/app/controllers/marketing_controller.rb
+++ b/control-plane/app/controllers/marketing_controller.rb
@@ -29,7 +29,6 @@ class MarketingController < ApplicationController
     def assign_public_install_command
       @cli_install_base_url = request.base_url
       @cli_install_command = "curl -fsSL #{@cli_install_base_url}/lfg.sh | bash"
-      @agent_uninstall_command = "curl -fsSL #{@cli_install_base_url}/uninstall.sh | bash -s -- --purge-runtime"
     end
 
     def assign_legal_page

--- a/control-plane/app/views/marketing/docs.html.erb
+++ b/control-plane/app/views/marketing/docs.html.erb
@@ -352,7 +352,7 @@
         <span class="terminal-bar-title">devopsellence.yml</span>
       </div>
       <div class="terminal-body">
-        <pre class="config-pre"><code>schema_version: 6
+        <pre class="config-pre"><code>schema_version: 1
 app:
   type: rails
 organization: solo
@@ -577,7 +577,7 @@ jobs:
         <span class="terminal-bar-title">devopsellence.yml</span>
       </div>
       <div class="terminal-body">
-        <pre class="config-pre"><code>schema_version: 6
+        <pre class="config-pre"><code>schema_version: 1
 
 app:
   type: rails
@@ -629,7 +629,7 @@ tasks:
     <dl class="docs-fields">
       <div class="docs-field">
         <dt><code>schema_version</code></dt>
-        <dd>Required. Currently <code>5</code>.</dd>
+        <dd>Required. Currently <code>1</code>.</dd>
       </div>
       <div class="docs-field">
         <dt><code>app.type</code></dt>
@@ -1156,7 +1156,7 @@ tasks:
   <section class="prose-section" id="cleanup">
     <h2>Cleanup &amp; uninstall</h2>
 
-    <h3>Remove a node</h3>
+    <h3>Remove a solo node</h3>
     <div class="terminal">
       <div class="terminal-bar">
         <span class="dot dot-red"></span>
@@ -1164,9 +1164,9 @@ tasks:
         <span class="dot dot-green"></span>
       </div>
       <div class="terminal-body">
-        <div class="tl"><span class="tp">$</span> devopsellence node detach 42</div>
-        <div class="tl tl-muted"># Then on the server, run the agent uninstall:</div>
-        <div class="tl"><span class="tp">$</span> <%= @agent_uninstall_command %></div>
+        <div class="tl"><span class="tp">$</span> devopsellence agent uninstall prod-1 --yes</div>
+        <div class="tl"><span class="tp">$</span> devopsellence node detach prod-1</div>
+        <div class="tl"><span class="tp">$</span> devopsellence node remove prod-1 --yes</div>
       </div>
     </div>
 

--- a/control-plane/test/integration/installs_test.rb
+++ b/control-plane/test/integration/installs_test.rb
@@ -275,6 +275,7 @@ class InstallsTest < ActionDispatch::IntegrationTest
     Dir.mktmpdir("devopsellence-cli-install-test") do |tmpdir|
       fixtures_dir = File.join(tmpdir, "fixtures")
       fakebin_dir = File.join(tmpdir, "fakebin")
+      safebin_dir = File.join(tmpdir, "safebin")
       effective_install_dir = install_dir == :explicit ? File.join(tmpdir, "install") : install_dir
       script_path = File.join(tmpdir, "lfg.sh")
       artifact_path = File.join(fixtures_dir, "cli-linux-amd64")
@@ -283,7 +284,53 @@ class InstallsTest < ActionDispatch::IntegrationTest
 
       FileUtils.mkdir_p(fixtures_dir)
       FileUtils.mkdir_p(fakebin_dir)
+      FileUtils.mkdir_p(safebin_dir)
       FileUtils.mkdir_p(effective_install_dir) if effective_install_dir
+      host_path = ENV.fetch("PATH").split(File::PATH_SEPARATOR)
+      link_host_command = lambda do |name|
+        path = host_path.find { |entry| File.executable?(File.join(entry, name)) }
+        raise "Required command not found in PATH for safebin setup: #{name}" unless path
+
+        FileUtils.ln_s(File.join(path, name), File.join(safebin_dir, name))
+      end
+      %w[bash tr mktemp rm awk chmod mkdir mv cp].each(&link_host_command)
+
+      sha256sum_path = host_path.find { |entry| File.executable?(File.join(entry, "sha256sum")) }
+      shasum_path = host_path.find { |entry| File.executable?(File.join(entry, "shasum")) }
+      raise "Required checksum command not found in PATH for safebin setup: sha256sum or shasum" unless sha256sum_path || shasum_path
+
+      if sha256sum_path
+        FileUtils.ln_s(File.join(sha256sum_path, "sha256sum"), File.join(safebin_dir, "sha256sum"))
+      else
+        sha256sum_shim_path = File.join(safebin_dir, "sha256sum")
+        File.write(sha256sum_shim_path, <<~SH)
+          #!/usr/bin/env bash
+          exec shasum -a 256 "$@"
+        SH
+        FileUtils.chmod("u+x", sha256sum_shim_path)
+      end
+
+      if shasum_path
+        FileUtils.ln_s(File.join(shasum_path, "shasum"), File.join(safebin_dir, "shasum"))
+      else
+        shasum_shim_path = File.join(safebin_dir, "shasum")
+        File.write(shasum_shim_path, <<~SH)
+          #!/usr/bin/env bash
+          set -euo pipefail
+
+          if [[ "${1:-}" == "-a" ]]; then
+            algorithm="${2:-}"
+            shift 2
+            if [[ "$algorithm" != "256" ]]; then
+              echo "unsupported shasum algorithm: $algorithm" >&2
+              exit 1
+            fi
+          fi
+
+          exec sha256sum "$@"
+        SH
+        FileUtils.chmod("u+x", shasum_shim_path)
+      end
 
       File.write(artifact_path, "prerelease build\n")
       digest = Digest::SHA256.file(artifact_path).hexdigest
@@ -363,7 +410,7 @@ class InstallsTest < ActionDispatch::IntegrationTest
       path_entries = path_entries.reject { |entry| File.executable?(File.join(entry, "npx")) } unless include_npx
 
       env = {
-        "PATH" => ([fakebin_dir] + path_entries).join(File::PATH_SEPARATOR),
+        "PATH" => ([fakebin_dir, safebin_dir] + path_entries).join(File::PATH_SEPARATOR),
         "HOME" => tmpdir,
         "SHELL" => ENV.fetch("SHELL", "/bin/bash"),
         "DEVOPSELLENCE_CLI_VERSION" => version,

--- a/deployment-core/pkg/deploycore/config/config.go
+++ b/deployment-core/pkg/deploycore/config/config.go
@@ -15,7 +15,7 @@ import (
 const (
 	FilePath               = "devopsellence.yml"
 	GenericFilePath        = FilePath
-	SchemaVersion          = 6
+	SchemaVersion          = 1
 	DefaultEnvironment     = "production"
 	DefaultBuildContext    = "."
 	DefaultDockerfile      = "Dockerfile"

--- a/deployment-core/pkg/deploycore/config/config_test.go
+++ b/deployment-core/pkg/deploycore/config/config_test.go
@@ -82,7 +82,7 @@ func TestLoadAppliesDefaultBuildPlatforms(t *testing.T) {
 	root := t.TempDir()
 	path := filepath.Join(root, FilePath)
 	content := strings.Join([]string{
-		"schema_version: 6",
+		"schema_version: 1",
 		"organization: acme",
 		"project: ShopApp",
 		"default_environment: production",
@@ -119,7 +119,7 @@ func TestLoadRejectsLegacyInitHook(t *testing.T) {
 	root := t.TempDir()
 	path := filepath.Join(root, FilePath)
 	content := strings.Join([]string{
-		"schema_version: 6",
+		"schema_version: 1",
 		"organization: acme",
 		"project: ShopApp",
 		"default_environment: production",
@@ -152,7 +152,7 @@ func TestLoadRejectsStringCommandSyntax(t *testing.T) {
 	root := t.TempDir()
 	path := filepath.Join(root, FilePath)
 	content := strings.Join([]string{
-		"schema_version: 6",
+		"schema_version: 1",
 		"organization: acme",
 		"project: ShopApp",
 		"default_environment: production",
@@ -202,7 +202,7 @@ func TestLoadRejectsLegacyDirectConfig(t *testing.T) {
 	root := t.TempDir()
 	path := filepath.Join(root, FilePath)
 	content := strings.Join([]string{
-		"schema_version: 6",
+		"schema_version: 1",
 		"organization: acme",
 		"project: ShopApp",
 		"default_environment: production",
@@ -238,7 +238,7 @@ func TestLoadRejectsLegacySoloConfigBlock(t *testing.T) {
 	root := t.TempDir()
 	path := filepath.Join(root, FilePath)
 	content := strings.Join([]string{
-		"schema_version: 6",
+		"schema_version: 1",
 		"organization: solo",
 		"project: ShopApp",
 		"default_environment: production",
@@ -286,7 +286,7 @@ func TestLoadNormalizesIngressHostsAndRuleHosts(t *testing.T) {
 	root := t.TempDir()
 	path := filepath.Join(root, FilePath)
 	content := strings.Join([]string{
-		"schema_version: 6",
+		"schema_version: 1",
 		"organization: acme",
 		"project: ShopApp",
 		"default_environment: production",
@@ -333,7 +333,7 @@ func TestLoadRejectsDuplicateIngressHostsAfterNormalization(t *testing.T) {
 	root := t.TempDir()
 	path := filepath.Join(root, FilePath)
 	content := strings.Join([]string{
-		"schema_version: 6",
+		"schema_version: 1",
 		"organization: acme",
 		"project: ShopApp",
 		"default_environment: production",
@@ -606,7 +606,7 @@ func TestLoadRejectsOverlayServiceNotInBase(t *testing.T) {
 	root := t.TempDir()
 	path := filepath.Join(root, FilePath)
 	content := strings.Join([]string{
-		"schema_version: 6",
+		"schema_version: 1",
 		"organization: acme",
 		"project: ShopApp",
 		"default_environment: production",
@@ -643,7 +643,7 @@ func TestLoadRejectsUnknownOverlayKeys(t *testing.T) {
 	root := t.TempDir()
 	path := filepath.Join(root, FilePath)
 	content := strings.Join([]string{
-		"schema_version: 6",
+		"schema_version: 1",
 		"organization: acme",
 		"project: ShopApp",
 		"default_environment: production",

--- a/docs/specs/2026-04-24-explicit-ingress-rules-and-generic-services.md
+++ b/docs/specs/2026-04-24-explicit-ingress-rules-and-generic-services.md
@@ -62,7 +62,7 @@ The result is a split model where repo config is more opinionated and less expre
 ### Before
 
 ```yaml
-schema_version: 5
+schema_version: 1
 organization: acme
 project: demo
 default_environment: production
@@ -99,7 +99,7 @@ ingress:
 ### After
 
 ```yaml
-schema_version: 6
+schema_version: 1
 organization: acme
 project: demo
 default_environment: production
@@ -356,11 +356,11 @@ The desired-state proto and merge logic already model per-route service+port tar
 
 ## Migration
 
-This is a schema change and should be a clean break under `schema_version: 6`.
+This is a clean-slate config change under `schema_version: 1`; there is no compatibility promise or automatic backfill.
 
-### Automatic mapping from v5 to v6
+### Manual mapping from the previous ingress shape
 
-A straightforward migration exists for current configs:
+A straightforward edit exists for older local configs:
 
 ```yaml
 ingress:

--- a/test/e2e/solo_e2e.rb
+++ b/test/e2e/solo_e2e.rb
@@ -537,7 +537,7 @@ PY
 
   def write_devopsellence_yml!
     config = {
-      "schema_version" => 6,
+      "schema_version" => 1,
       "organization" => "solo",
       "project" => @project_name,
       "default_environment" => "production",


### PR DESCRIPTION
## Summary
- reset devopsellence.yml schema back to 1 across core, docs, README, and tests
- scope solo doctor/node list to the current environment by default, with node list --all for global inspection
- redact private solo node list fields and add fallback agent logs when workload containers are missing
- align cleanup docs with the CLI flow and harden installer test PATH isolation

## Validation
- go test ./... (deployment-core)
- mise run test:cli
- mise run test:cp

Root cause: dogfood showed stale docs and global solo state leaking into current-workspace agent workflows.