### PR TITLE
Make ingress check the endpoint command

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ devopsellence logs --node prod-1 --lines 100
 devopsellence node logs prod-1 --lines 100
 ```
 
-`devopsellence status` includes `public_urls` when it can infer where the app should be reachable. For default solo HTTP ingress, try the node URL it prints.
+`devopsellence status` includes `public_urls` when it can infer where the app should be reachable. `devopsellence ingress check` is the public endpoint DNS check for configured hostnames; it prints `public_urls`, DNS diagnostics, and next steps. For default solo HTTP ingress, try the node URL from `status`.
 
 Solo deploy scope comes from the nodes attached to the current workspace/environment. Use `devopsellence node attach <name>` and `devopsellence node detach <name>` to change which nodes receive the deploy.
 
@@ -137,7 +137,6 @@ devopsellence provider login hetzner --token "$HCLOUD_TOKEN"
 devopsellence node create prod-1 --provider hetzner
 devopsellence deploy
 devopsellence status
-devopsellence open
 ```
 
 The root verbs stay the same. The selected workspace mode decides how they behave.

--- a/cli/internal/workflow/app.go
+++ b/cli/internal/workflow/app.go
@@ -216,12 +216,6 @@ type EnvironmentUseOptions struct {
 	Name         string
 }
 
-type EnvironmentOpenOptions struct {
-	Organization string
-	Project      string
-	Environment  string
-}
-
 type EnvironmentIngressOptions struct {
 	Organization    string
 	Project         string
@@ -2139,35 +2133,6 @@ func (a *App) EnvironmentUse(ctx context.Context, opts EnvironmentUseOptions) er
 		"environment":         environment,
 		"workspace_key":       a.modeWorkspaceKey(),
 		"default_environment": cfg.DefaultEnvironment,
-	})
-
-}
-
-func (a *App) EnvironmentOpen(ctx context.Context, opts EnvironmentOpenOptions) error {
-	tokens, err := a.ensureAuth(ctx, false)
-	if err != nil {
-		return err
-	}
-	workspace, err := a.resolveWorkspace(ctx, tokens.AccessToken, opts.Organization, opts.Project, opts.Environment, false)
-	if err != nil {
-		return err
-	}
-	status, err := a.API.EnvironmentStatus(ctx, tokens.AccessToken, workspace.Environment.ID)
-	if err != nil {
-		return wrapError(err)
-	}
-	publicURL := nestedString(status, "ingress", "public_url")
-	if strings.TrimSpace(publicURL) == "" {
-		return ExitError{Code: 1, Err: errors.New("environment has no public URL")}
-	}
-
-	return a.Printer.PrintJSON(map[string]any{
-		"schema_version": outputSchemaVersion,
-		"ok":             true,
-		"url":            publicURL,
-		"organization":   workspace.Organization,
-		"project":        workspace.Project,
-		"environment":    workspace.Environment,
 	})
 
 }

--- a/cli/internal/workflow/management_test.go
+++ b/cli/internal/workflow/management_test.go
@@ -418,51 +418,6 @@ func TestEnvironmentUseUpdatesWorkspaceStateNotConfig(t *testing.T) {
 	}
 }
 
-func TestEnvironmentOpenUsesWorkspaceContext(t *testing.T) {
-	t.Parallel()
-
-	root := makeRailsRoot(t, "ShopApp")
-	if _, err := config.Write(root, config.DefaultProjectConfig("default", "ShopApp", "staging")); err != nil {
-		t.Fatalf("write config: %v", err)
-	}
-
-	app := newTestApp(t, root, roundTripFunc(func(r *http.Request) (*http.Response, error) {
-		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/cli/organizations":
-			return jsonResponse(t, map[string]any{"organizations": []map[string]any{{"id": 7, "name": "default", "role": "owner"}}}), nil
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/cli/projects":
-			return jsonResponse(t, map[string]any{"projects": []map[string]any{{"id": 11, "name": "ShopApp"}}}), nil
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/cli/projects/11/environments":
-			return jsonResponse(t, map[string]any{"environments": []map[string]any{{"id": 44, "name": "staging"}}}), nil
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/cli/environments/44/status":
-			return jsonResponse(t, map[string]any{
-				"organization": map[string]any{"id": 7, "name": "default"},
-				"project":      map[string]any{"id": 11, "name": "ShopApp"},
-				"environment":  map[string]any{"id": 44, "name": "staging"},
-				"ingress":      map[string]any{"public_url": "https://shop.example.test"},
-			}), nil
-		default:
-			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
-			return nil, nil
-		}
-	}))
-
-	var stdout bytes.Buffer
-	app.Printer = output.New(&stdout, io.Discard)
-	app.Auth.OpenURL = func(value string) error {
-		t.Fatalf("OpenURL(%q) should not run in agent-primary JSON mode", value)
-		return nil
-	}
-
-	if err := app.EnvironmentOpen(context.Background(), EnvironmentOpenOptions{}); err != nil {
-		t.Fatalf("EnvironmentOpen() error = %v", err)
-	}
-	payload := decodeJSONOutput(t, &stdout)
-	if payload["url"] != "https://shop.example.test" {
-		t.Fatalf("url = %v, want https://shop.example.test", payload["url"])
-	}
-}
-
 func TestConfigResolvePrintsResolvedEnvironmentConfig(t *testing.T) {
 	t.Parallel()
 

--- a/cli/internal/workflow/root.go
+++ b/cli/internal/workflow/root.go
@@ -585,7 +585,7 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 	ingressSetCommand.Flags().BoolVar(&ingressSetOpts.RedirectHTTP, "redirect-http", true, "Redirect HTTP to HTTPS")
 	ingressCheckCommand := &cobra.Command{
 		Use:   "check",
-		Short: "Check that ingress DNS points at public web nodes",
+		Short: "Check public endpoint DNS for configured hostnames",
 		RunE: runByMode(func(ctx context.Context) error {
 			return app.IngressCheck(ctx, ingressCheckOpts)
 		}, func(ctx context.Context) error {
@@ -622,19 +622,6 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 			return app.Doctor(ctx)
 		}),
 	})
-
-	var openSharedOpts EnvironmentOpenOptions
-	openCommand := &cobra.Command{
-		Use:   "open",
-		Short: "Open the current shared environment URL",
-		RunE: runSharedOnly("open", func(ctx context.Context) error {
-			return app.EnvironmentOpen(ctx, openSharedOpts)
-		}),
-	}
-	openCommand.Flags().StringVar(&openSharedOpts.Organization, "org", "", "Organization name override")
-	openCommand.Flags().StringVar(&openSharedOpts.Project, "project", "", "Project name override")
-	openCommand.Flags().StringVar(&openSharedOpts.Environment, "env", "", "Environment name override")
-	root.AddCommand(openCommand)
 
 	var secretSharedSetOpts SecretSetOptions
 	var secretSoloSetOpts SoloSecretsSetOptions

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1403,22 +1403,8 @@ func soloStatusPublicURLs(cfg *config.ProjectConfig, nodes map[string]config.Nod
 	if cfg == nil || len(nodes) == 0 {
 		return nil
 	}
-	scheme := "http"
-	if cfg.Ingress != nil {
-		tlsMode := strings.TrimSpace(cfg.Ingress.TLS.Mode)
-		if strings.EqualFold(tlsMode, "auto") || strings.EqualFold(tlsMode, "manual") {
-			scheme = "https"
-		}
-	}
-	hosts := []string{}
-	if cfg.Ingress != nil {
-		for _, host := range normalizeIngressHosts(cfg.Ingress.Hosts) {
-			if host == "*" {
-				continue
-			}
-			hosts = append(hosts, host)
-		}
-	}
+	scheme := ingressURLScheme(cfg)
+	hosts := concreteIngressHosts(cfg)
 	if len(hosts) == 0 {
 		for _, name := range sortedNodeNames(nodes) {
 			node := nodes[name]
@@ -1431,6 +1417,38 @@ func soloStatusPublicURLs(cfg *config.ProjectConfig, nodes map[string]config.Nod
 			}
 		}
 	}
+	return publicURLsForHosts(scheme, hosts)
+}
+
+func ingressConfiguredPublicURLs(cfg *config.ProjectConfig) []string {
+	return publicURLsForHosts(ingressURLScheme(cfg), concreteIngressHosts(cfg))
+}
+
+func ingressURLScheme(cfg *config.ProjectConfig) string {
+	if cfg != nil && cfg.Ingress != nil {
+		tlsMode := strings.TrimSpace(cfg.Ingress.TLS.Mode)
+		if strings.EqualFold(tlsMode, "auto") || strings.EqualFold(tlsMode, "manual") {
+			return "https"
+		}
+	}
+	return "http"
+}
+
+func concreteIngressHosts(cfg *config.ProjectConfig) []string {
+	if cfg == nil || cfg.Ingress == nil {
+		return nil
+	}
+	hosts := []string{}
+	for _, host := range normalizeIngressHosts(cfg.Ingress.Hosts) {
+		if host == "*" {
+			continue
+		}
+		hosts = append(hosts, host)
+	}
+	return hosts
+}
+
+func publicURLsForHosts(scheme string, hosts []string) []string {
 	urls := make([]string, 0, len(hosts))
 	seen := map[string]bool{}
 	for _, host := range hosts {
@@ -3171,14 +3189,14 @@ func (a *App) IngressCheck(ctx context.Context, opts IngressCheckOptions) error 
 		if err != nil {
 			return err
 		}
-		if report.OK || opts.Wait <= 0 || time.Now().After(deadline) {
+		if report.OK || !ingressDNSReportRetryable(report) || opts.Wait <= 0 || time.Now().After(deadline) {
 
 			if err := a.Printer.PrintJSON(report); err != nil {
 				return err
 			}
 
 			if !report.OK {
-				return ExitError{Code: 1, Err: fmt.Errorf("ingress DNS is not ready")}
+				return ExitError{Code: 1, Err: RenderedError{Err: ingressDNSReportError(report)}}
 			}
 			return nil
 		}
@@ -3301,8 +3319,10 @@ func configBoolPtr(value bool) *bool {
 type ingressDNSReportResult struct {
 	SchemaVersion int                    `json:"schema_version"`
 	OK            bool                   `json:"ok"`
+	PublicURLs    []string               `json:"public_urls,omitempty"`
 	ExpectedIPs   []string               `json:"expected_ips"`
 	Hosts         []ingressDNSHostResult `json:"hosts"`
+	NextSteps     []string               `json:"next_steps,omitempty"`
 }
 
 type ingressDNSHostResult struct {
@@ -3326,18 +3346,27 @@ func (a *App) checkIngressBeforeDeploy(ctx context.Context, cfg *config.ProjectC
 	if report.OK {
 		return nil
 	}
+	reportErr := ingressDNSReportError(report)
+	if len(report.Hosts) == 0 {
+		return fmt.Errorf("%w; configure ingress hostnames or pass --skip-dns-check", reportErr)
+	}
 
-	return fmt.Errorf("ingress DNS is not ready; update DNS or pass --skip-dns-check")
+	return fmt.Errorf("%w; update DNS or pass --skip-dns-check", reportErr)
+}
+
+func ingressDNSReportRetryable(report ingressDNSReportResult) bool {
+	return !report.OK && len(report.Hosts) > 0
+}
+
+func ingressDNSReportError(report ingressDNSReportResult) error {
+	if len(report.Hosts) == 0 {
+		return fmt.Errorf("no ingress hostnames configured")
+	}
+	return fmt.Errorf("ingress DNS is not ready")
 }
 
 func ingressDNSReport(ctx context.Context, cfg *config.ProjectConfig, selected map[string]config.Node) (ingressDNSReportResult, error) {
-	hosts := []string{}
-	if cfg != nil && cfg.Ingress != nil {
-		hosts = normalizeIngressHosts(cfg.Ingress.Hosts)
-	}
-	if len(hosts) == 0 {
-		return ingressDNSReportResult{}, fmt.Errorf("ingress.hosts is not configured")
-	}
+	hosts := concreteIngressHosts(cfg)
 	expected := webNodeIPs(cfg, selected)
 	if len(expected) == 0 {
 		return ingressDNSReportResult{}, fmt.Errorf("no web nodes configured")
@@ -3345,8 +3374,14 @@ func ingressDNSReport(ctx context.Context, cfg *config.ProjectConfig, selected m
 	report := ingressDNSReportResult{
 		SchemaVersion: outputSchemaVersion,
 		OK:            true,
+		PublicURLs:    ingressConfiguredPublicURLs(cfg),
 		ExpectedIPs:   expected,
 		Hosts:         make([]ingressDNSHostResult, 0, len(hosts)),
+	}
+	if len(hosts) == 0 {
+		report.OK = false
+		report.NextSteps = []string{"devopsellence status", "devopsellence ingress set --host <hostname> --service <service>", "devopsellence ingress check --wait 5m"}
+		return report, nil
 	}
 	for _, host := range hosts {
 		result := ingressDNSHostResult{Host: host}
@@ -3361,6 +3396,13 @@ func ingressDNSReport(ctx context.Context, cfg *config.ProjectConfig, selected m
 			report.OK = false
 		}
 		report.Hosts = append(report.Hosts, result)
+	}
+	if len(report.PublicURLs) > 0 {
+		if report.OK {
+			report.NextSteps = []string{"devopsellence status", "curl " + report.PublicURLs[0]}
+		} else {
+			report.NextSteps = []string{"devopsellence status", "update DNS records to point at expected_ips", "devopsellence ingress check --wait 5m"}
+		}
 	}
 	return report, nil
 }

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -788,6 +788,225 @@ func TestSoloStatusPublicURLsUseHTTPSForManualTLS(t *testing.T) {
 	}
 }
 
+func TestIngressDNSReportIncludesPublicURLsAndReadyNextSteps(t *testing.T) {
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	cfg.Ingress = &config.IngressConfig{
+		Hosts: []string{"127.0.0.1"},
+		Rules: []config.IngressRuleConfig{{Target: config.IngressTargetConfig{Service: config.DefaultWebServiceName}}},
+		TLS:   config.IngressTLSConfig{Mode: "auto"},
+	}
+
+	report, err := ingressDNSReport(context.Background(), &cfg, map[string]config.Node{
+		"node-a": {Host: "127.0.0.1", User: "root", Labels: []string{config.DefaultWebRole}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !report.OK {
+		t.Fatalf("OK = false, report = %#v", report)
+	}
+	if !reflect.DeepEqual(report.PublicURLs, []string{"https://127.0.0.1/"}) {
+		t.Fatalf("public_urls = %#v, want HTTPS loopback URL", report.PublicURLs)
+	}
+	if len(report.NextSteps) != 2 || report.NextSteps[0] != "devopsellence status" || report.NextSteps[1] != "curl https://127.0.0.1/" {
+		t.Fatalf("next_steps = %#v, want status and curl", report.NextSteps)
+	}
+}
+
+func TestIngressCheckReturnsRenderedErrorAfterPrintingDNSReport(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	cfg.Ingress = &config.IngressConfig{
+		Hosts: []string{"192.0.2.55"},
+		Rules: []config.IngressRuleConfig{{
+			Match:  config.IngressMatchConfig{Host: "192.0.2.55", PathPrefix: "/"},
+			Target: config.IngressTargetConfig{Service: config.DefaultWebServiceName, Port: "http"},
+		}},
+		TLS: config.IngressTLSConfig{Mode: "off"},
+	}
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.Node{
+			"node-a": {Host: "203.0.113.10", User: "root", Labels: []string{config.DefaultWebRole}},
+		},
+		Attachments: map[string]solo.AttachmentRecord{},
+		Snapshots:   map[string]desiredstate.DeploySnapshot{},
+	}
+	if _, _, err := current.AttachNode(workspaceRoot, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{
+		Printer:     output.New(&stdout, io.Discard),
+		SoloState:   soloState,
+		ConfigStore: config.NewStore(),
+		Cwd:         workspaceRoot,
+	}
+
+	err := app.IngressCheck(context.Background(), IngressCheckOptions{})
+	if err == nil {
+		t.Fatal("IngressCheck() error = nil, want DNS readiness failure")
+	}
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 1 {
+		t.Fatalf("error = %#v, want ExitError code 1", err)
+	}
+	var renderedErr RenderedError
+	if !errors.As(exitErr.Err, &renderedErr) {
+		t.Fatalf("exit error = %#v, want RenderedError", exitErr.Err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	if payload["ok"] != false {
+		t.Fatalf("payload ok = %v, want false", payload["ok"])
+	}
+}
+
+func TestCheckIngressBeforeDeployDistinguishesMissingConcreteHostnames(t *testing.T) {
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	cfg.Ingress = &config.IngressConfig{
+		Hosts: []string{"*"},
+		Rules: []config.IngressRuleConfig{{Target: config.IngressTargetConfig{Service: config.DefaultWebServiceName}}},
+		TLS:   config.IngressTLSConfig{Mode: "auto"},
+	}
+
+	app := &App{}
+	err := app.checkIngressBeforeDeploy(context.Background(), &cfg, map[string]config.Node{
+		"node-a": {Host: "127.0.0.1", User: "root", Labels: []string{config.DefaultWebRole}},
+	}, false)
+	if err == nil {
+		t.Fatal("checkIngressBeforeDeploy() error = nil, want missing hostname failure")
+	}
+	if !strings.Contains(err.Error(), "no ingress hostnames configured") || !strings.Contains(err.Error(), "configure ingress hostnames") {
+		t.Fatalf("error = %q, want missing-hostname guidance", err.Error())
+	}
+	if strings.Contains(err.Error(), "update DNS") {
+		t.Fatalf("error = %q, did not expect DNS mismatch guidance", err.Error())
+	}
+}
+
+func TestIngressCheckDoesNotWaitForMissingConcreteHostnames(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	cfg.Ingress = &config.IngressConfig{
+		Hosts: []string{"*"},
+		Rules: []config.IngressRuleConfig{{
+			Match:  config.IngressMatchConfig{Host: "*", PathPrefix: "/"},
+			Target: config.IngressTargetConfig{Service: config.DefaultWebServiceName, Port: "http"},
+		}},
+		TLS: config.IngressTLSConfig{Mode: "auto"},
+	}
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.Node{
+			"node-a": {Host: "127.0.0.1", User: "root", Labels: []string{config.DefaultWebRole}},
+		},
+		Attachments: map[string]solo.AttachmentRecord{},
+		Snapshots:   map[string]desiredstate.DeploySnapshot{},
+	}
+	if _, _, err := current.AttachNode(workspaceRoot, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	var stdout bytes.Buffer
+	app := &App{
+		Printer:     output.New(&stdout, io.Discard),
+		SoloState:   soloState,
+		ConfigStore: config.NewStore(),
+		Cwd:         workspaceRoot,
+	}
+
+	err := app.IngressCheck(ctx, IngressCheckOptions{Wait: time.Hour})
+	if err == nil {
+		t.Fatal("IngressCheck() error = nil, want missing hostname failure")
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("IngressCheck() error = %v, want immediate non-retryable failure", err)
+	}
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 1 || !strings.Contains(exitErr.Err.Error(), "no ingress hostnames configured") {
+		t.Fatalf("error = %#v, want no-hostname ExitError", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	if payload["ok"] != false {
+		t.Fatalf("payload ok = %v, want false", payload["ok"])
+	}
+}
+
+func TestIngressDNSReportBootstrapWildcardHostPromptsForRealHostnames(t *testing.T) {
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	cfg.Ingress = &config.IngressConfig{
+		Hosts: []string{"*"},
+		Rules: []config.IngressRuleConfig{{Target: config.IngressTargetConfig{Service: config.DefaultWebServiceName}}},
+		TLS:   config.IngressTLSConfig{Mode: "auto"},
+	}
+
+	report, err := ingressDNSReport(context.Background(), &cfg, map[string]config.Node{
+		"node-a": {Host: "127.0.0.1", User: "root", Labels: []string{config.DefaultWebRole}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.OK {
+		t.Fatalf("OK = true, want hostname configuration guidance")
+	}
+	if len(report.PublicURLs) != 0 {
+		t.Fatalf("public_urls = %#v, want wildcard bootstrap host filtered out", report.PublicURLs)
+	}
+	if len(report.Hosts) != 0 {
+		t.Fatalf("hosts = %#v, want no DNS lookup for wildcard bootstrap host", report.Hosts)
+	}
+	if len(report.NextSteps) != 3 || report.NextSteps[0] != "devopsellence status" || !strings.Contains(report.NextSteps[1], "ingress set") {
+		t.Fatalf("next_steps = %#v, want status first and hostname guidance", report.NextSteps)
+	}
+	for _, step := range report.NextSteps {
+		if strings.Contains(step, "*") {
+			t.Fatalf("next_steps = %#v, want wildcard host omitted", report.NextSteps)
+		}
+	}
+}
+
+func TestIngressDNSReportIncludesRepairNextStepsWhenDNSIsNotReady(t *testing.T) {
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	cfg.Ingress = &config.IngressConfig{
+		Hosts: []string{"192.0.2.55"},
+		Rules: []config.IngressRuleConfig{{Target: config.IngressTargetConfig{Service: config.DefaultWebServiceName}}},
+		TLS:   config.IngressTLSConfig{Mode: "off"},
+	}
+
+	report, err := ingressDNSReport(context.Background(), &cfg, map[string]config.Node{
+		"node-a": {Host: "203.0.113.10", User: "root", Labels: []string{config.DefaultWebRole}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.OK {
+		t.Fatalf("OK = true, want DNS mismatch failure")
+	}
+	if !reflect.DeepEqual(report.PublicURLs, []string{"http://192.0.2.55/"}) {
+		t.Fatalf("public_urls = %#v, want configured endpoint URL", report.PublicURLs)
+	}
+	if len(report.NextSteps) != 3 || report.NextSteps[0] != "devopsellence status" || report.NextSteps[1] != "update DNS records to point at expected_ips" {
+		t.Fatalf("next_steps = %#v, want status first and repair guidance", report.NextSteps)
+	}
+}
+
 func TestSoloStatusNodesWithoutAttachmentsReturnsEmptySet(t *testing.T) {
 	t.Parallel()
 

--- a/control-plane/app/views/marketing/docs.html.erb
+++ b/control-plane/app/views/marketing/docs.html.erb
@@ -879,10 +879,6 @@ tasks:
         <dt><code>devopsellence context show</code></dt>
         <dd>Show workspace mode plus the current org, project, and environment context.</dd>
       </div>
-      <div class="docs-field">
-        <dt><code>devopsellence open</code></dt>
-        <dd>Open the current shared environment URL.</dd>
-      </div>
     </dl>
 
     <h3>Auth</h3>
@@ -977,7 +973,7 @@ tasks:
       </div>
       <div class="docs-field">
         <dt><code>devopsellence ingress check --wait 5m</code></dt>
-        <dd>Check DNS against public web node IPs before deploy.</dd>
+        <dd>Check public endpoint DNS for configured hostnames. The JSON output includes public URLs, DNS diagnostics, and next steps.</dd>
       </div>
       <div class="docs-field">
         <dt><code>devopsellence logs [service]</code></dt>


### PR DESCRIPTION
## Summary
- remove the top-level `open` CLI command so endpoint discovery stays in `status`/`ingress check`
- include `public_urls` and `next_steps` in solo `ingress check` DNS diagnostics
- update README and docs to point agents at `status` and `ingress check` instead of `open`

## Tests
- `mise run test:cli`

Follow-up to https://github.com/devopsellence/managed-devopsellence/issues/5