### PR TITLE
[codex] add solo exec commands

### DIFF
--- a/cli/internal/workflow/app.go
+++ b/cli/internal/workflow/app.go
@@ -59,6 +59,56 @@ func (e ExitError) Unwrap() error {
 	return e.Err
 }
 
+type UnsupportedOperationError struct {
+	Operation      string
+	Mode           string
+	SupportedModes []string
+	Reason         string
+}
+
+func (e UnsupportedOperationError) Error() string {
+	reason := strings.TrimSpace(e.Reason)
+	mode := strings.TrimSpace(e.Mode)
+	if mode == "" {
+		if reason == "" {
+			return "operation is not supported"
+		}
+		return reason
+	}
+	operation := strings.TrimSpace(e.Operation)
+	if operation == "" {
+		operation = "operation"
+	}
+	if reason == "" {
+		return fmt.Sprintf("%s is not supported in %s mode", operation, mode)
+	}
+	return fmt.Sprintf("%s is not supported in %s mode: %s", operation, mode, reason)
+}
+
+func (e UnsupportedOperationError) ErrorFields() map[string]any {
+	reason := strings.TrimSpace(e.Reason)
+	if reason == "" {
+		reason = "operation is not supported"
+	}
+	mode := strings.TrimSpace(e.Mode)
+	fields := map[string]any{
+		"kind":   "unsupported",
+		"reason": reason,
+	}
+	if mode != "" {
+		operation := strings.TrimSpace(e.Operation)
+		if operation == "" {
+			operation = "operation"
+		}
+		fields["operation"] = operation
+		fields["mode"] = mode
+	}
+	if len(e.SupportedModes) > 0 {
+		fields["supported_modes"] = e.SupportedModes
+	}
+	return fields
+}
+
 type App struct {
 	In                  io.Reader
 	Printer             output.Printer

--- a/cli/internal/workflow/root.go
+++ b/cli/internal/workflow/root.go
@@ -776,9 +776,11 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 	var nodeDiagnoseOpts NodeDiagnoseOptions
 	var soloNodeDiagnoseOpts SoloNodeDiagnoseOptions
 	var nodeLogsOpts SoloLogsOptions
+	var nodeExecOpts SoloNodeExecOptions
 	var nodeLabels string
 	var nodeAttachEnvironment string
 	var workloadLogsOpts SoloWorkloadLogsOptions
+	var workloadExecOpts SoloExecOptions
 	nodeCommand := &cobra.Command{
 		Use:   "node",
 		Short: "Manage nodes for the selected workspace mode",
@@ -972,7 +974,29 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 		},
 	}
 	nodeLogsCommand.Flags().IntVar(&nodeLogsOpts.Lines, "lines", soloLogsDefaultLines, fmt.Sprintf("Number of recent log lines to return, 1-%d", soloLogsMaxLines))
-	nodeCommand.AddCommand(nodeRegisterCommand, nodeCreateCommand, nodeListCommand, nodeAttachCommand, nodeDetachCommand, nodeRemoveCommand, nodeLabelCommand, nodeDiagnoseCommand, nodeLogsCommand)
+	nodeExecCommand := &cobra.Command{
+		Use:   "exec <name> -- <command>",
+		Short: "Run a command on a solo node over SSH",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			nodeExecOpts.Node = args[0]
+			if len(args) < 2 {
+				return ExitError{Code: 2, Err: errors.New("missing command after --")}
+			}
+			nodeExecOpts.Command = append([]string(nil), args[1:]...)
+			return runByMode(func(ctx context.Context) error {
+				return app.SoloNodeExec(ctx, nodeExecOpts)
+			}, func(ctx context.Context) error {
+				return ExitError{Code: 2, Err: UnsupportedOperationError{
+					Operation:      "node exec",
+					Mode:           string(ModeShared),
+					SupportedModes: []string{string(ModeSolo)},
+					Reason:         "shared node exec requires an exec tunnel",
+				}}
+			})(cmd, args)
+		},
+	}
+	nodeCommand.AddCommand(nodeRegisterCommand, nodeCreateCommand, nodeListCommand, nodeAttachCommand, nodeDetachCommand, nodeRemoveCommand, nodeLabelCommand, nodeDiagnoseCommand, nodeLogsCommand, nodeExecCommand)
 	root.AddCommand(nodeCommand)
 
 	logsCommand := &cobra.Command{
@@ -995,6 +1019,31 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 	logsCommand.Flags().StringSliceVar(&workloadLogsOpts.Nodes, "node", nil, "Solo node name to read logs from (repeatable or comma-separated)")
 	logsCommand.Flags().IntVar(&workloadLogsOpts.Lines, "lines", soloLogsDefaultLines, fmt.Sprintf("Number of recent log lines to return, 1-%d", soloLogsMaxLines))
 	root.AddCommand(logsCommand)
+
+	execCommand := &cobra.Command{
+		Use:   "exec <service> -- <command>",
+		Short: "Run a command in a workload service container",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			workloadExecOpts.ServiceName = args[0]
+			if len(args) < 2 {
+				return ExitError{Code: 2, Err: errors.New("missing command after --")}
+			}
+			workloadExecOpts.Command = append([]string(nil), args[1:]...)
+			return runByMode(func(ctx context.Context) error {
+				return app.SoloExec(ctx, workloadExecOpts)
+			}, func(ctx context.Context) error {
+				return ExitError{Code: 2, Err: UnsupportedOperationError{
+					Operation:      "exec",
+					Mode:           string(ModeShared),
+					SupportedModes: []string{string(ModeSolo)},
+					Reason:         "shared service exec requires an exec tunnel",
+				}}
+			})(cmd, args)
+		},
+	}
+	execCommand.Flags().StringSliceVar(&workloadExecOpts.Nodes, "node", nil, "Solo node name to run exec on (repeatable or comma-separated)")
+	root.AddCommand(execCommand)
 
 	var agentInstallOpts SoloAgentInstallOptions
 	var agentUninstallOpts SoloAgentUninstallOptions

--- a/cli/internal/workflow/root_test.go
+++ b/cli/internal/workflow/root_test.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -411,10 +412,118 @@ func TestNodeHelpShowsSharedAndSoloActions(t *testing.T) {
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
-	for _, snippet := range []string{"register", "create", "attach", "detach", "remove", "logs"} {
+	for _, snippet := range []string{"register", "create", "attach", "detach", "remove", "logs", "exec"} {
 		if !strings.Contains(stdout.String(), snippet) {
 			t.Fatalf("help output = %q, want %q command", stdout.String(), snippet)
 		}
+	}
+}
+
+func TestExecReturnsStructuredUnsupportedInSharedMode(t *testing.T) {
+	var stdout bytes.Buffer
+	cwd := rootTestWorkspaceWithMode(t, ModeShared)
+	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, cwd)
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{"exec", "web", "--", "bin/rails", "runner", "puts Rails.env"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() error = nil, want unsupported error")
+	}
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("error = %T %v, want ExitError", err, err)
+	}
+	var unsupported UnsupportedOperationError
+	if !errors.As(err, &unsupported) {
+		t.Fatalf("error = %T %v, want UnsupportedOperationError", err, err)
+	}
+	fields := unsupported.ErrorFields()
+	if fields["kind"] != "unsupported" || fields["mode"] != "shared" {
+		t.Fatalf("fields = %#v, want shared unsupported", fields)
+	}
+}
+
+func TestNodeExecReturnsStructuredUnsupportedInSharedMode(t *testing.T) {
+	var stdout bytes.Buffer
+	cwd := rootTestWorkspaceWithMode(t, ModeShared)
+	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, cwd)
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{"node", "exec", "web", "--", "bin/rails", "runner", "puts Rails.env"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() error = nil, want unsupported error")
+	}
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("error = %T %v, want ExitError", err, err)
+	}
+	var unsupported UnsupportedOperationError
+	if !errors.As(err, &unsupported) {
+		t.Fatalf("error = %T %v, want UnsupportedOperationError", err, err)
+	}
+	fields := unsupported.ErrorFields()
+	if fields["kind"] != "unsupported" || fields["mode"] != "shared" {
+		t.Fatalf("fields = %#v, want shared unsupported", fields)
+	}
+}
+
+func TestUnsupportedOperationErrorUsesFallbackOperation(t *testing.T) {
+	err := UnsupportedOperationError{Mode: " shared ", Reason: " not here "}
+	if got, want := err.Error(), "operation is not supported in shared mode: not here"; got != want {
+		t.Fatalf("Error() = %q, want %q", got, want)
+	}
+	fields := err.ErrorFields()
+	if fields["operation"] != "operation" || fields["mode"] != "shared" || fields["reason"] != "not here" {
+		t.Fatalf("ErrorFields() = %#v, want normalized fallback operation fields", fields)
+	}
+
+	err = UnsupportedOperationError{Operation: " exec ", Mode: " shared "}
+	if got, want := err.Error(), "exec is not supported in shared mode"; got != want {
+		t.Fatalf("Error() = %q, want %q", got, want)
+	}
+}
+
+func TestExecReturnsMissingCommandAfterSeparator(t *testing.T) {
+	var stdout bytes.Buffer
+	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, rootTestSoloWorkspace(t))
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{"exec", "web", "--"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() error = nil, want missing command")
+	}
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 2 {
+		t.Fatalf("error = %T %v, want ExitError code 2", err, err)
+	}
+	if !strings.Contains(err.Error(), "missing command after --") {
+		t.Fatalf("error = %v, want missing command after --", err)
+	}
+}
+
+func TestNodeExecReturnsMissingCommandAfterSeparator(t *testing.T) {
+	var stdout bytes.Buffer
+	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, rootTestSoloWorkspace(t))
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{"node", "exec", "node-a", "--"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() error = nil, want missing command")
+	}
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 2 {
+		t.Fatalf("error = %T %v, want ExitError code 2", err, err)
+	}
+	if !strings.Contains(err.Error(), "missing command after --") {
+		t.Fatalf("error = %v, want missing command after --", err)
 	}
 }
 

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -22,6 +23,7 @@ import (
 
 	"github.com/devopsellence/cli/internal/api"
 	"github.com/devopsellence/cli/internal/discovery"
+	"github.com/devopsellence/cli/internal/output"
 	"github.com/devopsellence/cli/internal/solo"
 	"github.com/devopsellence/cli/internal/solo/providers"
 	cliversion "github.com/devopsellence/cli/internal/version"
@@ -96,6 +98,17 @@ type SoloWorkloadLogsOptions struct {
 	ServiceName string
 	Nodes       []string
 	Lines       int
+}
+
+type SoloExecOptions struct {
+	ServiceName string
+	Nodes       []string
+	Command     []string
+}
+
+type SoloNodeExecOptions struct {
+	Node    string
+	Command []string
 }
 
 type SoloNodeDiagnoseOptions struct {
@@ -185,8 +198,9 @@ type soloNodeStatusEnvironment struct {
 }
 
 type soloNodeStatusService struct {
-	Name  string `json:"name"`
-	State string `json:"state"`
+	Name      string `json:"name"`
+	State     string `json:"state"`
+	Container string `json:"container"`
 }
 
 type soloNodeStatusResult struct {
@@ -2280,6 +2294,382 @@ func (a *App) SoloWorkloadLogs(ctx context.Context, opts SoloWorkloadLogsOptions
 		return ExitError{Code: 1, Err: RenderedError{Err: fmt.Errorf("workload logs failed")}}
 	}
 	return nil
+}
+
+func (a *App) SoloNodeExec(ctx context.Context, opts SoloNodeExecOptions) error {
+	command, err := remoteUserCommand(opts.Command)
+	if err != nil {
+		return err
+	}
+	current, err := a.readSoloState()
+	if err != nil {
+		return err
+	}
+	node, ok := current.Nodes[opts.Node]
+	if !ok {
+		return fmt.Errorf("node %q not found", opts.Node)
+	}
+	target := soloExecTarget{
+		Kind:    "node",
+		Node:    opts.Node,
+		Command: append([]string(nil), opts.Command...),
+	}
+	return a.runSoloExecCommand(ctx, node, target, command)
+}
+
+func (a *App) SoloExec(ctx context.Context, opts SoloExecOptions) error {
+	serviceName := strings.TrimSpace(opts.ServiceName)
+	if serviceName == "" {
+		return ExitError{Code: 2, Err: errors.New("service name is required")}
+	}
+	if _, err := remoteUserCommand(opts.Command); err != nil {
+		return err
+	}
+	nodes, cfg, err := a.soloStatusSelection(SoloStatusOptions{Nodes: opts.Nodes})
+	if err != nil {
+		return err
+	}
+	if len(nodes) == 0 {
+		return fmt.Errorf("no nodes selected; attach a node or pass --node")
+	}
+	if cfg == nil {
+		return fmt.Errorf("no workspace selected; attach a workspace or run this command from a workspace")
+	}
+	if _, ok := cfg.Services[serviceName]; !ok {
+		return ExitError{Code: 2, Err: fmt.Errorf("service %q not found in devopsellence.yml", serviceName)}
+	}
+	environmentName := soloEnvironmentName(cfg, "")
+	candidates := []soloExecTarget{}
+	for _, nodeName := range sortedNodeNames(nodes) {
+		result, err := readNodeStatus(ctx, nodes[nodeName])
+		if err != nil {
+			return fmt.Errorf("[%s] read status: %w", nodeName, err)
+		}
+		if result.Missing {
+			continue
+		}
+		container := statusServiceContainer(result.Status, environmentName, serviceName)
+		if container == "" {
+			continue
+		}
+		candidates = append(candidates, soloExecTarget{
+			Kind:        "service",
+			Node:        nodeName,
+			Environment: environmentName,
+			Service:     serviceName,
+			Container:   container,
+			Command:     append([]string(nil), opts.Command...),
+		})
+	}
+	if len(candidates) == 0 {
+		return fmt.Errorf("no active container found for service %q in environment %s", serviceName, environmentName)
+	}
+	if len(candidates) > 1 {
+		names := make([]string, 0, len(candidates))
+		for _, candidate := range candidates {
+			names = append(names, candidate.Node)
+		}
+		return ExitError{Code: 2, Err: fmt.Errorf("service %q is running on multiple nodes (%s); select a single node with --node <node>", serviceName, strings.Join(names, ", "))}
+	}
+	target := candidates[0]
+	return a.runSoloExecCommand(ctx, nodes[target.Node], target, remoteDockerExecCommand(target.Container, opts.Command))
+}
+
+type soloExecTarget struct {
+	Kind        string
+	Node        string
+	Environment string
+	Service     string
+	Container   string
+	Command     []string
+}
+
+const (
+	soloExecExitMarkerPrefix = "__DEVOPSELLENCE_EXEC_EXIT_CODE__"
+	// Keep raw messages well below 1 MiB. NDJSON encoding can expand control
+	// characters up to six bytes each before consumers scan the line.
+	soloExecMaxLineBytes = 128 * 1024
+)
+
+func (a *App) runSoloExecCommand(ctx context.Context, node config.Node, target soloExecTarget, command string) error {
+	operation := soloExecOperation(target.Kind)
+	stream := a.Printer.Stream(operation)
+	if err := a.printSoloExecEvent(stream, output.EventStarted, target, nil); err != nil {
+		return err
+	}
+
+	exitCode := -1
+	exitMarker, err := newSoloExecExitMarker()
+	if err != nil {
+		if renderErr := a.printSoloExecError(operation, target, 1, err); renderErr != nil {
+			return renderErr
+		}
+		return ExitError{Code: 1, Err: RenderedError{Err: err}}
+	}
+	stdout := &soloExecEventWriter{stream: stream, target: target, streamName: "stdout", exitCode: &exitCode, exitMarker: exitMarker}
+	stderr := &soloExecEventWriter{stream: stream, target: target, streamName: "stderr", exitCode: &exitCode, exitMarker: exitMarker}
+	err = solo.RunSSHInteractive(ctx, node, remoteExecWrapper(command, exitMarker), stdout, stderr)
+	if flushErr := stdout.Flush(); flushErr != nil && err == nil {
+		err = flushErr
+	}
+	if flushErr := stderr.Flush(); flushErr != nil && err == nil {
+		err = flushErr
+	}
+	if stdout.Err() != nil && err == nil {
+		err = stdout.Err()
+	}
+	if stderr.Err() != nil && err == nil {
+		err = stderr.Err()
+	}
+	if err != nil {
+		if renderErr := a.printSoloExecError(operation, target, 1, err); renderErr != nil {
+			return renderErr
+		}
+		return ExitError{Code: 1, Err: RenderedError{Err: err}}
+	}
+	if exitCode < 0 {
+		err := errors.New("exec did not report a remote exit code")
+		if renderErr := a.printSoloExecError(operation, target, 1, err); renderErr != nil {
+			return renderErr
+		}
+		return ExitError{Code: 1, Err: RenderedError{Err: err}}
+	}
+	if exitCode != 0 {
+		processCode := exitCode
+		if processCode < 1 || processCode > 255 {
+			processCode = 1
+		}
+		message := fmt.Sprintf("exec failed with exit code %d", exitCode)
+		if err := a.printSoloExecError(operation, target, exitCode, errors.New(message)); err != nil {
+			return err
+		}
+		return ExitError{Code: processCode, Err: RenderedError{Err: fmt.Errorf("exec failed with exit code %d", exitCode)}}
+	}
+	fields := soloExecFields(target)
+	fields["exit_code"] = exitCode
+	return stream.Result(fields)
+}
+
+func soloExecOperation(kind string) string {
+	if kind == "node" {
+		return "devopsellence node exec"
+	}
+	return "devopsellence exec"
+}
+
+func (a *App) printSoloExecEvent(stream output.Stream, event string, target soloExecTarget, fields map[string]any) error {
+	payload := soloExecFields(target)
+	for key, value := range fields {
+		payload[key] = value
+	}
+	return stream.Event(event, payload)
+}
+
+func (a *App) printSoloExecError(operation string, target soloExecTarget, exitCode int, err error) error {
+	return a.Printer.PrintErrorEvent(operation, output.ErrorPayload{
+		Code:     "command_failed",
+		Message:  err.Error(),
+		ExitCode: exitCode,
+		Fields:   output.Fields(soloExecFields(target)),
+	})
+}
+
+type soloExecEventWriter struct {
+	stream     output.Stream
+	target     soloExecTarget
+	streamName string
+	exitCode   *int
+	exitMarker string
+	buf        bytes.Buffer
+	dropping   bool
+	err        error
+	emptyLines int
+}
+
+func (w *soloExecEventWriter) Write(p []byte) (int, error) {
+	written := 0
+	for _, b := range p {
+		if b == '\n' {
+			if w.dropping {
+				w.dropping = false
+				written++
+				continue
+			}
+			if err := w.flushLine(false); err != nil {
+				w.err = err
+				return written, err
+			}
+			w.dropping = false
+			written++
+			continue
+		}
+		if w.dropping {
+			written++
+			continue
+		}
+		if w.buf.Len() >= soloExecMaxLineBytes {
+			if err := w.flushLine(true); err != nil {
+				w.err = err
+				return written, err
+			}
+			w.dropping = true
+			written++
+			continue
+		}
+		_ = w.buf.WriteByte(b)
+		written++
+	}
+	return len(p), nil
+}
+
+func (w *soloExecEventWriter) Flush() error {
+	if w.dropping {
+		w.buf.Reset()
+		w.dropping = false
+		return nil
+	}
+	if w.emptyLines > 0 {
+		if err := w.flushEmptyLines(w.emptyLines); err != nil {
+			w.err = err
+			return err
+		}
+		w.emptyLines = 0
+	}
+	if w.buf.Len() == 0 {
+		return nil
+	}
+	return w.flushLine(false)
+}
+
+func (w *soloExecEventWriter) Err() error {
+	return w.err
+}
+
+func (w *soloExecEventWriter) flushLine(truncated bool) error {
+	line := w.buf.String()
+	w.buf.Reset()
+	if w.streamName == "stderr" {
+		code, isExitMarker, err := parseSoloExecExitCodeLine(line, w.exitMarker)
+		if err != nil {
+			return err
+		}
+		if isExitMarker {
+			if w.emptyLines > 1 {
+				if err := w.flushEmptyLines(w.emptyLines - 1); err != nil {
+					return err
+				}
+			}
+			w.emptyLines = 0
+			*w.exitCode = code
+			return nil
+		}
+	}
+	if w.streamName == "stderr" && line == "" && !truncated {
+		w.emptyLines++
+		return nil
+	}
+	if w.emptyLines > 0 {
+		if err := w.flushEmptyLines(w.emptyLines); err != nil {
+			return err
+		}
+		w.emptyLines = 0
+	}
+	return w.emitLine(line, truncated)
+}
+
+func (w *soloExecEventWriter) flushEmptyLines(count int) error {
+	for i := 0; i < count; i++ {
+		if err := w.emitLine("", false); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (w *soloExecEventWriter) emitLine(line string, truncated bool) error {
+	fields := map[string]any{
+		"stream":  w.streamName,
+		"message": line,
+	}
+	if truncated {
+		fields["truncated"] = true
+	}
+	payload := soloExecFields(w.target)
+	for key, value := range fields {
+		payload[key] = value
+	}
+	return w.stream.Event("output", payload)
+}
+
+func parseSoloExecExitCodeLine(line, marker string) (int, bool, error) {
+	normalized := strings.TrimSuffix(line, "\r")
+	if !strings.HasPrefix(normalized, marker) {
+		return 0, false, nil
+	}
+	rawCode := strings.TrimPrefix(normalized, marker)
+	if rawCode == "" {
+		return 0, false, nil
+	}
+	for _, ch := range rawCode {
+		if ch < '0' || ch > '9' {
+			return 0, false, nil
+		}
+	}
+	code, err := strconv.Atoi(rawCode)
+	if err != nil {
+		return 0, true, fmt.Errorf("parse remote exec exit code: %w", err)
+	}
+	return code, true, nil
+}
+
+func newSoloExecExitMarker() (string, error) {
+	var nonce [16]byte
+	if _, err := rand.Read(nonce[:]); err != nil {
+		return "", fmt.Errorf("generate exec marker nonce: %w", err)
+	}
+	return soloExecExitMarkerPrefix + hex.EncodeToString(nonce[:]) + "__", nil
+}
+
+func soloExecFields(target soloExecTarget) map[string]any {
+	payload := map[string]any{
+		"target":  target.Kind,
+		"node":    target.Node,
+		"command": target.Command,
+	}
+	if target.Environment != "" {
+		payload["environment"] = target.Environment
+	}
+	if target.Service != "" {
+		payload["service"] = target.Service
+	}
+	if target.Container != "" {
+		payload["container"] = target.Container
+	}
+	return payload
+}
+
+func statusServiceContainer(status soloNodeStatus, environmentName, serviceName string) string {
+	for _, environment := range status.Environments {
+		if strings.TrimSpace(environment.Name) != environmentName {
+			continue
+		}
+		for _, service := range environment.Services {
+			if strings.TrimSpace(service.Name) != serviceName {
+				continue
+			}
+			container := strings.TrimSpace(service.Container)
+			if container == "" {
+				return ""
+			}
+			switch strings.TrimSpace(service.State) {
+			case "running", "starting", "unhealthy":
+				return container
+			default:
+				return ""
+			}
+		}
+	}
+	return ""
 }
 
 func (a *App) SoloNodeDiagnose(ctx context.Context, opts SoloNodeDiagnoseOptions) error {
@@ -4554,7 +4944,38 @@ for id in $ids; do
     rc=$logs_status
   fi
 done
-exit "$rc"`, env, service, service, env, soloWorkloadLogsContainerLimit, soloNoWorkloadContainersSentinel, service, env, lines)
+	exit "$rc"`, env, service, service, env, soloWorkloadLogsContainerLimit, soloNoWorkloadContainersSentinel, service, env, lines)
+}
+
+func remoteUserCommand(args []string) (string, error) {
+	if len(args) == 0 {
+		return "", ExitError{Code: 2, Err: errors.New("missing command after --")}
+	}
+	parts := make([]string, 0, len(args))
+	for _, arg := range args {
+		parts = append(parts, shellQuote(arg))
+	}
+	return strings.Join(parts, " "), nil
+}
+
+func remoteDockerExecCommand(container string, args []string) string {
+	command, err := remoteUserCommand(args)
+	if err != nil {
+		return fmt.Sprintf("echo %s >&2; exit %d", shellQuote(err.Error()), remoteCommandExitCode(err))
+	}
+	return fmt.Sprintf("if docker info >/dev/null 2>&1; then docker_cmd=docker; elif command -v sudo >/dev/null 2>&1 && sudo -n docker info >/dev/null 2>&1; then docker_cmd=\"sudo -n docker\"; else echo 'Docker is not reachable' >&2; exit 1; fi\nexec $docker_cmd exec %s %s", shellQuote(container), command)
+}
+
+func remoteCommandExitCode(err error) int {
+	var exitErr ExitError
+	if errors.As(err, &exitErr) && exitErr.Code != 0 {
+		return exitErr.Code
+	}
+	return 1
+}
+
+func remoteExecWrapper(command, exitMarker string) string {
+	return fmt.Sprintf("(%s); rc=$?; printf '\\n%s%%s\\n' \"$rc\" >&2; exit 0", command, exitMarker)
 }
 
 func withRemoteLineLimit(command string, limit int) string {

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -28,6 +28,14 @@ import (
 	corerelease "github.com/devopsellence/devopsellence/deployment-core/pkg/deploycore/release"
 )
 
+type errorWriter struct{}
+
+func (errorWriter) Write([]byte) (int, error) {
+	return 0, errors.New("write failed")
+}
+
+const testSoloExecExitMarker = soloExecExitMarkerPrefix + "0123456789abcdef0123456789abcdef__"
+
 func TestSoloImageTagSlugifiesProjectName(t *testing.T) {
 	got := soloImageTag("ShopApp", "abc1234")
 	if got != "shop-app:abc1234" {
@@ -1415,6 +1423,248 @@ func TestSoloWorkloadLogsReadsDockerLogs(t *testing.T) {
 	lines := jsonArrayFromMap(t, node, "lines")
 	if len(lines) < 3 || lines[1] != "app line one" {
 		t.Fatalf("lines = %#v, want workload logs", lines)
+	}
+}
+
+func TestSoloExecRunsCommandInServiceContainer(t *testing.T) {
+	cwd := rootTestSoloWorkspace(t)
+	installFakeSoloCommands(t, []fakeSSHResponse{{stdout: `{"revision":"abc","phase":"settled","environments":[{"name":"production","services":[{"name":"web","state":"starting","container":"svc-production-web-abc"}]}]}` + "\n"}})
+	current := solo.State{}
+	if err := current.SetNode("node-a", config.Node{Host: "203.0.113.10", User: "root"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := current.AttachNode(cwd, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	if err := solo.NewStateStore(solo.DefaultStatePath()).Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := NewApp(bytes.NewBuffer(nil), &stdout, io.Discard, cwd)
+	err := app.SoloExec(context.Background(), SoloExecOptions{ServiceName: "web", Command: []string{"bin/rails", "runner", "puts Rails.env"}})
+	if err != nil {
+		t.Fatalf("SoloExec() error = %v", err)
+	}
+	events := decodeNDJSONOutput(t, &stdout)
+	if len(events) != 4 {
+		t.Fatalf("events = %#v, want started/stdout/stderr/finished", events)
+	}
+	if events[0]["event"] != "started" || events[0]["operation"] != "devopsellence exec" || events[0]["target"] != "service" || events[0]["container"] != "svc-production-web-abc" {
+		t.Fatalf("started event = %#v", events[0])
+	}
+	var sawStdout, sawStderr bool
+	for _, event := range events {
+		if event["event"] == "output" && event["stream"] == "stdout" && event["message"] == "service stdout" {
+			sawStdout = true
+		}
+		if event["event"] == "output" && event["stream"] == "stderr" && event["message"] == "service stderr" {
+			sawStderr = true
+		}
+	}
+	if !sawStdout || !sawStderr {
+		t.Fatalf("events = %#v, want stdout and stderr output events", events)
+	}
+	if events[3]["event"] != "result" || events[3]["exit_code"] != float64(0) || events[3]["ok"] != true {
+		t.Fatalf("finished event = %#v", events[3])
+	}
+}
+
+func TestSoloExecPreservesRemoteExitCodeInErrorEvent(t *testing.T) {
+	installFakeSoloCommands(t, nil)
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{Nodes: map[string]config.Node{
+		"node-a": {Host: "203.0.113.10", User: "root"},
+	}}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState}
+	err := app.SoloNodeExec(context.Background(), SoloNodeExecOptions{Node: "node-a", Command: []string{"missing-command"}})
+	if err == nil {
+		t.Fatal("SoloNodeExec() error = nil, want remote failure")
+	}
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 127 {
+		t.Fatalf("error = %#v, want ExitError code 127", err)
+	}
+	events := decodeNDJSONOutput(t, &stdout)
+	last := events[len(events)-1]
+	if last["event"] != "error" || last["ok"] != false {
+		t.Fatalf("last event = %#v, want error", last)
+	}
+	errorPayload := jsonMapFromAny(t, last["error"])
+	if errorPayload["exit_code"] != float64(127) {
+		t.Fatalf("error payload = %#v, want remote exit 127", errorPayload)
+	}
+}
+
+func TestSoloExecRequiresNodeWhenServiceHasMultipleContainers(t *testing.T) {
+	cwd := rootTestSoloWorkspace(t)
+	status := `{"revision":"abc","phase":"settled","environments":[{"name":"production","services":[{"name":"web","state":"running","container":"svc-production-web-abc"}]}]}` + "\n"
+	installFakeSoloCommands(t, []fakeSSHResponse{{stdout: status}, {stdout: status}})
+	current := solo.State{}
+	for _, nodeName := range []string{"node-a", "node-b"} {
+		if err := current.SetNode(nodeName, config.Node{Host: "203.0.113.10", User: "root"}); err != nil {
+			t.Fatal(err)
+		}
+		if _, _, err := current.AttachNode(cwd, "production", nodeName); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := solo.NewStateStore(solo.DefaultStatePath()).Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := NewApp(bytes.NewBuffer(nil), &stdout, io.Discard, cwd)
+	err := app.SoloExec(context.Background(), SoloExecOptions{ServiceName: "web", Command: []string{"true"}})
+	if err == nil || !strings.Contains(err.Error(), "select a single node with --node <node>") {
+		t.Fatalf("SoloExec() error = %v, want single-node guidance", err)
+	}
+}
+
+func TestSoloNodeExecRunsSSHCommand(t *testing.T) {
+	installFakeSoloCommands(t, nil)
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{Nodes: map[string]config.Node{
+		"node-a": {Host: "203.0.113.10", User: "root"},
+	}}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState}
+	err := app.SoloNodeExec(context.Background(), SoloNodeExecOptions{Node: "node-a", Command: []string{"uptime"}})
+	if err != nil {
+		t.Fatalf("SoloNodeExec() error = %v", err)
+	}
+	events := decodeNDJSONOutput(t, &stdout)
+	if len(events) != 3 {
+		t.Fatalf("events = %#v, want started/output/finished", events)
+	}
+	if events[0]["event"] != "started" || events[0]["operation"] != "devopsellence node exec" || events[0]["target"] != "node" {
+		t.Fatalf("started event = %#v", events[0])
+	}
+	if events[1]["stream"] != "stdout" || events[1]["message"] != "node stdout" {
+		t.Fatalf("output event = %#v", events[1])
+	}
+	if events[2]["exit_code"] != float64(0) {
+		t.Fatalf("finished event = %#v", events[2])
+	}
+}
+
+func TestSoloExecEventWriterSuppressesOnlyWrapperStderrNewline(t *testing.T) {
+	var stdout bytes.Buffer
+	exitCode := -1
+	target := soloExecTarget{Kind: "node", Node: "node-a", Command: []string{"sh", "-c", "printf '\\n' >&2"}}
+	writer := &soloExecEventWriter{
+		stream:     output.New(&stdout, io.Discard).Stream("devopsellence node exec"),
+		target:     target,
+		streamName: "stderr",
+		exitCode:   &exitCode,
+		exitMarker: testSoloExecExitMarker,
+	}
+
+	if _, err := writer.Write([]byte("\n\n" + testSoloExecExitMarker + "0\n")); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	if err := writer.Flush(); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+	if exitCode != 0 {
+		t.Fatalf("exit code = %d, want 0", exitCode)
+	}
+	events := decodeNDJSONOutput(t, &stdout)
+	if len(events) != 1 || events[0]["stream"] != "stderr" || events[0]["message"] != "" {
+		t.Fatalf("events = %#v, want one blank stderr line", events)
+	}
+}
+
+func TestSoloExecEventWriterReturnsProcessedBytesOnStreamError(t *testing.T) {
+	exitCode := -1
+	writer := &soloExecEventWriter{
+		stream:     output.New(errorWriter{}, io.Discard).Stream("devopsellence node exec"),
+		target:     soloExecTarget{Kind: "node", Node: "node-a", Command: []string{"uptime"}},
+		streamName: "stdout",
+		exitCode:   &exitCode,
+		exitMarker: testSoloExecExitMarker,
+	}
+
+	n, err := writer.Write([]byte("abc\nnext"))
+	if err == nil {
+		t.Fatal("Write() error = nil, want stream write error")
+	}
+	if n != 3 {
+		t.Fatalf("Write() n = %d, want 3", n)
+	}
+}
+
+func TestSoloExecEventWriterRequiresExactExitMarker(t *testing.T) {
+	var stdout bytes.Buffer
+	exitCode := -1
+	writer := &soloExecEventWriter{
+		stream:     output.New(&stdout, io.Discard).Stream("devopsellence node exec"),
+		target:     soloExecTarget{Kind: "node", Node: "node-a", Command: []string{"echo"}},
+		streamName: "stderr",
+		exitCode:   &exitCode,
+		exitMarker: testSoloExecExitMarker,
+	}
+
+	input := testSoloExecExitMarker + "0 trailing text\n" + testSoloExecExitMarker + "7\n"
+	if _, err := writer.Write([]byte(input)); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	if err := writer.Flush(); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+	if exitCode != 7 {
+		t.Fatalf("exit code = %d, want 7", exitCode)
+	}
+	events := decodeNDJSONOutput(t, &stdout)
+	if len(events) != 1 || events[0]["message"] != testSoloExecExitMarker+"0 trailing text" {
+		t.Fatalf("events = %#v, want non-exact marker emitted as stderr", events)
+	}
+}
+
+func TestSoloExecEventWriterDoesNotEmitBlankLineAfterTruncation(t *testing.T) {
+	var stdout bytes.Buffer
+	exitCode := -1
+	writer := &soloExecEventWriter{
+		stream:     output.New(&stdout, io.Discard).Stream("devopsellence node exec"),
+		target:     soloExecTarget{Kind: "node", Node: "node-a", Command: []string{"yes"}},
+		streamName: "stdout",
+		exitCode:   &exitCode,
+		exitMarker: testSoloExecExitMarker,
+	}
+
+	line := strings.Repeat("x", soloExecMaxLineBytes+8) + "\n"
+	if _, err := writer.Write([]byte(line)); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	if err := writer.Flush(); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+	output := stdout.String()
+	if strings.Count(output, "\n") != 1 {
+		t.Fatalf("output line count = %d, want one truncated output event", strings.Count(output, "\n"))
+	}
+	for _, snippet := range []string{`"event":"output"`, `"stream":"stdout"`, `"truncated":true`} {
+		if !strings.Contains(output, snippet) {
+			t.Fatalf("output = %q, want %q", output, snippet)
+		}
+	}
+}
+
+func TestRemoteDockerExecCommandReportsMissingCommand(t *testing.T) {
+	command := remoteDockerExecCommand("svc-production-web-abc", nil)
+	for _, snippet := range []string{"missing command after --", "exit 2"} {
+		if !strings.Contains(command, snippet) {
+			t.Fatalf("command = %q, want %q", command, snippet)
+		}
 	}
 }
 
@@ -3349,6 +3599,29 @@ fi
 
 if [[ "$command" == *"docker image inspect"* ]]; then
   printf 'present\n'
+  exit 0
+fi
+
+exec_marker=""
+if [[ "$command" =~ (__DEVOPSELLENCE_EXEC_EXIT_CODE__[0-9a-f]+__) ]]; then
+  exec_marker="${BASH_REMATCH[1]}"
+fi
+
+if [[ -n "$exec_marker" && "$command" == *"svc-production-web-abc"* ]]; then
+  printf 'service stdout\n'
+  printf 'service stderr\n%s0\n' "$exec_marker" >&2
+  exit 0
+fi
+
+if [[ -n "$exec_marker" && "$command" == *"'uptime'"* ]]; then
+  printf 'node stdout\n'
+  printf '%s0\n' "$exec_marker" >&2
+  exit 0
+fi
+
+if [[ -n "$exec_marker" && "$command" == *"'missing-command'"* ]]; then
+  printf 'missing-command: command not found\n' >&2
+  printf '%s127\n' "$exec_marker" >&2
   exit 0
 fi
 

--- a/control-plane/app/views/marketing/docs.html.erb
+++ b/control-plane/app/views/marketing/docs.html.erb
@@ -943,8 +943,16 @@ tasks:
         <dd>Show recent Docker workload logs from attached solo nodes. Pass <code>--node</code> to target a specific node.</dd>
       </div>
       <div class="docs-field">
+        <dt><code>devopsellence exec &lt;service&gt; -- &lt;command&gt;</code></dt>
+        <dd>Run a command in a solo service container when it is in an active state such as <code>running</code>, <code>starting</code>, or <code>unhealthy</code>. Pass <code>--node</code> when the service is running on more than one node.</dd>
+      </div>
+      <div class="docs-field">
         <dt><code>devopsellence node logs &lt;name&gt;</code></dt>
         <dd>Show <code>devopsellence-agent</code> journal logs from a solo node.</dd>
+      </div>
+      <div class="docs-field">
+        <dt><code>devopsellence node exec &lt;name&gt; -- &lt;command&gt;</code></dt>
+        <dd>Run a command on a solo node over SSH.</dd>
       </div>
       <div class="docs-field">
         <dt><code>devopsellence doctor</code></dt>


### PR DESCRIPTION
## What changed

- Added `devopsellence exec <service> -- <command>` for solo service-container exec.
- Added `devopsellence node exec <name> -- <command>` as the solo node escape hatch.
- Emit compact JSONL exec events on stdout: started, output, result/error.
- Return structured unsupported errors for shared mode until an exec tunnel exists.
- Documented the new solo exec commands.

## Why

P3 from the solo production-usability plan needs first-class service exec and node exec without making agents scrape SSH or Docker prose. Solo already had SSH transport, workload labels, and status container names, so this adds the CLI surface on top of those existing primitives.

## Validation

- `mise run test:cli`
