### PR TITLE
Make agent skill install non-interactive

### DIFF
--- a/cli/scripts/release-local.sh
+++ b/cli/scripts/release-local.sh
@@ -105,17 +105,17 @@ case "$INSTALL_AGENT_SKILL" in
   1|true|TRUE|yes|YES)
     if command -v npx >/dev/null 2>&1; then
       echo "installing devopsellence agent skill..."
-      npx skills add devopsellence/devopsellence --skill devopsellence -g
+      npx --yes skills add devopsellence/devopsellence --skill devopsellence -g --yes
     else
       echo "devopsellence CLI installed. Agent skill install requested, but npx was not found." >&2
       echo "Install the skill later with:" >&2
-      echo "  npx skills add devopsellence/devopsellence --skill devopsellence -g" >&2
+      echo "  npx --yes skills add devopsellence/devopsellence --skill devopsellence -g --yes" >&2
       exit 1
     fi
     ;;
   *)
     echo "agent skill available:"
-    echo "  npx skills add devopsellence/devopsellence --skill devopsellence -g"
+    echo "  npx --yes skills add devopsellence/devopsellence --skill devopsellence -g --yes"
     echo "or rerun installer with DEVOPSELLENCE_INSTALL_AGENT_SKILL=1"
     ;;
 esac

--- a/control-plane/app/controllers/cli_installs_controller.rb
+++ b/control-plane/app/controllers/cli_installs_controller.rb
@@ -210,17 +210,17 @@ class CliInstallsController < ActionController::Base
         1|true|TRUE|yes|YES)
           if command -v npx >/dev/null 2>&1; then
             echo "installing devopsellence agent skill..."
-            npx skills add devopsellence/devopsellence --skill devopsellence -g
+            npx --yes skills add devopsellence/devopsellence --skill devopsellence -g --yes
           else
             echo "devopsellence CLI installed. Agent skill install requested, but npx was not found." >&2
             echo "Install the skill later with:" >&2
-            echo "  npx skills add devopsellence/devopsellence --skill devopsellence -g" >&2
+            echo "  npx --yes skills add devopsellence/devopsellence --skill devopsellence -g --yes" >&2
             exit 1
           fi
           ;;
         *)
           echo "agent skill available:"
-          echo "  npx skills add devopsellence/devopsellence --skill devopsellence -g"
+          echo "  npx --yes skills add devopsellence/devopsellence --skill devopsellence -g --yes"
           echo "or install CLI + skill together with:"
           echo "  curl -fsSL \"$INSTALL_SCRIPT_URL?version=$CLI_VERSION\" | bash -s -- --install-agent-skill"
           ;;

--- a/control-plane/test/integration/installs_test.rb
+++ b/control-plane/test/integration/installs_test.rb
@@ -65,7 +65,7 @@ class InstallsTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "PATH_EXPORT='export PATH=\"'\"$INSTALL_DIR\"':$PATH\"'"
     assert_includes response.body, "echo '$PATH_EXPORT' >> $RC_FILE"
     assert_includes response.body, "source $RC_FILE"
-    assert_includes response.body, "npx skills add devopsellence/devopsellence --skill devopsellence -g"
+    assert_includes response.body, "npx --yes skills add devopsellence/devopsellence --skill devopsellence -g --yes"
     assert_includes response.body, 'curl -fsSL "$INSTALL_SCRIPT_URL?version=$CLI_VERSION" | bash -s -- --install-agent-skill'
   end
 
@@ -135,7 +135,7 @@ class InstallsTest < ActionDispatch::IntegrationTest
     assert_predicate status, :success?, -> { "stdout:\n#{stdout}\nstderr:\n#{stderr}" }
     assert_includes stdout, "installing devopsellence agent skill"
     assert_equal "prerelease build\n", installed_cli
-    assert_equal [ "skills", "add", "devopsellence/devopsellence", "--skill", "devopsellence", "-g" ], skill_args
+    assert_equal [ "--yes", "skills", "add", "devopsellence/devopsellence", "--skill", "devopsellence", "-g", "--yes" ], skill_args
   end
 
   test "cli install script fails when requested agent skill cannot install without npx" do


### PR DESCRIPTION
## Summary
- add npx and skills yes flags for agent skill installs
- update printed fallback commands and install-script assertions

## Test
- cd control-plane && mise run test -- test/integration/installs_test.rb