### PR TITLE
Make long-running CLI output NDJSON

### DIFF
--- a/cli/cmd/devopsellence/main.go
+++ b/cli/cmd/devopsellence/main.go
@@ -2,12 +2,12 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"os"
 	"os/signal"
 	"syscall"
 
+	"github.com/devopsellence/cli/internal/output"
 	"github.com/devopsellence/cli/internal/workflow"
 )
 
@@ -26,7 +26,7 @@ func main() {
 		if errors.Is(err, context.Canceled) {
 			code = 130
 		}
-		if !errors.Is(err, context.Canceled) && !errors.As(err, &renderedErr) {
+		if !errors.As(err, &renderedErr) {
 			operation := command.CommandPath()
 			if executedCommand != nil {
 				operation = executedCommand.CommandPath()
@@ -40,35 +40,20 @@ func main() {
 }
 
 func writeError(operation string, exitCode int, err error) {
-	errorObject := map[string]any{
-		"code":      "command_failed",
-		"message":   err.Error(),
-		"exit_code": exitCode,
-	}
-	reservedErrorKeys := map[string]struct{}{
-		"code":      {},
-		"message":   {},
-		"exit_code": {},
-	}
+	fields := output.Fields{}
 	var structured workflow.StructuredError
 	if errors.As(err, &structured) {
 		for key, value := range structured.ErrorFields() {
-			if _, reserved := reservedErrorKeys[key]; reserved {
-				continue
-			}
-			errorObject[key] = value
+			fields[key] = value
 		}
 	}
-	payload := map[string]any{
-		"ok":             false,
-		"schema_version": workflow.OutputSchemaVersion,
-		"operation":      operation,
-		"error":          errorObject,
+	payload := output.ErrorPayload{
+		Code:     "command_failed",
+		Message:  err.Error(),
+		ExitCode: exitCode,
+		Fields:   fields,
 	}
-	encoder := json.NewEncoder(os.Stderr)
-	encoder.SetIndent("", "  ")
-	encoder.SetEscapeHTML(false)
-	if encodeErr := encoder.Encode(payload); encodeErr != nil {
+	if encodeErr := output.New(os.Stdout, os.Stderr).PrintErrorEvent(operation, payload); encodeErr != nil {
 		_, _ = os.Stderr.WriteString(err.Error() + "\n")
 	}
 }

--- a/cli/cmd/devopsellence/main_test.go
+++ b/cli/cmd/devopsellence/main_test.go
@@ -21,17 +21,17 @@ func (structuredTestError) ErrorFields() map[string]any {
 }
 
 func TestWriteErrorIncludesStructuredFields(t *testing.T) {
-	originalStderr := os.Stderr
+	originalStdout := os.Stdout
 	reader, writer, err := os.Pipe()
 	if err != nil {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() {
-		os.Stderr = originalStderr
+		os.Stdout = originalStdout
 		_ = reader.Close()
 		_ = writer.Close()
 	})
-	os.Stderr = writer
+	os.Stdout = writer
 
 	writeError("devopsellence deploy", 1, structuredTestError{})
 	if err := writer.Close(); err != nil {

--- a/cli/internal/output/output.go
+++ b/cli/internal/output/output.go
@@ -9,12 +9,64 @@ import (
 
 const SchemaVersion = 1
 
-// Printer writes command results. The CLI is agent-primary: final command
-// results are JSON on stdout, and progress events are structured JSON on stderr.
+const (
+	// EventStarted marks the beginning of a long-running command stream.
+	EventStarted = "started"
+	// EventProgress reports intermediate progress for a long-running command.
+	EventProgress = "progress"
+	// EventResult is the final successful event in a long-running command stream.
+	EventResult = "result"
+	// EventError is the final failed event for command execution errors.
+	EventError = "error"
+)
+
+// Fields carries command-specific schema fields. Reserved envelope keys are
+// ignored when an event or error payload is encoded.
+type Fields map[string]any
+
+// Event is the stable NDJSON envelope for streaming or long-running commands.
+//
+// Required fields:
+//   - schema_version: output schema version
+//   - event: stable event name
+//
+// Long-running command events should also set operation. Result events set
+// ok=true. Error events set ok=false and include error.
+//
+// Command-specific fields are flattened into the top-level event object so
+// existing agents can read events without a nested "fields" object while still
+// preserving a single envelope schema.
+type Event struct {
+	SchemaVersion int
+	Operation     string
+	Event         string
+	OK            *bool
+	Error         *ErrorPayload
+	Fields        Fields
+}
+
+// ErrorPayload is the stable structured command error schema.
+type ErrorPayload struct {
+	Code     string
+	Message  string
+	ExitCode int
+	Fields   Fields
+}
+
+// Printer writes command results. The CLI is agent-primary: stdout is always
+// machine-readable. Bounded commands emit one JSON document; streaming commands
+// emit newline-delimited JSON events on stdout. Err is kept for command-owned
+// diagnostics that are not part of the command contract.
 type Printer struct {
 	Out io.Writer
 	Err io.Writer
 	mu  *sync.Mutex
+}
+
+// Stream writes newline-delimited JSON events for one long-running operation.
+type Stream struct {
+	printer   Printer
+	operation string
 }
 
 func New(out, err io.Writer) Printer {
@@ -25,6 +77,35 @@ func New(out, err io.Writer) Printer {
 	}
 }
 
+func (e Event) MarshalJSON() ([]byte, error) {
+	payload := Fields{}
+	copyFields(payload, e.Fields, reservedEventKeys)
+	if e.SchemaVersion == 0 {
+		e.SchemaVersion = SchemaVersion
+	}
+	payload["schema_version"] = e.SchemaVersion
+	if e.Operation != "" {
+		payload["operation"] = e.Operation
+	}
+	payload["event"] = e.Event
+	if e.OK != nil {
+		payload["ok"] = *e.OK
+	}
+	if e.Error != nil {
+		payload["error"] = e.Error
+	}
+	return json.Marshal(payload)
+}
+
+func (e ErrorPayload) MarshalJSON() ([]byte, error) {
+	payload := Fields{}
+	copyFields(payload, e.Fields, reservedErrorKeys)
+	payload["code"] = e.Code
+	payload["message"] = e.Message
+	payload["exit_code"] = e.ExitCode
+	return json.Marshal(payload)
+}
+
 func (p Printer) PrintJSON(value any) error {
 	encoder := json.NewEncoder(p.Out)
 	encoder.SetIndent("", "  ")
@@ -33,28 +114,108 @@ func (p Printer) PrintJSON(value any) error {
 }
 
 func (p Printer) PrintEvent(event string, fields map[string]any) error {
-	if p.Err == nil {
+	if p.Out == nil {
 		return nil
 	}
-	payload := map[string]any{}
-	for key, value := range fields {
-		if key == "schema_version" || key == "event" {
-			continue
-		}
-		payload[key] = value
+	envelope := Event{
+		SchemaVersion: SchemaVersion,
+		Event:         event,
+		Operation:     stringField(fields, "operation"),
+		Fields:        Fields(fields),
 	}
-	payload["schema_version"] = SchemaVersion
-	payload["event"] = event
+	return p.writeJSONLine(envelope)
+}
+
+func (p Printer) PrintResultEvent(operation string, fields map[string]any) error {
+	ok := true
+	envelope := Event{
+		SchemaVersion: SchemaVersion,
+		Operation:     operation,
+		Event:         EventResult,
+		OK:            &ok,
+		Fields:        Fields(fields),
+	}
+	return p.writeJSONLine(envelope)
+}
+
+func (p Printer) PrintErrorEvent(operation string, err ErrorPayload) error {
+	ok := false
+	return p.writeJSONLine(Event{
+		SchemaVersion: SchemaVersion,
+		Operation:     operation,
+		Event:         EventError,
+		OK:            &ok,
+		Error:         &err,
+	})
+}
+
+func (p Printer) Stream(operation string) Stream {
+	return Stream{printer: p, operation: operation}
+}
+
+func (s Stream) Event(event string, fields map[string]any) error {
+	envelope := Event{
+		SchemaVersion: SchemaVersion,
+		Operation:     s.operation,
+		Event:         event,
+		Fields:        Fields(fields),
+	}
+	return s.printer.writeJSONLine(envelope)
+}
+
+func (s Stream) Result(fields map[string]any) error {
+	return s.printer.PrintResultEvent(s.operation, fields)
+}
+
+func (p Printer) writeJSONLine(value any) error {
+	if p.Out == nil {
+		return nil
+	}
 	var buf bytes.Buffer
 	encoder := json.NewEncoder(&buf)
 	encoder.SetEscapeHTML(false)
-	if err := encoder.Encode(payload); err != nil {
+	if err := encoder.Encode(value); err != nil {
 		return err
 	}
 	if p.mu != nil {
 		p.mu.Lock()
 		defer p.mu.Unlock()
 	}
-	_, err := p.Err.Write(buf.Bytes())
+	_, err := p.Out.Write(buf.Bytes())
 	return err
+}
+
+func copyFields(dst Fields, src Fields, reserved map[string]struct{}) {
+	for key, value := range src {
+		if _, ok := reserved[key]; ok {
+			continue
+		}
+		dst[key] = value
+	}
+}
+
+func stringField(fields map[string]any, key string) string {
+	value, ok := fields[key]
+	if !ok {
+		return ""
+	}
+	text, ok := value.(string)
+	if !ok {
+		return ""
+	}
+	return text
+}
+
+var reservedEventKeys = map[string]struct{}{
+	"schema_version": {},
+	"operation":      {},
+	"event":          {},
+	"ok":             {},
+	"error":          {},
+}
+
+var reservedErrorKeys = map[string]struct{}{
+	"code":      {},
+	"message":   {},
+	"exit_code": {},
 }

--- a/cli/internal/output/output_test.go
+++ b/cli/internal/output/output_test.go
@@ -1,0 +1,128 @@
+package output
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+func TestPrintEventWritesCompactJSONLineToStdout(t *testing.T) {
+	t.Parallel()
+
+	var stdout, stderr bytes.Buffer
+	printer := New(&stdout, &stderr)
+
+	if err := printer.PrintEvent("progress", map[string]any{"operation": "devopsellence deploy", "message": "building"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want no command-contract output", stderr.String())
+	}
+	line := bytes.TrimSpace(stdout.Bytes())
+	if bytes.Contains(line, []byte("\n")) {
+		t.Fatalf("event output = %q, want one JSON line", stdout.String())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(line, &payload); err != nil {
+		t.Fatalf("event is not JSON: %v\n%s", err, line)
+	}
+	if payload["schema_version"] != float64(SchemaVersion) || payload["event"] != "progress" || payload["operation"] != "devopsellence deploy" || payload["message"] != "building" {
+		t.Fatalf("payload = %#v", payload)
+	}
+}
+
+func TestEventEnvelopeIgnoresReservedFieldOverrides(t *testing.T) {
+	t.Parallel()
+
+	payload, err := json.Marshal(Event{
+		SchemaVersion: SchemaVersion,
+		Operation:     "devopsellence deploy",
+		Event:         EventProgress,
+		Fields: Fields{
+			"schema_version": 99,
+			"operation":      "ignored",
+			"event":          "ignored",
+			"ok":             false,
+			"message":        "building",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var event map[string]any
+	if err := json.Unmarshal(payload, &event); err != nil {
+		t.Fatal(err)
+	}
+	if event["schema_version"] != float64(SchemaVersion) || event["operation"] != "devopsellence deploy" || event["event"] != EventProgress || event["ok"] != nil || event["message"] != "building" {
+		t.Fatalf("event = %#v", event)
+	}
+}
+
+func TestPrintErrorEventWritesStructuredErrorEnvelope(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	err := ErrorPayload{
+		Code:     "command_failed",
+		Message:  "boom",
+		ExitCode: 1,
+		Fields: Fields{
+			"message":    "ignored",
+			"next_steps": []string{"devopsellence status"},
+		},
+	}
+	if writeErr := New(&stdout, nil).PrintErrorEvent("devopsellence deploy", err); writeErr != nil {
+		t.Fatal(writeErr)
+	}
+	var event map[string]any
+	if err := json.Unmarshal(bytes.TrimSpace(stdout.Bytes()), &event); err != nil {
+		t.Fatal(err)
+	}
+	if event["event"] != EventError || event["ok"] != false || event["operation"] != "devopsellence deploy" {
+		t.Fatalf("event = %#v", event)
+	}
+	errorPayload := event["error"].(map[string]any)
+	if errorPayload["code"] != "command_failed" || errorPayload["message"] != "boom" || errorPayload["exit_code"] != float64(1) {
+		t.Fatalf("error = %#v", errorPayload)
+	}
+	steps := errorPayload["next_steps"].([]any)
+	if len(steps) != 1 || steps[0] != "devopsellence status" {
+		t.Fatalf("next_steps = %#v", steps)
+	}
+}
+
+func TestStreamResultWritesNDJSONEvent(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	stream := New(&stdout, nil).Stream("devopsellence node create")
+	if err := stream.Event("started", nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := stream.Result(map[string]any{"node": "prod-1"}); err != nil {
+		t.Fatal(err)
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(stdout.Bytes()))
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	var events []map[string]any
+	for scanner.Scan() {
+		var event map[string]any
+		if err := json.Unmarshal(scanner.Bytes(), &event); err != nil {
+			t.Fatalf("line is not JSON: %v\n%s", err, scanner.Text())
+		}
+		events = append(events, event)
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("events = %#v, want 2", events)
+	}
+	result := events[1]
+	if result["event"] != "result" || result["operation"] != "devopsellence node create" || result["ok"] != true || result["node"] != "prod-1" {
+		t.Fatalf("result = %#v", result)
+	}
+}

--- a/cli/internal/workflow/install_logs_test.go
+++ b/cli/internal/workflow/install_logs_test.go
@@ -21,11 +21,11 @@ func TestNewSoloInstallReporterCapturesInstallNoiseAndEmitsStructuredProgress(t 
 	}
 	reporter.Close()
 
-	if got := out.String(); got != "" {
-		t.Fatalf("reporter stdout = %q, want no final output", got)
+	if got := out.String(); !bytes.Contains([]byte(got), []byte(`"event":"progress"`)) || !bytes.Contains([]byte(got), []byte(`"node":"prod-2"`)) {
+		t.Fatalf("progress stdout = %q, want structured progress event", got)
 	}
-	if got := errOut.String(); !bytes.Contains([]byte(got), []byte(`"event":"progress"`)) || !bytes.Contains([]byte(got), []byte(`"node":"prod-2"`)) {
-		t.Fatalf("progress stderr = %q, want structured progress event", got)
+	if got := errOut.String(); got != "" {
+		t.Fatalf("progress stderr = %q, want no command-contract output", got)
 	}
 	if got := reporter.CapturedStdout(); got != "progress: downloading agent binary\nplain log\npartial" {
 		t.Fatalf("captured stdout = %q", got)

--- a/cli/internal/workflow/json_test.go
+++ b/cli/internal/workflow/json_test.go
@@ -1,6 +1,7 @@
 package workflow
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/json"
 	"testing"
@@ -31,4 +32,35 @@ func jsonMapFromAny(t *testing.T, value any) map[string]any {
 		t.Fatalf("value = %#v, want object", value)
 	}
 	return item
+}
+
+func decodeNDJSONOutput(t *testing.T, output *bytes.Buffer) []map[string]any {
+	t.Helper()
+	var events []map[string]any
+	scanner := bufio.NewScanner(bytes.NewReader(output.Bytes()))
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		var event map[string]any
+		if err := json.Unmarshal(line, &event); err != nil {
+			t.Fatalf("output line is not valid JSON: %v\n%s", err, line)
+		}
+		events = append(events, event)
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if len(events) == 0 {
+		t.Fatalf("output has no NDJSON events")
+	}
+	return events
+}
+
+func lastNDJSONEvent(t *testing.T, output *bytes.Buffer) map[string]any {
+	t.Helper()
+	events := decodeNDJSONOutput(t, output)
+	return events[len(events)-1]
 }

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -334,6 +334,10 @@ func expandSoloSSHKeyPath(path string) (string, error) {
 }
 
 func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
+	stream := a.Printer.Stream("devopsellence deploy")
+	if err := stream.Event("started", map[string]any{}); err != nil {
+		return err
+	}
 	cfg, workspaceRoot, err := a.loadSoloProjectConfig()
 	if err != nil {
 		return err
@@ -416,7 +420,6 @@ func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 	}
 
 	payload := map[string]any{
-		"schema_version":          outputSchemaVersion,
 		"workload_revision":       shortSHA,
 		"desired_state_revisions": desiredStateRevisions,
 		"image":                   imageTag,
@@ -430,7 +433,7 @@ func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 	} else {
 		payload["next_steps"] = append([]string{"devopsellence status"}, soloNodeLogNextSteps(nodes)...)
 	}
-	return a.Printer.PrintJSON(payload)
+	return stream.Result(payload)
 
 }
 
@@ -2366,7 +2369,7 @@ func (a *App) SoloAgentInstall(ctx context.Context, opts SoloAgentInstallOptions
 		return err
 	}
 
-	return a.Printer.PrintJSON(map[string]any{"node": opts.Node, "action": "installed"})
+	return a.Printer.PrintResultEvent("devopsellence agent install", map[string]any{"node": opts.Node, "action": "installed"})
 
 }
 
@@ -2395,7 +2398,7 @@ func (a *App) SoloAgentUninstall(ctx context.Context, opts SoloAgentUninstallOpt
 	if err := solo.RunSSHInteractiveWithStdin(ctx, node, "bash -s", strings.NewReader(script), stdout, stderr); err != nil {
 		return sshInteractiveError("failed to run uninstall script over SSH", err, stdout.String(), stderr.String())
 	}
-	return a.Printer.PrintJSON(map[string]any{
+	return a.Printer.PrintResultEvent("devopsellence agent uninstall", map[string]any{
 		"node":              opts.Node,
 		"action":            "uninstalled",
 		"workloads_removed": !opts.KeepWorkloads,
@@ -2620,9 +2623,8 @@ func (a *App) SoloNodeCreate(ctx context.Context, opts SoloNodeCreateOptions) er
 	var node config.Node
 	var labels []string
 	result := map[string]any{
-		"schema_version": outputSchemaVersion,
-		"node":           nodeName,
-		"config_path":    a.ConfigStore.PathFor(workspaceRoot),
+		"node":        nodeName,
+		"config_path": a.ConfigStore.PathFor(workspaceRoot),
 	}
 	if hasHost {
 		node, labels, err = existingSSHNodeFromCreateOptions(opts)
@@ -2695,7 +2697,7 @@ func (a *App) SoloNodeCreate(ctx context.Context, opts SoloNodeCreateOptions) er
 	result["labels"] = labels
 	result["agent_installed"] = installed
 	result["attached"] = attached
-	return a.Printer.PrintJSON(result)
+	return a.Printer.PrintResultEvent("devopsellence node create", result)
 
 }
 
@@ -2923,7 +2925,7 @@ func (a *App) SoloNodeRemove(ctx context.Context, opts SoloNodeRemoveOptions) er
 			payload["known_hosts_error"] = knownHostsErr.Error()
 			payload["warnings"] = []string{"manual SSH node forgotten locally, but SSH known_hosts cleanup failed"}
 		}
-		return a.Printer.PrintJSON(payload)
+		return a.Printer.PrintResultEvent("devopsellence node remove", payload)
 
 	}
 	if provider == "" || providerServerID == "" {
@@ -2962,7 +2964,7 @@ func (a *App) SoloNodeRemove(ctx context.Context, opts SoloNodeRemoveOptions) er
 		payload["known_hosts_error"] = knownHostsErr.Error()
 		payload["warnings"] = []string{"provider node deleted and local state removed, but SSH known_hosts cleanup failed"}
 	}
-	return a.Printer.PrintJSON(payload)
+	return a.Printer.PrintResultEvent("devopsellence node remove", payload)
 
 }
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -585,16 +585,23 @@ func TestSoloNodeCreateProviderReportsMetadataAndProgress(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	payload := decodeJSONOutput(t, &stdout)
+	events := decodeNDJSONOutput(t, &stdout)
+	payload := events[len(events)-1]
+	if payload["event"] != "result" || payload["ok"] != true {
+		t.Fatalf("result event = %#v, want successful result", payload)
+	}
 	if payload["provider"] != providerHetzner || payload["provider_server_id"] != "srv-1" || payload["provider_region"] != "ash" || payload["provider_size"] != "cpx11" || payload["provider_image"] != providers.DefaultHetznerImage {
 		t.Fatalf("payload = %#v, want provider metadata", payload)
 	}
 	if fakeProvider.createInput.Image != providers.DefaultHetznerImage {
 		t.Fatalf("CreateServer image = %q, want normalized default image", fakeProvider.createInput.Image)
 	}
-	progress := stderr.String()
+	progress := stdout.String()
 	if !strings.Contains(progress, "Creating hetzner server") || !strings.Contains(progress, "Server srv-1 ready at 203.0.113.20") {
 		t.Fatalf("progress = %q, want provider create/ready events", progress)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want no command-contract output", stderr.String())
 	}
 }
 
@@ -1809,7 +1816,11 @@ func TestSoloDeployWaitsForSettledStatusBeforeSuccess(t *testing.T) {
 	if got := readFakeSSHStatusCount(t, statusCountPath); got != 3 {
 		t.Fatalf("status poll count = %d, want 3", got)
 	}
-	payload := decodeJSONOutput(t, &stdout)
+	events := decodeNDJSONOutput(t, &stdout)
+	payload := events[len(events)-1]
+	if payload["event"] != "result" || payload["ok"] != true {
+		t.Fatalf("result event = %#v, want successful result", payload)
+	}
 	if payload["environment"] != "production" || payload["workload_revision"] == "" || payload["phase"] != "settled" {
 		t.Fatalf("payload = %#v, want settled deploy JSON", payload)
 	}


### PR DESCRIPTION
## Summary

- make command events write NDJSON to stdout instead of stderr
- add stream/result helpers for long-running command output
- convert deploy, node create/remove, and agent install/uninstall to result events
- emit structured top-level errors on stdout with an error event

## Tests

- mise run test:cli

Refs devopsellence/managed-devopsellence#5