### PR TITLE
Add automatic agent disk care

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Existing SSH node prerequisites:
 - devopsellence stores SSH host keys in its own state directory and uses OpenSSH `StrictHostKeyChecking=accept-new`, so first contact does not write to your global `~/.ssh/known_hosts`;
 - Docker must be reachable by the SSH user, or the SSH user must have passwordless sudo for Docker. On supported Ubuntu VMs, `devopsellence agent install` can install Docker when it is missing;
 - `agent install` writes `/usr/local/bin/devopsellence-agent`, creates a `devopsellence-agent` systemd service, and uses `/var/lib/devopsellence` for node state by default.
+- The agent bounds disk growth for devopsellence-managed runtime artifacts: new managed containers get Docker log rotation by default, and old app image versions are expired automatically while retaining the current release and recent rollback candidates. This does not replace centralized logging or clean up user-owned Docker resources.
 
 If remote checks fail, start with:
 

--- a/agent/cmd/devopsellence/diskcare.go
+++ b/agent/cmd/devopsellence/diskcare.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"log/slog"
+	"strconv"
+
+	"github.com/devopsellence/devopsellence/agent/internal/config"
+	"github.com/devopsellence/devopsellence/agent/internal/diskcare"
+	"github.com/devopsellence/devopsellence/agent/internal/engine"
+	"github.com/devopsellence/devopsellence/agent/internal/engine/docker"
+)
+
+func managedLogConfig(cfg *config.Config) *engine.LogConfig {
+	if cfg == nil || cfg.ContainerLogMaxSize == "" || cfg.ContainerLogMaxFile < 1 {
+		return nil
+	}
+	return &engine.LogConfig{
+		Driver: "json-file",
+		Options: map[string]string{
+			"max-size": cfg.ContainerLogMaxSize,
+			"max-file": strconv.Itoa(cfg.ContainerLogMaxFile),
+		},
+	}
+}
+
+func newDiskCare(eng *docker.Engine, cfg *config.Config, logger *slog.Logger) *diskcare.Manager {
+	return diskcare.New(eng, diskcare.Config{
+		StatePath:                cfg.DiskCareStatePath,
+		RetainedPreviousReleases: cfg.ImageRetainedPreviousReleases,
+		ProtectedImages:          []string{cfg.EnvoyImage},
+		ContainerLogMaxSize:      cfg.ContainerLogMaxSize,
+		ContainerLogMaxFile:      cfg.ContainerLogMaxFile,
+	}, logger.With("component", "disk-care"))
+}

--- a/agent/cmd/devopsellence/main.go
+++ b/agent/cmd/devopsellence/main.go
@@ -115,14 +115,15 @@ func runSolo(ctx context.Context, cfg *config.Config, eng *docker.Engine, logger
 	})
 
 	reconciler := reconcile.New(eng, reconcile.Options{
-		Network:     cfg.NetworkName,
-		StopTimeout: cfg.StopTimeout,
-		DrainDelay:  cfg.DrainDelay,
-		WebPort:     cfg.WebPort,
-		LogConfig:   logConfig,
-		Envoy:       envoyManager,
-		IngressCert: ingressCertManager,
-		Logger:      logger,
+		Network:                    cfg.NetworkName,
+		StopTimeout:                cfg.StopTimeout,
+		DrainDelay:                 cfg.DrainDelay,
+		WebPort:                    cfg.WebPort,
+		LogConfig:                  logConfig,
+		PersistentSystemContainers: []string{cfg.EnvoyContainer},
+		Envoy:                      envoyManager,
+		IngressCert:                ingressCertManager,
+		Logger:                     logger,
 	})
 
 	reporter := file.New(cfg.StatusPath, logger)
@@ -239,15 +240,16 @@ func runShared(ctx context.Context, cfg *config.Config, eng *docker.Engine, logg
 	}
 
 	reconciler := reconcile.New(eng, reconcile.Options{
-		Network:       cfg.NetworkName,
-		StopTimeout:   cfg.StopTimeout,
-		DrainDelay:    cfg.DrainDelay,
-		WebPort:       cfg.WebPort,
-		LogConfig:     logConfig,
-		Envoy:         envoyManager,
-		ImagePullAuth: imagePullAuth,
-		IngressCert:   ingressCertManager,
-		Logger:        logger,
+		Network:                    cfg.NetworkName,
+		StopTimeout:                cfg.StopTimeout,
+		DrainDelay:                 cfg.DrainDelay,
+		WebPort:                    cfg.WebPort,
+		LogConfig:                  logConfig,
+		PersistentSystemContainers: []string{cfg.EnvoyContainer},
+		Envoy:                      envoyManager,
+		ImagePullAuth:              imagePullAuth,
+		IngressCert:                ingressCertManager,
+		Logger:                     logger,
 	})
 
 	controlPlaneReporter, err := controlplane.New(controlplane.Config{

--- a/agent/cmd/devopsellence/main.go
+++ b/agent/cmd/devopsellence/main.go
@@ -115,15 +115,15 @@ func runSolo(ctx context.Context, cfg *config.Config, eng *docker.Engine, logger
 	})
 
 	reconciler := reconcile.New(eng, reconcile.Options{
-		Network:                    cfg.NetworkName,
-		StopTimeout:                cfg.StopTimeout,
-		DrainDelay:                 cfg.DrainDelay,
-		WebPort:                    cfg.WebPort,
-		LogConfig:                  logConfig,
-		PersistentSystemContainers: []string{cfg.EnvoyContainer},
-		Envoy:                      envoyManager,
-		IngressCert:                ingressCertManager,
-		Logger:                     logger,
+		Network:                      cfg.NetworkName,
+		StopTimeout:                  cfg.StopTimeout,
+		DrainDelay:                   cfg.DrainDelay,
+		WebPort:                      cfg.WebPort,
+		LogConfig:                    logConfig,
+		ProtectedEnvoyContainerNames: []string{cfg.EnvoyContainer},
+		Envoy:                        envoyManager,
+		IngressCert:                  ingressCertManager,
+		Logger:                       logger,
 	})
 
 	reporter := file.New(cfg.StatusPath, logger)
@@ -240,16 +240,16 @@ func runShared(ctx context.Context, cfg *config.Config, eng *docker.Engine, logg
 	}
 
 	reconciler := reconcile.New(eng, reconcile.Options{
-		Network:                    cfg.NetworkName,
-		StopTimeout:                cfg.StopTimeout,
-		DrainDelay:                 cfg.DrainDelay,
-		WebPort:                    cfg.WebPort,
-		LogConfig:                  logConfig,
-		PersistentSystemContainers: []string{cfg.EnvoyContainer},
-		Envoy:                      envoyManager,
-		ImagePullAuth:              imagePullAuth,
-		IngressCert:                ingressCertManager,
-		Logger:                     logger,
+		Network:                      cfg.NetworkName,
+		StopTimeout:                  cfg.StopTimeout,
+		DrainDelay:                   cfg.DrainDelay,
+		WebPort:                      cfg.WebPort,
+		LogConfig:                    logConfig,
+		ProtectedEnvoyContainerNames: []string{cfg.EnvoyContainer},
+		Envoy:                        envoyManager,
+		ImagePullAuth:                imagePullAuth,
+		IngressCert:                  ingressCertManager,
+		Logger:                       logger,
 	})
 
 	controlPlaneReporter, err := controlplane.New(controlplane.Config{

--- a/agent/cmd/devopsellence/main.go
+++ b/agent/cmd/devopsellence/main.go
@@ -85,6 +85,7 @@ func main() {
 
 func runSolo(ctx context.Context, cfg *config.Config, eng *docker.Engine, logger *slog.Logger, metrics *observability.Metrics) {
 	desiredAuthority := solo.New(cfg.DesiredStateOverridePath, logger.With("authority", "solo"))
+	logConfig := managedLogConfig(cfg)
 
 	envoyManager := envoy.New(eng, envoy.Config{
 		Image:               cfg.EnvoyImage,
@@ -101,6 +102,7 @@ func runSolo(ctx context.Context, cfg *config.Config, eng *docker.Engine, logger
 		ClusterName:         "devopsellence_web",
 		StartupTimeout:      cfg.StopTimeout,
 		RestartPolicy:       cfg.EnvoyRestartPolicy,
+		LogConfig:           logConfig,
 	}, logger)
 
 	ingressCertManager := acme.New(acme.Config{
@@ -117,6 +119,7 @@ func runSolo(ctx context.Context, cfg *config.Config, eng *docker.Engine, logger
 		StopTimeout: cfg.StopTimeout,
 		DrainDelay:  cfg.DrainDelay,
 		WebPort:     cfg.WebPort,
+		LogConfig:   logConfig,
 		Envoy:       envoyManager,
 		IngressCert: ingressCertManager,
 		Logger:      logger,
@@ -133,6 +136,7 @@ func runSolo(ctx context.Context, cfg *config.Config, eng *docker.Engine, logger
 		metrics,
 		lifecycle.NewStore(cfg.LifecycleStatePath),
 	)
+	ag.SetDiskCare(newDiskCare(eng, cfg, logger))
 	logger.Info("starting agent in solo mode", "desired_state_path", cfg.DesiredStateOverridePath)
 	if err := ag.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
 		logger.Error("agent stopped", "error", err)
@@ -141,6 +145,7 @@ func runSolo(ctx context.Context, cfg *config.Config, eng *docker.Engine, logger
 }
 
 func runShared(ctx context.Context, cfg *config.Config, eng *docker.Engine, logger *slog.Logger, _ *prometheus.Registry, metrics *observability.Metrics) {
+	logConfig := managedLogConfig(cfg)
 	var systemImagePrefetcher *systemimages.Prefetcher
 	var prefetchOnce sync.Once
 	triggerSystemImagePrefetch := func() {
@@ -218,6 +223,7 @@ func runShared(ctx context.Context, cfg *config.Config, eng *docker.Engine, logg
 		ClusterName:         "devopsellence_web",
 		StartupTimeout:      cfg.StopTimeout,
 		RestartPolicy:       cfg.EnvoyRestartPolicy,
+		LogConfig:           logConfig,
 	}, logger)
 
 	ingressCertManager := acme.New(acme.Config{
@@ -237,6 +243,7 @@ func runShared(ctx context.Context, cfg *config.Config, eng *docker.Engine, logg
 		StopTimeout:   cfg.StopTimeout,
 		DrainDelay:    cfg.DrainDelay,
 		WebPort:       cfg.WebPort,
+		LogConfig:     logConfig,
 		Envoy:         envoyManager,
 		ImagePullAuth: imagePullAuth,
 		IngressCert:   ingressCertManager,
@@ -270,6 +277,7 @@ func runShared(ctx context.Context, cfg *config.Config, eng *docker.Engine, logg
 		metrics,
 		lifecycle.NewStore(cfg.LifecycleStatePath),
 	)
+	ag.SetDiskCare(newDiskCare(eng, cfg, logger))
 	ag.SetDiagnoser(diagnose.NewRunner(diagnoseClient, diagnose.NewCollector(eng), logger))
 	if err := ag.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
 		logger.Error("agent stopped", "error", err)

--- a/agent/internal/agent/agent.go
+++ b/agent/internal/agent/agent.go
@@ -326,7 +326,10 @@ func (f *reportFingerprint) suppresses(other *reportFingerprint) bool {
 		return false
 	}
 	if f.phase == report.PhaseSettled {
-		return true
+		if f.diskCareHash == "" && other.diskCareHash == "" {
+			return true
+		}
+		return f.diskCareHash == other.diskCareHash
 	}
 	return f.revision == other.revision &&
 		f.message == other.message &&
@@ -368,8 +371,6 @@ func fingerprintDiskCare(status *report.DiskCareStatus) string {
 	builder.WriteString(fmt.Sprintf("%d", status.LogMaxFile))
 	builder.WriteByte(0)
 	builder.WriteString(fmt.Sprintf("%d", status.ReclaimedBytes))
-	builder.WriteByte(0)
-	builder.WriteString(fmt.Sprintf("%d", status.DockerLogBytes))
 	builder.WriteByte(0)
 	builder.WriteString(status.LastError)
 	builder.WriteByte(0)

--- a/agent/internal/agent/agent.go
+++ b/agent/internal/agent/agent.go
@@ -326,10 +326,7 @@ func (f *reportFingerprint) suppresses(other *reportFingerprint) bool {
 		return false
 	}
 	if f.phase == report.PhaseSettled {
-		if f.diskCareHash == "" && other.diskCareHash == "" {
-			return true
-		}
-		return f.diskCareHash == other.diskCareHash
+		return true
 	}
 	return f.revision == other.revision &&
 		f.message == other.message &&

--- a/agent/internal/agent/agent.go
+++ b/agent/internal/agent/agent.go
@@ -370,8 +370,6 @@ func fingerprintDiskCare(status *report.DiskCareStatus) string {
 	builder.WriteByte(0)
 	builder.WriteString(fmt.Sprintf("%d", status.LogMaxFile))
 	builder.WriteByte(0)
-	builder.WriteString(status.LastCleanupAt.UTC().Truncate(time.Hour).Format(time.RFC3339))
-	builder.WriteByte(0)
 	builder.WriteString(fmt.Sprintf("%d", status.ReclaimedBytes))
 	builder.WriteByte(0)
 	builder.WriteString(fmt.Sprintf("%d", status.DockerLogBytes))

--- a/agent/internal/agent/agent.go
+++ b/agent/internal/agent/agent.go
@@ -357,6 +357,8 @@ func fingerprintTask(task *report.TaskStatus) string {
 	return builder.String()
 }
 
+const dockerLogBytesFingerprintBucket = 10 * 1024 * 1024
+
 func fingerprintDiskCare(status *report.DiskCareStatus) string {
 	if status == nil {
 		return ""
@@ -371,6 +373,12 @@ func fingerprintDiskCare(status *report.DiskCareStatus) string {
 	builder.WriteString(fmt.Sprintf("%d", status.LogMaxFile))
 	builder.WriteByte(0)
 	builder.WriteString(fmt.Sprintf("%d", status.ReclaimedBytes))
+	builder.WriteByte(0)
+	if !status.LastCleanupAt.IsZero() {
+		builder.WriteString(status.LastCleanupAt.UTC().Truncate(time.Hour).Format(time.RFC3339))
+	}
+	builder.WriteByte(0)
+	builder.WriteString(fmt.Sprintf("%d", status.DockerLogBytes/dockerLogBytesFingerprintBucket))
 	builder.WriteByte(0)
 	builder.WriteString(status.LastError)
 	builder.WriteByte(0)

--- a/agent/internal/agent/agent.go
+++ b/agent/internal/agent/agent.go
@@ -23,6 +23,7 @@ type Agent struct {
 	reporter               report.Reporter
 	reconciler             *reconcile.Reconciler
 	diagnoser              Diagnoser
+	diskCare               DiskCare
 	interval               time.Duration
 	logger                 *slog.Logger
 	metrics                *observability.Metrics
@@ -33,6 +34,11 @@ type Agent struct {
 
 type Diagnoser interface {
 	RunOnce(ctx context.Context, desiredStateSequence int64) error
+}
+
+// DiskCare performs best-effort node-local cleanup after successful reconcile.
+type DiskCare interface {
+	Run(ctx context.Context, desired *desiredstatepb.DesiredState) (*report.DiskCareStatus, error)
 }
 
 func New(authority authority.Authority, reconciler *reconcile.Reconciler, reporter report.Reporter, interval time.Duration, logger *slog.Logger, metrics *observability.Metrics, taskStore *lifecycle.Store) *Agent {
@@ -49,6 +55,11 @@ func New(authority authority.Authority, reconciler *reconcile.Reconciler, report
 
 func (a *Agent) SetDiagnoser(diagnoser Diagnoser) {
 	a.diagnoser = diagnoser
+}
+
+// SetDiskCare enables best-effort automatic cleanup after successful reconcile.
+func (a *Agent) SetDiskCare(diskCare DiskCare) {
+	a.diskCare = diskCare
 }
 
 func (a *Agent) Run(ctx context.Context) error {
@@ -133,6 +144,8 @@ func (a *Agent) reconcileOnce(ctx context.Context) error {
 	a.metrics.ContainersUpdated.Add(float64(result.Updated))
 	a.metrics.ContainersRemoved.Add(float64(result.Removed))
 
+	diskCareStatus := a.runDiskCare(ctx, desired)
+
 	summary, environments, err := a.reconciler.CurrentStatus(ctx, desired)
 	if err != nil {
 		a.metrics.ReconcileErrors.Inc()
@@ -151,6 +164,7 @@ func (a *Agent) reconcileOnce(ctx context.Context) error {
 		Revision:     desired.Revision,
 		Message:      fmt.Sprintf("created=%d updated=%d removed=%d unchanged=%d", result.Created, result.Updated, result.Removed, result.Unchanged),
 		Summary:      summary,
+		DiskCare:     diskCareStatus,
 		Environments: environments,
 	}, fetched.Sequence)
 
@@ -163,6 +177,22 @@ func (a *Agent) reconcileOnce(ctx context.Context) error {
 	)
 
 	return nil
+}
+
+func (a *Agent) runDiskCare(ctx context.Context, desired *desiredstatepb.DesiredState) *report.DiskCareStatus {
+	if a.diskCare == nil {
+		return nil
+	}
+	status, err := a.diskCare.Run(ctx, desired)
+	if err != nil {
+		a.logger.Warn("disk care failed", "error", err)
+		if status == nil {
+			status = &report.DiskCareStatus{LastError: err.Error()}
+		} else if status.LastError == "" {
+			status.LastError = err.Error()
+		}
+	}
+	return status
 }
 
 func (a *Agent) runTaskOnce(ctx context.Context, sequence int64, revision string, task *desiredstatepb.Task) error {
@@ -271,6 +301,7 @@ type reportFingerprint struct {
 	message          string
 	err              string
 	taskHash         string
+	diskCareHash     string
 	environmentsHash string
 }
 
@@ -282,6 +313,7 @@ func newReportFingerprint(sequence int64, status report.Status) *reportFingerpri
 		message:          status.Message,
 		err:              status.Error,
 		taskHash:         fingerprintTask(status.Task),
+		diskCareHash:     fingerprintDiskCare(status.DiskCare),
 		environmentsHash: fingerprintEnvironments(status.Environments),
 	}
 }
@@ -294,12 +326,16 @@ func (f *reportFingerprint) suppresses(other *reportFingerprint) bool {
 		return false
 	}
 	if f.phase == report.PhaseSettled {
-		return true
+		if f.diskCareHash == "" && other.diskCareHash == "" {
+			return true
+		}
+		return f.diskCareHash == other.diskCareHash
 	}
 	return f.revision == other.revision &&
 		f.message == other.message &&
 		f.err == other.err &&
 		f.taskHash == other.taskHash &&
+		f.diskCareHash == other.diskCareHash &&
 		f.environmentsHash == other.environmentsHash
 }
 
@@ -318,6 +354,38 @@ func fingerprintTask(task *report.TaskStatus) string {
 	builder.WriteString(task.Error)
 	builder.WriteByte(0)
 	builder.WriteString(fmt.Sprintf("%d", task.ExitCode))
+	return builder.String()
+}
+
+func fingerprintDiskCare(status *report.DiskCareStatus) string {
+	if status == nil {
+		return ""
+	}
+	var builder strings.Builder
+	builder.WriteString(fmt.Sprintf("%d", status.RetainedPreviousReleases))
+	builder.WriteByte(0)
+	builder.WriteString(fmt.Sprintf("%d", status.RetainedReleaseCount))
+	builder.WriteByte(0)
+	builder.WriteString(status.LogMaxSize)
+	builder.WriteByte(0)
+	builder.WriteString(fmt.Sprintf("%d", status.LogMaxFile))
+	builder.WriteByte(0)
+	builder.WriteString(fmt.Sprintf("%d", status.ReclaimedBytes))
+	builder.WriteByte(0)
+	builder.WriteString(fmt.Sprintf("%d", status.DockerLogBytes))
+	builder.WriteByte(0)
+	builder.WriteString(status.LastError)
+	builder.WriteByte(0)
+	for _, artifact := range status.RemovedArtifacts {
+		builder.WriteString(artifact.Type)
+		builder.WriteByte(0)
+		builder.WriteString(artifact.Reference)
+		builder.WriteByte(0)
+		builder.WriteString(artifact.Reason)
+		builder.WriteByte(0)
+		builder.WriteString(fmt.Sprintf("%d", artifact.Bytes))
+		builder.WriteByte(0)
+	}
 	return builder.String()
 }
 

--- a/agent/internal/agent/agent.go
+++ b/agent/internal/agent/agent.go
@@ -370,6 +370,8 @@ func fingerprintDiskCare(status *report.DiskCareStatus) string {
 	builder.WriteByte(0)
 	builder.WriteString(fmt.Sprintf("%d", status.LogMaxFile))
 	builder.WriteByte(0)
+	builder.WriteString(status.LastCleanupAt.UTC().Truncate(time.Hour).Format(time.RFC3339))
+	builder.WriteByte(0)
 	builder.WriteString(fmt.Sprintf("%d", status.ReclaimedBytes))
 	builder.WriteByte(0)
 	builder.WriteString(fmt.Sprintf("%d", status.DockerLogBytes))

--- a/agent/internal/agent/agent.go
+++ b/agent/internal/agent/agent.go
@@ -374,7 +374,7 @@ func fingerprintDiskCare(status *report.DiskCareStatus) string {
 	builder.WriteByte(0)
 	builder.WriteString(fmt.Sprintf("%d", status.ReclaimedBytes))
 	builder.WriteByte(0)
-	if !status.LastCleanupAt.IsZero() {
+	if status.LastCleanupAt != nil && !status.LastCleanupAt.IsZero() {
 		builder.WriteString(status.LastCleanupAt.UTC().Truncate(time.Hour).Format(time.RFC3339))
 	}
 	builder.WriteByte(0)

--- a/agent/internal/agent/agent.go
+++ b/agent/internal/agent/agent.go
@@ -24,6 +24,10 @@ type Agent struct {
 	reconciler             *reconcile.Reconciler
 	diagnoser              Diagnoser
 	diskCare               DiskCare
+	diskCareMinInterval    time.Duration
+	lastDiskCareAt         time.Time
+	lastDiskCareSequence   int64
+	lastDiskCareStatus     *report.DiskCareStatus
 	interval               time.Duration
 	logger                 *slog.Logger
 	metrics                *observability.Metrics
@@ -41,15 +45,18 @@ type DiskCare interface {
 	Run(ctx context.Context, desired *desiredstatepb.DesiredState) (*report.DiskCareStatus, error)
 }
 
+const defaultDiskCareMinInterval = 5 * time.Minute
+
 func New(authority authority.Authority, reconciler *reconcile.Reconciler, reporter report.Reporter, interval time.Duration, logger *slog.Logger, metrics *observability.Metrics, taskStore *lifecycle.Store) *Agent {
 	return &Agent{
-		authority:  authority,
-		reconciler: reconciler,
-		reporter:   reporter,
-		interval:   interval,
-		logger:     logger,
-		metrics:    metrics,
-		taskStore:  taskStore,
+		authority:           authority,
+		reconciler:          reconciler,
+		reporter:            reporter,
+		interval:            interval,
+		diskCareMinInterval: defaultDiskCareMinInterval,
+		logger:              logger,
+		metrics:             metrics,
+		taskStore:           taskStore,
 	}
 }
 
@@ -144,7 +151,7 @@ func (a *Agent) reconcileOnce(ctx context.Context) error {
 	a.metrics.ContainersUpdated.Add(float64(result.Updated))
 	a.metrics.ContainersRemoved.Add(float64(result.Removed))
 
-	diskCareStatus := a.runDiskCare(ctx, desired)
+	diskCareStatus := a.runDiskCare(ctx, desired, fetched.Sequence)
 
 	summary, environments, err := a.reconciler.CurrentStatus(ctx, desired)
 	if err != nil {
@@ -179,9 +186,13 @@ func (a *Agent) reconcileOnce(ctx context.Context) error {
 	return nil
 }
 
-func (a *Agent) runDiskCare(ctx context.Context, desired *desiredstatepb.DesiredState) *report.DiskCareStatus {
+func (a *Agent) runDiskCare(ctx context.Context, desired *desiredstatepb.DesiredState, sequence int64) *report.DiskCareStatus {
 	if a.diskCare == nil {
 		return nil
+	}
+	now := time.Now()
+	if a.lastDiskCareStatus != nil && sequence == a.lastDiskCareSequence && a.diskCareMinInterval > 0 && now.Sub(a.lastDiskCareAt) < a.diskCareMinInterval {
+		return a.lastDiskCareStatus
 	}
 	status, err := a.diskCare.Run(ctx, desired)
 	if err != nil {
@@ -191,6 +202,11 @@ func (a *Agent) runDiskCare(ctx context.Context, desired *desiredstatepb.Desired
 		} else if status.LastError == "" {
 			status.LastError = err.Error()
 		}
+	}
+	if status != nil {
+		a.lastDiskCareAt = now
+		a.lastDiskCareSequence = sequence
+		a.lastDiskCareStatus = status
 	}
 	return status
 }

--- a/agent/internal/agent/agent_test.go
+++ b/agent/internal/agent/agent_test.go
@@ -172,6 +172,15 @@ func (f *fakeEngine) Logs(_ context.Context, _ string, _ int) ([]byte, error) {
 	return nil, nil
 }
 
+type fakeDiskCare struct {
+	calls int
+}
+
+func (f *fakeDiskCare) Run(context.Context, *desiredstatepb.DesiredState) (*report.DiskCareStatus, error) {
+	f.calls++
+	return &report.DiskCareStatus{DockerLogBytes: int64(f.calls)}, nil
+}
+
 type fakeEnvoy struct {
 	updated bool
 }
@@ -489,6 +498,30 @@ func TestEnvironmentTasksAreSatisfiedPerEnvironment(t *testing.T) {
 	}
 	if len(eng.waitCalls) != 2 {
 		t.Fatalf("wait calls = %d, want 2", len(eng.waitCalls))
+	}
+}
+
+func TestDiskCareIsThrottledBetweenDesiredStateChanges(t *testing.T) {
+	diskCare := &fakeDiskCare{}
+	ag := &Agent{
+		diskCare:            diskCare,
+		diskCareMinInterval: time.Hour,
+		logger:              slog.New(slog.NewJSONHandler(io.Discard, nil)),
+	}
+	desired := desiredWithWeb("rev-1")
+
+	first := ag.runDiskCare(context.Background(), desired, 1)
+	second := ag.runDiskCare(context.Background(), desired, 1)
+	if diskCare.calls != 1 {
+		t.Fatalf("disk care calls = %d, want 1", diskCare.calls)
+	}
+	if first != second {
+		t.Fatal("expected throttled disk care to reuse last status")
+	}
+
+	ag.runDiskCare(context.Background(), desired, 2)
+	if diskCare.calls != 2 {
+		t.Fatalf("disk care calls after sequence change = %d, want 2", diskCare.calls)
 	}
 }
 

--- a/agent/internal/agent/agent_test.go
+++ b/agent/internal/agent/agent_test.go
@@ -493,17 +493,19 @@ func TestEnvironmentTasksAreSatisfiedPerEnvironment(t *testing.T) {
 }
 
 func TestSettledReportSuppressionAllowsCoarseDiskCareUpdates(t *testing.T) {
+	baseCleanup := time.Date(2026, 4, 28, 12, 15, 0, 0, time.UTC)
 	base := report.Status{
 		Phase: report.PhaseSettled,
 		DiskCare: &report.DiskCareStatus{
-			LastCleanupAt:  time.Date(2026, 4, 28, 12, 15, 0, 0, time.UTC),
+			LastCleanupAt:  &baseCleanup,
 			DockerLogBytes: 5 * 1024 * 1024,
 		},
 	}
 
+	laterCleanupSameBucket := time.Date(2026, 4, 28, 12, 55, 0, 0, time.UTC)
 	laterSameBucket := base
 	laterSameBucket.DiskCare = &report.DiskCareStatus{
-		LastCleanupAt:  time.Date(2026, 4, 28, 12, 55, 0, 0, time.UTC),
+		LastCleanupAt:  &laterCleanupSameBucket,
 		DockerLogBytes: 9 * 1024 * 1024,
 	}
 	if !newReportFingerprint(1, base).suppresses(newReportFingerprint(1, laterSameBucket)) {
@@ -519,9 +521,10 @@ func TestSettledReportSuppressionAllowsCoarseDiskCareUpdates(t *testing.T) {
 		t.Fatal("expected new Docker log usage bucket to be reported")
 	}
 
+	cleanupNextHour := time.Date(2026, 4, 28, 13, 0, 0, 0, time.UTC)
 	newCleanupHour := base
 	newCleanupHour.DiskCare = &report.DiskCareStatus{
-		LastCleanupAt:  time.Date(2026, 4, 28, 13, 0, 0, 0, time.UTC),
+		LastCleanupAt:  &cleanupNextHour,
 		DockerLogBytes: base.DiskCare.DockerLogBytes,
 	}
 	if newReportFingerprint(1, base).suppresses(newReportFingerprint(1, newCleanupHour)) {

--- a/agent/internal/agent/agent_test.go
+++ b/agent/internal/agent/agent_test.go
@@ -491,3 +491,40 @@ func TestEnvironmentTasksAreSatisfiedPerEnvironment(t *testing.T) {
 		t.Fatalf("wait calls = %d, want 2", len(eng.waitCalls))
 	}
 }
+
+func TestSettledReportSuppressionAllowsCoarseDiskCareUpdates(t *testing.T) {
+	base := report.Status{
+		Phase: report.PhaseSettled,
+		DiskCare: &report.DiskCareStatus{
+			LastCleanupAt:  time.Date(2026, 4, 28, 12, 15, 0, 0, time.UTC),
+			DockerLogBytes: 5 * 1024 * 1024,
+		},
+	}
+
+	laterSameBucket := base
+	laterSameBucket.DiskCare = &report.DiskCareStatus{
+		LastCleanupAt:  time.Date(2026, 4, 28, 12, 55, 0, 0, time.UTC),
+		DockerLogBytes: 9 * 1024 * 1024,
+	}
+	if !newReportFingerprint(1, base).suppresses(newReportFingerprint(1, laterSameBucket)) {
+		t.Fatal("expected same-hour, same-log-bucket disk-care status to be suppressed")
+	}
+
+	newLogBucket := base
+	newLogBucket.DiskCare = &report.DiskCareStatus{
+		LastCleanupAt:  base.DiskCare.LastCleanupAt,
+		DockerLogBytes: 11 * 1024 * 1024,
+	}
+	if newReportFingerprint(1, base).suppresses(newReportFingerprint(1, newLogBucket)) {
+		t.Fatal("expected new Docker log usage bucket to be reported")
+	}
+
+	newCleanupHour := base
+	newCleanupHour.DiskCare = &report.DiskCareStatus{
+		LastCleanupAt:  time.Date(2026, 4, 28, 13, 0, 0, 0, time.UTC),
+		DockerLogBytes: base.DiskCare.DockerLogBytes,
+	}
+	if newReportFingerprint(1, base).suppresses(newReportFingerprint(1, newCleanupHour)) {
+		t.Fatal("expected new cleanup hour to be reported")
+	}
+}

--- a/agent/internal/config/config.go
+++ b/agent/internal/config/config.go
@@ -19,46 +19,50 @@ const (
 )
 
 type Config struct {
-	Mode                         string
-	ShowVersion                  bool
-	MetricsAddr                  string
-	DockerSock                   string
-	NetworkName                  string
-	PrefetchSystemImages         bool
-	StopTimeout                  time.Duration
-	DrainDelay                   time.Duration
-	ReconcileInterval            time.Duration
-	LogLevel                     slog.Level
-	StatusPath                   string
-	LifecycleStatePath           string
-	DesiredStateCachePath        string
-	DesiredStateOverridePath     string
-	EnvoyImage                   string
-	EnvoyContainer               string
-	EnvoyBootstrapPath           string
-	EnvoyPort                    uint16
-	EnvoyUID                     int
-	EnvoyGID                     int
-	EnvoyTLSCertPath             string
-	EnvoyTLSKeyPath              string
-	EnvoyPublicHTTPPublishPort   uint16
-	EnvoyPublicHTTPSPublishPort  uint16
-	IngressCertRenewBefore       time.Duration
-	EnvoyRestartPolicy           string
-	WebPort                      uint16
-	ControlPlaneBaseURL          string
-	BootstrapToken               string
-	NodeName                     string
-	CloudInitInstanceDataPath    string
-	AuthStatePath                string
-	AuthCheckInterval            time.Duration
-	TokenRefreshSkew             time.Duration
-	GCSAPIEndpoint               string
-	SecretManagerEndpoint        string
-	GoogleMetadataEndpoint       string
-	GoogleSTSEndpoint            string
-	GoogleIAMCredentialsEndpoint string
-	GoogleScopes                 []string
+	Mode                          string
+	ShowVersion                   bool
+	MetricsAddr                   string
+	DockerSock                    string
+	NetworkName                   string
+	PrefetchSystemImages          bool
+	StopTimeout                   time.Duration
+	DrainDelay                    time.Duration
+	ReconcileInterval             time.Duration
+	LogLevel                      slog.Level
+	StatusPath                    string
+	LifecycleStatePath            string
+	DiskCareStatePath             string
+	DesiredStateCachePath         string
+	DesiredStateOverridePath      string
+	ContainerLogMaxSize           string
+	ContainerLogMaxFile           int
+	ImageRetainedPreviousReleases int
+	EnvoyImage                    string
+	EnvoyContainer                string
+	EnvoyBootstrapPath            string
+	EnvoyPort                     uint16
+	EnvoyUID                      int
+	EnvoyGID                      int
+	EnvoyTLSCertPath              string
+	EnvoyTLSKeyPath               string
+	EnvoyPublicHTTPPublishPort    uint16
+	EnvoyPublicHTTPSPublishPort   uint16
+	IngressCertRenewBefore        time.Duration
+	EnvoyRestartPolicy            string
+	WebPort                       uint16
+	ControlPlaneBaseURL           string
+	BootstrapToken                string
+	NodeName                      string
+	CloudInitInstanceDataPath     string
+	AuthStatePath                 string
+	AuthCheckInterval             time.Duration
+	TokenRefreshSkew              time.Duration
+	GCSAPIEndpoint                string
+	SecretManagerEndpoint         string
+	GoogleMetadataEndpoint        string
+	GoogleSTSEndpoint             string
+	GoogleIAMCredentialsEndpoint  string
+	GoogleScopes                  []string
 }
 
 const DefaultEnvoyImage = "docker.io/envoyproxy/envoy@sha256:d9b4a70739d92b3e28cd407f106b0e90d55df453d7d87773efd22b4429777fe8"
@@ -78,6 +82,10 @@ func Load(args []string) (*Config, error) {
 	var logLevel string
 	var desiredStateCachePath string
 	var desiredStateOverridePath string
+	var diskCareStatePath string
+	var containerLogMaxSize string
+	var containerLogMaxFile int
+	var imageRetainedPreviousReleases int
 	var envoyImage string
 	var envoyContainer string
 	var envoyBootstrapPath string
@@ -122,6 +130,10 @@ func Load(args []string) (*Config, error) {
 	fs.StringVar(&logLevel, "log-level", "info", "log level: debug, info, warn, error")
 	fs.StringVar(&desiredStateCachePath, "desired-state-cache-path", "", "path to persisted last-known-good desired state cache (defaults next to auth state)")
 	fs.StringVar(&desiredStateOverridePath, "desired-state-override-path", "", "path to optional emergency local desired state override (defaults next to auth state)")
+	fs.StringVar(&diskCareStatePath, "disk-care-state-path", "", "path to persisted node disk care state (defaults next to auth state)")
+	fs.StringVar(&containerLogMaxSize, "container-log-max-size", "10m", "max size for each Docker json-file log on devopsellence-managed containers")
+	fs.IntVar(&containerLogMaxFile, "container-log-max-file", 5, "max rotated Docker json-file log files for devopsellence-managed containers")
+	fs.IntVar(&imageRetainedPreviousReleases, "image-retained-previous-releases", 10, "previous successful releases to retain for devopsellence-managed app image rollback")
 	fs.StringVar(&envoyImage, "envoy-image", DefaultEnvoyImage, "envoy image reference")
 	fs.StringVar(&envoyContainer, "envoy-container", "devopsellence-envoy", "envoy container name")
 	fs.StringVar(&envoyBootstrapPath, "envoy-bootstrap-path", envOrDefault("DEVOPSELLENCE_ENVOY_BOOTSTRAP_PATH", envoy.DefaultBootstrapPath), "path to the rendered envoy bootstrap file")
@@ -154,43 +166,47 @@ func Load(args []string) (*Config, error) {
 	}
 
 	cfg := &Config{
-		Mode:                         mode,
-		ShowVersion:                  showVersion,
-		MetricsAddr:                  metricsAddr,
-		DockerSock:                   dockerSock,
-		NetworkName:                  networkName,
-		PrefetchSystemImages:         prefetchSystemImages,
-		StopTimeout:                  stopTimeout,
-		DrainDelay:                   drainDelay,
-		ReconcileInterval:            reconcileInterval,
-		EnvoyImage:                   envoyImage,
-		EnvoyContainer:               envoyContainer,
-		EnvoyBootstrapPath:           strings.TrimSpace(envoyBootstrapPath),
-		EnvoyPort:                    uint16(envoyPort),
-		EnvoyUID:                     envoyUID,
-		EnvoyGID:                     envoyGID,
-		EnvoyTLSCertPath:             strings.TrimSpace(envoyTLSCertPath),
-		EnvoyTLSKeyPath:              strings.TrimSpace(envoyTLSKeyPath),
-		EnvoyPublicHTTPPublishPort:   uint16(envoyPublicHTTPPort),
-		EnvoyPublicHTTPSPublishPort:  uint16(envoyPublicHTTPSPort),
-		IngressCertRenewBefore:       ingressCertRenewBefore,
-		EnvoyRestartPolicy:           envoyRestartPolicy,
-		WebPort:                      uint16(webPort),
-		ControlPlaneBaseURL:          strings.TrimRight(strings.TrimSpace(controlPlaneBaseURL), "/"),
-		BootstrapToken:               strings.TrimSpace(bootstrapToken),
-		NodeName:                     strings.TrimSpace(nodeName),
-		CloudInitInstanceDataPath:    strings.TrimSpace(cloudInitInstanceDataPath),
-		AuthStatePath:                strings.TrimSpace(authStatePath),
-		DesiredStateCachePath:        strings.TrimSpace(desiredStateCachePath),
-		DesiredStateOverridePath:     strings.TrimSpace(desiredStateOverridePath),
-		AuthCheckInterval:            authCheckInterval,
-		TokenRefreshSkew:             tokenRefreshSkew,
-		GCSAPIEndpoint:               strings.TrimRight(strings.TrimSpace(gcsAPIEndpoint), "/"),
-		SecretManagerEndpoint:        strings.TrimRight(strings.TrimSpace(secretManagerEndpoint), "/"),
-		GoogleMetadataEndpoint:       strings.TrimRight(strings.TrimSpace(googleMetadataEndpoint), "/"),
-		GoogleSTSEndpoint:            strings.TrimSpace(googleSTSEndpoint),
-		GoogleIAMCredentialsEndpoint: strings.TrimRight(strings.TrimSpace(googleIAMCredentialsEndpoint), "/"),
-		GoogleScopes:                 parseCSV(googleScopesCSV),
+		Mode:                          mode,
+		ShowVersion:                   showVersion,
+		MetricsAddr:                   metricsAddr,
+		DockerSock:                    dockerSock,
+		NetworkName:                   networkName,
+		PrefetchSystemImages:          prefetchSystemImages,
+		StopTimeout:                   stopTimeout,
+		DrainDelay:                    drainDelay,
+		ReconcileInterval:             reconcileInterval,
+		EnvoyImage:                    envoyImage,
+		EnvoyContainer:                envoyContainer,
+		EnvoyBootstrapPath:            strings.TrimSpace(envoyBootstrapPath),
+		EnvoyPort:                     uint16(envoyPort),
+		EnvoyUID:                      envoyUID,
+		EnvoyGID:                      envoyGID,
+		EnvoyTLSCertPath:              strings.TrimSpace(envoyTLSCertPath),
+		EnvoyTLSKeyPath:               strings.TrimSpace(envoyTLSKeyPath),
+		EnvoyPublicHTTPPublishPort:    uint16(envoyPublicHTTPPort),
+		EnvoyPublicHTTPSPublishPort:   uint16(envoyPublicHTTPSPort),
+		IngressCertRenewBefore:        ingressCertRenewBefore,
+		EnvoyRestartPolicy:            envoyRestartPolicy,
+		WebPort:                       uint16(webPort),
+		ControlPlaneBaseURL:           strings.TrimRight(strings.TrimSpace(controlPlaneBaseURL), "/"),
+		BootstrapToken:                strings.TrimSpace(bootstrapToken),
+		NodeName:                      strings.TrimSpace(nodeName),
+		CloudInitInstanceDataPath:     strings.TrimSpace(cloudInitInstanceDataPath),
+		AuthStatePath:                 strings.TrimSpace(authStatePath),
+		DesiredStateCachePath:         strings.TrimSpace(desiredStateCachePath),
+		DesiredStateOverridePath:      strings.TrimSpace(desiredStateOverridePath),
+		DiskCareStatePath:             strings.TrimSpace(diskCareStatePath),
+		ContainerLogMaxSize:           strings.TrimSpace(containerLogMaxSize),
+		ContainerLogMaxFile:           containerLogMaxFile,
+		ImageRetainedPreviousReleases: imageRetainedPreviousReleases,
+		AuthCheckInterval:             authCheckInterval,
+		TokenRefreshSkew:              tokenRefreshSkew,
+		GCSAPIEndpoint:                strings.TrimRight(strings.TrimSpace(gcsAPIEndpoint), "/"),
+		SecretManagerEndpoint:         strings.TrimRight(strings.TrimSpace(secretManagerEndpoint), "/"),
+		GoogleMetadataEndpoint:        strings.TrimRight(strings.TrimSpace(googleMetadataEndpoint), "/"),
+		GoogleSTSEndpoint:             strings.TrimSpace(googleSTSEndpoint),
+		GoogleIAMCredentialsEndpoint:  strings.TrimRight(strings.TrimSpace(googleIAMCredentialsEndpoint), "/"),
+		GoogleScopes:                  parseCSV(googleScopesCSV),
 	}
 
 	lvl, err := parseLevel(logLevel)
@@ -219,6 +235,15 @@ func Load(args []string) (*Config, error) {
 	if cfg.Mode != ModeShared && cfg.Mode != ModeSolo {
 		return nil, fmt.Errorf("--mode must be %q or %q", ModeShared, ModeSolo)
 	}
+	if cfg.ContainerLogMaxSize == "" {
+		return nil, errors.New("--container-log-max-size is required")
+	}
+	if cfg.ContainerLogMaxFile < 1 {
+		return nil, errors.New("--container-log-max-file must be at least 1")
+	}
+	if cfg.ImageRetainedPreviousReleases < 0 {
+		return nil, errors.New("--image-retained-previous-releases cannot be negative")
+	}
 
 	if cfg.AuthStatePath == "" {
 		return nil, errors.New("--auth-state-path is required")
@@ -233,6 +258,9 @@ func Load(args []string) (*Config, error) {
 	}
 	if cfg.DesiredStateOverridePath == "" {
 		cfg.DesiredStateOverridePath = filepath.Join(stateDir, "desired-state-override.json")
+	}
+	if cfg.DiskCareStatePath == "" {
+		cfg.DiskCareStatePath = filepath.Join(stateDir, "disk-care-state.json")
 	}
 	if cfg.EnvoyTLSCertPath == "" {
 		cfg.EnvoyTLSCertPath = filepath.Join(stateDir, "ingress-cert.pem")

--- a/agent/internal/config/config_test.go
+++ b/agent/internal/config/config_test.go
@@ -65,6 +65,15 @@ func TestLoadDefaults(t *testing.T) {
 	if cfg.DesiredStateOverridePath != "/tmp/desired-state-override.json" {
 		t.Fatalf("expected default desired state override path, got %s", cfg.DesiredStateOverridePath)
 	}
+	if cfg.DiskCareStatePath != "/tmp/disk-care-state.json" {
+		t.Fatalf("expected default disk care state path, got %s", cfg.DiskCareStatePath)
+	}
+	if cfg.ContainerLogMaxSize != "10m" || cfg.ContainerLogMaxFile != 5 {
+		t.Fatalf("unexpected default log retention: size=%s files=%d", cfg.ContainerLogMaxSize, cfg.ContainerLogMaxFile)
+	}
+	if cfg.ImageRetainedPreviousReleases != 10 {
+		t.Fatalf("unexpected default image retention: %d", cfg.ImageRetainedPreviousReleases)
+	}
 	if cfg.GoogleMetadataEndpoint != "http://metadata.google.internal/computeMetadata/v1" {
 		t.Fatalf("unexpected metadata endpoint default: %s", cfg.GoogleMetadataEndpoint)
 	}
@@ -115,6 +124,10 @@ func TestLoadFullConfig(t *testing.T) {
 		"--auth-state-path=/tmp/agent-auth-state.json",
 		"--desired-state-cache-path=/var/lib/devopsellence/custom-cache.json",
 		"--desired-state-override-path=/var/lib/devopsellence/custom-override.json",
+		"--disk-care-state-path=/var/lib/devopsellence/custom-disk-care.json",
+		"--container-log-max-size=25m",
+		"--container-log-max-file=3",
+		"--image-retained-previous-releases=4",
 		"--prefetch-system-images=false",
 		"--envoy-bootstrap-path=/var/lib/devopsellence/envoy/envoy.yaml",
 		"--envoy-public-http-port=18080",
@@ -142,6 +155,15 @@ func TestLoadFullConfig(t *testing.T) {
 	}
 	if cfg.DesiredStateOverridePath != "/var/lib/devopsellence/custom-override.json" {
 		t.Fatalf("unexpected desired state override path: %s", cfg.DesiredStateOverridePath)
+	}
+	if cfg.DiskCareStatePath != "/var/lib/devopsellence/custom-disk-care.json" {
+		t.Fatalf("unexpected disk care state path: %s", cfg.DiskCareStatePath)
+	}
+	if cfg.ContainerLogMaxSize != "25m" || cfg.ContainerLogMaxFile != 3 {
+		t.Fatalf("unexpected log retention: size=%s files=%d", cfg.ContainerLogMaxSize, cfg.ContainerLogMaxFile)
+	}
+	if cfg.ImageRetainedPreviousReleases != 4 {
+		t.Fatalf("unexpected image retention: %d", cfg.ImageRetainedPreviousReleases)
 	}
 	if cfg.GoogleMetadataEndpoint != "" {
 		t.Fatalf("expected metadata endpoint disabled, got %s", cfg.GoogleMetadataEndpoint)

--- a/agent/internal/diskcare/diskcare.go
+++ b/agent/internal/diskcare/diskcare.go
@@ -409,19 +409,24 @@ func (s *store) dropRemovedImages(removed map[string]struct{}, retainedKeys map[
 }
 
 func retainedReleaseKeys(releases []releaseRecord, current []releaseRecord, keepPerEnvironment int) map[string]struct{} {
-	if keepPerEnvironment < 1 {
-		keepPerEnvironment = 1
+	if keepPerEnvironment < 0 {
+		keepPerEnvironment = 0
 	}
 	retained := map[string]struct{}{}
+	currentEnvironments := map[string]struct{}{}
 	for _, release := range current {
 		retained[releaseKey(release.Environment, release.Revision)] = struct{}{}
+		currentEnvironments[strings.TrimSpace(release.Environment)] = struct{}{}
 	}
 	byEnvironment := map[string][]releaseRecord{}
 	for _, release := range releases {
 		environment := strings.TrimSpace(release.Environment)
 		byEnvironment[environment] = append(byEnvironment[environment], release)
 	}
-	for _, envReleases := range byEnvironment {
+	for environment, envReleases := range byEnvironment {
+		if _, ok := currentEnvironments[environment]; !ok {
+			continue
+		}
 		sort.SliceStable(envReleases, func(i, j int) bool {
 			return envReleases[i].LastSeenAt.After(envReleases[j].LastSeenAt)
 		})

--- a/agent/internal/diskcare/diskcare.go
+++ b/agent/internal/diskcare/diskcare.go
@@ -120,17 +120,19 @@ func (m *Manager) Run(ctx context.Context, desired *desiredstatepb.DesiredState)
 		}
 
 		size := sizeForImage(image, imageSizes)
-		if _, removeErr := m.engine.RemoveImage(ctx, image); removeErr != nil {
+		removeResp, removeErr := m.engine.RemoveImage(ctx, image)
+		if removeErr != nil {
 			firstErr = joinFirst(firstErr, fmt.Errorf("remove image %s: %w", image, removeErr))
 			continue
 		}
+		reclaimedBytes := reclaimedBytesForRemoval(removeResp, size)
 		removedImages[image] = struct{}{}
-		status.ReclaimedBytes += size
+		status.ReclaimedBytes += reclaimedBytes
 		status.RemovedArtifacts = append(status.RemovedArtifacts, report.DiskCareArtifact{
 			Type:      "image",
 			Reference: image,
 			Reason:    "older_than_retention_window",
-			Bytes:     size,
+			Bytes:     reclaimedBytes,
 		})
 	}
 
@@ -162,6 +164,31 @@ func (m *Manager) imageExists(ctx context.Context, image string, imageRefs map[s
 	return m.engine.ImageExists(ctx, image)
 }
 
+func reclaimedBytesForRemoval(removed []engine.ImageDelete, size int64) int64 {
+	for _, item := range removed {
+		if strings.TrimSpace(item.Deleted) != "" {
+			return size
+		}
+	}
+	return 0
+}
+
+func logPaths(path string, maxFile int) []string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return nil
+	}
+	if maxFile < 1 {
+		maxFile = 1
+	}
+	paths := make([]string, 0, maxFile)
+	paths = append(paths, path)
+	for i := 1; i < maxFile; i++ {
+		paths = append(paths, fmt.Sprintf("%s.%d", path, i))
+	}
+	return paths
+}
+
 func (m *Manager) dockerLogBytes(ctx context.Context, containers []engine.ContainerState) (int64, error) {
 	var total int64
 	var firstErr error
@@ -177,15 +204,17 @@ func (m *Manager) dockerLogBytes(ctx context.Context, containers []engine.Contai
 		if strings.TrimSpace(info.LogPath) == "" {
 			continue
 		}
-		stat, err := os.Stat(info.LogPath)
-		if err != nil {
-			if errors.Is(err, os.ErrNotExist) {
+		for _, path := range logPaths(info.LogPath, m.cfg.ContainerLogMaxFile) {
+			stat, err := os.Stat(path)
+			if err != nil {
+				if errors.Is(err, os.ErrNotExist) {
+					continue
+				}
+				firstErr = joinFirst(firstErr, fmt.Errorf("stat log %s: %w", path, err))
 				continue
 			}
-			firstErr = joinFirst(firstErr, fmt.Errorf("stat log %s: %w", info.LogPath, err))
-			continue
+			total += stat.Size()
 		}
-		total += stat.Size()
 	}
 	return total, firstErr
 }

--- a/agent/internal/diskcare/diskcare.go
+++ b/agent/internal/diskcare/diskcare.go
@@ -1,0 +1,488 @@
+package diskcare
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/devopsellence/devopsellence/agent/internal/desiredstate"
+	"github.com/devopsellence/devopsellence/agent/internal/desiredstatepb"
+	"github.com/devopsellence/devopsellence/agent/internal/engine"
+	"github.com/devopsellence/devopsellence/agent/internal/report"
+)
+
+const defaultRetainedPreviousReleases = 10
+
+// Engine is the Docker-facing surface used by automatic disk care.
+type Engine interface {
+	ListManaged(ctx context.Context) ([]engine.ContainerState, error)
+	ListContainers(ctx context.Context) ([]engine.ContainerState, error)
+	ListImages(ctx context.Context) ([]engine.ImageState, error)
+	ImageExists(ctx context.Context, image string) (bool, error)
+	RemoveImage(ctx context.Context, reference string) ([]engine.ImageDelete, error)
+	Inspect(ctx context.Context, name string) (engine.ContainerInfo, error)
+}
+
+// Config controls node-local disk retention for managed artifacts.
+type Config struct {
+	StatePath                string
+	RetainedPreviousReleases int
+	ProtectedImages          []string
+	ContainerLogMaxSize      string
+	ContainerLogMaxFile      int
+}
+
+// Manager runs automatic node-local cleanup for devopsellence-managed artifacts.
+type Manager struct {
+	engine Engine
+	cfg    Config
+	logger *slog.Logger
+}
+
+// New creates a disk-care manager.
+func New(engine Engine, cfg Config, logger *slog.Logger) *Manager {
+	if cfg.RetainedPreviousReleases < 0 {
+		cfg.RetainedPreviousReleases = defaultRetainedPreviousReleases
+	}
+	return &Manager{engine: engine, cfg: cfg, logger: logger}
+}
+
+// Run records the current desired-state images, removes old managed image
+// references outside the retention window, and reports local log usage.
+func (m *Manager) Run(ctx context.Context, desired *desiredstatepb.DesiredState) (*report.DiskCareStatus, error) {
+	status := &report.DiskCareStatus{
+		RetainedPreviousReleases: m.cfg.RetainedPreviousReleases,
+		LogMaxSize:               m.cfg.ContainerLogMaxSize,
+		LogMaxFile:               m.cfg.ContainerLogMaxFile,
+		LastCleanupAt:            time.Now().UTC(),
+	}
+	if m == nil || m.engine == nil || desired == nil {
+		return status, nil
+	}
+
+	store, err := m.loadStore()
+	if err != nil {
+		status.LastError = err.Error()
+		return status, err
+	}
+
+	now := status.LastCleanupAt
+	current := releasesFromDesired(desired, now)
+	store.upsert(current)
+
+	managed, err := m.engine.ListManaged(ctx)
+	if err != nil {
+		status.LastError = fmt.Sprintf("list managed containers: %v", err)
+		return status, err
+	}
+	allContainers, err := m.engine.ListContainers(ctx)
+	if err != nil {
+		status.LastError = fmt.Sprintf("list containers: %v", err)
+		return status, err
+	}
+	images, err := m.engine.ListImages(ctx)
+	if err != nil {
+		status.LastError = fmt.Sprintf("list images: %v", err)
+		return status, err
+	}
+
+	imageSizes := imageSizeIndex(images)
+	imageRefs := imageRefSet(images)
+	protectedImages := stringSet(m.cfg.ProtectedImages)
+	usedImages := usedContainerImages(allContainers)
+
+	retainedKeys := retainedReleaseKeys(store.Releases, current, m.cfg.RetainedPreviousReleases+1)
+	status.RetainedReleaseCount = len(retainedKeys)
+	retainedImages := retainedImageRefs(store.Releases, retainedKeys, current, protectedImages, usedImages)
+
+	removedImages := map[string]struct{}{}
+	var firstErr error
+	for _, image := range pruneCandidates(store.Releases, retainedKeys, retainedImages, protectedImages) {
+		if _, ok := usedImages[image]; ok {
+			continue
+		}
+		exists, existsErr := m.imageExists(ctx, image, imageRefs)
+		if existsErr != nil {
+			firstErr = joinFirst(firstErr, fmt.Errorf("inspect image %s: %w", image, existsErr))
+			continue
+		}
+		if !exists {
+			removedImages[image] = struct{}{}
+			continue
+		}
+
+		size := sizeForImage(image, imageSizes)
+		if _, removeErr := m.engine.RemoveImage(ctx, image); removeErr != nil {
+			firstErr = joinFirst(firstErr, fmt.Errorf("remove image %s: %w", image, removeErr))
+			continue
+		}
+		removedImages[image] = struct{}{}
+		status.ReclaimedBytes += size
+		status.RemovedArtifacts = append(status.RemovedArtifacts, report.DiskCareArtifact{
+			Type:      "image",
+			Reference: image,
+			Reason:    "older_than_retention_window",
+			Bytes:     size,
+		})
+	}
+
+	store.dropRemovedImages(removedImages, retainedKeys)
+	if saveErr := m.saveStore(store); saveErr != nil {
+		firstErr = joinFirst(firstErr, saveErr)
+	}
+
+	logBytes, logErr := m.dockerLogBytes(ctx, managed)
+	if logErr != nil {
+		firstErr = joinFirst(firstErr, logErr)
+	}
+	status.DockerLogBytes = logBytes
+
+	if firstErr != nil {
+		status.LastError = firstErr.Error()
+		if m.logger != nil {
+			m.logger.Warn("disk care completed with errors", "error", firstErr)
+		}
+		return status, firstErr
+	}
+	return status, nil
+}
+
+func (m *Manager) imageExists(ctx context.Context, image string, imageRefs map[string]struct{}) (bool, error) {
+	if _, ok := imageRefs[image]; ok {
+		return true, nil
+	}
+	return m.engine.ImageExists(ctx, image)
+}
+
+func (m *Manager) dockerLogBytes(ctx context.Context, containers []engine.ContainerState) (int64, error) {
+	var total int64
+	var firstErr error
+	for _, container := range containers {
+		if strings.TrimSpace(container.Name) == "" {
+			continue
+		}
+		info, err := m.engine.Inspect(ctx, container.Name)
+		if err != nil {
+			firstErr = joinFirst(firstErr, fmt.Errorf("inspect container %s for logs: %w", container.Name, err))
+			continue
+		}
+		if strings.TrimSpace(info.LogPath) == "" {
+			continue
+		}
+		stat, err := os.Stat(info.LogPath)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			firstErr = joinFirst(firstErr, fmt.Errorf("stat log %s: %w", info.LogPath, err))
+			continue
+		}
+		total += stat.Size()
+	}
+	return total, firstErr
+}
+
+type store struct {
+	Releases []releaseRecord `json:"releases,omitempty"`
+}
+
+type releaseRecord struct {
+	Environment string    `json:"environment"`
+	Revision    string    `json:"revision"`
+	Images      []string  `json:"images,omitempty"`
+	LastSeenAt  time.Time `json:"last_seen_at"`
+}
+
+func (m *Manager) loadStore() (*store, error) {
+	if strings.TrimSpace(m.cfg.StatePath) == "" {
+		return &store{}, nil
+	}
+	data, err := os.ReadFile(m.cfg.StatePath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return &store{}, nil
+		}
+		return nil, fmt.Errorf("read disk care state: %w", err)
+	}
+	if len(strings.TrimSpace(string(data))) == 0 {
+		return &store{}, nil
+	}
+	var s store
+	if err := json.Unmarshal(data, &s); err != nil {
+		return nil, fmt.Errorf("parse disk care state: %w", err)
+	}
+	return &s, nil
+}
+
+func (m *Manager) saveStore(s *store) error {
+	if strings.TrimSpace(m.cfg.StatePath) == "" {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(m.cfg.StatePath), 0o755); err != nil {
+		return fmt.Errorf("create disk care state dir: %w", err)
+	}
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal disk care state: %w", err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(m.cfg.StatePath, data, 0o600); err != nil {
+		return fmt.Errorf("write disk care state: %w", err)
+	}
+	return nil
+}
+
+func releasesFromDesired(state *desiredstatepb.DesiredState, now time.Time) []releaseRecord {
+	releases := map[string]*releaseRecord{}
+	for _, runtime := range desiredstate.RuntimeServices(state) {
+		addReleaseImage(releases, runtime.EnvironmentName, runtime.EnvironmentRevision, runtime.Service.GetImage(), now)
+	}
+	for _, runtime := range desiredstate.RuntimeTasks(state) {
+		addReleaseImage(releases, runtime.EnvironmentName, runtime.EnvironmentRevision, runtime.Task.GetImage(), now)
+	}
+	out := make([]releaseRecord, 0, len(releases))
+	for _, release := range releases {
+		sort.Strings(release.Images)
+		out = append(out, *release)
+	}
+	return out
+}
+
+func addReleaseImage(releases map[string]*releaseRecord, environment string, revision string, image string, now time.Time) {
+	environment = strings.TrimSpace(environment)
+	revision = strings.TrimSpace(revision)
+	image = strings.TrimSpace(image)
+	if environment == "" || revision == "" || image == "" {
+		return
+	}
+	key := releaseKey(environment, revision)
+	release := releases[key]
+	if release == nil {
+		release = &releaseRecord{Environment: environment, Revision: revision, LastSeenAt: now}
+		releases[key] = release
+	}
+	if !containsString(release.Images, image) {
+		release.Images = append(release.Images, image)
+	}
+}
+
+func (s *store) upsert(releases []releaseRecord) {
+	byKey := map[string]int{}
+	for i, release := range s.Releases {
+		byKey[releaseKey(release.Environment, release.Revision)] = i
+	}
+	for _, release := range releases {
+		key := releaseKey(release.Environment, release.Revision)
+		if idx, ok := byKey[key]; ok {
+			existing := &s.Releases[idx]
+			existing.Images = mergeStrings(existing.Images, release.Images)
+			existing.LastSeenAt = release.LastSeenAt
+			continue
+		}
+		s.Releases = append(s.Releases, release)
+	}
+}
+
+func (s *store) dropRemovedImages(removed map[string]struct{}, retainedKeys map[string]struct{}) {
+	if len(removed) == 0 {
+		return
+	}
+	kept := s.Releases[:0]
+	for _, release := range s.Releases {
+		key := releaseKey(release.Environment, release.Revision)
+		if _, retained := retainedKeys[key]; retained {
+			kept = append(kept, release)
+			continue
+		}
+		images := release.Images[:0]
+		for _, image := range release.Images {
+			if _, ok := removed[image]; !ok {
+				images = append(images, image)
+			}
+		}
+		release.Images = images
+		if len(release.Images) > 0 {
+			kept = append(kept, release)
+		}
+	}
+	s.Releases = kept
+}
+
+func retainedReleaseKeys(releases []releaseRecord, current []releaseRecord, keepPerEnvironment int) map[string]struct{} {
+	if keepPerEnvironment < 1 {
+		keepPerEnvironment = 1
+	}
+	retained := map[string]struct{}{}
+	for _, release := range current {
+		retained[releaseKey(release.Environment, release.Revision)] = struct{}{}
+	}
+	byEnvironment := map[string][]releaseRecord{}
+	for _, release := range releases {
+		byEnvironment[release.Environment] = append(byEnvironment[release.Environment], release)
+	}
+	for _, envReleases := range byEnvironment {
+		sort.SliceStable(envReleases, func(i, j int) bool {
+			return envReleases[i].LastSeenAt.After(envReleases[j].LastSeenAt)
+		})
+		limit := keepPerEnvironment
+		if len(envReleases) < limit {
+			limit = len(envReleases)
+		}
+		for i := 0; i < limit; i++ {
+			retained[releaseKey(envReleases[i].Environment, envReleases[i].Revision)] = struct{}{}
+		}
+	}
+	return retained
+}
+
+func retainedImageRefs(releases []releaseRecord, retainedKeys map[string]struct{}, current []releaseRecord, protectedImages map[string]struct{}, usedImages map[string]struct{}) map[string]struct{} {
+	retained := map[string]struct{}{}
+	for image := range protectedImages {
+		retained[image] = struct{}{}
+	}
+	for image := range usedImages {
+		retained[image] = struct{}{}
+	}
+	for _, release := range current {
+		for _, image := range release.Images {
+			retained[image] = struct{}{}
+		}
+	}
+	for _, release := range releases {
+		if _, ok := retainedKeys[releaseKey(release.Environment, release.Revision)]; !ok {
+			continue
+		}
+		for _, image := range release.Images {
+			retained[image] = struct{}{}
+		}
+	}
+	return retained
+}
+
+func pruneCandidates(releases []releaseRecord, retainedKeys map[string]struct{}, retainedImages map[string]struct{}, protectedImages map[string]struct{}) []string {
+	candidates := map[string]struct{}{}
+	for _, release := range releases {
+		if _, ok := retainedKeys[releaseKey(release.Environment, release.Revision)]; ok {
+			continue
+		}
+		for _, image := range release.Images {
+			if _, ok := retainedImages[image]; ok {
+				continue
+			}
+			if _, ok := protectedImages[image]; ok {
+				continue
+			}
+			candidates[image] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(candidates))
+	for image := range candidates {
+		out = append(out, image)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func imageRefSet(images []engine.ImageState) map[string]struct{} {
+	refs := map[string]struct{}{}
+	for _, image := range images {
+		for _, ref := range imageRefs(image) {
+			refs[ref] = struct{}{}
+		}
+	}
+	return refs
+}
+
+func imageSizeIndex(images []engine.ImageState) map[string]int64 {
+	index := map[string]int64{}
+	for _, image := range images {
+		for _, ref := range imageRefs(image) {
+			index[ref] = image.Size
+		}
+	}
+	return index
+}
+
+func imageRefs(image engine.ImageState) []string {
+	refs := make([]string, 0, len(image.RepoTags)+len(image.RepoDigests)+1)
+	refs = append(refs, image.ID)
+	refs = append(refs, image.RepoTags...)
+	refs = append(refs, image.RepoDigests...)
+	return refs
+}
+
+func sizeForImage(image string, sizes map[string]int64) int64 {
+	if size, ok := sizes[image]; ok {
+		return size
+	}
+	return 0
+}
+
+func usedContainerImages(containers []engine.ContainerState) map[string]struct{} {
+	used := map[string]struct{}{}
+	for _, container := range containers {
+		image := strings.TrimSpace(container.Image)
+		if image == "" {
+			continue
+		}
+		used[image] = struct{}{}
+	}
+	return used
+}
+
+func stringSet(values []string) map[string]struct{} {
+	set := map[string]struct{}{}
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		set[value] = struct{}{}
+	}
+	return set
+}
+
+func mergeStrings(a []string, b []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(a)+len(b))
+	for _, value := range append(a, b...) {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}
+
+func releaseKey(environment string, revision string) string {
+	return strings.TrimSpace(environment) + "\x00" + strings.TrimSpace(revision)
+}
+
+func joinFirst(first error, next error) error {
+	if first != nil {
+		return first
+	}
+	return next
+}

--- a/agent/internal/diskcare/diskcare.go
+++ b/agent/internal/diskcare/diskcare.go
@@ -23,7 +23,6 @@ const defaultRetainedPreviousReleases = 10
 
 // Engine is the Docker-facing surface used by automatic disk care.
 type Engine interface {
-	ListManaged(ctx context.Context) ([]engine.ContainerState, error)
 	ListContainers(ctx context.Context) ([]engine.ContainerState, error)
 	ListImages(ctx context.Context) ([]engine.ImageState, error)
 	ImageExists(ctx context.Context, image string) (bool, error)
@@ -82,12 +81,6 @@ func (m *Manager) Run(ctx context.Context, desired *desiredstatepb.DesiredState)
 	current := releasesFromDesired(desired, now)
 	store.upsert(current)
 
-	managed, err := m.engine.ListManaged(ctx)
-	if err != nil {
-		err = fmt.Errorf("list managed containers: %w", err)
-		status.LastError = err.Error()
-		return status, err
-	}
 	allContainers, err := m.engine.ListContainers(ctx)
 	if err != nil {
 		err = fmt.Errorf("list containers: %w", err)
@@ -101,6 +94,7 @@ func (m *Manager) Run(ctx context.Context, desired *desiredstatepb.DesiredState)
 		return status, err
 	}
 
+	managed := managedContainers(allContainers)
 	imageSizes := imageSizeIndex(images)
 	imageRefs := imageRefSet(images)
 	protectedImages := stringSet(m.cfg.ProtectedImages)
@@ -523,6 +517,16 @@ func sizeForImage(image string, sizes map[string]int64) int64 {
 		return size
 	}
 	return 0
+}
+
+func managedContainers(containers []engine.ContainerState) []engine.ContainerState {
+	managed := make([]engine.ContainerState, 0, len(containers))
+	for _, container := range containers {
+		if container.Managed {
+			managed = append(managed, container)
+		}
+	}
+	return managed
 }
 
 func usedContainerImages(containers []engine.ContainerState) map[string]struct{} {

--- a/agent/internal/diskcare/diskcare.go
+++ b/agent/internal/diskcare/diskcare.go
@@ -83,17 +83,20 @@ func (m *Manager) Run(ctx context.Context, desired *desiredstatepb.DesiredState)
 
 	managed, err := m.engine.ListManaged(ctx)
 	if err != nil {
-		status.LastError = fmt.Sprintf("list managed containers: %v", err)
+		err = fmt.Errorf("list managed containers: %w", err)
+		status.LastError = err.Error()
 		return status, err
 	}
 	allContainers, err := m.engine.ListContainers(ctx)
 	if err != nil {
-		status.LastError = fmt.Sprintf("list containers: %v", err)
+		err = fmt.Errorf("list containers: %w", err)
+		status.LastError = err.Error()
 		return status, err
 	}
 	images, err := m.engine.ListImages(ctx)
 	if err != nil {
-		status.LastError = fmt.Sprintf("list images: %v", err)
+		err = fmt.Errorf("list images: %w", err)
+		status.LastError = err.Error()
 		return status, err
 	}
 

--- a/agent/internal/diskcare/diskcare.go
+++ b/agent/internal/diskcare/diskcare.go
@@ -68,7 +68,10 @@ func (m *Manager) Run(ctx context.Context, desired *desiredstatepb.DesiredState)
 		return status, nil
 	}
 
-	store, err := m.loadStore()
+	store, loadWarning, err := m.loadStore()
+	if loadWarning != "" {
+		status.LastError = loadWarning
+	}
 	if err != nil {
 		status.LastError = err.Error()
 		return status, err
@@ -230,28 +233,29 @@ type releaseRecord struct {
 	LastSeenAt  time.Time `json:"last_seen_at"`
 }
 
-func (m *Manager) loadStore() (*store, error) {
+func (m *Manager) loadStore() (*store, string, error) {
 	if strings.TrimSpace(m.cfg.StatePath) == "" {
-		return &store{}, nil
+		return &store{}, "", nil
 	}
 	data, err := os.ReadFile(m.cfg.StatePath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return &store{}, nil
+			return &store{}, "", nil
 		}
-		return nil, fmt.Errorf("read disk care state: %w", err)
+		return nil, "", fmt.Errorf("read disk care state: %w", err)
 	}
 	if len(strings.TrimSpace(string(data))) == 0 {
-		return &store{}, nil
+		return &store{}, "", nil
 	}
 	var s store
 	if err := json.Unmarshal(data, &s); err != nil {
+		warning := fmt.Sprintf("ignored corrupt disk care state: %v", err)
 		if m.logger != nil {
 			m.logger.Warn("ignoring corrupt disk care state", "path", m.cfg.StatePath, "error", err)
 		}
-		return &store{}, nil
+		return &store{}, warning, nil
 	}
-	return &s, nil
+	return &s, "", nil
 }
 
 func (m *Manager) saveStore(s *store) error {
@@ -261,6 +265,9 @@ func (m *Manager) saveStore(s *store) error {
 	dir := filepath.Dir(m.cfg.StatePath)
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf("create disk care state dir: %w", err)
+	}
+	if err := os.Chmod(dir, 0o700); err != nil {
+		return fmt.Errorf("set disk care state dir permissions: %w", err)
 	}
 	data, err := json.MarshalIndent(s, "", "  ")
 	if err != nil {

--- a/agent/internal/diskcare/diskcare.go
+++ b/agent/internal/diskcare/diskcare.go
@@ -57,7 +57,8 @@ func New(engine Engine, cfg Config, logger *slog.Logger) *Manager {
 // Run records the current desired-state images, removes old managed image
 // references outside the retention window, and reports local log usage.
 func (m *Manager) Run(ctx context.Context, desired *desiredstatepb.DesiredState) (*report.DiskCareStatus, error) {
-	status := &report.DiskCareStatus{LastCleanupAt: time.Now().UTC()}
+	now := time.Now().UTC()
+	status := &report.DiskCareStatus{LastCleanupAt: &now}
 	if m == nil {
 		return status, nil
 	}
@@ -77,7 +78,6 @@ func (m *Manager) Run(ctx context.Context, desired *desiredstatepb.DesiredState)
 		return status, err
 	}
 
-	now := status.LastCleanupAt
 	current := releasesFromDesired(desired, now)
 	store.upsert(current)
 

--- a/agent/internal/diskcare/diskcare.go
+++ b/agent/internal/diskcare/diskcare.go
@@ -57,13 +57,14 @@ func New(engine Engine, cfg Config, logger *slog.Logger) *Manager {
 // Run records the current desired-state images, removes old managed image
 // references outside the retention window, and reports local log usage.
 func (m *Manager) Run(ctx context.Context, desired *desiredstatepb.DesiredState) (*report.DiskCareStatus, error) {
-	status := &report.DiskCareStatus{
-		RetainedPreviousReleases: m.cfg.RetainedPreviousReleases,
-		LogMaxSize:               m.cfg.ContainerLogMaxSize,
-		LogMaxFile:               m.cfg.ContainerLogMaxFile,
-		LastCleanupAt:            time.Now().UTC(),
+	status := &report.DiskCareStatus{LastCleanupAt: time.Now().UTC()}
+	if m == nil {
+		return status, nil
 	}
-	if m == nil || m.engine == nil || desired == nil {
+	status.RetainedPreviousReleases = m.cfg.RetainedPreviousReleases
+	status.LogMaxSize = m.cfg.ContainerLogMaxSize
+	status.LogMaxFile = m.cfg.ContainerLogMaxFile
+	if m.engine == nil || desired == nil {
 		return status, nil
 	}
 

--- a/agent/internal/diskcare/diskcare.go
+++ b/agent/internal/diskcare/diskcare.go
@@ -15,6 +15,7 @@ import (
 	"github.com/devopsellence/devopsellence/agent/internal/desiredstate"
 	"github.com/devopsellence/devopsellence/agent/internal/desiredstatepb"
 	"github.com/devopsellence/devopsellence/agent/internal/engine"
+	"github.com/devopsellence/devopsellence/agent/internal/fileaccess"
 	"github.com/devopsellence/devopsellence/agent/internal/report"
 )
 
@@ -258,6 +259,7 @@ func (m *Manager) loadStore() (*store, string, error) {
 		}
 		return &store{}, warning, nil
 	}
+	s.normalize()
 	return &s, "", nil
 }
 
@@ -266,11 +268,8 @@ func (m *Manager) saveStore(s *store) error {
 		return nil
 	}
 	dir := filepath.Dir(m.cfg.StatePath)
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return fmt.Errorf("create disk care state dir: %w", err)
-	}
-	if err := os.Chmod(dir, 0o700); err != nil {
-		return fmt.Errorf("set disk care state dir permissions: %w", err)
+	if err := fileaccess.EnsureDirMode(dir, 0o700); err != nil {
+		return fmt.Errorf("prepare disk care state dir: %w", err)
 	}
 	data, err := json.MarshalIndent(s, "", "  ")
 	if err != nil {
@@ -340,7 +339,40 @@ func addReleaseImage(releases map[string]*releaseRecord, environment string, rev
 	}
 }
 
+func (s *store) normalize() {
+	if s == nil || len(s.Releases) == 0 {
+		return
+	}
+	byKey := map[string]releaseRecord{}
+	order := make([]string, 0, len(s.Releases))
+	for _, release := range s.Releases {
+		release.Environment = strings.TrimSpace(release.Environment)
+		release.Revision = strings.TrimSpace(release.Revision)
+		release.Images = mergeStrings(nil, release.Images)
+		if release.Environment == "" || release.Revision == "" || len(release.Images) == 0 {
+			continue
+		}
+		key := releaseKey(release.Environment, release.Revision)
+		existing, ok := byKey[key]
+		if !ok {
+			byKey[key] = release
+			order = append(order, key)
+			continue
+		}
+		existing.Images = mergeStrings(existing.Images, release.Images)
+		if release.LastSeenAt.After(existing.LastSeenAt) {
+			existing.LastSeenAt = release.LastSeenAt
+		}
+		byKey[key] = existing
+	}
+	s.Releases = s.Releases[:0]
+	for _, key := range order {
+		s.Releases = append(s.Releases, byKey[key])
+	}
+}
+
 func (s *store) upsert(releases []releaseRecord) {
+	s.normalize()
 	byKey := map[string]int{}
 	for i, release := range s.Releases {
 		byKey[releaseKey(release.Environment, release.Revision)] = i
@@ -392,7 +424,8 @@ func retainedReleaseKeys(releases []releaseRecord, current []releaseRecord, keep
 	}
 	byEnvironment := map[string][]releaseRecord{}
 	for _, release := range releases {
-		byEnvironment[release.Environment] = append(byEnvironment[release.Environment], release)
+		environment := strings.TrimSpace(release.Environment)
+		byEnvironment[environment] = append(byEnvironment[environment], release)
 	}
 	for _, envReleases := range byEnvironment {
 		sort.SliceStable(envReleases, func(i, j int) bool {

--- a/agent/internal/diskcare/diskcare.go
+++ b/agent/internal/diskcare/diskcare.go
@@ -246,7 +246,10 @@ func (m *Manager) loadStore() (*store, error) {
 	}
 	var s store
 	if err := json.Unmarshal(data, &s); err != nil {
-		return nil, fmt.Errorf("parse disk care state: %w", err)
+		if m.logger != nil {
+			m.logger.Warn("ignoring corrupt disk care state", "path", m.cfg.StatePath, "error", err)
+		}
+		return &store{}, nil
 	}
 	return &s, nil
 }
@@ -255,7 +258,8 @@ func (m *Manager) saveStore(s *store) error {
 	if strings.TrimSpace(m.cfg.StatePath) == "" {
 		return nil
 	}
-	if err := os.MkdirAll(filepath.Dir(m.cfg.StatePath), 0o755); err != nil {
+	dir := filepath.Dir(m.cfg.StatePath)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf("create disk care state dir: %w", err)
 	}
 	data, err := json.MarshalIndent(s, "", "  ")
@@ -263,10 +267,33 @@ func (m *Manager) saveStore(s *store) error {
 		return fmt.Errorf("marshal disk care state: %w", err)
 	}
 	data = append(data, '\n')
-	if err := os.WriteFile(m.cfg.StatePath, data, 0o600); err != nil {
+	if err := writeFileAtomic(m.cfg.StatePath, data, 0o600); err != nil {
 		return fmt.Errorf("write disk care state: %w", err)
 	}
 	return nil
+}
+
+func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+"-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(perm); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
 }
 
 func releasesFromDesired(state *desiredstatepb.DesiredState, now time.Time) []releaseRecord {

--- a/agent/internal/diskcare/diskcare_test.go
+++ b/agent/internal/diskcare/diskcare_test.go
@@ -12,12 +12,13 @@ import (
 )
 
 type fakeEngine struct {
-	managed      []engine.ContainerState
-	containers   []engine.ContainerState
-	images       []engine.ImageState
-	logPaths     map[string]string
-	removed      []string
-	removeErrors map[string]error
+	managed       []engine.ContainerState
+	containers    []engine.ContainerState
+	images        []engine.ImageState
+	logPaths      map[string]string
+	removed       []string
+	removeErrors  map[string]error
+	removeResults map[string][]engine.ImageDelete
 }
 
 func (f *fakeEngine) ListManaged(context.Context) ([]engine.ContainerState, error) {
@@ -48,6 +49,9 @@ func (f *fakeEngine) RemoveImage(_ context.Context, reference string) ([]engine.
 		return nil, err
 	}
 	f.removed = append(f.removed, reference)
+	if result := f.removeResults[reference]; len(result) > 0 {
+		return result, nil
+	}
 	return []engine.ImageDelete{{Untagged: reference}}, nil
 }
 
@@ -71,9 +75,10 @@ func TestRunRemovesOnlyImagesOutsideRetentionWindow(t *testing.T) {
 			{ID: "sha256:3", RepoTags: []string{"app:rev3"}, Size: 300},
 			{ID: "sha256:envoy", RepoTags: []string{"envoy:latest"}, Size: 400},
 		},
-		containers: []engine.ContainerState{{Name: "web", Image: "app:rev3", Managed: true}},
-		managed:    []engine.ContainerState{{Name: "web", Image: "app:rev3", Managed: true}},
-		logPaths:   map[string]string{},
+		containers:    []engine.ContainerState{{Name: "web", Image: "app:rev3", Managed: true}},
+		managed:       []engine.ContainerState{{Name: "web", Image: "app:rev3", Managed: true}},
+		logPaths:      map[string]string{},
+		removeResults: map[string][]engine.ImageDelete{"app:rev1": {{Deleted: "sha256:1"}}},
 	}
 	mgr := New(eng, Config{StatePath: statePath, RetainedPreviousReleases: 1, ProtectedImages: []string{"envoy:latest"}, ContainerLogMaxSize: "10m", ContainerLogMaxFile: 5}, nil)
 	if err := mgr.saveStore(initial); err != nil {
@@ -127,6 +132,9 @@ func TestRunReportsManagedDockerLogUsage(t *testing.T) {
 	if err := os.WriteFile(logPath, []byte("hello logs"), 0o600); err != nil {
 		t.Fatalf("write log: %v", err)
 	}
+	if err := os.WriteFile(logPath+".1", []byte("rotated"), 0o600); err != nil {
+		t.Fatalf("write rotated log: %v", err)
+	}
 	eng := &fakeEngine{
 		managed:    []engine.ContainerState{{Name: "web", Image: "app:rev1", Managed: true}},
 		containers: []engine.ContainerState{{Name: "web", Image: "app:rev1", Managed: true}},
@@ -139,7 +147,7 @@ func TestRunReportsManagedDockerLogUsage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("run: %v", err)
 	}
-	if status.DockerLogBytes != int64(len("hello logs")) {
+	if status.DockerLogBytes != int64(len("hello logs")+len("rotated")) {
 		t.Fatalf("docker log bytes = %d", status.DockerLogBytes)
 	}
 	if status.LogMaxSize != "10m" || status.LogMaxFile != 5 {

--- a/agent/internal/diskcare/diskcare_test.go
+++ b/agent/internal/diskcare/diskcare_test.go
@@ -126,6 +126,47 @@ func TestRunProtectsImagesUsedByAnyContainer(t *testing.T) {
 	}
 }
 
+func TestRunIgnoresCorruptState(t *testing.T) {
+	dir := t.TempDir()
+	statePath := filepath.Join(dir, "disk-care-state.json")
+	if err := os.WriteFile(statePath, []byte("{"), 0o600); err != nil {
+		t.Fatalf("write corrupt state: %v", err)
+	}
+	eng := &fakeEngine{
+		containers: []engine.ContainerState{{Name: "web", Image: "app:rev1", Managed: true}},
+		managed:    []engine.ContainerState{{Name: "web", Image: "app:rev1", Managed: true}},
+		images:     []engine.ImageState{{ID: "sha256:1", RepoTags: []string{"app:rev1"}, Size: 100}},
+		logPaths:   map[string]string{},
+	}
+	mgr := New(eng, Config{StatePath: statePath, RetainedPreviousReleases: 10}, nil)
+
+	if _, err := mgr.Run(context.Background(), desiredState("rev-1", "app:rev1")); err != nil {
+		t.Fatalf("run with corrupt state: %v", err)
+	}
+	data, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatalf("read rewritten state: %v", err)
+	}
+	if string(data) == "{" {
+		t.Fatal("expected corrupt state to be replaced")
+	}
+}
+
+func TestSaveStoreUsesPrivateDirectory(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "state")
+	mgr := New(nil, Config{StatePath: filepath.Join(dir, "disk-care-state.json")}, nil)
+	if err := mgr.saveStore(&store{}); err != nil {
+		t.Fatalf("save store: %v", err)
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat state dir: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o700 {
+		t.Fatalf("state dir mode = %o, want 700", got)
+	}
+}
+
 func TestRunReportsManagedDockerLogUsage(t *testing.T) {
 	dir := t.TempDir()
 	logPath := filepath.Join(dir, "container-json.log")

--- a/agent/internal/diskcare/diskcare_test.go
+++ b/agent/internal/diskcare/diskcare_test.go
@@ -1,0 +1,164 @@
+package diskcare
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/devopsellence/devopsellence/agent/internal/desiredstatepb"
+	"github.com/devopsellence/devopsellence/agent/internal/engine"
+)
+
+type fakeEngine struct {
+	managed      []engine.ContainerState
+	containers   []engine.ContainerState
+	images       []engine.ImageState
+	logPaths     map[string]string
+	removed      []string
+	removeErrors map[string]error
+}
+
+func (f *fakeEngine) ListManaged(context.Context) ([]engine.ContainerState, error) {
+	return append([]engine.ContainerState(nil), f.managed...), nil
+}
+
+func (f *fakeEngine) ListContainers(context.Context) ([]engine.ContainerState, error) {
+	return append([]engine.ContainerState(nil), f.containers...), nil
+}
+
+func (f *fakeEngine) ListImages(context.Context) ([]engine.ImageState, error) {
+	return append([]engine.ImageState(nil), f.images...), nil
+}
+
+func (f *fakeEngine) ImageExists(_ context.Context, image string) (bool, error) {
+	for _, item := range f.images {
+		for _, ref := range append(append([]string{item.ID}, item.RepoTags...), item.RepoDigests...) {
+			if ref == image {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+func (f *fakeEngine) RemoveImage(_ context.Context, reference string) ([]engine.ImageDelete, error) {
+	if err := f.removeErrors[reference]; err != nil {
+		return nil, err
+	}
+	f.removed = append(f.removed, reference)
+	return []engine.ImageDelete{{Untagged: reference}}, nil
+}
+
+func (f *fakeEngine) Inspect(_ context.Context, name string) (engine.ContainerInfo, error) {
+	return engine.ContainerInfo{Name: name, LogPath: f.logPaths[name]}, nil
+}
+
+func TestRunRemovesOnlyImagesOutsideRetentionWindow(t *testing.T) {
+	dir := t.TempDir()
+	statePath := filepath.Join(dir, "disk-care-state.json")
+	now := time.Now().Add(-time.Hour).UTC()
+	initial := &store{Releases: []releaseRecord{
+		{Environment: "production", Revision: "rev-1", Images: []string{"app:rev1"}, LastSeenAt: now.Add(1 * time.Minute)},
+		{Environment: "production", Revision: "rev-2", Images: []string{"app:rev2"}, LastSeenAt: now.Add(2 * time.Minute)},
+		{Environment: "production", Revision: "rev-3", Images: []string{"app:rev3"}, LastSeenAt: now.Add(3 * time.Minute)},
+	}}
+	eng := &fakeEngine{
+		images: []engine.ImageState{
+			{ID: "sha256:1", RepoTags: []string{"app:rev1"}, Size: 100},
+			{ID: "sha256:2", RepoTags: []string{"app:rev2"}, Size: 200},
+			{ID: "sha256:3", RepoTags: []string{"app:rev3"}, Size: 300},
+			{ID: "sha256:envoy", RepoTags: []string{"envoy:latest"}, Size: 400},
+		},
+		containers: []engine.ContainerState{{Name: "web", Image: "app:rev3", Managed: true}},
+		managed:    []engine.ContainerState{{Name: "web", Image: "app:rev3", Managed: true}},
+		logPaths:   map[string]string{},
+	}
+	mgr := New(eng, Config{StatePath: statePath, RetainedPreviousReleases: 1, ProtectedImages: []string{"envoy:latest"}, ContainerLogMaxSize: "10m", ContainerLogMaxFile: 5}, nil)
+	if err := mgr.saveStore(initial); err != nil {
+		t.Fatalf("save store: %v", err)
+	}
+
+	status, err := mgr.Run(context.Background(), desiredState("rev-3", "app:rev3"))
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(eng.removed) != 1 || eng.removed[0] != "app:rev1" {
+		t.Fatalf("removed = %#v, want app:rev1", eng.removed)
+	}
+	if status.ReclaimedBytes != 100 {
+		t.Fatalf("reclaimed bytes = %d, want 100", status.ReclaimedBytes)
+	}
+	if status.RetainedReleaseCount != 2 {
+		t.Fatalf("retained release count = %d, want 2", status.RetainedReleaseCount)
+	}
+}
+
+func TestRunProtectsImagesUsedByAnyContainer(t *testing.T) {
+	dir := t.TempDir()
+	statePath := filepath.Join(dir, "disk-care-state.json")
+	initial := &store{Releases: []releaseRecord{
+		{Environment: "production", Revision: "rev-1", Images: []string{"app:rev1"}, LastSeenAt: time.Now().Add(-time.Hour)},
+		{Environment: "production", Revision: "rev-2", Images: []string{"app:rev2"}, LastSeenAt: time.Now()},
+	}}
+	eng := &fakeEngine{
+		images:     []engine.ImageState{{ID: "sha256:1", RepoTags: []string{"app:rev1"}, Size: 100}, {ID: "sha256:2", RepoTags: []string{"app:rev2"}, Size: 200}},
+		containers: []engine.ContainerState{{Name: "user", Image: "app:rev1", Managed: false}},
+		logPaths:   map[string]string{},
+	}
+	mgr := New(eng, Config{StatePath: statePath, RetainedPreviousReleases: 0}, nil)
+	if err := mgr.saveStore(initial); err != nil {
+		t.Fatalf("save store: %v", err)
+	}
+
+	_, err := mgr.Run(context.Background(), desiredState("rev-2", "app:rev2"))
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(eng.removed) != 0 {
+		t.Fatalf("removed = %#v, want none", eng.removed)
+	}
+}
+
+func TestRunReportsManagedDockerLogUsage(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "container-json.log")
+	if err := os.WriteFile(logPath, []byte("hello logs"), 0o600); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+	eng := &fakeEngine{
+		managed:    []engine.ContainerState{{Name: "web", Image: "app:rev1", Managed: true}},
+		containers: []engine.ContainerState{{Name: "web", Image: "app:rev1", Managed: true}},
+		images:     []engine.ImageState{{ID: "sha256:1", RepoTags: []string{"app:rev1"}, Size: 100}},
+		logPaths:   map[string]string{"web": logPath},
+	}
+	mgr := New(eng, Config{StatePath: filepath.Join(dir, "state.json"), RetainedPreviousReleases: 10, ContainerLogMaxSize: "10m", ContainerLogMaxFile: 5}, nil)
+
+	status, err := mgr.Run(context.Background(), desiredState("rev-1", "app:rev1"))
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if status.DockerLogBytes != int64(len("hello logs")) {
+		t.Fatalf("docker log bytes = %d", status.DockerLogBytes)
+	}
+	if status.LogMaxSize != "10m" || status.LogMaxFile != 5 {
+		t.Fatalf("unexpected log config in status: %#v", status)
+	}
+}
+
+func desiredState(revision string, image string) *desiredstatepb.DesiredState {
+	return &desiredstatepb.DesiredState{
+		SchemaVersion: 2,
+		Revision:      revision,
+		Environments: []*desiredstatepb.Environment{{
+			Name:     "production",
+			Revision: revision,
+			Services: []*desiredstatepb.Service{{
+				Name:  "web",
+				Kind:  "web",
+				Image: image,
+			}},
+		}},
+	}
+}

--- a/agent/internal/diskcare/diskcare_test.go
+++ b/agent/internal/diskcare/diskcare_test.go
@@ -140,8 +140,12 @@ func TestRunIgnoresCorruptState(t *testing.T) {
 	}
 	mgr := New(eng, Config{StatePath: statePath, RetainedPreviousReleases: 10}, nil)
 
-	if _, err := mgr.Run(context.Background(), desiredState("rev-1", "app:rev1")); err != nil {
+	status, err := mgr.Run(context.Background(), desiredState("rev-1", "app:rev1"))
+	if err != nil {
 		t.Fatalf("run with corrupt state: %v", err)
+	}
+	if status.LastError == "" {
+		t.Fatal("expected corrupt state warning in status")
 	}
 	data, err := os.ReadFile(statePath)
 	if err != nil {
@@ -154,6 +158,9 @@ func TestRunIgnoresCorruptState(t *testing.T) {
 
 func TestSaveStoreUsesPrivateDirectory(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "state")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
 	mgr := New(nil, Config{StatePath: filepath.Join(dir, "disk-care-state.json")}, nil)
 	if err := mgr.saveStore(&store{}); err != nil {
 		t.Fatalf("save store: %v", err)

--- a/agent/internal/diskcare/diskcare_test.go
+++ b/agent/internal/diskcare/diskcare_test.go
@@ -203,6 +203,46 @@ func TestRunReportsManagedDockerLogUsage(t *testing.T) {
 	}
 }
 
+func TestRetainedReleaseKeysNormalizesEnvironmentNames(t *testing.T) {
+	older := time.Now().Add(-time.Hour)
+	newer := time.Now()
+	releases := []releaseRecord{
+		{Environment: "production ", Revision: "rev-1", Images: []string{"app:rev1"}, LastSeenAt: older},
+		{Environment: "production", Revision: "rev-2", Images: []string{"app:rev2"}, LastSeenAt: newer},
+	}
+
+	retained := retainedReleaseKeys(releases, nil, 1)
+	if _, ok := retained[releaseKey("production", "rev-2")]; !ok {
+		t.Fatal("expected newest production release to be retained")
+	}
+	if _, ok := retained[releaseKey("production", "rev-1")]; ok {
+		t.Fatal("expected older whitespace-variant production release to fall outside retention")
+	}
+}
+
+func TestStoreNormalizeCanonicalizesPersistedReleaseRecords(t *testing.T) {
+	now := time.Now()
+	s := &store{Releases: []releaseRecord{
+		{Environment: " production ", Revision: " rev-1", Images: []string{" app:rev1 ", "app:rev1"}, LastSeenAt: now.Add(-time.Minute)},
+		{Environment: "production", Revision: "rev-1", Images: []string{"app:rev1b"}, LastSeenAt: now},
+	}}
+
+	s.normalize()
+	if len(s.Releases) != 1 {
+		t.Fatalf("releases = %#v, want one normalized record", s.Releases)
+	}
+	got := s.Releases[0]
+	if got.Environment != "production" || got.Revision != "rev-1" {
+		t.Fatalf("normalized release = %#v", got)
+	}
+	if len(got.Images) != 2 || got.Images[0] != "app:rev1" || got.Images[1] != "app:rev1b" {
+		t.Fatalf("normalized images = %#v", got.Images)
+	}
+	if !got.LastSeenAt.Equal(now) {
+		t.Fatalf("last seen = %v, want %v", got.LastSeenAt, now)
+	}
+}
+
 func desiredState(revision string, image string) *desiredstatepb.DesiredState {
 	return &desiredstatepb.DesiredState{
 		SchemaVersion: 2,

--- a/agent/internal/diskcare/diskcare_test.go
+++ b/agent/internal/diskcare/diskcare_test.go
@@ -210,13 +210,25 @@ func TestRetainedReleaseKeysNormalizesEnvironmentNames(t *testing.T) {
 		{Environment: "production ", Revision: "rev-1", Images: []string{"app:rev1"}, LastSeenAt: older},
 		{Environment: "production", Revision: "rev-2", Images: []string{"app:rev2"}, LastSeenAt: newer},
 	}
+	current := []releaseRecord{{Environment: " production ", Revision: "rev-2", Images: []string{"app:rev2"}, LastSeenAt: newer}}
 
-	retained := retainedReleaseKeys(releases, nil, 1)
+	retained := retainedReleaseKeys(releases, current, 1)
 	if _, ok := retained[releaseKey("production", "rev-2")]; !ok {
 		t.Fatal("expected newest production release to be retained")
 	}
 	if _, ok := retained[releaseKey("production", "rev-1")]; ok {
 		t.Fatal("expected older whitespace-variant production release to fall outside retention")
+	}
+}
+
+func TestRetainedReleaseKeysDropsDeletedEnvironments(t *testing.T) {
+	releases := []releaseRecord{
+		{Environment: "deleted", Revision: "rev-1", Images: []string{"app:rev1"}, LastSeenAt: time.Now()},
+	}
+
+	retained := retainedReleaseKeys(releases, nil, 1)
+	if len(retained) != 0 {
+		t.Fatalf("retained = %#v, want none for deleted environments", retained)
 	}
 }
 

--- a/agent/internal/engine/docker/docker.go
+++ b/agent/internal/engine/docker/docker.go
@@ -43,6 +43,14 @@ func New(socketPath string) (*Engine, error) {
 
 func (e *Engine) ListManaged(ctx context.Context) ([]engine.ContainerState, error) {
 	filters := make(client.Filters).Add("label", engine.LabelManaged+"=true")
+	return e.listContainers(ctx, filters)
+}
+
+func (e *Engine) ListContainers(ctx context.Context) ([]engine.ContainerState, error) {
+	return e.listContainers(ctx, nil)
+}
+
+func (e *Engine) listContainers(ctx context.Context, filters client.Filters) ([]engine.ContainerState, error) {
 	result, err := e.client.ContainerList(ctx, client.ContainerListOptions{
 		All:     true,
 		Filters: filters,
@@ -58,6 +66,7 @@ func (e *Engine) ListManaged(ctx context.Context) ([]engine.ContainerState, erro
 			Name:        name,
 			Image:       c.Image,
 			Running:     c.State == "running",
+			Managed:     c.Labels[engine.LabelManaged] == "true",
 			Hash:        c.Labels[engine.LabelHash],
 			Environment: c.Labels[engine.LabelEnvironment],
 			Service:     c.Labels[engine.LabelService],
@@ -123,6 +132,12 @@ func buildContainerCreateConfig(spec engine.ContainerSpec) (*container.Config, *
 		hostCfg.RestartPolicy = container.RestartPolicy{
 			Name:              container.RestartPolicyMode(spec.Restart.Name),
 			MaximumRetryCount: spec.Restart.MaxRetries,
+		}
+	}
+	if spec.Log != nil {
+		hostCfg.LogConfig = container.LogConfig{
+			Type:   spec.Log.Driver,
+			Config: cloneStringMap(spec.Log.Options),
 		}
 	}
 
@@ -223,6 +238,35 @@ func (e *Engine) PullImage(ctx context.Context, image string, auth *engine.Regis
 	return err
 }
 
+func (e *Engine) ListImages(ctx context.Context) ([]engine.ImageState, error) {
+	result, err := e.client.ImageList(ctx, client.ImageListOptions{All: true})
+	if err != nil {
+		return nil, err
+	}
+	images := make([]engine.ImageState, 0, len(result.Items))
+	for _, item := range result.Items {
+		images = append(images, engine.ImageState{
+			ID:          item.ID,
+			RepoTags:    append([]string(nil), item.RepoTags...),
+			RepoDigests: append([]string(nil), item.RepoDigests...),
+			Size:        item.Size,
+		})
+	}
+	return images, nil
+}
+
+func (e *Engine) RemoveImage(ctx context.Context, reference string) ([]engine.ImageDelete, error) {
+	result, err := e.client.ImageRemove(ctx, reference, client.ImageRemoveOptions{Force: false, PruneChildren: false})
+	if err != nil {
+		return nil, err
+	}
+	removed := make([]engine.ImageDelete, 0, len(result.Items))
+	for _, item := range result.Items {
+		removed = append(removed, engine.ImageDelete{Deleted: item.Deleted, Untagged: item.Untagged})
+	}
+	return removed, nil
+}
+
 func (e *Engine) Inspect(ctx context.Context, name string) (engine.ContainerInfo, error) {
 	res, err := e.client.ContainerInspect(ctx, name, client.ContainerInspectOptions{})
 	if err != nil {
@@ -265,6 +309,11 @@ func (e *Engine) Inspect(ctx context.Context, name string) (engine.ContainerInfo
 		PublishHostPort: len(publishedPorts) > 0,
 		PublishedPorts:  publishedPorts,
 		NetworkIP:       map[string]string{},
+		LogPath:         res.Container.LogPath,
+	}
+	if res.Container.HostConfig != nil {
+		info.LogDriver = res.Container.HostConfig.LogConfig.Type
+		info.LogOptions = cloneStringMap(res.Container.HostConfig.LogConfig.Config)
 	}
 	if res.Container.State != nil && res.Container.State.Health != nil {
 		info.Health = string(res.Container.State.Health.Status)
@@ -357,4 +406,15 @@ func encodeRegistryAuth(auth *engine.RegistryAuth) (string, error) {
 		return "", fmt.Errorf("encode registry auth: %w", err)
 	}
 	return base64.URLEncoding.EncodeToString(payload), nil
+}
+
+func cloneStringMap(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
 }

--- a/agent/internal/engine/docker/docker_test.go
+++ b/agent/internal/engine/docker/docker_test.go
@@ -33,3 +33,28 @@ func TestBuildContainerCreateConfigSetsNetworkModeForManagedNetwork(t *testing.T
 		t.Fatalf("expected endpoint config for managed network")
 	}
 }
+
+func TestBuildContainerCreateConfigSetsPerContainerLogConfig(t *testing.T) {
+	spec := engine.ContainerSpec{
+		Name:  "web",
+		Image: "example/web:rev1",
+		Log: &engine.LogConfig{
+			Driver: "json-file",
+			Options: map[string]string{
+				"max-size": "10m",
+				"max-file": "5",
+			},
+		},
+	}
+
+	_, hostCfg, _, err := buildContainerCreateConfig(spec)
+	if err != nil {
+		t.Fatalf("buildContainerCreateConfig returned error: %v", err)
+	}
+	if hostCfg.LogConfig.Type != "json-file" {
+		t.Fatalf("log driver = %q, want json-file", hostCfg.LogConfig.Type)
+	}
+	if hostCfg.LogConfig.Config["max-size"] != "10m" || hostCfg.LogConfig.Config["max-file"] != "5" {
+		t.Fatalf("unexpected log options: %#v", hostCfg.LogConfig.Config)
+	}
+}

--- a/agent/internal/engine/engine.go
+++ b/agent/internal/engine/engine.go
@@ -46,10 +46,17 @@ type ContainerSpec struct {
 	Labels     map[string]string
 	Health     *Healthcheck
 	Restart    *RestartPolicy
+	Log        *LogConfig
 	Network    string
 	Binds      []string
 	Ports      []PortBinding
 	ExtraHosts []string // e.g. ["host.docker.internal:host-gateway"]
+}
+
+// LogConfig describes per-container Docker logging configuration.
+type LogConfig struct {
+	Driver  string
+	Options map[string]string
 }
 
 type Healthcheck struct {
@@ -75,11 +82,26 @@ type ContainerState struct {
 	Name        string
 	Image       string
 	Running     bool
+	Managed     bool
 	Hash        string
 	Environment string
 	Service     string
 	ServiceKind string
 	System      string
+}
+
+// ImageState describes a local Docker image known to the engine.
+type ImageState struct {
+	ID          string
+	RepoTags    []string
+	RepoDigests []string
+	Size        int64
+}
+
+// ImageDelete reports an image delete/untag operation returned by Docker.
+type ImageDelete struct {
+	Deleted  string
+	Untagged string
 }
 
 type ContainerInfo struct {
@@ -90,4 +112,7 @@ type ContainerInfo struct {
 	PublishHostPort bool
 	PublishedPorts  []PortBinding
 	NetworkIP       map[string]string
+	LogPath         string
+	LogDriver       string
+	LogOptions      map[string]string
 }

--- a/agent/internal/engine/engine.go
+++ b/agent/internal/engine/engine.go
@@ -59,6 +59,23 @@ type LogConfig struct {
 	Options map[string]string
 }
 
+// CloneLogConfig returns a deep copy of cfg.
+func CloneLogConfig(cfg *LogConfig) *LogConfig {
+	if cfg == nil {
+		return nil
+	}
+	cloned := *cfg
+	if len(cfg.Options) > 0 {
+		cloned.Options = make(map[string]string, len(cfg.Options))
+		for key, value := range cfg.Options {
+			cloned.Options[key] = value
+		}
+	} else {
+		cloned.Options = nil
+	}
+	return &cloned
+}
+
 type Healthcheck struct {
 	Test        []string
 	Interval    time.Duration

--- a/agent/internal/engine/engine.go
+++ b/agent/internal/engine/engine.go
@@ -2,6 +2,10 @@ package engine
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"sort"
+	"strings"
 	"time"
 )
 
@@ -57,6 +61,45 @@ type ContainerSpec struct {
 type LogConfig struct {
 	Driver  string
 	Options map[string]string
+}
+
+// LogConfigHash returns a stable hash fragment for cfg.
+func LogConfigHash(cfg *LogConfig) string {
+	if cfg == nil {
+		return ""
+	}
+	var builder strings.Builder
+	builder.WriteString(strings.TrimSpace(cfg.Driver))
+	builder.WriteByte(0)
+	keys := make([]string, 0, len(cfg.Options))
+	for key := range cfg.Options {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		builder.WriteString(strings.TrimSpace(key))
+		builder.WriteByte(0)
+		builder.WriteString(strings.TrimSpace(cfg.Options[key]))
+		builder.WriteByte(0)
+	}
+	sum := sha256.Sum256([]byte(builder.String()))
+	return hex.EncodeToString(sum[:])
+}
+
+// LogConfigMatches reports whether an inspected Docker log config matches cfg.
+func LogConfigMatches(driver string, options map[string]string, cfg *LogConfig) bool {
+	if cfg == nil {
+		return true
+	}
+	if strings.TrimSpace(driver) != strings.TrimSpace(cfg.Driver) {
+		return false
+	}
+	for key, value := range cfg.Options {
+		if strings.TrimSpace(options[key]) != strings.TrimSpace(value) {
+			return false
+		}
+	}
+	return true
 }
 
 // CloneLogConfig returns a deep copy of cfg.

--- a/agent/internal/engine/engine.go
+++ b/agent/internal/engine/engine.go
@@ -94,12 +94,28 @@ func LogConfigMatches(driver string, options map[string]string, cfg *LogConfig) 
 	if strings.TrimSpace(driver) != strings.TrimSpace(cfg.Driver) {
 		return false
 	}
-	for key, value := range cfg.Options {
-		if strings.TrimSpace(options[key]) != strings.TrimSpace(value) {
+	actual := normalizeLogOptions(options)
+	expected := normalizeLogOptions(cfg.Options)
+	if len(actual) != len(expected) {
+		return false
+	}
+	for key, value := range expected {
+		if actual[key] != value {
 			return false
 		}
 	}
 	return true
+}
+
+func normalizeLogOptions(options map[string]string) map[string]string {
+	if len(options) == 0 {
+		return nil
+	}
+	normalized := make(map[string]string, len(options))
+	for key, value := range options {
+		normalized[strings.TrimSpace(key)] = strings.TrimSpace(value)
+	}
+	return normalized
 }
 
 // CloneLogConfig returns a deep copy of cfg.

--- a/agent/internal/engine/engine_test.go
+++ b/agent/internal/engine/engine_test.go
@@ -1,0 +1,20 @@
+package engine
+
+import "testing"
+
+func TestLogConfigMatchesRequiresExactOptions(t *testing.T) {
+	cfg := &LogConfig{Driver: "json-file", Options: map[string]string{"max-size": "10m"}}
+
+	if !LogConfigMatches(" json-file ", map[string]string{" max-size ": " 10m "}, cfg) {
+		t.Fatal("expected matching trimmed driver and options")
+	}
+	if LogConfigMatches("json-file", map[string]string{"max-size": "10m", "max-file": "5"}, cfg) {
+		t.Fatal("expected extra actual log option to be treated as mismatch")
+	}
+	if LogConfigMatches("json-file", nil, cfg) {
+		t.Fatal("expected missing log option to be treated as mismatch")
+	}
+	if LogConfigMatches("json-file", map[string]string{"max-size": "10m"}, &LogConfig{Driver: "json-file"}) {
+		t.Fatal("expected configured empty options to reject actual options")
+	}
+}

--- a/agent/internal/envoy/manager.go
+++ b/agent/internal/envoy/manager.go
@@ -321,7 +321,7 @@ func (m *Manager) createEnvoy(ctx context.Context, ingress *desiredstatepb.Ingre
 		Binds:   mounts,
 		Health:  m.config.Healthcheck,
 		Restart: engine.RestartPolicyFromString(m.config.RestartPolicy),
-		Log:     cloneLogConfig(m.config.LogConfig),
+		Log:     engine.CloneLogConfig(m.config.LogConfig),
 	}
 	if publicIngressEnabled {
 		spec.ExtraHosts = []string{"host.docker.internal:host-gateway"}
@@ -589,20 +589,6 @@ func dirOf(path string) string {
 		return path[:idx]
 	}
 	return "."
-}
-
-func cloneLogConfig(cfg *engine.LogConfig) *engine.LogConfig {
-	if cfg == nil {
-		return nil
-	}
-	cloned := &engine.LogConfig{Driver: cfg.Driver}
-	if len(cfg.Options) > 0 {
-		cloned.Options = make(map[string]string, len(cfg.Options))
-		for key, value := range cfg.Options {
-			cloned.Options[key] = value
-		}
-	}
-	return cloned
 }
 
 func containsMount(mounts []string, dir string) bool {

--- a/agent/internal/envoy/manager.go
+++ b/agent/internal/envoy/manager.go
@@ -621,7 +621,7 @@ func cloneIngress(ingress *desiredstatepb.Ingress) *desiredstatepb.Ingress {
 	}
 	cloned, ok := proto.Clone(ingress).(*desiredstatepb.Ingress)
 	if !ok {
-		return nil
+		return ingress
 	}
 	return cloned
 }

--- a/agent/internal/envoy/manager.go
+++ b/agent/internal/envoy/manager.go
@@ -172,6 +172,12 @@ func (m *Manager) Ensure(ctx context.Context, ingress *desiredstatepb.Ingress) e
 		}
 		info.Running = false
 	}
+	if info.Running && !engine.LogConfigMatches(info.LogDriver, info.LogOptions, m.config.LogConfig) {
+		if err := m.engine.Remove(ctx, m.config.ContainerName); err != nil {
+			return fmt.Errorf("remove envoy (log config changed): %w", err)
+		}
+		info.Running = false
+	}
 	if info.Running && bootstrapChanged {
 		if err := m.engine.Remove(ctx, m.config.ContainerName); err != nil {
 			return fmt.Errorf("remove envoy (bootstrap changed): %w", err)

--- a/agent/internal/envoy/manager.go
+++ b/agent/internal/envoy/manager.go
@@ -611,11 +611,7 @@ func cloneIngress(ingress *desiredstatepb.Ingress) *desiredstatepb.Ingress {
 	if ingress == nil {
 		return nil
 	}
-	cloned, ok := proto.Clone(ingress).(*desiredstatepb.Ingress)
-	if !ok {
-		return ingress
-	}
-	return cloned
+	return proto.Clone(ingress).(*desiredstatepb.Ingress)
 }
 
 func normalizedIngressMode(ingress *desiredstatepb.Ingress) string {

--- a/agent/internal/envoy/manager.go
+++ b/agent/internal/envoy/manager.go
@@ -17,6 +17,7 @@ import (
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/devopsellence/devopsellence/agent/internal/desiredstatepb"
 	"github.com/devopsellence/devopsellence/agent/internal/engine"
+	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -44,6 +45,7 @@ type Config struct {
 	Healthcheck         *engine.Healthcheck
 	StartupTimeout      time.Duration
 	RestartPolicy       string
+	LogConfig           *engine.LogConfig
 	RouteTimeout        time.Duration
 	RouteInterval       time.Duration
 	HTTPClient          *http.Client
@@ -312,12 +314,14 @@ func (m *Manager) createEnvoy(ctx context.Context, ingress *desiredstatepb.Ingre
 		Image:   m.config.Image,
 		Command: []string{"-c", m.config.BootstrapPath, "--log-level", "warning", "--log-path", "/dev/stderr"},
 		Labels: map[string]string{
-			engine.LabelSystem: "envoy",
+			engine.LabelManaged: "true",
+			engine.LabelSystem:  "envoy",
 		},
 		Network: m.config.NetworkName,
 		Binds:   mounts,
 		Health:  m.config.Healthcheck,
 		Restart: engine.RestartPolicyFromString(m.config.RestartPolicy),
+		Log:     cloneLogConfig(m.config.LogConfig),
 	}
 	if publicIngressEnabled {
 		spec.ExtraHosts = []string{"host.docker.internal:host-gateway"}
@@ -587,6 +591,20 @@ func dirOf(path string) string {
 	return "."
 }
 
+func cloneLogConfig(cfg *engine.LogConfig) *engine.LogConfig {
+	if cfg == nil {
+		return nil
+	}
+	cloned := &engine.LogConfig{Driver: cfg.Driver}
+	if len(cfg.Options) > 0 {
+		cloned.Options = make(map[string]string, len(cfg.Options))
+		for key, value := range cfg.Options {
+			cloned.Options[key] = value
+		}
+	}
+	return cloned
+}
+
 func containsMount(mounts []string, dir string) bool {
 	needle := fmt.Sprintf("%s:%s:ro", dir, dir)
 	for _, mount := range mounts {
@@ -601,9 +619,11 @@ func cloneIngress(ingress *desiredstatepb.Ingress) *desiredstatepb.Ingress {
 	if ingress == nil {
 		return nil
 	}
-
-	copy := *ingress
-	return &copy
+	cloned, ok := proto.Clone(ingress).(*desiredstatepb.Ingress)
+	if !ok {
+		return nil
+	}
+	return cloned
 }
 
 func normalizedIngressMode(ingress *desiredstatepb.Ingress) string {

--- a/agent/internal/envoy/manager_test.go
+++ b/agent/internal/envoy/manager_test.go
@@ -59,6 +59,10 @@ func (f *fakeEngine) CreateAndStart(ctx context.Context, spec engine.ContainerSp
 		PublishedPorts:  append([]engine.PortBinding(nil), spec.Ports...),
 		NetworkIP:       map[string]string{spec.Network: networkIP},
 	}
+	if spec.Log != nil {
+		f.inspectInfo.LogDriver = spec.Log.Driver
+		f.inspectInfo.LogOptions = appendMap(spec.Log.Options)
+	}
 	return nil
 }
 
@@ -103,6 +107,17 @@ func (f *fakeEngine) Logs(_ context.Context, _ string, _ int) ([]byte, error) {
 
 func (f *fakeEngine) EnsureNetwork(ctx context.Context, name string) error {
 	return nil
+}
+
+func appendMap(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
 }
 
 func tempBootstrapPath(t *testing.T) string {
@@ -378,6 +393,45 @@ func TestEnsureRestartsRunningEnvoyWhenBootstrapChanges(t *testing.T) {
 	}
 	if eng.createdSpec == nil {
 		t.Fatal("expected CreateAndStart to be called after bootstrap change")
+	}
+}
+
+func TestEnsureRestartsRunningEnvoyWhenLogConfigChanges(t *testing.T) {
+	eng := &fakeEngine{
+		imageExists: true,
+		inspectInfo: engine.ContainerInfo{
+			Name:            "devopsellence-envoy",
+			Running:         true,
+			Health:          "healthy",
+			HasHealthcheck:  true,
+			PublishHostPort: true,
+			NetworkIP:       map[string]string{"devopsellence": "172.18.0.2"},
+			LogDriver:       "json-file",
+			LogOptions:      map[string]string{"max-size": "100m", "max-file": "1"},
+		},
+	}
+	logger := slog.New(slog.NewJSONHandler(io.Discard, &slog.HandlerOptions{}))
+	bootstrapPath := tempBootstrapPath(t)
+	mgr := New(eng, Config{
+		Image:          "docker.io/envoyproxy/envoy:v1.37.0",
+		ContainerName:  "devopsellence-envoy",
+		NetworkName:    "devopsellence",
+		BootstrapPath:  bootstrapPath,
+		Port:           8000,
+		ClusterName:    "devopsellence_web",
+		RestartPolicy:  "unless-stopped",
+		LogConfig:      &engine.LogConfig{Driver: "json-file", Options: map[string]string{"max-size": "10m", "max-file": "5"}},
+		StartupTimeout: 2 * time.Second,
+	}, logger)
+
+	if err := mgr.Ensure(context.Background(), nil); err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+	if len(eng.removed) == 0 {
+		t.Fatal("expected running envoy to be recreated when log config changes")
+	}
+	if eng.createdSpec == nil || eng.createdSpec.Log == nil || eng.createdSpec.Log.Options["max-size"] != "10m" {
+		t.Fatalf("expected recreated envoy with new log config, got %#v", eng.createdSpec)
 	}
 }
 

--- a/agent/internal/envoy/manager_test.go
+++ b/agent/internal/envoy/manager_test.go
@@ -123,6 +123,7 @@ func TestEnsureCreatesEnvoyWithDefaults(t *testing.T) {
 		Port:           8000,
 		ClusterName:    "devopsellence_web",
 		RestartPolicy:  "unless-stopped",
+		LogConfig:      &engine.LogConfig{Driver: "json-file", Options: map[string]string{"max-size": "10m", "max-file": "5"}},
 		StartupTimeout: 2 * time.Second,
 	}, logger)
 
@@ -144,6 +145,12 @@ func TestEnsureCreatesEnvoyWithDefaults(t *testing.T) {
 	}
 	if eng.createdSpec.Restart == nil || eng.createdSpec.Restart.Name != "unless-stopped" {
 		t.Fatalf("unexpected restart policy: %+v", eng.createdSpec.Restart)
+	}
+	if eng.createdSpec.Labels[engine.LabelManaged] != "true" || eng.createdSpec.Labels[engine.LabelSystem] != "envoy" {
+		t.Fatalf("unexpected labels: %#v", eng.createdSpec.Labels)
+	}
+	if eng.createdSpec.Log == nil || eng.createdSpec.Log.Options["max-size"] != "10m" || eng.createdSpec.Log.Options["max-file"] != "5" {
+		t.Fatalf("unexpected log config: %#v", eng.createdSpec.Log)
 	}
 	if len(eng.createdSpec.Ports) != 1 {
 		t.Fatalf("expected envoy host port published, got %+v", eng.createdSpec.Ports)

--- a/agent/internal/reconcile/reconcile.go
+++ b/agent/internal/reconcile/reconcile.go
@@ -47,17 +47,17 @@ type HTTPProber interface {
 }
 
 type Options struct {
-	Network                    string
-	StopTimeout                time.Duration
-	DrainDelay                 time.Duration
-	WebPort                    uint16
-	LogConfig                  *engine.LogConfig
-	PersistentSystemContainers []string
-	Envoy                      EnvoyManager
-	ImagePullAuth              ImagePullAuthProvider
-	IngressCert                IngressCertManager
-	HTTPProber                 HTTPProber
-	Logger                     *slog.Logger
+	Network                      string
+	StopTimeout                  time.Duration
+	DrainDelay                   time.Duration
+	WebPort                      uint16
+	LogConfig                    *engine.LogConfig
+	ProtectedEnvoyContainerNames []string
+	Envoy                        EnvoyManager
+	ImagePullAuth                ImagePullAuthProvider
+	IngressCert                  IngressCertManager
+	HTTPProber                   HTTPProber
+	Logger                       *slog.Logger
 }
 
 type Reconciler struct {
@@ -123,7 +123,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, desired *desiredstatepb.Desi
 		if _, ok := desiredByService[containerServiceKey(c)]; ok {
 			continue
 		}
-		if c.Name == "" || isPersistentSystemContainer(c, r.opts.PersistentSystemContainers) {
+		if c.Name == "" || isPersistentEnvoyContainer(c, r.opts.ProtectedEnvoyContainerNames) {
 			continue
 		}
 		if err := r.stopAndRemove(ctx, c); err != nil {
@@ -432,14 +432,17 @@ func runtimeContainerHash(baseHash string, logConfig *engine.LogConfig) string {
 	return hex.EncodeToString(sum[:])
 }
 
-func isPersistentSystemContainer(c engine.ContainerState, protectedNames []string) bool {
+func isPersistentEnvoyContainer(c engine.ContainerState, protectedNames []string) bool {
+	if strings.TrimSpace(c.System) != "envoy" {
+		return false
+	}
 	name := strings.TrimSpace(c.Name)
 	for _, protected := range protectedNames {
 		if name == strings.TrimSpace(protected) {
 			return true
 		}
 	}
-	return len(protectedNames) == 0 && strings.TrimSpace(c.System) == "envoy" && name == "devopsellence-envoy"
+	return len(protectedNames) == 0 && name == "devopsellence-envoy"
 }
 
 // tearDownFailedContainer stops a container that failed to become healthy,

--- a/agent/internal/reconcile/reconcile.go
+++ b/agent/internal/reconcile/reconcile.go
@@ -120,7 +120,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, desired *desiredstatepb.Desi
 		if _, ok := desiredByService[containerServiceKey(c)]; ok {
 			continue
 		}
-		if c.Name == "" || c.Service == "" {
+		if c.Name == "" || isPersistentSystemContainer(c) {
 			continue
 		}
 		if err := r.stopAndRemove(ctx, c); err != nil {
@@ -418,6 +418,10 @@ func runtimeServiceKey(environmentName, serviceName string) string {
 
 func containerServiceKey(c engine.ContainerState) string {
 	return runtimeServiceKey(c.Environment, c.Service)
+}
+
+func isPersistentSystemContainer(c engine.ContainerState) bool {
+	return strings.TrimSpace(c.System) == "envoy"
 }
 
 // tearDownFailedContainer stops a container that failed to become healthy,

--- a/agent/internal/reconcile/reconcile.go
+++ b/agent/internal/reconcile/reconcile.go
@@ -3,6 +3,8 @@ package reconcile
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -421,6 +423,15 @@ func containerServiceKey(c engine.ContainerState) string {
 	return runtimeServiceKey(c.Environment, c.Service)
 }
 
+func runtimeContainerHash(baseHash string, logConfig *engine.LogConfig) string {
+	logHash := engine.LogConfigHash(logConfig)
+	if logHash == "" {
+		return baseHash
+	}
+	sum := sha256.Sum256([]byte(baseHash + "\x00" + logHash))
+	return hex.EncodeToString(sum[:])
+}
+
 func isPersistentSystemContainer(c engine.ContainerState, protectedNames []string) bool {
 	if strings.TrimSpace(c.System) != "envoy" {
 		return false
@@ -577,6 +588,7 @@ func (r *Reconciler) specForService(runtime desiredstate.RuntimeService) (string
 		return "", "", engine.ContainerSpec{}, fmt.Errorf("hash service %s/%s: %w", runtime.EnvironmentName, runtime.ServiceName, err)
 	}
 
+	hash = runtimeContainerHash(hash, r.opts.LogConfig)
 	name, err := desiredstate.ServiceContainerName(runtime.EnvironmentName, runtime.ServiceName, runtime.EnvironmentRevision, hash)
 	if err != nil {
 		return "", "", engine.ContainerSpec{}, err

--- a/agent/internal/reconcile/reconcile.go
+++ b/agent/internal/reconcile/reconcile.go
@@ -49,6 +49,7 @@ type Options struct {
 	StopTimeout   time.Duration
 	DrainDelay    time.Duration
 	WebPort       uint16
+	LogConfig     *engine.LogConfig
 	Envoy         EnvoyManager
 	ImagePullAuth ImagePullAuthProvider
 	IngressCert   IngressCertManager
@@ -119,7 +120,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, desired *desiredstatepb.Desi
 		if _, ok := desiredByService[containerServiceKey(c)]; ok {
 			continue
 		}
-		if c.Name == "" {
+		if c.Name == "" || c.Service == "" {
 			continue
 		}
 		if err := r.stopAndRemove(ctx, c); err != nil {
@@ -586,6 +587,7 @@ func (r *Reconciler) specForService(runtime desiredstate.RuntimeService) (string
 		Env:        env,
 		Binds:      volumeBinds(service.VolumeMounts),
 		Labels:     labels,
+		Log:        cloneLogConfig(r.opts.LogConfig),
 		Network:    r.opts.Network,
 	}
 
@@ -621,10 +623,25 @@ func (r *Reconciler) specForTask(task *desiredstatepb.Task, revision string) (st
 			engine.LabelRevision: revision,
 			engine.LabelSystem:   task.GetName(),
 		},
+		Log:     cloneLogConfig(r.opts.LogConfig),
 		Network: r.opts.Network,
 	}
 
 	return name, hash, spec, nil
+}
+
+func cloneLogConfig(cfg *engine.LogConfig) *engine.LogConfig {
+	if cfg == nil {
+		return nil
+	}
+	cloned := &engine.LogConfig{Driver: cfg.Driver}
+	if len(cfg.Options) > 0 {
+		cloned.Options = make(map[string]string, len(cfg.Options))
+		for key, value := range cfg.Options {
+			cloned.Options[key] = value
+		}
+	}
+	return cloned
 }
 
 func volumeBinds(mounts []*desiredstatepb.VolumeMount) []string {

--- a/agent/internal/reconcile/reconcile.go
+++ b/agent/internal/reconcile/reconcile.go
@@ -433,19 +433,13 @@ func runtimeContainerHash(baseHash string, logConfig *engine.LogConfig) string {
 }
 
 func isPersistentSystemContainer(c engine.ContainerState, protectedNames []string) bool {
-	if strings.TrimSpace(c.System) != "envoy" {
-		return false
-	}
 	name := strings.TrimSpace(c.Name)
-	if len(protectedNames) == 0 {
-		return name == "devopsellence-envoy"
-	}
 	for _, protected := range protectedNames {
 		if name == strings.TrimSpace(protected) {
 			return true
 		}
 	}
-	return false
+	return len(protectedNames) == 0 && strings.TrimSpace(c.System) == "envoy" && name == "devopsellence-envoy"
 }
 
 // tearDownFailedContainer stops a container that failed to become healthy,

--- a/agent/internal/reconcile/reconcile.go
+++ b/agent/internal/reconcile/reconcile.go
@@ -591,7 +591,7 @@ func (r *Reconciler) specForService(runtime desiredstate.RuntimeService) (string
 		Env:        env,
 		Binds:      volumeBinds(service.VolumeMounts),
 		Labels:     labels,
-		Log:        cloneLogConfig(r.opts.LogConfig),
+		Log:        engine.CloneLogConfig(r.opts.LogConfig),
 		Network:    r.opts.Network,
 	}
 
@@ -627,25 +627,11 @@ func (r *Reconciler) specForTask(task *desiredstatepb.Task, revision string) (st
 			engine.LabelRevision: revision,
 			engine.LabelSystem:   task.GetName(),
 		},
-		Log:     cloneLogConfig(r.opts.LogConfig),
+		Log:     engine.CloneLogConfig(r.opts.LogConfig),
 		Network: r.opts.Network,
 	}
 
 	return name, hash, spec, nil
-}
-
-func cloneLogConfig(cfg *engine.LogConfig) *engine.LogConfig {
-	if cfg == nil {
-		return nil
-	}
-	cloned := &engine.LogConfig{Driver: cfg.Driver}
-	if len(cfg.Options) > 0 {
-		cloned.Options = make(map[string]string, len(cfg.Options))
-		for key, value := range cfg.Options {
-			cloned.Options[key] = value
-		}
-	}
-	return cloned
 }
 
 func volumeBinds(mounts []*desiredstatepb.VolumeMount) []string {

--- a/agent/internal/reconcile/reconcile.go
+++ b/agent/internal/reconcile/reconcile.go
@@ -45,16 +45,17 @@ type HTTPProber interface {
 }
 
 type Options struct {
-	Network       string
-	StopTimeout   time.Duration
-	DrainDelay    time.Duration
-	WebPort       uint16
-	LogConfig     *engine.LogConfig
-	Envoy         EnvoyManager
-	ImagePullAuth ImagePullAuthProvider
-	IngressCert   IngressCertManager
-	HTTPProber    HTTPProber
-	Logger        *slog.Logger
+	Network                    string
+	StopTimeout                time.Duration
+	DrainDelay                 time.Duration
+	WebPort                    uint16
+	LogConfig                  *engine.LogConfig
+	PersistentSystemContainers []string
+	Envoy                      EnvoyManager
+	ImagePullAuth              ImagePullAuthProvider
+	IngressCert                IngressCertManager
+	HTTPProber                 HTTPProber
+	Logger                     *slog.Logger
 }
 
 type Reconciler struct {
@@ -120,7 +121,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, desired *desiredstatepb.Desi
 		if _, ok := desiredByService[containerServiceKey(c)]; ok {
 			continue
 		}
-		if c.Name == "" || isPersistentSystemContainer(c) {
+		if c.Name == "" || isPersistentSystemContainer(c, r.opts.PersistentSystemContainers) {
 			continue
 		}
 		if err := r.stopAndRemove(ctx, c); err != nil {
@@ -420,8 +421,20 @@ func containerServiceKey(c engine.ContainerState) string {
 	return runtimeServiceKey(c.Environment, c.Service)
 }
 
-func isPersistentSystemContainer(c engine.ContainerState) bool {
-	return strings.TrimSpace(c.System) == "envoy"
+func isPersistentSystemContainer(c engine.ContainerState, protectedNames []string) bool {
+	if strings.TrimSpace(c.System) != "envoy" {
+		return false
+	}
+	name := strings.TrimSpace(c.Name)
+	if len(protectedNames) == 0 {
+		return name == "devopsellence-envoy"
+	}
+	for _, protected := range protectedNames {
+		if name == strings.TrimSpace(protected) {
+			return true
+		}
+	}
+	return false
 }
 
 // tearDownFailedContainer stops a container that failed to become healthy,

--- a/agent/internal/reconcile/reconcile_test.go
+++ b/agent/internal/reconcile/reconcile_test.go
@@ -710,6 +710,51 @@ func TestReconcileAppliesLogConfigToRuntimeContainers(t *testing.T) {
 	}
 }
 
+func TestReconcileRecreatesRuntimeContainerWhenLogConfigChanges(t *testing.T) {
+	eng := newFakeEngine()
+	eng.images["busybox"] = true
+	service := workerService("worker", nil)
+	oldHash, err := desiredstate.HashService(service)
+	if err != nil {
+		t.Fatalf("hash service: %v", err)
+	}
+	oldName, err := desiredstate.ServiceContainerName("production", "worker", "rev-1", oldHash)
+	if err != nil {
+		t.Fatalf("container name: %v", err)
+	}
+	eng.containers[oldName] = engine.ContainerState{
+		Name:        oldName,
+		Image:       "busybox",
+		Running:     true,
+		Managed:     true,
+		Hash:        oldHash,
+		Environment: "production",
+		Service:     "worker",
+		ServiceKind: "worker",
+	}
+
+	rec := New(eng, Options{
+		Network: "devopsellence",
+		LogConfig: &engine.LogConfig{Driver: "json-file", Options: map[string]string{
+			"max-size": "10m",
+			"max-file": "5",
+		}},
+	})
+	result, err := rec.Reconcile(context.Background(), desiredState(service))
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if result.Updated != 1 || result.Removed != 1 {
+		t.Fatalf("result = %#v, want updated=1 removed=1", result)
+	}
+	if !containsString(eng.removed, oldName) {
+		t.Fatalf("expected old container removed; removed=%#v", eng.removed)
+	}
+	if len(eng.created) != 1 || eng.created[0].Name == oldName {
+		t.Fatalf("expected replacement container with log-config hash, created=%#v", eng.created)
+	}
+}
+
 func TestReconcileDoesNotRemoveManagedSystemContainers(t *testing.T) {
 	eng := newFakeEngine()
 	eng.containers["devopsellence-envoy"] = engine.ContainerState{

--- a/agent/internal/reconcile/reconcile_test.go
+++ b/agent/internal/reconcile/reconcile_test.go
@@ -719,6 +719,13 @@ func TestReconcileDoesNotRemoveManagedSystemContainers(t *testing.T) {
 		Managed: true,
 		System:  "envoy",
 	}
+	eng.containers["release-task"] = engine.ContainerState{
+		Name:    "release-task",
+		Image:   "busybox",
+		Running: false,
+		Managed: true,
+		System:  "release",
+	}
 	eng.images["busybox"] = true
 	rec := New(eng, Options{Network: "devopsellence"})
 	if _, err := rec.Reconcile(context.Background(), desiredState(workerService("worker", nil))); err != nil {
@@ -729,6 +736,18 @@ func TestReconcileDoesNotRemoveManagedSystemContainers(t *testing.T) {
 			t.Fatalf("envoy should not be removed; removed=%#v", eng.removed)
 		}
 	}
+	if !containsString(eng.removed, "release-task") {
+		t.Fatalf("expected orphaned task container to be removed; removed=%#v", eng.removed)
+	}
+}
+
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
 }
 
 func desiredState(services ...*desiredstatepb.Service) *desiredstatepb.DesiredState {

--- a/agent/internal/reconcile/reconcile_test.go
+++ b/agent/internal/reconcile/reconcile_test.go
@@ -755,7 +755,7 @@ func TestReconcileRecreatesRuntimeContainerWhenLogConfigChanges(t *testing.T) {
 	}
 }
 
-func TestReconcileDoesNotRemoveManagedSystemContainers(t *testing.T) {
+func TestReconcileOnlyProtectsPersistentEnvoyContainer(t *testing.T) {
 	eng := newFakeEngine()
 	eng.containers["devopsellence-envoy"] = engine.ContainerState{
 		Name:    "devopsellence-envoy",

--- a/agent/internal/reconcile/reconcile_test.go
+++ b/agent/internal/reconcile/reconcile_test.go
@@ -689,6 +689,48 @@ func TestReconcileWebContainerSpecHasNoDockerHealthcheck(t *testing.T) {
 	}
 }
 
+func TestReconcileAppliesLogConfigToRuntimeContainers(t *testing.T) {
+	eng := newFakeEngine()
+	eng.images["busybox"] = true
+	rec := New(eng, Options{
+		Network: "devopsellence",
+		LogConfig: &engine.LogConfig{Driver: "json-file", Options: map[string]string{
+			"max-size": "10m",
+			"max-file": "5",
+		}},
+	})
+	if _, err := rec.Reconcile(context.Background(), desiredState(workerService("worker", nil))); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if len(eng.created) != 1 {
+		t.Fatalf("expected one created container, got %d", len(eng.created))
+	}
+	if eng.created[0].Log == nil || eng.created[0].Log.Options["max-size"] != "10m" || eng.created[0].Log.Options["max-file"] != "5" {
+		t.Fatalf("unexpected log config: %#v", eng.created[0].Log)
+	}
+}
+
+func TestReconcileDoesNotRemoveManagedSystemContainers(t *testing.T) {
+	eng := newFakeEngine()
+	eng.containers["devopsellence-envoy"] = engine.ContainerState{
+		Name:    "devopsellence-envoy",
+		Image:   "envoy:latest",
+		Running: true,
+		Managed: true,
+		System:  "envoy",
+	}
+	eng.images["busybox"] = true
+	rec := New(eng, Options{Network: "devopsellence"})
+	if _, err := rec.Reconcile(context.Background(), desiredState(workerService("worker", nil))); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	for _, name := range eng.removed {
+		if name == "devopsellence-envoy" {
+			t.Fatalf("envoy should not be removed; removed=%#v", eng.removed)
+		}
+	}
+}
+
 func desiredState(services ...*desiredstatepb.Service) *desiredstatepb.DesiredState {
 	return &desiredstatepb.DesiredState{
 		SchemaVersion: 2,

--- a/agent/internal/reconcile/reconcile_test.go
+++ b/agent/internal/reconcile/reconcile_test.go
@@ -726,6 +726,13 @@ func TestReconcileDoesNotRemoveManagedSystemContainers(t *testing.T) {
 		Managed: true,
 		System:  "release",
 	}
+	eng.containers["task-called-envoy"] = engine.ContainerState{
+		Name:    "task-called-envoy",
+		Image:   "busybox",
+		Running: false,
+		Managed: true,
+		System:  "envoy",
+	}
 	eng.images["busybox"] = true
 	rec := New(eng, Options{Network: "devopsellence"})
 	if _, err := rec.Reconcile(context.Background(), desiredState(workerService("worker", nil))); err != nil {
@@ -738,6 +745,9 @@ func TestReconcileDoesNotRemoveManagedSystemContainers(t *testing.T) {
 	}
 	if !containsString(eng.removed, "release-task") {
 		t.Fatalf("expected orphaned task container to be removed; removed=%#v", eng.removed)
+	}
+	if !containsString(eng.removed, "task-called-envoy") {
+		t.Fatalf("expected task named envoy to be removed; removed=%#v", eng.removed)
 	}
 }
 

--- a/agent/internal/report/status.go
+++ b/agent/internal/report/status.go
@@ -60,7 +60,7 @@ type DiskCareStatus struct {
 	RetainedReleaseCount     int                `json:"retained_release_count,omitempty"`
 	LogMaxSize               string             `json:"log_max_size,omitempty"`
 	LogMaxFile               int                `json:"log_max_file,omitempty"`
-	LastCleanupAt            time.Time          `json:"last_cleanup_at,omitempty"`
+	LastCleanupAt            *time.Time         `json:"last_cleanup_at,omitempty"`
 	RemovedArtifacts         []DiskCareArtifact `json:"removed_artifacts,omitempty"`
 	ReclaimedBytes           int64              `json:"reclaimed_bytes,omitempty"`
 	DockerLogBytes           int64              `json:"docker_log_bytes,omitempty"`

--- a/agent/internal/report/status.go
+++ b/agent/internal/report/status.go
@@ -18,6 +18,7 @@ type Status struct {
 	Error        string              `json:"error,omitempty"`
 	Summary      *Summary            `json:"summary,omitempty"`
 	Task         *TaskStatus         `json:"task,omitempty"`
+	DiskCare     *DiskCareStatus     `json:"disk_care,omitempty"`
 	Environments []EnvironmentStatus `json:"environments,omitempty"`
 }
 
@@ -50,4 +51,26 @@ type TaskStatus struct {
 	Message  string `json:"message,omitempty"`
 	Error    string `json:"error,omitempty"`
 	ExitCode int64  `json:"exit_code,omitempty"`
+}
+
+// DiskCareStatus reports node-local cleanup and retention state for
+// devopsellence-managed Docker artifacts.
+type DiskCareStatus struct {
+	RetainedPreviousReleases int                `json:"retained_previous_releases"`
+	RetainedReleaseCount     int                `json:"retained_release_count,omitempty"`
+	LogMaxSize               string             `json:"log_max_size,omitempty"`
+	LogMaxFile               int                `json:"log_max_file,omitempty"`
+	LastCleanupAt            time.Time          `json:"last_cleanup_at,omitempty"`
+	RemovedArtifacts         []DiskCareArtifact `json:"removed_artifacts,omitempty"`
+	ReclaimedBytes           int64              `json:"reclaimed_bytes,omitempty"`
+	DockerLogBytes           int64              `json:"docker_log_bytes,omitempty"`
+	LastError                string             `json:"last_error,omitempty"`
+}
+
+// DiskCareArtifact describes one artifact removed by automatic disk care.
+type DiskCareArtifact struct {
+	Type      string `json:"type"`
+	Reference string `json:"reference"`
+	Reason    string `json:"reason,omitempty"`
+	Bytes     int64  `json:"bytes,omitempty"`
 }


### PR DESCRIPTION
## Summary

- add node-agent disk care that records successful desired-state image releases and prunes old devopsellence-managed app image references outside the retention window
- configure per-container Docker json-file log rotation for managed app, task, and Envoy containers
- expose disk-care retention/log settings, cleanup results, reclaimed bytes, log usage, and errors in structured agent status

Closes devopsellence/managed-devopsellence#18

## Tests

- `cd agent && GOCACHE=$(pwd)/.gocache go vet ./...`
- `mise run test:agent`
