### PR TITLE
[codex] Extract release core for solo rollback

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -5,15 +5,16 @@ go 1.26.0
 require (
 	github.com/charmbracelet/keygen v0.5.4
 	github.com/devopsellence/devopsellence/deployment-core v0.0.0
+	github.com/oklog/ulid/v2 v2.1.1
 	github.com/spf13/cobra v1.10.2
 	golang.org/x/crypto v0.50.0
-	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	golang.org/x/sys v0.43.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 replace github.com/devopsellence/devopsellence/deployment-core => ../deployment-core

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -3,6 +3,9 @@ github.com/charmbracelet/keygen v0.5.4/go.mod h1:t4oBRr41bvK7FaJsAaAQhhkUuHslzFX
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/oklog/ulid/v2 v2.1.1 h1:suPZ4ARWLOJLegGFiZZ1dFAkqzhMjL3J1TzI+5wHz8s=
+github.com/oklog/ulid/v2 v2.1.1/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNsTT1QQ=
+github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=

--- a/cli/internal/solo/state.go
+++ b/cli/internal/solo/state.go
@@ -13,6 +13,7 @@ import (
 	"github.com/devopsellence/cli/internal/state"
 	"github.com/devopsellence/devopsellence/deployment-core/pkg/deploycore/config"
 	"github.com/devopsellence/devopsellence/deployment-core/pkg/deploycore/desiredstate"
+	corerelease "github.com/devopsellence/devopsellence/deployment-core/pkg/deploycore/release"
 )
 
 const soloStateSchemaVersion = 1
@@ -26,6 +27,9 @@ type State struct {
 	Nodes         map[string]config.Node                 `json:"nodes,omitempty"`
 	Attachments   map[string]AttachmentRecord            `json:"attachments,omitempty"`
 	Snapshots     map[string]desiredstate.DeploySnapshot `json:"snapshots,omitempty"`
+	Releases      map[string]corerelease.Release         `json:"releases,omitempty"`
+	Current       map[string]string                      `json:"current_releases,omitempty"`
+	Deployments   map[string]corerelease.Deployment      `json:"deployments,omitempty"`
 	Secrets       map[string]SecretRecord                `json:"secrets,omitempty"`
 }
 
@@ -278,6 +282,9 @@ func newState() State {
 		Nodes:         map[string]config.Node{},
 		Attachments:   map[string]AttachmentRecord{},
 		Snapshots:     map[string]desiredstate.DeploySnapshot{},
+		Releases:      map[string]corerelease.Release{},
+		Current:       map[string]string{},
+		Deployments:   map[string]corerelease.Deployment{},
 		Secrets:       map[string]SecretRecord{},
 	}
 }
@@ -294,6 +301,15 @@ func (s *State) ensureDefaults() {
 	}
 	if s.Snapshots == nil {
 		s.Snapshots = map[string]desiredstate.DeploySnapshot{}
+	}
+	if s.Releases == nil {
+		s.Releases = map[string]corerelease.Release{}
+	}
+	if s.Current == nil {
+		s.Current = map[string]string{}
+	}
+	if s.Deployments == nil {
+		s.Deployments = map[string]corerelease.Deployment{}
 	}
 	if s.Secrets == nil {
 		s.Secrets = map[string]SecretRecord{}
@@ -352,6 +368,128 @@ func normalizeState(current State) (State, error) {
 		normalizedSnapshots[normalizedKey] = snapshot
 	}
 	current.Snapshots = normalizedSnapshots
+
+	releaseIDs := make([]string, 0, len(current.Releases))
+	for id := range current.Releases {
+		releaseIDs = append(releaseIDs, id)
+	}
+	sort.Strings(releaseIDs)
+	normalizedReleases := make(map[string]corerelease.Release, len(current.Releases))
+	for _, id := range releaseIDs {
+		release := current.Releases[id]
+		release.ID = strings.TrimSpace(firstNonEmpty(release.ID, id))
+		release.EnvironmentID = strings.TrimSpace(release.EnvironmentID)
+		release.Revision = strings.TrimSpace(release.Revision)
+		release.CreatedAt = strings.TrimSpace(release.CreatedAt)
+		if release.ID == "" {
+			return State{}, fmt.Errorf("release %q id is required", id)
+		}
+		if release.EnvironmentID == "" {
+			return State{}, fmt.Errorf("release %q environment_id is required", id)
+		}
+		if release.Revision == "" {
+			return State{}, fmt.Errorf("release %q revision is required", id)
+		}
+		if _, err := time.Parse(time.RFC3339Nano, release.CreatedAt); err != nil {
+			return State{}, fmt.Errorf("release %q has invalid created_at: %w", id, err)
+		}
+		normalizedKey, snapshot, err := normalizeSnapshotRecord(release.EnvironmentID, release.Snapshot)
+		if err != nil {
+			return State{}, fmt.Errorf("release %q snapshot is invalid: %w", id, err)
+		}
+		release.EnvironmentID = normalizedKey
+		release.Snapshot = snapshot
+		release.Snapshot.Revision = release.Revision
+		if _, exists := normalizedReleases[release.ID]; exists {
+			return State{}, fmt.Errorf("duplicate release id %q after normalization", release.ID)
+		}
+		normalizedReleases[release.ID] = release
+	}
+	current.Releases = normalizedReleases
+
+	currentKeys := make([]string, 0, len(current.Current))
+	for key := range current.Current {
+		currentKeys = append(currentKeys, key)
+	}
+	sort.Strings(currentKeys)
+	normalizedCurrent := make(map[string]string, len(current.Current))
+	for _, key := range currentKeys {
+		_, workspaceKey, err := normalizeWorkspaceIdentity(key, "", "")
+		if err != nil {
+			return State{}, fmt.Errorf("normalize current release %q: %w", key, err)
+		}
+		_, keyEnvironment := splitEnvironmentStateKey(key)
+		environment := defaultEnvironmentName(keyEnvironment)
+		releaseID := strings.TrimSpace(current.Current[key])
+		if releaseID == "" {
+			continue
+		}
+		normalizedKey := workspaceKey + "\n" + environment
+		release, ok := current.Releases[releaseID]
+		if !ok {
+			return State{}, fmt.Errorf("current release %q references missing release %q", key, releaseID)
+		}
+		if release.EnvironmentID != normalizedKey {
+			return State{}, fmt.Errorf("current release %q references release %q for different workspace/environment %q", key, releaseID, release.EnvironmentID)
+		}
+		if existingReleaseID, exists := normalizedCurrent[normalizedKey]; exists {
+			if existingReleaseID != releaseID {
+				return State{}, fmt.Errorf("duplicate current release for workspace/environment %q after normalization", normalizedKey)
+			}
+			continue
+		}
+		normalizedCurrent[normalizedKey] = releaseID
+	}
+	current.Current = normalizedCurrent
+
+	deploymentIDs := make([]string, 0, len(current.Deployments))
+	for id := range current.Deployments {
+		deploymentIDs = append(deploymentIDs, id)
+	}
+	sort.Strings(deploymentIDs)
+	normalizedDeployments := make(map[string]corerelease.Deployment, len(current.Deployments))
+	for _, id := range deploymentIDs {
+		deployment := current.Deployments[id]
+		deployment.ID = strings.TrimSpace(firstNonEmpty(deployment.ID, id))
+		deployment.EnvironmentID = strings.TrimSpace(deployment.EnvironmentID)
+		deployment.ReleaseID = strings.TrimSpace(deployment.ReleaseID)
+		deployment.Kind = strings.TrimSpace(deployment.Kind)
+		deployment.Status = strings.TrimSpace(deployment.Status)
+		if deployment.ID == "" {
+			return State{}, fmt.Errorf("deployment %q id is required", id)
+		}
+		if deployment.EnvironmentID == "" {
+			return State{}, fmt.Errorf("deployment %q environment_id is required", id)
+		}
+		if deployment.ReleaseID == "" {
+			return State{}, fmt.Errorf("deployment %q release_id is required", id)
+		}
+		release, ok := current.Releases[deployment.ReleaseID]
+		if !ok {
+			return State{}, fmt.Errorf("deployment %q references missing release %q", id, deployment.ReleaseID)
+		}
+		if release.EnvironmentID != deployment.EnvironmentID {
+			return State{}, fmt.Errorf("deployment %q references release %q for different workspace/environment %q", id, deployment.ReleaseID, release.EnvironmentID)
+		}
+		switch deployment.Kind {
+		case corerelease.DeploymentKindDeploy, corerelease.DeploymentKindRollback, corerelease.DeploymentKindRepublish:
+		default:
+			return State{}, fmt.Errorf("deployment %q has unsupported kind %q", id, deployment.Kind)
+		}
+		switch deployment.Status {
+		case corerelease.DeploymentStatusPending, corerelease.DeploymentStatusRunning, corerelease.DeploymentStatusSettled, corerelease.DeploymentStatusFailed:
+		default:
+			return State{}, fmt.Errorf("deployment %q has unsupported status %q", id, deployment.Status)
+		}
+		if deployment.Sequence <= 0 {
+			return State{}, fmt.Errorf("deployment %q sequence must be greater than zero", id)
+		}
+		if _, exists := normalizedDeployments[deployment.ID]; exists {
+			return State{}, fmt.Errorf("duplicate deployment id %q after normalization", deployment.ID)
+		}
+		normalizedDeployments[deployment.ID] = deployment
+	}
+	current.Deployments = normalizedDeployments
 
 	secretKeys := make([]string, 0, len(current.Secrets))
 	for key := range current.Secrets {
@@ -559,6 +697,86 @@ func (s *State) SaveSnapshot(snapshot desiredstate.DeploySnapshot) (string, erro
 	snapshot.WorkspaceKey, _ = splitEnvironmentStateKey(key)
 	s.Snapshots[key] = snapshot
 	return key, nil
+}
+
+func (s *State) SaveRelease(release corerelease.Release) (string, error) {
+	s.ensureDefaults()
+	if strings.TrimSpace(release.ID) == "" {
+		return "", errors.New("release id is required")
+	}
+	if strings.TrimSpace(release.Revision) == "" {
+		return "", errors.New("release revision is required")
+	}
+	if strings.TrimSpace(release.Snapshot.WorkspaceRoot) == "" {
+		return "", errors.New("release snapshot workspace_root is required")
+	}
+	if strings.TrimSpace(release.Snapshot.Environment) == "" {
+		return "", errors.New("release snapshot environment is required")
+	}
+	key, err := EnvironmentStateKey(release.Snapshot.WorkspaceRoot, release.Snapshot.Environment)
+	if err != nil {
+		return "", err
+	}
+	release.EnvironmentID = key
+	release.Snapshot.WorkspaceKey, _ = splitEnvironmentStateKey(key)
+	release.Snapshot.Environment = defaultEnvironmentName(release.Snapshot.Environment)
+	release.Snapshot.Revision = release.Revision
+	s.Releases[release.ID] = release
+	s.Current[key] = release.ID
+	s.Snapshots[key] = release.Snapshot
+	return key, nil
+}
+
+func (s *State) CurrentRelease(workspaceRoot, environment string) (string, corerelease.Release, bool, error) {
+	s.ensureDefaults()
+	key, err := EnvironmentStateKey(workspaceRoot, environment)
+	if err != nil {
+		return "", corerelease.Release{}, false, err
+	}
+	releaseID := strings.TrimSpace(s.Current[key])
+	if releaseID == "" {
+		return key, corerelease.Release{}, false, nil
+	}
+	release, ok := s.Releases[releaseID]
+	return key, release, ok, nil
+}
+
+func (s *State) ReleaseHistory(workspaceRoot, environment string) ([]corerelease.Release, error) {
+	s.ensureDefaults()
+	key, err := EnvironmentStateKey(workspaceRoot, environment)
+	if err != nil {
+		return nil, err
+	}
+	releases := []corerelease.Release{}
+	for _, release := range s.Releases {
+		if release.EnvironmentID == key {
+			releases = append(releases, release)
+		}
+	}
+	createdAtByID := make(map[string]time.Time, len(releases))
+	for _, release := range releases {
+		createdAt, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(release.CreatedAt))
+		if err != nil {
+			return nil, fmt.Errorf("release %q has invalid created_at: %w", release.ID, err)
+		}
+		createdAtByID[release.ID] = createdAt
+	}
+	sort.SliceStable(releases, func(i, j int) bool {
+		if !createdAtByID[releases[i].ID].Equal(createdAtByID[releases[j].ID]) {
+			return createdAtByID[releases[i].ID].After(createdAtByID[releases[j].ID])
+		}
+		return releases[i].ID > releases[j].ID
+	})
+	return releases, nil
+}
+
+func (s *State) SaveDeployment(deployment corerelease.Deployment) error {
+	s.ensureDefaults()
+	if strings.TrimSpace(deployment.ID) == "" {
+		return errors.New("deployment id is required")
+	}
+	s.Deployments[deployment.ID] = deployment
+	return nil
 }
 
 func (s *State) AttachNode(workspaceRoot, environment, nodeName string) (AttachmentRecord, bool, error) {

--- a/cli/internal/solo/state_test.go
+++ b/cli/internal/solo/state_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/devopsellence/devopsellence/deployment-core/pkg/deploycore/config"
 	"github.com/devopsellence/devopsellence/deployment-core/pkg/deploycore/desiredstate"
+	corerelease "github.com/devopsellence/devopsellence/deployment-core/pkg/deploycore/release"
 )
 
 func TestCanonicalWorkspaceKeyResolvesSymlinks(t *testing.T) {
@@ -154,6 +155,160 @@ func TestStateStoreReadNormalizesLegacySnapshots(t *testing.T) {
 	}
 	if snapshot.Environment != "production" {
 		t.Fatalf("environment = %q, want production", snapshot.Environment)
+	}
+}
+
+func TestStateStoreReadRejectsDuplicateNormalizedReleaseIDs(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "solo-state.json")
+	if err := os.WriteFile(path, []byte(`{
+  "schema_version": 1,
+  "releases": {
+    " rel-1 ": {
+      "environment_id": "/workspace/demo\nproduction",
+      "revision": "aaa1111",
+      "created_at": "2026-04-28T12:00:00Z"
+    },
+    "rel-1": {
+      "environment_id": "/workspace/demo\nproduction",
+      "revision": "bbb2222",
+      "created_at": "2026-04-28T12:01:00Z"
+    }
+  }
+}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := NewStateStore(path).Read()
+	if err == nil || !strings.Contains(err.Error(), "duplicate release id") {
+		t.Fatalf("Read() error = %v, want duplicate release id", err)
+	}
+}
+
+func TestStateStoreReadNormalizesReleaseSnapshots(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "solo-state.json")
+	if err := os.WriteFile(path, []byte(`{
+  "schema_version": 1,
+  "releases": {
+    "rel-1": {
+      "environment_id": "/workspace/demo\nproduction",
+      "revision": "aaa1111",
+      "created_at": "2026-04-28T12:00:00Z",
+      "snapshot": {}
+    }
+  }
+}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := NewStateStore(path).Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+	release := loaded.Releases["rel-1"]
+	if release.Snapshot.WorkspaceKey != "/workspace/demo" || release.Snapshot.Environment != "production" || release.Snapshot.Revision != "aaa1111" {
+		t.Fatalf("release snapshot = %#v, want normalized workspace/environment/revision", release.Snapshot)
+	}
+}
+
+func TestStateStoreReadRejectsInvalidReleaseCreatedAt(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "solo-state.json")
+	if err := os.WriteFile(path, []byte(`{
+  "schema_version": 1,
+  "releases": {
+    "rel-1": {
+      "environment_id": "/workspace/demo\nproduction",
+      "revision": "aaa1111",
+      "created_at": "not-a-time",
+      "snapshot": {}
+    }
+  }
+}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := NewStateStore(path).Read()
+	if err == nil || !strings.Contains(err.Error(), "invalid created_at") {
+		t.Fatalf("Read() error = %v, want invalid created_at", err)
+	}
+}
+
+func TestStateStoreReadRejectsDuplicateNormalizedDeploymentIDs(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "solo-state.json")
+	if err := os.WriteFile(path, []byte(`{
+  "schema_version": 1,
+  "releases": {
+    "rel-1": {
+      "environment_id": "/workspace/demo\nproduction",
+      "revision": "aaa1111",
+      "created_at": "2026-04-28T12:00:00Z",
+      "snapshot": {}
+    }
+  },
+  "deployments": {
+    " dep-1 ": {
+      "environment_id": "/workspace/demo\nproduction",
+      "release_id": "rel-1",
+      "kind": "deploy",
+      "sequence": 1,
+      "status": "settled"
+    },
+    "dep-1": {
+      "id": "dep-1",
+      "environment_id": "/workspace/demo\nproduction",
+      "release_id": "rel-1",
+      "kind": "deploy",
+      "sequence": 2,
+      "status": "settled"
+    }
+  }
+}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := NewStateStore(path).Read()
+	if err == nil || !strings.Contains(err.Error(), "duplicate deployment id") {
+		t.Fatalf("Read() error = %v, want duplicate deployment id", err)
+	}
+}
+
+func TestStateStoreReadRejectsDeploymentForDifferentReleaseEnvironment(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "solo-state.json")
+	if err := os.WriteFile(path, []byte(`{
+  "schema_version": 1,
+  "releases": {
+    "rel-1": {
+      "environment_id": "/workspace/demo\nstaging",
+      "revision": "aaa1111",
+      "created_at": "2026-04-28T12:00:00Z",
+      "snapshot": {}
+    }
+  },
+  "deployments": {
+    "dep-1": {
+      "environment_id": "/workspace/demo\nproduction",
+      "release_id": "rel-1",
+      "kind": "deploy",
+      "sequence": 1,
+      "status": "settled"
+    }
+  }
+}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := NewStateStore(path).Read()
+	if err == nil || !strings.Contains(err.Error(), "different workspace/environment") {
+		t.Fatalf("Read() error = %v, want deployment environment validation", err)
 	}
 }
 
@@ -367,6 +522,148 @@ func TestSaveSnapshotPersistsWorkspaceEnvironmentIdentity(t *testing.T) {
 		if snapshot.Metadata.ConfigPath != "/workspace/demo/devopsellence.yml" {
 			t.Fatalf("config path = %q", snapshot.Metadata.ConfigPath)
 		}
+	}
+}
+
+func TestSaveReleasePersistsCurrentReleaseAndHistory(t *testing.T) {
+	t.Parallel()
+
+	current := newState()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	snapshot, err := BuildDeploySnapshot(&cfg, "/workspace/demo", "/workspace/demo/devopsellence.yml", "demo:abc1234", "abc1234", map[string]string{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	release, err := corerelease.NewRelease(corerelease.ReleaseCreateInput{
+		ID:            "rel-1",
+		EnvironmentID: "/workspace/demo\nproduction",
+		Revision:      "abc1234",
+		Snapshot:      snapshot,
+		Image:         corerelease.ImageRef{Reference: "demo:abc1234"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	key, err := current.SaveRelease(release)
+	if err != nil {
+		t.Fatal(err)
+	}
+	currentKey, currentRelease, ok, err := current.CurrentRelease("/workspace/demo", "production")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || currentKey != key || currentRelease.ID != "rel-1" {
+		t.Fatalf("current release key=%q ok=%v release=%#v", currentKey, ok, currentRelease)
+	}
+	history, err := current.ReleaseHistory("/workspace/demo", "production")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(history) != 1 || history[0].ID != "rel-1" {
+		t.Fatalf("history = %#v", history)
+	}
+}
+
+func TestReleaseHistoryOrdersTimestampTiesDeterministically(t *testing.T) {
+	t.Parallel()
+
+	current := newState()
+	key := "/workspace/demo\nproduction"
+	current.Releases = map[string]corerelease.Release{
+		"rel-a": {ID: "rel-a", EnvironmentID: key, Revision: "aaa1111", CreatedAt: "2026-04-28T12:00:00Z"},
+		"rel-c": {ID: "rel-c", EnvironmentID: key, Revision: "ccc3333", CreatedAt: "2026-04-28T08:01:00-04:00"},
+		"rel-b": {ID: "rel-b", EnvironmentID: key, Revision: "bbb2222", CreatedAt: "2026-04-28T12:00:00Z"},
+	}
+
+	history, err := current.ReleaseHistory("/workspace/demo", "production")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(history) != 3 {
+		t.Fatalf("history = %#v, want 3 releases", history)
+	}
+	got := []string{history[0].ID, history[1].ID, history[2].ID}
+	if !reflect.DeepEqual(got, []string{"rel-c", "rel-b", "rel-a"}) {
+		t.Fatalf("history order = %#v, want deterministic created_at/id order", got)
+	}
+}
+
+func TestNormalizeStateRejectsDuplicateCurrentReleaseKeys(t *testing.T) {
+	t.Parallel()
+
+	workspaceRoot := t.TempDir()
+	key := workspaceRoot + "\nproduction"
+	current := newState()
+	current.Releases = map[string]corerelease.Release{
+		"rel-1": {ID: "rel-1", EnvironmentID: key, Revision: "aaa1111", CreatedAt: "2026-04-28T12:00:00Z"},
+		"rel-2": {ID: "rel-2", EnvironmentID: key, Revision: "bbb2222", CreatedAt: "2026-04-28T12:01:00Z"},
+	}
+	current.Current = map[string]string{
+		" " + workspaceRoot + " \nproduction": "rel-1",
+		workspaceRoot + "\nproduction":        "rel-2",
+	}
+
+	_, err := normalizeState(current)
+	if err == nil || !strings.Contains(err.Error(), "duplicate current release") {
+		t.Fatalf("normalizeState() error = %v, want duplicate current release", err)
+	}
+}
+
+func TestNormalizeStateRejectsCurrentReleaseFromDifferentEnvironment(t *testing.T) {
+	t.Parallel()
+
+	workspaceRoot := t.TempDir()
+	productionKey := workspaceRoot + "\nproduction"
+	stagingKey := workspaceRoot + "\nstaging"
+	current := newState()
+	current.Releases = map[string]corerelease.Release{
+		"rel-1": {ID: "rel-1", EnvironmentID: stagingKey, Revision: "aaa1111", CreatedAt: "2026-04-28T12:00:00Z"},
+	}
+	current.Current = map[string]string{
+		productionKey: "rel-1",
+	}
+
+	_, err := normalizeState(current)
+	if err == nil || !strings.Contains(err.Error(), "different workspace/environment") {
+		t.Fatalf("normalizeState() error = %v, want different environment", err)
+	}
+}
+
+func TestSaveReleaseRejectsIncompleteRelease(t *testing.T) {
+	t.Parallel()
+
+	current := newState()
+	_, err := current.SaveRelease(corerelease.Release{
+		ID: "rel-1",
+		Snapshot: desiredstate.DeploySnapshot{
+			WorkspaceRoot: "/workspace/demo",
+			Environment:   "production",
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "release revision is required") {
+		t.Fatalf("SaveRelease() error = %v, want revision validation", err)
+	}
+
+	_, err = current.SaveRelease(corerelease.Release{
+		ID:       "rel-1",
+		Revision: "abc1234",
+		Snapshot: desiredstate.DeploySnapshot{
+			Environment: "production",
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "workspace_root is required") {
+		t.Fatalf("SaveRelease() error = %v, want workspace validation", err)
+	}
+
+	_, err = current.SaveRelease(corerelease.Release{
+		ID:       "rel-1",
+		Revision: "abc1234",
+		Snapshot: desiredstate.DeploySnapshot{
+			WorkspaceRoot: "/workspace/demo",
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "environment is required") {
+		t.Fatalf("SaveRelease() error = %v, want environment validation", err)
 	}
 }
 

--- a/cli/internal/workflow/root.go
+++ b/cli/internal/workflow/root.go
@@ -613,6 +613,40 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 	statusCommand.Flags().StringVar(&statusSharedOpts.Environment, "env", "", "Environment name override (shared mode)")
 	root.AddCommand(statusCommand)
 
+	var releaseListOpts SoloReleaseListOptions
+	var releaseRollbackOpts SoloReleaseRollbackOptions
+	releaseCommand := &cobra.Command{
+		Use:   "release",
+		Short: "Manage release history for the selected workspace mode",
+	}
+	releaseListCommand := &cobra.Command{
+		Use:   "list",
+		Short: "List release history",
+		RunE: runByMode(func(ctx context.Context) error {
+			return app.SoloReleaseList(ctx, releaseListOpts)
+		}, func(ctx context.Context) error {
+			return ExitError{Code: 2, Err: errors.New("release list is not wired for shared mode yet")}
+		}),
+	}
+	releaseListCommand.Flags().IntVar(&releaseListOpts.Limit, "limit", 20, "Maximum releases to return (0 for full history)")
+	releaseRollbackCommand := &cobra.Command{
+		Use:   "rollback [revision-or-release-id]",
+		Short: "Republish a previous release",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				releaseRollbackOpts.Selector = strings.TrimSpace(args[0])
+			}
+			return runByMode(func(ctx context.Context) error {
+				return app.SoloReleaseRollback(ctx, releaseRollbackOpts)
+			}, func(ctx context.Context) error {
+				return ExitError{Code: 2, Err: errors.New("release rollback is not wired for shared mode yet")}
+			})(cmd, args)
+		},
+	}
+	releaseCommand.AddCommand(releaseListCommand, releaseRollbackCommand)
+	root.AddCommand(releaseCommand)
+
 	root.AddCommand(&cobra.Command{
 		Use:   "doctor",
 		Short: "Check the current workspace and runtime prerequisites",

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -26,15 +27,30 @@ import (
 	cliversion "github.com/devopsellence/cli/internal/version"
 	"github.com/devopsellence/devopsellence/deployment-core/pkg/deploycore/config"
 	"github.com/devopsellence/devopsellence/deployment-core/pkg/deploycore/desiredstate"
+	corerelease "github.com/devopsellence/devopsellence/deployment-core/pkg/deploycore/release"
+	"github.com/oklog/ulid/v2"
 )
 
 type SoloDeployOptions struct {
 	SkipDNSCheck bool
 }
 
+type SoloReleaseListOptions struct {
+	Limit int
+}
+
+type SoloReleaseRollbackOptions struct {
+	Selector string
+}
+
 type SoloStatusOptions struct {
 	Nodes []string
 }
+
+var (
+	soloULIDMu      sync.Mutex
+	soloULIDEntropy = ulid.Monotonic(rand.Reader, 0)
+)
 
 type SoloSecretsSetOptions struct {
 	Key         string
@@ -393,7 +409,46 @@ func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 	if err != nil {
 		return err
 	}
-	if _, err := current.SaveSnapshot(solo.RedactDeploySnapshotSecrets(snapshot, cfg)); err != nil {
+	redactedSnapshot := solo.RedactDeploySnapshotSecrets(snapshot, cfg)
+	environmentID, err := solo.EnvironmentStateKey(workspaceRoot, environmentName)
+	if err != nil {
+		return err
+	}
+	now := time.Now().UTC()
+	releaseID := soloReleaseID(shortSHA, now)
+	release, err := corerelease.NewRelease(corerelease.ReleaseCreateInput{
+		ID:            releaseID,
+		EnvironmentID: environmentID,
+		Revision:      shortSHA,
+		Snapshot:      redactedSnapshot,
+		Image:         corerelease.ImageRef{Reference: imageTag},
+		TargetNodeIDs: attachedNodeNames,
+		CreatedAt:     now,
+	})
+	if err != nil {
+		return err
+	}
+	if _, err := current.SaveRelease(release); err != nil {
+		return err
+	}
+	deployment, err := corerelease.NewDeployment(corerelease.DeploymentCreateInput{
+		ID:            soloDeploymentID(corerelease.DeploymentKindDeploy, shortSHA, now),
+		EnvironmentID: release.EnvironmentID,
+		ReleaseID:     release.ID,
+		Kind:          corerelease.DeploymentKindDeploy,
+		Sequence:      nextSoloDeploymentSequence(current, release.EnvironmentID),
+		TargetNodeIDs: attachedNodeNames,
+		CreatedAt:     now,
+	})
+	if err != nil {
+		return err
+	}
+	if err := current.SaveDeployment(deployment); err != nil {
+		return err
+	}
+	deployment.Status = corerelease.DeploymentStatusRunning
+	deployment.StatusMessage = "publishing desired state"
+	if err := current.SaveDeployment(deployment); err != nil {
 		return err
 	}
 	// Persist desired local state first so follow-up republish operations can
@@ -403,23 +458,42 @@ func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 	}
 	desiredStateRevisions, err := a.republishNodes(ctx, current, attachedNodeNames)
 	if err != nil {
+		if persistErr := a.persistSoloDeploymentFailure(current, deployment, desiredStateRevisions, err); persistErr != nil {
+			return errors.Join(err, fmt.Errorf("persist deployment failure: %w", persistErr))
+		}
 		return err
 	}
 	if err := a.waitForSoloRollout(ctx, nodes, desiredStateRevisions); err != nil {
+		resultErr := err
 		var rolloutErr *soloRolloutError
 		if errors.As(err, &rolloutErr) {
 			rolloutErr.Healthchecks = soloDeployHealthcheckDetails(cfg)
-			return ExitError{Code: 1, Err: rolloutErr}
+			resultErr = ExitError{Code: 1, Err: rolloutErr}
 		}
 		var timeoutErr *soloRolloutTimeoutError
 		if errors.As(err, &timeoutErr) {
 			timeoutErr.Healthchecks = soloDeployHealthcheckDetails(cfg)
-			return ExitError{Code: 1, Err: timeoutErr}
+			resultErr = ExitError{Code: 1, Err: timeoutErr}
 		}
+		if persistErr := a.persistSoloDeploymentRolloutFailure(current, deployment, desiredStateRevisions, resultErr); persistErr != nil {
+			return errors.Join(resultErr, fmt.Errorf("persist deployment failure: %w", persistErr))
+		}
+		return resultErr
+	}
+	deployment.Status = corerelease.DeploymentStatusSettled
+	deployment.StatusMessage = "release settled"
+	deployment.FinishedAt = time.Now().UTC().Format(time.RFC3339)
+	deployment.PublicationResult = soloDeploymentPublicationResult(desiredStateRevisions, nil)
+	if err := current.SaveDeployment(deployment); err != nil {
+		return err
+	}
+	if err := a.writeSoloState(current); err != nil {
 		return err
 	}
 
 	payload := map[string]any{
+		"release_id":              release.ID,
+		"deployment_id":           deployment.ID,
 		"workload_revision":       shortSHA,
 		"desired_state_revisions": desiredStateRevisions,
 		"image":                   imageTag,
@@ -910,10 +984,10 @@ func (a *App) republishNodes(ctx context.Context, current solo.State, nodeNames 
 					return
 				}
 			}
-			publication, err := desiredstate.PlanNodePublication(desiredstate.NodePublicationInput{
+			publication, err := corerelease.PlanPublication(corerelease.PublicationPlanInput{
 				NodeName:     name,
-				CurrentNode:  node,
-				Snapshots:    inputs.snapshots,
+				Node:         node,
+				Releases:     publicationReleasesFromSnapshots(inputs.snapshots),
 				ReleaseNodes: inputs.releaseNodes,
 				NodePeers:    inputs.peers,
 			})
@@ -928,13 +1002,8 @@ func (a *App) republishNodes(ctx context.Context, current solo.State, nodeNames 
 				appendSoloRepublishError(&mu, &errs, name, "write desired state", err)
 				return
 			}
-			revision, err := desiredStateRevision(desiredStateJSON)
-			if err != nil {
-				appendSoloRepublishError(&mu, &errs, name, "parse desired state revision", err)
-				return
-			}
 			mu.Lock()
-			revisions[name] = revision
+			revisions[name] = publication.Revision
 			mu.Unlock()
 		}(nodeName, node, inputs)
 	}
@@ -1183,6 +1252,26 @@ func snapshotNeedsImageOnNode(snapshot desiredstate.DeploySnapshot, node config.
 	return snapshot.ReleaseTask != nil && runReleaseTask
 }
 
+func publicationReleasesFromSnapshots(snapshots []desiredstate.DeploySnapshot) []corerelease.Release {
+	releases := make([]corerelease.Release, 0, len(snapshots))
+	for _, snapshot := range snapshots {
+		workspaceKey := strings.TrimSpace(snapshot.WorkspaceKey)
+		environment := strings.TrimSpace(snapshot.Environment)
+		if environment == "" {
+			environment = config.DefaultEnvironment
+		}
+		snapshot.WorkspaceKey = workspaceKey
+		snapshot.Environment = environment
+		releases = append(releases, corerelease.Release{
+			ID:       workspaceKey + "\n" + environment,
+			Revision: strings.TrimSpace(snapshot.Revision),
+			Snapshot: snapshot,
+			Image:    corerelease.ImageRef{Reference: strings.TrimSpace(snapshot.Image)},
+		})
+	}
+	return releases
+}
+
 func desiredStateRevision(data []byte) (string, error) {
 	var payload struct {
 		Revision string `json:"revision"`
@@ -1264,9 +1353,15 @@ func soloNodeDesiredStateInputs(current solo.State, nodeName string) ([]desireds
 
 	for _, key := range current.AttachmentKeysForNode(nodeName) {
 		attachment := current.Attachments[key]
-		snapshot, ok := current.Snapshots[key]
+		releaseID := strings.TrimSpace(current.Current[key])
+		release, ok := current.Releases[releaseID]
+		snapshot := release.Snapshot
 		if !ok {
-			continue
+			var snapshotOK bool
+			snapshot, snapshotOK = current.Snapshots[key]
+			if !snapshotOK {
+				continue
+			}
 		}
 		snapshots = append(snapshots, snapshot)
 		if image := strings.TrimSpace(snapshot.Image); image != "" && !imageSet[image] {
@@ -1305,6 +1400,15 @@ func soloNodeDesiredStateInputs(current solo.State, nodeName string) ([]desireds
 	}
 	sort.Strings(images)
 	return snapshots, releaseNodes, peers, images, nil
+}
+
+func soloAttachmentHasReleaseState(current solo.State, attachment solo.AttachmentRecord) bool {
+	key := attachment.WorkspaceKey + "\n" + attachment.Environment
+	if strings.TrimSpace(current.Current[key]) != "" {
+		return true
+	}
+	_, ok := current.Snapshots[key]
+	return ok
 }
 
 func releaseNodeForSnapshot(snapshot desiredstate.DeploySnapshot, attachment solo.AttachmentRecord, nodes map[string]config.Node) (string, error) {
@@ -1397,6 +1501,160 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 		return ExitError{Code: 1, Err: RenderedError{Err: fmt.Errorf("status failed for %d node(s)", readErrors)}}
 	}
 	return nil
+}
+
+func (a *App) SoloReleaseList(ctx context.Context, opts SoloReleaseListOptions) error {
+	cfg, workspaceRoot, err := a.loadSoloProjectConfig()
+	if err != nil {
+		return err
+	}
+	current, err := a.readSoloState()
+	if err != nil {
+		return err
+	}
+	environmentName := soloEnvironmentName(cfg, "")
+	environmentID, currentRelease, hasCurrent, err := current.CurrentRelease(workspaceRoot, environmentName)
+	if err != nil {
+		return err
+	}
+	releases, err := current.ReleaseHistory(workspaceRoot, environmentName)
+	if err != nil {
+		return err
+	}
+	limit := opts.Limit
+	if limit > 0 && len(releases) > limit {
+		releases = releases[:limit]
+	}
+	items := make([]map[string]any, 0, len(releases))
+	for _, release := range releases {
+		items = append(items, map[string]any{
+			"id":            release.ID,
+			"revision":      release.Revision,
+			"config_digest": release.ConfigDigest,
+			"image":         release.Image.Reference,
+			"created_at":    release.CreatedAt,
+			"current":       hasCurrent && release.ID == currentRelease.ID,
+			"target_nodes":  release.TargetNodeIDs,
+		})
+	}
+	return a.Printer.PrintJSON(map[string]any{
+		"schema_version": outputSchemaVersion,
+		"environment":    environmentName,
+		"environment_id": environmentID,
+		"current_release_id": func() string {
+			if hasCurrent {
+				return currentRelease.ID
+			}
+			return ""
+		}(),
+		"releases": items,
+	})
+}
+
+func (a *App) SoloReleaseRollback(ctx context.Context, opts SoloReleaseRollbackOptions) error {
+	stream := a.Printer.Stream("devopsellence release rollback")
+	if err := stream.Event("started", map[string]any{}); err != nil {
+		return err
+	}
+	cfg, workspaceRoot, err := a.loadSoloProjectConfig()
+	if err != nil {
+		return err
+	}
+	current, err := a.readSoloState()
+	if err != nil {
+		return err
+	}
+	environmentName := soloEnvironmentName(cfg, "")
+	attachedNodeNames, err := current.AttachedNodeNames(workspaceRoot, environmentName)
+	if err != nil {
+		return err
+	}
+	if len(attachedNodeNames) == 0 {
+		return fmt.Errorf("no nodes attached to %s; run `devopsellence node attach <name>`", environmentName)
+	}
+	environmentID, currentRelease, hasCurrent, err := current.CurrentRelease(workspaceRoot, environmentName)
+	if err != nil {
+		return err
+	}
+	if !hasCurrent {
+		return fmt.Errorf("no current release for %s; run `devopsellence deploy` first", environmentName)
+	}
+	releases, err := current.ReleaseHistory(workspaceRoot, environmentName)
+	if err != nil {
+		return err
+	}
+	selected, err := corerelease.SelectRollbackRelease(releases, currentRelease.ID, opts.Selector)
+	if err != nil {
+		return err
+	}
+	rollbackTargetNodeNames, err := soloRollbackTargetNodeNames(attachedNodeNames, selected)
+	if err != nil {
+		return err
+	}
+	nodes, err := a.resolveNodes(current, rollbackTargetNodeNames)
+	if err != nil {
+		return err
+	}
+	now := time.Now().UTC()
+	deployment, err := corerelease.NewDeployment(corerelease.DeploymentCreateInput{
+		ID:            soloDeploymentID(corerelease.DeploymentKindRollback, selected.Revision, now),
+		EnvironmentID: environmentID,
+		ReleaseID:     selected.ID,
+		Kind:          corerelease.DeploymentKindRollback,
+		Sequence:      nextSoloDeploymentSequence(current, environmentID),
+		TargetNodeIDs: rollbackTargetNodeNames,
+		CreatedAt:     now,
+	})
+	if err != nil {
+		return err
+	}
+	if _, err := current.SaveRelease(selected); err != nil {
+		return err
+	}
+	if err := current.SaveDeployment(deployment); err != nil {
+		return err
+	}
+	deployment.Status = corerelease.DeploymentStatusRunning
+	deployment.StatusMessage = "publishing desired state"
+	if err := current.SaveDeployment(deployment); err != nil {
+		return err
+	}
+	if err := a.writeSoloState(current); err != nil {
+		return err
+	}
+	desiredStateRevisions, err := a.republishNodes(ctx, current, rollbackTargetNodeNames)
+	if err != nil {
+		if persistErr := a.persistSoloDeploymentFailure(current, deployment, desiredStateRevisions, err); persistErr != nil {
+			return errors.Join(err, fmt.Errorf("persist deployment failure: %w", persistErr))
+		}
+		return err
+	}
+	if err := a.waitForSoloRollout(ctx, nodes, desiredStateRevisions); err != nil {
+		if persistErr := a.persistSoloDeploymentRolloutFailure(current, deployment, desiredStateRevisions, err); persistErr != nil {
+			return errors.Join(err, fmt.Errorf("persist deployment failure: %w", persistErr))
+		}
+		return err
+	}
+	deployment.Status = corerelease.DeploymentStatusSettled
+	deployment.StatusMessage = "rollback settled"
+	deployment.FinishedAt = time.Now().UTC().Format(time.RFC3339)
+	deployment.PublicationResult = soloDeploymentPublicationResult(desiredStateRevisions, nil)
+	if err := current.SaveDeployment(deployment); err != nil {
+		return err
+	}
+	if err := a.writeSoloState(current); err != nil {
+		return err
+	}
+	return stream.Result(map[string]any{
+		"release_id":              selected.ID,
+		"deployment_id":           deployment.ID,
+		"rolled_back_from":        currentRelease.ID,
+		"workload_revision":       selected.Revision,
+		"desired_state_revisions": desiredStateRevisions,
+		"environment":             environmentName,
+		"nodes":                   sortedNodeNames(nodes),
+		"phase":                   "settled",
+	})
 }
 
 func soloStatusPublicURLs(cfg *config.ProjectConfig, nodes map[string]config.Node) []string {
@@ -1792,7 +2050,7 @@ func (a *App) SoloNodeAttach(ctx context.Context, opts SoloNodeAttachOptions) er
 	if err := a.writeSoloState(current); err != nil {
 		return err
 	}
-	if _, ok := current.Snapshots[attachment.WorkspaceKey+"\n"+attachment.Environment]; ok {
+	if soloAttachmentHasReleaseState(current, attachment) {
 		if _, err := a.republishNodes(ctx, current, attachment.NodeNames); err != nil {
 			return err
 		}
@@ -2686,7 +2944,7 @@ func (a *App) SoloNodeCreate(ctx context.Context, opts SoloNodeCreateOptions) er
 	}
 
 	if attached {
-		if _, ok := current.Snapshots[attachment.WorkspaceKey+"\n"+attachment.Environment]; ok {
+		if soloAttachmentHasReleaseState(current, attachment) {
 			if _, err := a.republishNodes(ctx, current, attachment.NodeNames); err != nil {
 				return err
 			}
@@ -3958,6 +4216,155 @@ func dockerBuildArgs(contextPath, dockerfile, tag string, platforms []string) ([
 
 func soloImageTag(project, revision string) string {
 	return fmt.Sprintf("%s:%s", discovery.Slugify(project), revision)
+}
+
+func soloReleaseID(revision string, now time.Time) string {
+	revision = strings.TrimSpace(revision)
+	if revision == "" {
+		revision = "unknown"
+	}
+	return fmt.Sprintf("rel_%s_%s", sanitizeSoloIDPart(revision), soloULID(now))
+}
+
+func soloDeploymentID(kind, revision string, now time.Time) string {
+	kind = strings.TrimSpace(kind)
+	if kind == "" {
+		kind = corerelease.DeploymentKindDeploy
+	}
+	revision = strings.TrimSpace(revision)
+	if revision == "" {
+		revision = "unknown"
+	}
+	return fmt.Sprintf("dep_%s_%s_%s", sanitizeSoloIDPart(kind), sanitizeSoloIDPart(revision), soloULID(now))
+}
+
+func soloULID(now time.Time) string {
+	soloULIDMu.Lock()
+	defer soloULIDMu.Unlock()
+	id, err := ulid.New(ulid.Timestamp(now.UTC()), soloULIDEntropy)
+	if err != nil {
+		return ulid.Make().String()
+	}
+	return id.String()
+}
+
+func sanitizeSoloIDPart(value string) string {
+	value = strings.TrimSpace(value)
+	var b strings.Builder
+	for _, r := range value {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r)
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == '-' || r == '_' || r == '.':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('_')
+		}
+	}
+	if b.Len() == 0 {
+		return "unknown"
+	}
+	return b.String()
+}
+
+func nextSoloDeploymentSequence(current solo.State, environmentID string) int {
+	sequence := 0
+	for _, deployment := range current.Deployments {
+		if deployment.EnvironmentID == environmentID && deployment.Sequence > sequence {
+			sequence = deployment.Sequence
+		}
+	}
+	return sequence + 1
+}
+
+func soloDeploymentPublicationResult(revisions map[string]string, publishErr error) *corerelease.DeploymentPublicationResult {
+	result := &corerelease.DeploymentPublicationResult{
+		Status: corerelease.PublicationStatusWritten,
+	}
+	if publishErr != nil {
+		result.Status = corerelease.PublicationStatusFailed
+		result.ErrorMessage = publishErr.Error()
+	}
+	for _, nodeName := range sortedMapKeys(revisions) {
+		result.NodeResults = append(result.NodeResults, corerelease.DesiredStatePublication{
+			NodeName: nodeName,
+			Revision: revisions[nodeName],
+			Status:   corerelease.PublicationStatusWritten,
+		})
+	}
+	return result
+}
+
+func (a *App) persistSoloDeploymentFailure(current solo.State, deployment corerelease.Deployment, revisions map[string]string, failure error) error {
+	deployment.Status = corerelease.DeploymentStatusFailed
+	deployment.StatusMessage = "deployment failed"
+	deployment.FinishedAt = time.Now().UTC().Format(time.RFC3339)
+	deployment.PublicationResult = soloDeploymentPublicationResult(revisions, failure)
+	if err := current.SaveDeployment(deployment); err != nil {
+		return err
+	}
+	return a.writeSoloState(current)
+}
+
+func (a *App) persistSoloDeploymentRolloutFailure(current solo.State, deployment corerelease.Deployment, revisions map[string]string, failure error) error {
+	deployment.Status = corerelease.DeploymentStatusFailed
+	deployment.StatusMessage = "rollout failed: " + failure.Error()
+	deployment.FinishedAt = time.Now().UTC().Format(time.RFC3339)
+	deployment.PublicationResult = soloDeploymentPublicationResult(revisions, nil)
+	if err := current.SaveDeployment(deployment); err != nil {
+		return err
+	}
+	return a.writeSoloState(current)
+}
+
+func soloRollbackTargetNodeNames(attachedNodeNames []string, release corerelease.Release) ([]string, error) {
+	normalizedAttached := make([]string, 0, len(attachedNodeNames))
+	attached := make(map[string]bool, len(attachedNodeNames))
+	for _, nodeName := range attachedNodeNames {
+		nodeName = strings.TrimSpace(nodeName)
+		if nodeName != "" && !attached[nodeName] {
+			normalizedAttached = append(normalizedAttached, nodeName)
+			attached[nodeName] = true
+		}
+	}
+	normalizedTargets := make([]string, 0, len(release.TargetNodeIDs))
+	targeted := make(map[string]bool, len(release.TargetNodeIDs))
+	for _, nodeName := range release.TargetNodeIDs {
+		nodeName = strings.TrimSpace(nodeName)
+		if nodeName != "" && !targeted[nodeName] {
+			normalizedTargets = append(normalizedTargets, nodeName)
+			targeted[nodeName] = true
+		}
+	}
+	if len(normalizedTargets) == 0 {
+		if len(normalizedAttached) == 0 {
+			return nil, fmt.Errorf("selected rollback release %s does not target any currently attached nodes", release.Revision)
+		}
+		return normalizedAttached, nil
+	}
+	targets := make([]string, 0, len(normalizedTargets))
+	for _, nodeName := range normalizedTargets {
+		if attached[nodeName] {
+			targets = append(targets, nodeName)
+		}
+	}
+	if len(targets) == 0 {
+		return nil, fmt.Errorf("selected rollback release %s does not target any currently attached nodes", release.Revision)
+	}
+	return targets, nil
+}
+
+func sortedMapKeys(values map[string]string) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 // transferImage pipes `docker save | gzip` through ssh to `gunzip | docker load`.

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -25,12 +25,57 @@ import (
 	cliversion "github.com/devopsellence/cli/internal/version"
 	"github.com/devopsellence/devopsellence/deployment-core/pkg/deploycore/config"
 	"github.com/devopsellence/devopsellence/deployment-core/pkg/deploycore/desiredstate"
+	corerelease "github.com/devopsellence/devopsellence/deployment-core/pkg/deploycore/release"
 )
 
 func TestSoloImageTagSlugifiesProjectName(t *testing.T) {
 	got := soloImageTag("ShopApp", "abc1234")
 	if got != "shop-app:abc1234" {
 		t.Fatalf("image tag = %q, want shop-app:abc1234", got)
+	}
+}
+
+func TestSoloIDsIncludeUniqueSuffix(t *testing.T) {
+	now := time.Now().UTC()
+	releaseA := soloReleaseID("abc1234", now)
+	releaseB := soloReleaseID("abc1234", now)
+	if releaseA == releaseB {
+		t.Fatalf("release IDs matched: %q", releaseA)
+	}
+	if releaseA >= releaseB {
+		t.Fatalf("release IDs are not sortable: %q >= %q", releaseA, releaseB)
+	}
+	if got := strings.TrimPrefix(releaseA, "rel_abc1234_"); len(got) != 26 || got == releaseA {
+		t.Fatalf("release ID = %q, want ULID suffix", releaseA)
+	}
+	deploymentA := soloDeploymentID(corerelease.DeploymentKindDeploy, "abc1234", now)
+	deploymentB := soloDeploymentID(corerelease.DeploymentKindDeploy, "abc1234", now)
+	if deploymentA == deploymentB {
+		t.Fatalf("deployment IDs matched: %q", deploymentA)
+	}
+	if deploymentA >= deploymentB {
+		t.Fatalf("deployment IDs are not sortable: %q >= %q", deploymentA, deploymentB)
+	}
+}
+
+func TestPublicationReleasesFromSnapshotsDefaultsEnvironment(t *testing.T) {
+	t.Parallel()
+
+	releases := publicationReleasesFromSnapshots([]desiredstate.DeploySnapshot{{
+		WorkspaceKey: " /workspace/demo ",
+		Environment:  " ",
+		Revision:     " abc1234 ",
+		Image:        " demo:abc1234 ",
+	}})
+	if len(releases) != 1 {
+		t.Fatalf("releases = %#v, want one release", releases)
+	}
+	release := releases[0]
+	if release.ID != "/workspace/demo\nproduction" {
+		t.Fatalf("release ID = %q, want normalized production key", release.ID)
+	}
+	if release.Snapshot.WorkspaceKey != "/workspace/demo" || release.Snapshot.Environment != config.DefaultEnvironment {
+		t.Fatalf("snapshot = %#v, want normalized workspace/environment", release.Snapshot)
 	}
 }
 
@@ -374,13 +419,17 @@ func TestNodeDesiredStateInputsUsesOtherAttachedNodesAsPeers(t *testing.T) {
 		}
 	}
 	key := attachment.WorkspaceKey + "\nproduction"
-	current.Snapshots[key] = desiredstate.DeploySnapshot{
+	snapshot := desiredstate.DeploySnapshot{
 		WorkspaceRoot: "/workspace/demo",
 		WorkspaceKey:  attachment.WorkspaceKey,
 		Environment:   "production",
 		Revision:      "abc1234",
 		Image:         "demo:abc1234",
 	}
+	current.Releases = map[string]corerelease.Release{
+		"rel-1": {ID: "rel-1", EnvironmentID: key, Revision: "abc1234", Snapshot: snapshot},
+	}
+	current.Current = map[string]string{key: "rel-1"}
 
 	_, _, got, _, err := soloNodeDesiredStateInputs(current, "web-a")
 	if err != nil {
@@ -1824,9 +1873,19 @@ func TestSoloDeployWaitsForSettledStatusBeforeSuccess(t *testing.T) {
 	if payload["environment"] != "production" || payload["workload_revision"] == "" || payload["phase"] != "settled" {
 		t.Fatalf("payload = %#v, want settled deploy JSON", payload)
 	}
+	if payload["release_id"] == "" || payload["deployment_id"] == "" {
+		t.Fatalf("payload = %#v, want release and deployment ids", payload)
+	}
 	revisions := jsonMapFromAny(t, payload["desired_state_revisions"])
 	if revisions["node-a"] == "" {
 		t.Fatalf("desired_state_revisions = %#v, want node revision", revisions)
+	}
+	updatedState, err := soloState.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(updatedState.Releases) != 1 || len(updatedState.Deployments) != 1 {
+		t.Fatalf("state releases=%#v deployments=%#v, want one release and deployment", updatedState.Releases, updatedState.Deployments)
 	}
 	urls := jsonArrayFromMap(t, payload, "public_urls")
 	if len(urls) != 1 || urls[0] != "http://203.0.113.10/" {
@@ -1835,6 +1894,240 @@ func TestSoloDeployWaitsForSettledStatusBeforeSuccess(t *testing.T) {
 	nextSteps := jsonArrayFromMap(t, payload, "next_steps")
 	if len(nextSteps) != 4 || nextSteps[0] != "devopsellence status" || nextSteps[1] != "curl http://203.0.113.10/" || nextSteps[2] != "devopsellence logs --node 'node-a' --lines 100" || nextSteps[3] != "devopsellence node logs 'node-a' --lines 100" {
 		t.Fatalf("next_steps = %#v, want status, curl, and logs commands", nextSteps)
+	}
+}
+
+func TestSoloReleaseListReturnsCurrentReleaseHistory(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfigForType("solo", "demo", "production", config.AppTypeGeneric)
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := soloReleaseWorkflowState(workspaceRoot)
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{
+		Printer:     output.New(&stdout, io.Discard),
+		SoloState:   soloState,
+		ConfigStore: config.NewStore(),
+		Cwd:         workspaceRoot,
+	}
+	if err := app.SoloReleaseList(context.Background(), SoloReleaseListOptions{Limit: 1}); err != nil {
+		t.Fatal(err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	if payload["current_release_id"] != "rel-2" {
+		t.Fatalf("payload = %#v, want current release rel-2", payload)
+	}
+	releases := jsonArrayFromMap(t, payload, "releases")
+	if len(releases) != 1 {
+		t.Fatalf("releases = %#v, want limit 1", releases)
+	}
+	release := jsonMapFromAny(t, releases[0])
+	if release["id"] != "rel-2" || release["revision"] != "bbb2222" || release["current"] != true {
+		t.Fatalf("release = %#v, want current rel-2", release)
+	}
+	targets := jsonArrayFromMap(t, release, "target_nodes")
+	if !reflect.DeepEqual(targets, []any{"node-a", "node-c"}) {
+		t.Fatalf("target_nodes = %#v, want node-a/node-c", targets)
+	}
+
+	stdout.Reset()
+	if err := app.SoloReleaseList(context.Background(), SoloReleaseListOptions{Limit: 0}); err != nil {
+		t.Fatal(err)
+	}
+	payload = decodeJSONOutput(t, &stdout)
+	releases = jsonArrayFromMap(t, payload, "releases")
+	if len(releases) != 2 {
+		t.Fatalf("releases = %#v, want unlimited result", releases)
+	}
+}
+
+func TestSoloReleaseRollbackUsesSelectedReleaseTargets(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfigForType("solo", "demo", "production", config.AppTypeGeneric)
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := soloReleaseWorkflowState(workspaceRoot)
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+	installFakeSoloCommands(t, []fakeSSHResponse{
+		{stdout: soloStatusMissingSentinel + "\n"},
+		{stdout: `{"revision":"__REVISION__","phase":"reconciling"}` + "\n"},
+		{stdout: `{"revision":"__REVISION__","phase":"settled"}` + "\n"},
+	})
+
+	var stdout bytes.Buffer
+	app := &App{
+		Printer:            output.New(&stdout, io.Discard),
+		SoloState:          soloState,
+		ConfigStore:        config.NewStore(),
+		Cwd:                workspaceRoot,
+		DeployPollInterval: 5 * time.Millisecond,
+		DeployTimeout:      time.Second,
+	}
+	if err := app.SoloReleaseRollback(context.Background(), SoloReleaseRollbackOptions{Selector: "aaa1111"}); err != nil {
+		t.Fatal(err)
+	}
+	events := decodeNDJSONOutput(t, &stdout)
+	payload := events[len(events)-1]
+	if payload["release_id"] != "rel-1" || payload["rolled_back_from"] != "rel-2" || payload["phase"] != "settled" {
+		t.Fatalf("payload = %#v, want settled rollback to rel-1", payload)
+	}
+	nodes := jsonArrayFromMap(t, payload, "nodes")
+	if !reflect.DeepEqual(nodes, []any{"node-a"}) {
+		t.Fatalf("nodes = %#v, want only selected release target", nodes)
+	}
+	revisions := jsonMapFromAny(t, payload["desired_state_revisions"])
+	if len(revisions) != 1 || revisions["node-a"] == "" {
+		t.Fatalf("desired_state_revisions = %#v, want only node-a", revisions)
+	}
+	updatedState, err := soloState.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+	key := workspaceRoot + "\nproduction"
+	if updatedState.Current[key] != "rel-1" {
+		t.Fatalf("current release = %q, want rel-1", updatedState.Current[key])
+	}
+	var deployment corerelease.Deployment
+	for _, candidate := range updatedState.Deployments {
+		deployment = candidate
+	}
+	if deployment.Status != corerelease.DeploymentStatusSettled || !reflect.DeepEqual(deployment.TargetNodeIDs, []string{"node-a"}) {
+		t.Fatalf("deployment = %#v, want settled target node-a", deployment)
+	}
+}
+
+func TestSoloReleaseRollbackPersistsSelectedReleaseOnRolloutFailure(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfigForType("solo", "demo", "production", config.AppTypeGeneric)
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := soloReleaseWorkflowState(workspaceRoot)
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+	installFakeSoloCommands(t, []fakeSSHResponse{
+		{stdout: `{"revision":"__REVISION__","phase":"error","error":"healthcheck failed"}` + "\n"},
+	})
+
+	var stdout bytes.Buffer
+	app := &App{
+		Printer:            output.New(&stdout, io.Discard),
+		SoloState:          soloState,
+		ConfigStore:        config.NewStore(),
+		Cwd:                workspaceRoot,
+		DeployPollInterval: 5 * time.Millisecond,
+		DeployTimeout:      time.Second,
+	}
+	err := app.SoloReleaseRollback(context.Background(), SoloReleaseRollbackOptions{Selector: "aaa1111"})
+	if err == nil {
+		t.Fatal("expected rollout failure")
+	}
+	updatedState, readErr := soloState.Read()
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	key := workspaceRoot + "\nproduction"
+	if updatedState.Current[key] != "rel-1" {
+		t.Fatalf("current release = %q, want selected rollback release rel-1", updatedState.Current[key])
+	}
+	var deployment corerelease.Deployment
+	for _, candidate := range updatedState.Deployments {
+		deployment = candidate
+	}
+	if deployment.Status != corerelease.DeploymentStatusFailed || !strings.Contains(deployment.StatusMessage, "rollout failed") {
+		t.Fatalf("deployment = %#v, want failed rollout deployment", deployment)
+	}
+}
+
+func TestSoloRollbackTargetNodeNamesRejectsEmptyIntersection(t *testing.T) {
+	_, err := soloRollbackTargetNodeNames([]string{"node-b"}, corerelease.Release{
+		Revision:      "aaa1111",
+		TargetNodeIDs: []string{"node-a"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "does not target any currently attached nodes") {
+		t.Fatalf("error = %v, want empty intersection error", err)
+	}
+}
+
+func TestSoloRollbackTargetNodeNamesDefaultsEmptyTargetsToAttachedNodes(t *testing.T) {
+	targets, err := soloRollbackTargetNodeNames([]string{" node-b ", "", "node-a", "node-b"}, corerelease.Release{
+		Revision: "aaa1111",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(targets, []string{"node-b", "node-a"}) {
+		t.Fatalf("targets = %#v, want normalized attached nodes", targets)
+	}
+}
+
+func soloReleaseWorkflowState(workspaceRoot string) solo.State {
+	key := workspaceRoot + "\nproduction"
+	oldSnapshot := desiredstate.DeploySnapshot{
+		WorkspaceRoot: workspaceRoot,
+		WorkspaceKey:  workspaceRoot,
+		Environment:   "production",
+		Revision:      "aaa1111",
+		Image:         "demo:aaa1111",
+		Services:      []desiredstate.ServiceJSON{{Name: "web", Kind: config.ServiceKindWeb, Image: "demo:aaa1111"}},
+	}
+	currentSnapshot := desiredstate.DeploySnapshot{
+		WorkspaceRoot: workspaceRoot,
+		WorkspaceKey:  workspaceRoot,
+		Environment:   "production",
+		Revision:      "bbb2222",
+		Image:         "demo:bbb2222",
+		Services:      []desiredstate.ServiceJSON{{Name: "web", Kind: config.ServiceKindWeb, Image: "demo:bbb2222"}},
+	}
+	return solo.State{
+		Nodes: map[string]config.Node{
+			"node-a": {Host: "203.0.113.10", User: "root", Port: 22, AgentStateDir: "/var/lib/devopsellence", Labels: []string{config.DefaultWebRole}},
+			"node-b": {Host: "203.0.113.11", User: "root", Port: 22, AgentStateDir: "/var/lib/devopsellence", Labels: []string{config.DefaultWebRole}},
+			"node-c": {Host: "203.0.113.12", User: "root", Port: 22, AgentStateDir: "/var/lib/devopsellence", Labels: []string{config.DefaultWebRole}},
+		},
+		Attachments: map[string]solo.AttachmentRecord{
+			key: {
+				WorkspaceRoot: workspaceRoot,
+				WorkspaceKey:  workspaceRoot,
+				Environment:   "production",
+				NodeNames:     []string{"node-a", "node-b", "node-c"},
+			},
+		},
+		Snapshots: map[string]desiredstate.DeploySnapshot{key: currentSnapshot},
+		Releases: map[string]corerelease.Release{
+			"rel-1": {
+				ID:            "rel-1",
+				EnvironmentID: key,
+				Revision:      "aaa1111",
+				Snapshot:      oldSnapshot,
+				Image:         corerelease.ImageRef{Reference: "demo:aaa1111"},
+				TargetNodeIDs: []string{"node-a"},
+				CreatedAt:     "2026-04-28T12:01:00Z",
+			},
+			"rel-2": {
+				ID:            "rel-2",
+				EnvironmentID: key,
+				Revision:      "bbb2222",
+				Snapshot:      currentSnapshot,
+				Image:         corerelease.ImageRef{Reference: "demo:bbb2222"},
+				TargetNodeIDs: []string{"node-a", "node-c"},
+				CreatedAt:     "2026-04-28T12:02:00Z",
+			},
+		},
+		Current:     map[string]string{key: "rel-2"},
+		Deployments: map[string]corerelease.Deployment{},
 	}
 }
 
@@ -1889,6 +2182,26 @@ func TestSoloDeployRolloutFailureIncludesHealthcheckContext(t *testing.T) {
 	healthchecks := fields["healthchecks"].([]map[string]any)
 	if len(healthchecks) != 1 || healthchecks[0]["service_name"] != config.DefaultWebServiceName || healthchecks[0]["path"] != config.DefaultHealthcheckPath {
 		t.Fatalf("healthchecks = %#v, want web healthcheck context", healthchecks)
+	}
+	loaded, err := soloState.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(loaded.Deployments) != 1 {
+		t.Fatalf("deployments = %#v, want one failed deployment", loaded.Deployments)
+	}
+	var deployment corerelease.Deployment
+	for _, candidate := range loaded.Deployments {
+		deployment = candidate
+	}
+	if deployment.Status != corerelease.DeploymentStatusFailed || !strings.HasPrefix(deployment.StatusMessage, "rollout failed:") {
+		t.Fatalf("deployment = %#v, want rollout failure status", deployment)
+	}
+	if deployment.PublicationResult == nil || deployment.PublicationResult.Status != corerelease.PublicationStatusWritten || deployment.PublicationResult.ErrorMessage != "" {
+		t.Fatalf("publication result = %#v, want written result without rollout error", deployment.PublicationResult)
+	}
+	if len(deployment.PublicationResult.NodeResults) != 1 || deployment.PublicationResult.NodeResults[0].PublishedAt != "" {
+		t.Fatalf("node results = %#v, want no synthetic published_at", deployment.PublicationResult.NodeResults)
 	}
 }
 

--- a/deployment-core/pkg/deploycore/release/model.go
+++ b/deployment-core/pkg/deploycore/release/model.go
@@ -1,0 +1,364 @@
+package release
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/devopsellence/devopsellence/deployment-core/pkg/deploycore/config"
+	"github.com/devopsellence/devopsellence/deployment-core/pkg/deploycore/desiredstate"
+)
+
+const (
+	DeploymentKindDeploy     = "deploy"
+	DeploymentKindRollback   = "rollback"
+	DeploymentKindRepublish  = "republish"
+	DeploymentStatusPending  = "pending"
+	DeploymentStatusRunning  = "running"
+	DeploymentStatusSettled  = "settled"
+	DeploymentStatusFailed   = "failed"
+	PublicationStatusPending = "pending"
+	PublicationStatusWritten = "written"
+	PublicationStatusFailed  = "failed"
+)
+
+type Environment struct {
+	ID               string   `json:"id"`
+	Name             string   `json:"name"`
+	CurrentReleaseID string   `json:"current_release_id,omitempty"`
+	NodeIDs          []string `json:"node_ids,omitempty"`
+}
+
+type Node struct {
+	ID     string      `json:"id"`
+	Name   string      `json:"name"`
+	Config config.Node `json:"config"`
+}
+
+type Release struct {
+	ID            string                      `json:"id"`
+	EnvironmentID string                      `json:"environment_id"`
+	Revision      string                      `json:"revision"`
+	ConfigDigest  string                      `json:"config_digest,omitempty"`
+	Snapshot      desiredstate.DeploySnapshot `json:"snapshot"`
+	Image         ImageRef                    `json:"image"`
+	TargetNodeIDs []string                    `json:"target_node_ids,omitempty"`
+	CreatedAt     string                      `json:"created_at"`
+	CommandResult *OperationResult            `json:"command_result,omitempty"`
+}
+
+type ImageRef struct {
+	Repository string `json:"repository,omitempty"`
+	Digest     string `json:"digest,omitempty"`
+	Reference  string `json:"reference"`
+}
+
+type Deployment struct {
+	ID                string                       `json:"id"`
+	EnvironmentID     string                       `json:"environment_id"`
+	ReleaseID         string                       `json:"release_id"`
+	Kind              string                       `json:"kind"`
+	Sequence          int                          `json:"sequence"`
+	TargetNodeIDs     []string                     `json:"target_node_ids,omitempty"`
+	Status            string                       `json:"status"`
+	StatusMessage     string                       `json:"status_message,omitempty"`
+	CreatedAt         string                       `json:"created_at"`
+	FinishedAt        string                       `json:"finished_at,omitempty"`
+	CommandResult     *OperationResult             `json:"command_result,omitempty"`
+	PublicationResult *DeploymentPublicationResult `json:"publication_result,omitempty"`
+}
+
+type DeploymentPublicationResult struct {
+	Status       string                    `json:"status"`
+	NodeResults  []DesiredStatePublication `json:"node_results,omitempty"`
+	ErrorMessage string                    `json:"error_message,omitempty"`
+}
+
+type DesiredStatePublication struct {
+	NodeID      string `json:"node_id"`
+	NodeName    string `json:"node_name"`
+	Revision    string `json:"revision"`
+	Sequence    int    `json:"sequence"`
+	Status      string `json:"status"`
+	URI         string `json:"uri,omitempty"`
+	SHA256      string `json:"sha256,omitempty"`
+	PublishedAt string `json:"published_at,omitempty"`
+	Error       string `json:"error,omitempty"`
+}
+
+type OperationResult struct {
+	Status      string `json:"status"`
+	ExitCode    int    `json:"exit_code,omitempty"`
+	Message     string `json:"message,omitempty"`
+	CompletedAt string `json:"completed_at,omitempty"`
+}
+
+type ReleaseCreateInput struct {
+	ID            string
+	EnvironmentID string
+	Revision      string
+	ConfigDigest  string
+	Snapshot      desiredstate.DeploySnapshot
+	Image         ImageRef
+	TargetNodeIDs []string
+	CreatedAt     time.Time
+	CommandResult *OperationResult
+}
+
+func NewRelease(input ReleaseCreateInput) (Release, error) {
+	id := strings.TrimSpace(input.ID)
+	if id == "" {
+		return Release{}, errors.New("release id is required")
+	}
+	environmentID := strings.TrimSpace(input.EnvironmentID)
+	if environmentID == "" {
+		return Release{}, errors.New("environment id is required")
+	}
+	revision := strings.TrimSpace(input.Revision)
+	if revision == "" {
+		revision = strings.TrimSpace(input.Snapshot.Revision)
+	}
+	if revision == "" {
+		return Release{}, errors.New("release revision is required")
+	}
+	createdAt := input.CreatedAt
+	if createdAt.IsZero() {
+		createdAt = time.Now().UTC()
+	}
+	snapshot, err := cloneDeploySnapshot(input.Snapshot)
+	if err != nil {
+		return Release{}, fmt.Errorf("clone release snapshot: %w", err)
+	}
+	snapshot.Revision = revision
+	targets := normalizeStrings(input.TargetNodeIDs)
+	return Release{
+		ID:            id,
+		EnvironmentID: environmentID,
+		Revision:      revision,
+		ConfigDigest:  strings.TrimSpace(input.ConfigDigest),
+		Snapshot:      snapshot,
+		Image:         normalizeImage(input.Image, snapshot.Image),
+		TargetNodeIDs: targets,
+		CreatedAt:     createdAt.UTC().Format(time.RFC3339Nano),
+		CommandResult: input.CommandResult,
+	}, nil
+}
+
+type DeploymentCreateInput struct {
+	ID            string
+	EnvironmentID string
+	ReleaseID     string
+	Kind          string
+	Sequence      int
+	TargetNodeIDs []string
+	CreatedAt     time.Time
+}
+
+func NewDeployment(input DeploymentCreateInput) (Deployment, error) {
+	id := strings.TrimSpace(input.ID)
+	if id == "" {
+		return Deployment{}, errors.New("deployment id is required")
+	}
+	environmentID := strings.TrimSpace(input.EnvironmentID)
+	if environmentID == "" {
+		return Deployment{}, errors.New("environment id is required")
+	}
+	releaseID := strings.TrimSpace(input.ReleaseID)
+	if releaseID == "" {
+		return Deployment{}, errors.New("release id is required")
+	}
+	kind := strings.TrimSpace(input.Kind)
+	if kind == "" {
+		kind = DeploymentKindDeploy
+	}
+	switch kind {
+	case DeploymentKindDeploy, DeploymentKindRollback, DeploymentKindRepublish:
+	default:
+		return Deployment{}, fmt.Errorf("unsupported deployment kind %q", kind)
+	}
+	if input.Sequence <= 0 {
+		return Deployment{}, errors.New("deployment sequence must be greater than zero")
+	}
+	createdAt := input.CreatedAt
+	if createdAt.IsZero() {
+		createdAt = time.Now().UTC()
+	}
+	return Deployment{
+		ID:            id,
+		EnvironmentID: environmentID,
+		ReleaseID:     releaseID,
+		Kind:          kind,
+		Sequence:      input.Sequence,
+		TargetNodeIDs: normalizeStrings(input.TargetNodeIDs),
+		Status:        DeploymentStatusPending,
+		StatusMessage: "waiting to publish desired state",
+		CreatedAt:     createdAt.UTC().Format(time.RFC3339),
+	}, nil
+}
+
+func SelectRollbackRelease(releases []Release, currentReleaseID, selector string) (Release, error) {
+	currentReleaseID = strings.TrimSpace(currentReleaseID)
+	selector = strings.TrimSpace(selector)
+	candidates := append([]Release(nil), releases...)
+
+	if selector == "" {
+		if currentReleaseID == "" {
+			return Release{}, errors.New("current release is required")
+		}
+		createdAtByID := make(map[string]time.Time, len(candidates))
+		for _, candidate := range candidates {
+			createdAt, err := parseReleaseCreatedAt(candidate.CreatedAt)
+			if err != nil {
+				if candidate.ID != "" {
+					return Release{}, fmt.Errorf("release %q has invalid created_at: %w", candidate.ID, err)
+				}
+				return Release{}, err
+			}
+			createdAtByID[candidate.ID] = createdAt
+		}
+		sort.SliceStable(candidates, func(i, j int) bool {
+			if !createdAtByID[candidates[i].ID].Equal(createdAtByID[candidates[j].ID]) {
+				return createdAtByID[candidates[i].ID].After(createdAtByID[candidates[j].ID])
+			}
+			if candidates[i].ID != candidates[j].ID {
+				return candidates[i].ID > candidates[j].ID
+			}
+			return candidates[i].Revision > candidates[j].Revision
+		})
+		currentIndex := -1
+		for i, candidate := range candidates {
+			if candidate.ID == currentReleaseID {
+				currentIndex = i
+				break
+			}
+		}
+		if currentIndex == -1 {
+			return Release{}, fmt.Errorf("current release %q not found", currentReleaseID)
+		}
+		for i := currentIndex + 1; i < len(candidates); i++ {
+			if candidates[i].ID != "" {
+				return candidates[i], nil
+			}
+		}
+		return Release{}, errors.New("no previous release found")
+	}
+
+	matches := []Release{}
+	for _, candidate := range candidates {
+		if candidate.ID == selector || candidate.Revision == selector || strings.HasPrefix(candidate.Revision, selector) {
+			matches = append(matches, candidate)
+		}
+	}
+	if len(matches) == 0 {
+		return Release{}, fmt.Errorf("release %q not found", selector)
+	}
+	if len(matches) > 1 {
+		return Release{}, fmt.Errorf("release selector %q is ambiguous", selector)
+	}
+	return matches[0], nil
+}
+
+func parseReleaseCreatedAt(createdAt string) (time.Time, error) {
+	createdAt = strings.TrimSpace(createdAt)
+	if createdAt == "" {
+		return time.Time{}, errors.New("release created_at is required")
+	}
+	parsedAt, err := time.Parse(time.RFC3339Nano, createdAt)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("must be RFC3339: %w", err)
+	}
+	return parsedAt, nil
+}
+
+type PublicationPlanInput struct {
+	NodeName     string
+	Node         config.Node
+	Releases     []Release
+	ReleaseNodes map[string]string
+	NodePeers    []desiredstate.NodePeer
+}
+
+type PublicationPlan struct {
+	NodeName         string
+	DesiredStateJSON []byte
+	Revision         string
+}
+
+func PlanPublication(input PublicationPlanInput) (PublicationPlan, error) {
+	snapshots := make([]desiredstate.DeploySnapshot, 0, len(input.Releases))
+	for _, rel := range input.Releases {
+		snapshots = append(snapshots, rel.Snapshot)
+	}
+	publication, err := desiredstate.PlanNodePublication(desiredstate.NodePublicationInput{
+		NodeName:     input.NodeName,
+		CurrentNode:  input.Node,
+		Snapshots:    snapshots,
+		ReleaseNodes: input.ReleaseNodes,
+		NodePeers:    input.NodePeers,
+	})
+	if err != nil {
+		return PublicationPlan{}, err
+	}
+	revision, err := desiredStateRevision(publication.DesiredStateJSON)
+	if err != nil {
+		return PublicationPlan{}, err
+	}
+	return PublicationPlan{
+		NodeName:         publication.NodeName,
+		DesiredStateJSON: publication.DesiredStateJSON,
+		Revision:         revision,
+	}, nil
+}
+
+func normalizeImage(image ImageRef, fallback string) ImageRef {
+	image.Repository = strings.TrimSpace(image.Repository)
+	image.Digest = strings.TrimSpace(image.Digest)
+	image.Reference = strings.TrimSpace(image.Reference)
+	if image.Reference == "" {
+		image.Reference = strings.TrimSpace(fallback)
+	}
+	return image
+}
+
+func cloneDeploySnapshot(snapshot desiredstate.DeploySnapshot) (desiredstate.DeploySnapshot, error) {
+	data, err := json.Marshal(snapshot)
+	if err != nil {
+		return desiredstate.DeploySnapshot{}, err
+	}
+	var cloned desiredstate.DeploySnapshot
+	if err := json.Unmarshal(data, &cloned); err != nil {
+		return desiredstate.DeploySnapshot{}, err
+	}
+	return cloned, nil
+}
+
+func normalizeStrings(values []string) []string {
+	seen := map[string]bool{}
+	normalized := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" || seen[value] {
+			continue
+		}
+		seen[value] = true
+		normalized = append(normalized, value)
+	}
+	sort.Strings(normalized)
+	return normalized
+}
+
+func desiredStateRevision(data []byte) (string, error) {
+	var payload struct {
+		Revision string `json:"revision"`
+	}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(payload.Revision) == "" {
+		return "", errors.New("desired state revision is missing")
+	}
+	return strings.TrimSpace(payload.Revision), nil
+}

--- a/deployment-core/pkg/deploycore/release/model_test.go
+++ b/deployment-core/pkg/deploycore/release/model_test.go
@@ -1,0 +1,172 @@
+package release
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/devopsellence/devopsellence/deployment-core/pkg/deploycore/config"
+	"github.com/devopsellence/devopsellence/deployment-core/pkg/deploycore/desiredstate"
+)
+
+func TestNewReleaseNormalizesImmutableSnapshot(t *testing.T) {
+	env := map[string]string{"RAILS_ENV": "production"}
+	release, err := NewRelease(ReleaseCreateInput{
+		ID:            " rel-1 ",
+		EnvironmentID: " env-1 ",
+		Revision:      " abc1234 ",
+		ConfigDigest:  " sha256:cfg ",
+		Snapshot: desiredstate.DeploySnapshot{
+			Revision:    "old",
+			Image:       "shop:abc1234",
+			Environment: "production",
+			Services: []desiredstate.ServiceJSON{{
+				Name: "web",
+				Env:  env,
+			}},
+		},
+		TargetNodeIDs: []string{"web-a", "web-a", " worker-a "},
+		CreatedAt:     time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if release.ID != "rel-1" || release.EnvironmentID != "env-1" || release.Revision != "abc1234" {
+		t.Fatalf("release identity = %#v", release)
+	}
+	if release.Snapshot.Revision != "abc1234" {
+		t.Fatalf("snapshot revision = %q, want release revision", release.Snapshot.Revision)
+	}
+	if release.Image.Reference != "shop:abc1234" {
+		t.Fatalf("image reference = %q", release.Image.Reference)
+	}
+	if got, want := strings.Join(release.TargetNodeIDs, ","), "web-a,worker-a"; got != want {
+		t.Fatalf("target nodes = %q, want %q", got, want)
+	}
+	env["RAILS_ENV"] = "staging"
+	if got := release.Snapshot.Services[0].Env["RAILS_ENV"]; got != "production" {
+		t.Fatalf("release snapshot env = %q, want immutable production value", got)
+	}
+}
+
+func TestSelectRollbackReleaseDefaultsToPreviousCreatedRelease(t *testing.T) {
+	current := Release{ID: "rel-3", Revision: "ccc3333", CreatedAt: "2026-04-28T12:03:00Z"}
+	previous := Release{ID: "rel-2", Revision: "bbb2222", CreatedAt: "2026-04-28T12:02:00Z"}
+	oldest := Release{ID: "rel-1", Revision: "aaa1111", CreatedAt: "2026-04-28T12:01:00Z"}
+
+	got, err := SelectRollbackRelease([]Release{oldest, current, previous}, current.ID, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ID != previous.ID {
+		t.Fatalf("rollback release = %s, want %s", got.ID, previous.ID)
+	}
+}
+
+func TestSelectRollbackReleaseDefaultsToOlderThanCurrentWhenCurrentIsNotNewest(t *testing.T) {
+	newest := Release{ID: "rel-4", Revision: "ddd4444", CreatedAt: "2026-04-28T12:04:00Z"}
+	current := Release{ID: "rel-3", Revision: "ccc3333", CreatedAt: "2026-04-28T12:03:00Z"}
+	previous := Release{ID: "rel-2", Revision: "bbb2222", CreatedAt: "2026-04-28T12:02:00Z"}
+	oldest := Release{ID: "rel-1", Revision: "aaa1111", CreatedAt: "2026-04-28T12:01:00Z"}
+
+	got, err := SelectRollbackRelease([]Release{oldest, previous, newest, current}, current.ID, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ID != previous.ID {
+		t.Fatalf("rollback release = %s, want %s", got.ID, previous.ID)
+	}
+}
+
+func TestSelectRollbackReleaseDefaultsUsingParsedCreatedAt(t *testing.T) {
+	current := Release{ID: "rel-3", Revision: "ccc3333", CreatedAt: "2026-04-28T08:03:00-04:00"}
+	previous := Release{ID: "rel-2", Revision: "bbb2222", CreatedAt: "2026-04-28T12:02:00Z"}
+	oldest := Release{ID: "rel-1", Revision: "aaa1111", CreatedAt: "2026-04-28T12:01:00Z"}
+
+	got, err := SelectRollbackRelease([]Release{previous, oldest, current}, current.ID, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ID != previous.ID {
+		t.Fatalf("rollback release = %s, want %s", got.ID, previous.ID)
+	}
+}
+
+func TestSelectRollbackReleaseDefaultsWithDeterministicTimestampTie(t *testing.T) {
+	createdAt := "2026-04-28T12:00:00Z"
+	current := Release{ID: "rel-b", Revision: "bbb2222", CreatedAt: createdAt}
+	previous := Release{ID: "rel-a", Revision: "aaa1111", CreatedAt: createdAt}
+	newerTie := Release{ID: "rel-c", Revision: "ccc3333", CreatedAt: createdAt}
+
+	got, err := SelectRollbackRelease([]Release{previous, current, newerTie}, current.ID, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ID != previous.ID {
+		t.Fatalf("rollback release = %s, want %s", got.ID, previous.ID)
+	}
+}
+
+func TestSelectRollbackReleaseRejectsInvalidCreatedAtForDefault(t *testing.T) {
+	_, err := SelectRollbackRelease([]Release{
+		{ID: "rel-1", Revision: "aaa1111", CreatedAt: "not-a-time"},
+	}, "rel-1", "")
+	if err == nil || !strings.Contains(err.Error(), "invalid created_at") {
+		t.Fatalf("error = %v, want invalid created_at", err)
+	}
+}
+
+func TestSelectRollbackReleaseRejectsAmbiguousRevisionPrefix(t *testing.T) {
+	_, err := SelectRollbackRelease([]Release{
+		{ID: "rel-1", Revision: "abc1111"},
+		{ID: "rel-2", Revision: "abc2222"},
+	}, "", "abc")
+	if err == nil || !strings.Contains(err.Error(), "ambiguous") {
+		t.Fatalf("error = %v, want ambiguous", err)
+	}
+}
+
+func TestPlanPublicationUsesReleaseSnapshots(t *testing.T) {
+	plan, err := PlanPublication(PublicationPlanInput{
+		NodeName: "web-a",
+		Node: config.Node{
+			Labels: []string{"web"},
+		},
+		Releases: []Release{
+			{
+				ID:       "rel-1",
+				Revision: "abc1234",
+				Snapshot: desiredstate.DeploySnapshot{
+					WorkspaceKey: "/workspace/shop",
+					Environment:  "production",
+					Revision:     "abc1234",
+					Services: []desiredstate.ServiceJSON{
+						{Name: "web", Kind: "web", Image: "shop:abc1234"},
+						{Name: "worker", Kind: "worker", Image: "shop:abc1234"},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payload struct {
+		Revision     string `json:"revision"`
+		Environments []struct {
+			Services []struct {
+				Name string `json:"name"`
+			} `json:"services"`
+		} `json:"environments"`
+	}
+	if err := json.Unmarshal(plan.DesiredStateJSON, &payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload.Revision == "" || plan.Revision != payload.Revision {
+		t.Fatalf("revision = plan:%q payload:%q", plan.Revision, payload.Revision)
+	}
+	if len(payload.Environments) != 1 || len(payload.Environments[0].Services) != 1 || payload.Environments[0].Services[0].Name != "web" {
+		t.Fatalf("payload services = %#v", payload.Environments)
+	}
+}

--- a/deployment-core/pkg/deploycore/release/service.go
+++ b/deployment-core/pkg/deploycore/release/service.go
@@ -1,0 +1,259 @@
+package release
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/devopsellence/devopsellence/deployment-core/pkg/deploycore/config"
+	"github.com/devopsellence/devopsellence/deployment-core/pkg/deploycore/desiredstate"
+)
+
+type Service struct {
+	Store Store
+}
+
+type RollbackInput struct {
+	Environment  EnvironmentRef
+	Selector     string
+	DeploymentID string
+	Sequence     int
+	Now          time.Time
+}
+
+type RollbackResult struct {
+	Release      Release
+	Deployment   Deployment
+	Publications []DesiredStatePublication
+}
+
+func (s Service) Rollback(ctx context.Context, input RollbackInput) (RollbackResult, error) {
+	if s.Store == nil {
+		return RollbackResult{}, errors.New("release store is required")
+	}
+	var result RollbackResult
+	err := s.Store.WithEnvironmentLock(ctx, input.Environment, func(ctx context.Context, tx Tx) error {
+		environment, err := tx.Environment(ctx, input.Environment)
+		if err != nil {
+			return err
+		}
+		selected, err := rollbackRelease(ctx, tx, environment, input.Selector)
+		if err != nil {
+			return err
+		}
+		nodes, err := tx.Nodes(ctx, environment.ID)
+		if err != nil {
+			return err
+		}
+		targetNodes := targetNodesForRelease(nodes, selected)
+		targetIDs := make([]string, 0, len(targetNodes))
+		for _, node := range targetNodes {
+			targetIDs = append(targetIDs, node.ID)
+		}
+		deployment, err := NewDeployment(DeploymentCreateInput{
+			ID:            input.DeploymentID,
+			EnvironmentID: environment.ID,
+			ReleaseID:     selected.ID,
+			Kind:          DeploymentKindRollback,
+			Sequence:      input.Sequence,
+			TargetNodeIDs: targetIDs,
+			CreatedAt:     input.Now,
+		})
+		if err != nil {
+			return err
+		}
+		deployment, err = tx.CreateDeployment(ctx, deployment)
+		if err != nil {
+			return err
+		}
+		if len(targetNodes) == 0 {
+			err := errors.New("no target nodes match release")
+			if updateErr := failDeployment(ctx, tx, &deployment, "no target nodes match release", nil, err, input.Now); updateErr != nil {
+				return errors.Join(err, updateErr)
+			}
+			result = RollbackResult{Release: selected, Deployment: deployment}
+			return err
+		}
+		deployment.Status = DeploymentStatusRunning
+		deployment.StatusMessage = "publishing desired state"
+		if err := tx.UpdateDeployment(ctx, deployment); err != nil {
+			return err
+		}
+		releaseNodes := releaseNodesForPublication(selected, targetNodes)
+		publications := []DesiredStatePublication{}
+		for _, node := range targetNodes {
+			plan, err := PlanPublication(PublicationPlanInput{
+				NodeName:     node.Name,
+				Node:         node.Config,
+				Releases:     []Release{selected},
+				ReleaseNodes: releaseNodes,
+				NodePeers:    nodePeersForPublication(nodes, node.Name),
+			})
+			if err != nil {
+				failure := err
+				publication := DesiredStatePublication{
+					NodeID:   node.ID,
+					NodeName: node.Name,
+					Status:   PublicationStatusFailed,
+					Error:    failure.Error(),
+				}
+				publications = append(publications, publication)
+				if updateErr := failDeployment(ctx, tx, &deployment, "desired state publish failed", publications, failure, input.Now); updateErr != nil {
+					return errors.Join(failure, updateErr)
+				}
+				result = RollbackResult{Release: selected, Deployment: deployment, Publications: publications}
+				return failure
+			}
+			publication, err := tx.PublishDesiredState(ctx, node, plan)
+			if err != nil {
+				failure := err
+				publication = DesiredStatePublication{
+					NodeID:   node.ID,
+					NodeName: node.Name,
+					Revision: plan.Revision,
+					Status:   PublicationStatusFailed,
+					Error:    failure.Error(),
+				}
+				publications = append(publications, publication)
+				if updateErr := failDeployment(ctx, tx, &deployment, "desired state publish failed", publications, failure, input.Now); updateErr != nil {
+					return errors.Join(failure, updateErr)
+				}
+				result = RollbackResult{Release: selected, Deployment: deployment, Publications: publications}
+				return failure
+			}
+			publications = append(publications, publication)
+		}
+		if err := tx.SetCurrentRelease(ctx, environment.ID, selected.ID); err != nil {
+			if updateErr := failDeployment(ctx, tx, &deployment, "failed to set current release", publications, err, input.Now); updateErr != nil {
+				return errors.Join(err, updateErr)
+			}
+			result = RollbackResult{Release: selected, Deployment: deployment, Publications: publications}
+			return err
+		}
+		deployment.Status = DeploymentStatusSettled
+		deployment.StatusMessage = "rollback published"
+		deployment.FinishedAt = finishTime(input.Now)
+		deployment.PublicationResult = &DeploymentPublicationResult{
+			Status:      PublicationStatusWritten,
+			NodeResults: publications,
+		}
+		if err := tx.UpdateDeployment(ctx, deployment); err != nil {
+			return err
+		}
+		result = RollbackResult{Release: selected, Deployment: deployment, Publications: publications}
+		return nil
+	})
+	return result, err
+}
+
+func rollbackRelease(ctx context.Context, tx Tx, environment Environment, selector string) (Release, error) {
+	releases, err := tx.Releases(ctx, environment.ID, ReleaseListOptions{})
+	if err != nil {
+		return Release{}, err
+	}
+	return SelectRollbackRelease(releases, environment.CurrentReleaseID, selector)
+}
+
+func failDeployment(ctx context.Context, tx Tx, deployment *Deployment, message string, publications []DesiredStatePublication, failure error, now time.Time) error {
+	deployment.Status = DeploymentStatusFailed
+	deployment.StatusMessage = message
+	deployment.FinishedAt = finishTime(now)
+	deployment.PublicationResult = &DeploymentPublicationResult{
+		Status:       PublicationStatusFailed,
+		NodeResults:  publications,
+		ErrorMessage: failure.Error(),
+	}
+	return tx.UpdateDeployment(ctx, *deployment)
+}
+
+func finishTime(now time.Time) string {
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	return now.UTC().Format(time.RFC3339)
+}
+
+func targetNodesForRelease(nodes []Node, release Release) []Node {
+	if len(release.TargetNodeIDs) == 0 {
+		return append([]Node(nil), nodes...)
+	}
+	wanted := map[string]bool{}
+	for _, id := range release.TargetNodeIDs {
+		wanted[id] = true
+	}
+	targets := []Node{}
+	for _, node := range nodes {
+		if wanted[node.ID] {
+			targets = append(targets, node)
+		}
+	}
+	return targets
+}
+
+func releaseNodesForPublication(release Release, targetNodes []Node) map[string]string {
+	if release.Snapshot.ReleaseTask == nil {
+		return nil
+	}
+	nodeNames := make([]string, 0, len(targetNodes))
+	nodesByName := make(map[string]Node, len(targetNodes))
+	for _, node := range targetNodes {
+		name := strings.TrimSpace(node.Name)
+		if name == "" {
+			continue
+		}
+		nodeNames = append(nodeNames, name)
+		nodesByName[name] = node
+	}
+	sort.Strings(nodeNames)
+	for _, name := range nodeNames {
+		node := nodesByName[name]
+		if nodeCanRunKind(node.Config, release.Snapshot.ReleaseServiceKind) {
+			return map[string]string{releaseSnapshotKey(release.Snapshot): name}
+		}
+	}
+	return nil
+}
+
+func nodePeersForPublication(nodes []Node, currentNodeName string) []desiredstate.NodePeer {
+	currentNodeName = strings.TrimSpace(currentNodeName)
+	peers := make([]desiredstate.NodePeer, 0, len(nodes))
+	for _, node := range nodes {
+		name := strings.TrimSpace(node.Name)
+		host := strings.TrimSpace(node.Config.Host)
+		if name == "" || name == currentNodeName || host == "" {
+			continue
+		}
+		peers = append(peers, desiredstate.NodePeer{
+			Name:          name,
+			Labels:        append([]string(nil), node.Config.Labels...),
+			PublicAddress: host,
+		})
+	}
+	sort.Slice(peers, func(i, j int) bool {
+		return peers[i].Name < peers[j].Name
+	})
+	return peers
+}
+
+func nodeCanRunKind(node config.Node, kind string) bool {
+	if node.Labels == nil {
+		return true
+	}
+	kind = strings.TrimSpace(kind)
+	for _, label := range node.Labels {
+		if strings.TrimSpace(label) == kind {
+			return true
+		}
+	}
+	return false
+}
+
+func releaseSnapshotKey(snapshot desiredstate.DeploySnapshot) string {
+	environment := strings.TrimSpace(snapshot.Environment)
+	if environment == "" {
+		environment = config.DefaultEnvironment
+	}
+	return strings.TrimSpace(snapshot.WorkspaceKey) + "\n" + environment
+}

--- a/deployment-core/pkg/deploycore/release/service_test.go
+++ b/deployment-core/pkg/deploycore/release/service_test.go
@@ -1,0 +1,411 @@
+package release
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/devopsellence/devopsellence/deployment-core/pkg/deploycore/config"
+	"github.com/devopsellence/devopsellence/deployment-core/pkg/deploycore/desiredstate"
+)
+
+func TestServiceRollbackPublishesSelectedReleaseThroughStore(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	store := &fakeStore{
+		environment: Environment{ID: "env-1", Name: "production", CurrentReleaseID: "rel-2"},
+		nodes: []Node{{
+			ID:     "node-1",
+			Name:   "web-a",
+			Config: config.Node{Labels: []string{config.DefaultWebRole}},
+		}},
+		releases: []Release{
+			{
+				ID:            "rel-2",
+				EnvironmentID: "env-1",
+				Revision:      "bbb2222",
+				CreatedAt:     "2026-04-28T12:02:00Z",
+				Snapshot: desiredstate.DeploySnapshot{
+					WorkspaceKey: "/workspace/shop",
+					Environment:  "production",
+					Revision:     "bbb2222",
+					Services:     []desiredstate.ServiceJSON{{Name: "web", Kind: "web", Image: "shop:bbb2222"}},
+				},
+			},
+			{
+				ID:            "rel-1",
+				EnvironmentID: "env-1",
+				Revision:      "aaa1111",
+				CreatedAt:     "2026-04-28T12:01:00Z",
+				Snapshot: desiredstate.DeploySnapshot{
+					WorkspaceKey: "/workspace/shop",
+					Environment:  "production",
+					Revision:     "aaa1111",
+					Services:     []desiredstate.ServiceJSON{{Name: "web", Kind: "web", Image: "shop:aaa1111"}},
+				},
+			},
+		},
+	}
+
+	result, err := (Service{Store: store}).Rollback(ctx, RollbackInput{
+		Environment:  EnvironmentRef{ID: "env-1"},
+		DeploymentID: "dep-1",
+		Sequence:     7,
+		Now:          now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Release.ID != "rel-1" {
+		t.Fatalf("rollback release = %s, want rel-1", result.Release.ID)
+	}
+	if store.currentReleaseID != "rel-1" {
+		t.Fatalf("current release = %s, want rel-1", store.currentReleaseID)
+	}
+	if result.Deployment.Kind != DeploymentKindRollback || result.Deployment.Status != DeploymentStatusSettled {
+		t.Fatalf("deployment = %#v", result.Deployment)
+	}
+	if len(store.updatedDeployments) < 2 || store.updatedDeployments[0].Status != DeploymentStatusRunning {
+		t.Fatalf("updated deployments = %#v, want running state persisted before publish", store.updatedDeployments)
+	}
+	if len(store.publications) != 1 || store.publications[0].NodeName != "web-a" || store.publications[0].Revision == "" {
+		t.Fatalf("publications = %#v", store.publications)
+	}
+}
+
+func TestServiceRollbackFailsWhenReleaseTargetsNoCurrentNodes(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	store := &fakeStore{
+		environment: Environment{ID: "env-1", Name: "production", CurrentReleaseID: "rel-2"},
+		nodes: []Node{{
+			ID:     "node-1",
+			Name:   "web-a",
+			Config: config.Node{Labels: []string{config.DefaultWebRole}},
+		}},
+		releases: []Release{
+			{ID: "rel-2", EnvironmentID: "env-1", Revision: "bbb2222", CreatedAt: "2026-04-28T12:02:00Z"},
+			{
+				ID:            "rel-1",
+				EnvironmentID: "env-1",
+				Revision:      "aaa1111",
+				CreatedAt:     "2026-04-28T12:01:00Z",
+				TargetNodeIDs: []string{"missing-node"},
+				Snapshot: desiredstate.DeploySnapshot{
+					WorkspaceKey: "/workspace/shop",
+					Environment:  "production",
+					Revision:     "aaa1111",
+					Services:     []desiredstate.ServiceJSON{{Name: "web", Kind: "web", Image: "shop:aaa1111"}},
+				},
+			},
+		},
+	}
+
+	_, err := (Service{Store: store}).Rollback(ctx, RollbackInput{
+		Environment:  EnvironmentRef{ID: "env-1"},
+		DeploymentID: "dep-1",
+		Sequence:     7,
+		Now:          now,
+	})
+	if err == nil || err.Error() != "no target nodes match release" {
+		t.Fatalf("Rollback() error = %v, want no target nodes", err)
+	}
+	if store.currentReleaseID != "" {
+		t.Fatalf("current release = %s, want unchanged", store.currentReleaseID)
+	}
+	if len(store.updatedDeployments) != 1 || store.updatedDeployments[0].Status != DeploymentStatusFailed {
+		t.Fatalf("updated deployments = %#v, want failed deployment", store.updatedDeployments)
+	}
+}
+
+func TestServiceRollbackUsesCoreSelectionForExplicitSelector(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	store := &fakeStore{
+		environment: Environment{ID: "env-1", Name: "production", CurrentReleaseID: "rel-2"},
+		nodes: []Node{{
+			ID:     "node-1",
+			Name:   "web-a",
+			Config: config.Node{Labels: []string{config.DefaultWebRole}},
+		}},
+		releases: []Release{
+			{
+				ID:            "rel-1",
+				EnvironmentID: "env-1",
+				Revision:      "aaa1111",
+				CreatedAt:     "2026-04-28T12:01:00Z",
+				Snapshot: desiredstate.DeploySnapshot{
+					WorkspaceKey: "/workspace/shop",
+					Environment:  "production",
+					Revision:     "aaa1111",
+					Services:     []desiredstate.ServiceJSON{{Name: "web", Kind: "web", Image: "shop:aaa1111"}},
+				},
+			},
+		},
+	}
+
+	result, err := (Service{Store: store}).Rollback(ctx, RollbackInput{
+		Environment:  EnvironmentRef{ID: "env-1"},
+		Selector:     "aaa1111",
+		DeploymentID: "dep-1",
+		Sequence:     7,
+		Now:          now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Release.ID != "rel-1" {
+		t.Fatalf("rollback release = %s, want rel-1", result.Release.ID)
+	}
+	if store.releaseCalls != 0 || store.releaseListCalls != 1 {
+		t.Fatalf("release calls = %d, list calls = %d; want core release selection", store.releaseCalls, store.releaseListCalls)
+	}
+}
+
+func TestServiceRollbackPlansPublicationWithPlacementAndPeers(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	store := &fakeStore{
+		environment: Environment{ID: "env-1", Name: "production", CurrentReleaseID: "rel-2"},
+		nodes: []Node{
+			{
+				ID:     "node-1",
+				Name:   "web-a",
+				Config: config.Node{Host: "203.0.113.10", Labels: []string{config.DefaultWebRole}},
+			},
+			{
+				ID:     "node-2",
+				Name:   "web-b",
+				Config: config.Node{Host: "203.0.113.11", Labels: []string{config.DefaultWebRole}},
+			},
+		},
+		releases: []Release{
+			{ID: "rel-2", EnvironmentID: "env-1", Revision: "bbb2222", CreatedAt: "2026-04-28T12:02:00Z"},
+			{
+				ID:            "rel-1",
+				EnvironmentID: "env-1",
+				Revision:      "aaa1111",
+				CreatedAt:     "2026-04-28T12:01:00Z",
+				TargetNodeIDs: []string{"node-1", "node-2"},
+				Snapshot: desiredstate.DeploySnapshot{
+					WorkspaceKey:       "/workspace/shop",
+					Environment:        "production",
+					Revision:           "aaa1111",
+					Services:           []desiredstate.ServiceJSON{{Name: "web", Kind: "web", Image: "shop:aaa1111"}},
+					ReleaseTask:        &desiredstate.TaskJSON{Name: "release", Image: "shop:aaa1111"},
+					ReleaseService:     "web",
+					ReleaseServiceKind: config.DefaultWebRole,
+				},
+			},
+		},
+	}
+
+	_, err := (Service{Store: store}).Rollback(ctx, RollbackInput{
+		Environment:  EnvironmentRef{ID: "env-1"},
+		DeploymentID: "dep-1",
+		Sequence:     7,
+		Now:          now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var webAPlan PublicationPlan
+	for _, plan := range store.plans {
+		if plan.NodeName == "web-a" {
+			webAPlan = plan
+			break
+		}
+	}
+	if webAPlan.NodeName == "" {
+		t.Fatalf("plans = %#v, want web-a plan", store.plans)
+	}
+	var payload struct {
+		NodePeers []struct {
+			Name          string `json:"name"`
+			PublicAddress string `json:"publicAddress"`
+		} `json:"nodePeers"`
+		Environments []struct {
+			Tasks []struct {
+				Name string `json:"name"`
+			} `json:"tasks"`
+		} `json:"environments"`
+	}
+	if err := json.Unmarshal(webAPlan.DesiredStateJSON, &payload); err != nil {
+		t.Fatal(err)
+	}
+	if len(payload.NodePeers) != 1 || payload.NodePeers[0].Name != "web-b" || payload.NodePeers[0].PublicAddress != "203.0.113.11" {
+		t.Fatalf("node peers = %#v, want web-b peer", payload.NodePeers)
+	}
+	if len(payload.Environments) != 1 || len(payload.Environments[0].Tasks) != 1 || payload.Environments[0].Tasks[0].Name != "release" {
+		t.Fatalf("environments = %#v, want release task on selected node", payload.Environments)
+	}
+}
+
+func TestTargetNodesForReleaseMatchesNodeIDsOnly(t *testing.T) {
+	nodes := []Node{
+		{ID: "node-1", Name: "web-a"},
+		{ID: "node-2", Name: "node-1"},
+	}
+	targets := targetNodesForRelease(nodes, Release{
+		TargetNodeIDs: []string{"node-1"},
+	})
+	if len(targets) != 1 || targets[0].ID != "node-1" {
+		t.Fatalf("targets = %#v, want node-1 only", targets)
+	}
+}
+
+func TestNodePeersForPublicationSkipsCurrentAndEmptyHost(t *testing.T) {
+	peers := nodePeersForPublication([]Node{
+		{Name: " web-a ", Config: config.Node{Host: "203.0.113.10", Labels: []string{config.DefaultWebRole}}},
+		{Name: "web-b", Config: config.Node{Host: " 203.0.113.11 ", Labels: []string{config.DefaultWebRole}}},
+		{Name: "web-c", Config: config.Node{}},
+	}, "web-a")
+	if len(peers) != 1 || peers[0].Name != "web-b" || peers[0].PublicAddress != "203.0.113.11" {
+		t.Fatalf("peers = %#v, want only web-b with trimmed host", peers)
+	}
+}
+
+func TestServiceRollbackPersistsFailureWhenSetCurrentReleaseFails(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	store := &fakeStore{
+		environment:   Environment{ID: "env-1", Name: "production", CurrentReleaseID: "rel-2"},
+		setCurrentErr: errors.New("set current failed"),
+		nodes: []Node{{
+			ID:     "node-1",
+			Name:   "web-a",
+			Config: config.Node{Labels: []string{config.DefaultWebRole}},
+		}},
+		releases: []Release{
+			{ID: "rel-2", EnvironmentID: "env-1", Revision: "bbb2222", CreatedAt: "2026-04-28T12:02:00Z"},
+			{
+				ID:            "rel-1",
+				EnvironmentID: "env-1",
+				Revision:      "aaa1111",
+				CreatedAt:     "2026-04-28T12:01:00Z",
+				Snapshot: desiredstate.DeploySnapshot{
+					WorkspaceKey: "/workspace/shop",
+					Environment:  "production",
+					Revision:     "aaa1111",
+					Services:     []desiredstate.ServiceJSON{{Name: "web", Kind: "web", Image: "shop:aaa1111"}},
+				},
+			},
+		},
+	}
+
+	result, err := (Service{Store: store}).Rollback(ctx, RollbackInput{
+		Environment:  EnvironmentRef{ID: "env-1"},
+		DeploymentID: "dep-1",
+		Sequence:     7,
+		Now:          now,
+	})
+	if err == nil || err.Error() != "set current failed" {
+		t.Fatalf("Rollback() error = %v, want set current failed", err)
+	}
+	if result.Deployment.Status != DeploymentStatusFailed || result.Deployment.StatusMessage != "failed to set current release" {
+		t.Fatalf("deployment = %#v, want failed set-current state", result.Deployment)
+	}
+	if result.Deployment.FinishedAt == "" || result.Deployment.PublicationResult == nil || result.Deployment.PublicationResult.ErrorMessage != "set current failed" {
+		t.Fatalf("publication result = %#v, finished_at = %q", result.Deployment.PublicationResult, result.Deployment.FinishedAt)
+	}
+	if len(result.Publications) != 1 || len(result.Deployment.PublicationResult.NodeResults) != 1 || len(store.publications) != 1 {
+		t.Fatalf("publications = %#v, result = %#v", result.Publications, result.Deployment.PublicationResult)
+	}
+	if got := store.updatedDeployments[len(store.updatedDeployments)-1]; got.Status != DeploymentStatusFailed || got.StatusMessage != "failed to set current release" {
+		t.Fatalf("last updated deployment = %#v, want failed set-current state", got)
+	}
+}
+
+type fakeStore struct {
+	environment        Environment
+	nodes              []Node
+	releases           []Release
+	deployments        []Deployment
+	updatedDeployments []Deployment
+	currentReleaseID   string
+	publications       []DesiredStatePublication
+	plans              []PublicationPlan
+	releaseListCalls   int
+	releaseCalls       int
+	setCurrentErr      error
+	publishErr         error
+}
+
+func (s *fakeStore) WithEnvironmentLock(ctx context.Context, ref EnvironmentRef, fn func(context.Context, Tx) error) error {
+	return fn(ctx, s)
+}
+
+func (s *fakeStore) Environment(context.Context, EnvironmentRef) (Environment, error) {
+	return s.environment, nil
+}
+
+func (s *fakeStore) Nodes(context.Context, string) ([]Node, error) {
+	return s.nodes, nil
+}
+
+func (s *fakeStore) Releases(context.Context, string, ReleaseListOptions) ([]Release, error) {
+	s.releaseListCalls++
+	return s.releases, nil
+}
+
+func (s *fakeStore) Release(_ context.Context, _ string, selector ReleaseSelector) (Release, error) {
+	s.releaseCalls++
+	for _, release := range s.releases {
+		if release.ID == selector.Selector {
+			return release, nil
+		}
+		if selector.Selector != "" && (release.Revision == selector.Selector || strings.HasPrefix(release.Revision, selector.Selector)) {
+			return release, nil
+		}
+	}
+	return Release{}, fmt.Errorf("release not found")
+}
+
+func (s *fakeStore) CreateRelease(_ context.Context, release Release) (Release, error) {
+	s.releases = append(s.releases, release)
+	return release, nil
+}
+
+func (s *fakeStore) CreateDeployment(_ context.Context, deployment Deployment) (Deployment, error) {
+	s.deployments = append(s.deployments, deployment)
+	return deployment, nil
+}
+
+func (s *fakeStore) UpdateDeployment(_ context.Context, deployment Deployment) error {
+	s.updatedDeployments = append(s.updatedDeployments, deployment)
+	for i := range s.deployments {
+		if s.deployments[i].ID == deployment.ID {
+			s.deployments[i] = deployment
+			return nil
+		}
+	}
+	s.deployments = append(s.deployments, deployment)
+	return nil
+}
+
+func (s *fakeStore) SetCurrentRelease(_ context.Context, _, releaseID string) error {
+	if s.setCurrentErr != nil {
+		return s.setCurrentErr
+	}
+	s.currentReleaseID = releaseID
+	return nil
+}
+
+func (s *fakeStore) PublishDesiredState(_ context.Context, node Node, plan PublicationPlan) (DesiredStatePublication, error) {
+	if s.publishErr != nil {
+		return DesiredStatePublication{}, s.publishErr
+	}
+	s.plans = append(s.plans, plan)
+	publication := DesiredStatePublication{
+		NodeID:   node.ID,
+		NodeName: node.Name,
+		Revision: plan.Revision,
+		Status:   PublicationStatusWritten,
+	}
+	s.publications = append(s.publications, publication)
+	return publication, nil
+}

--- a/deployment-core/pkg/deploycore/release/store.go
+++ b/deployment-core/pkg/deploycore/release/store.go
@@ -1,0 +1,33 @@
+package release
+
+import "context"
+
+type EnvironmentRef struct {
+	ID   string
+	Name string
+}
+
+type ReleaseSelector struct {
+	Selector string
+}
+
+type ReleaseListOptions struct {
+	// Limit caps returned releases when greater than zero. Limit <= 0 means no limit.
+	Limit int
+}
+
+type Store interface {
+	WithEnvironmentLock(ctx context.Context, ref EnvironmentRef, fn func(context.Context, Tx) error) error
+}
+
+type Tx interface {
+	Environment(ctx context.Context, ref EnvironmentRef) (Environment, error)
+	Nodes(ctx context.Context, environmentID string) ([]Node, error)
+	Releases(ctx context.Context, environmentID string, opts ReleaseListOptions) ([]Release, error)
+	Release(ctx context.Context, environmentID string, selector ReleaseSelector) (Release, error)
+	CreateRelease(ctx context.Context, release Release) (Release, error)
+	CreateDeployment(ctx context.Context, deployment Deployment) (Deployment, error)
+	UpdateDeployment(ctx context.Context, deployment Deployment) error
+	SetCurrentRelease(ctx context.Context, environmentID, releaseID string) error
+	PublishDesiredState(ctx context.Context, node Node, plan PublicationPlan) (DesiredStatePublication, error)
+}

--- a/docs/specs/2026-04-28-shared-release-core.md
+++ b/docs/specs/2026-04-28-shared-release-core.md
@@ -1,0 +1,55 @@
+# Shared release core
+
+P4 should converge solo and shared on one logical release/deployment model.
+Shared Rails already has the better shape: immutable releases, deployments as
+operations, environment current-release pointers, and per-node desired-state
+publication. Solo should use that same model with a local store.
+
+## Core model
+
+`deployment-core/pkg/deploycore/release` owns:
+
+- environments;
+- nodes;
+- immutable releases;
+- deployments;
+- desired-state publications;
+- rollback selection;
+- desired-state publication planning;
+- a store interface for mode-specific persistence and publication IO.
+
+The store is the mode boundary:
+
+- solo store: local state plus SSH/file desired-state publication;
+- shared store: Rails/Postgres plus object storage or standalone desired-state
+  document publication.
+
+The core must not know whether a deployment is solo or shared.
+
+## Rollback
+
+Rollback is a deployment operation pointing at an old release. It should not
+create a new release and should not rebuild an image. By default it republishes
+the previous desired-state snapshot and waits for node reconciliation.
+
+Selector rules:
+
+- empty selector means the previous release before the current release;
+- explicit selector matches release id, exact revision, or unique revision
+  prefix;
+- ambiguous selectors fail with an error; selectors that match no release also
+  fail with an error. These are currently plain error strings, not structured
+  error values or types.
+
+## Current state
+
+Solo deploy now records core release and deployment records, publishes desired
+state through the core publication planner, and exposes:
+
+```sh
+devopsellence release list
+devopsellence release rollback [revision-or-release-id]
+```
+
+The next step is replacing Rails' Ruby desired-state publisher with the same
+core service through an RPC or binary boundary backed by a Rails store adapter.


### PR DESCRIPTION
## Summary
- add a deployment-core release package with shared release/deployment/publication models, store boundary, rollback service, and tests
- persist solo releases/deployments from deploy, route desired-state publication planning through the core package, and add release list/rollback commands
- document the shared release-core architecture and solo/shared store split

## Validation
- mise run test:core
- mise run test:cli
- git diff --check