### PR TITLE
Remove app type from project config

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,8 +149,6 @@ In shared mode, `node create` provisions the server and runs the registration in
 
 ```yaml
 schema_version: 1
-app:
-  type: rails
 organization: solo
 project: myapp
 default_environment: production

--- a/cli/internal/discovery/discovery.go
+++ b/cli/internal/discovery/discovery.go
@@ -1,60 +1,30 @@
 package discovery
 
 import (
-	"bufio"
-	"errors"
-	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strconv"
 	"strings"
 )
 
-var (
-	modulePattern      = regexp.MustCompile(`^\s*module\s+([A-Z][A-Za-z0-9_:]*)\b`)
-	applicationPattern = regexp.MustCompile(`^\s*class\s+Application\s*<\s*Rails::Application\b`)
-)
-
 type Result struct {
-	RailsRoot       string
 	WorkspaceRoot   string
-	AppType         string
 	ProjectName     string
 	ProjectSlug     string
-	ModuleName      string
-	FallbackUsed    bool
 	InferredWebPort int
 }
 
 func Discover(startDir string) (Result, error) {
-	root, appType, err := findWorkspaceRoot(startDir)
+	root, err := findWorkspaceRoot(startDir)
 	if err != nil {
 		return Result{}, err
 	}
-
-	moduleName := ""
-	fallbackUsed := false
 	projectName := filepath.Base(root)
-	if appType == "rails" {
-		moduleName, err = applicationModuleName(root)
-		if err != nil {
-			return Result{}, err
-		}
-		fallbackUsed = strings.TrimSpace(moduleName) == ""
-		if !fallbackUsed {
-			projectName = moduleName
-		}
-	}
 
 	return Result{
-		RailsRoot:       root,
 		WorkspaceRoot:   root,
-		AppType:         appType,
 		ProjectName:     projectName,
 		ProjectSlug:     Slugify(projectName),
-		ModuleName:      moduleName,
-		FallbackUsed:    fallbackUsed,
 		InferredWebPort: inferWebPort(root),
 	}, nil
 }
@@ -100,53 +70,40 @@ func isBoundary(prev, current rune) bool {
 	return false
 }
 
-func findWorkspaceRoot(startDir string) (string, string, error) {
+func findWorkspaceRoot(startDir string) (string, error) {
 	current, err := filepath.Abs(startDir)
 	if err != nil {
-		return "", "", err
+		return "", err
 	}
 	original := current
 	fallback := ""
 
 	for {
-		if railsRoot(current) {
-			return current, "rails", nil
+		if configRoot(current) {
+			return current, nil
 		}
-		if genericRoot(current) {
-			return current, "generic", nil
-		}
-		if fallback == "" && genericWorkspaceCandidate(current) {
+		if fallback == "" && workspaceCandidate(current) {
 			fallback = current
 		}
 		parent := filepath.Dir(current)
 		if parent == current {
 			if fallback != "" {
-				return fallback, "generic", nil
+				return fallback, nil
 			}
-			return original, "generic", nil
+			return original, nil
 		}
 		current = parent
 	}
 }
 
-func railsRoot(path string) bool {
-	if _, err := os.Stat(filepath.Join(path, "Gemfile")); err != nil {
-		return false
-	}
-	if _, err := os.Stat(filepath.Join(path, "config", "application.rb")); err != nil {
-		return false
-	}
-	return true
-}
-
-func genericRoot(path string) bool {
+func configRoot(path string) bool {
 	if _, err := os.Stat(filepath.Join(path, "devopsellence.yml")); err == nil {
 		return true
 	}
 	return false
 }
 
-func genericWorkspaceCandidate(path string) bool {
+func workspaceCandidate(path string) bool {
 	if _, err := os.Stat(filepath.Join(path, ".git")); err == nil {
 		return true
 	}
@@ -156,92 +113,12 @@ func genericWorkspaceCandidate(path string) bool {
 	return false
 }
 
-func applicationModuleName(root string) (string, error) {
-	file, err := os.Open(filepath.Join(root, "config", "application.rb"))
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return "", nil
-		}
-		return "", err
-	}
-	defer file.Close()
-
-	var modules []string
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		line := scanner.Text()
-		if match := modulePattern.FindStringSubmatch(line); len(match) == 2 {
-			modules = append(modules, strings.Split(match[1], "::")...)
-			continue
-		}
-		if applicationPattern.MatchString(line) {
-			if len(modules) == 0 {
-				return "", nil
-			}
-			return modules[len(modules)-1], nil
-		}
-	}
-	if err := scanner.Err(); err != nil {
-		return "", fmt.Errorf("read application module: %w", err)
-	}
-	return "", nil
-}
-
 func inferWebPort(root string) int {
-	dockerfilePath := filepath.Join(root, "Dockerfile")
-	data, err := os.ReadFile(dockerfilePath)
+	data, err := os.ReadFile(filepath.Join(root, "Dockerfile"))
 	if err != nil {
 		return 0
 	}
-
-	text := string(data)
-	if port := explicitRailsServerPort(text); port > 0 {
-		return port
-	}
-	if usesThrust(text) {
-		if port := firstExposePort(text); port > 0 {
-			return port
-		}
-		return 80
-	}
-	return firstExposePort(text)
-}
-
-func explicitRailsServerPort(text string) int {
-	for _, line := range strings.Split(text, "\n") {
-		lower := strings.ToLower(strings.TrimSpace(line))
-		if !strings.Contains(lower, "rails") || !strings.Contains(lower, "server") {
-			continue
-		}
-		fields := strings.Fields(strings.NewReplacer("[", " ", "]", " ", ",", " ", "\"", " ", "'", " ").Replace(line))
-		for idx := 0; idx < len(fields); idx++ {
-			switch fields[idx] {
-			case "-p", "--port":
-				if idx+1 >= len(fields) {
-					continue
-				}
-				if port, err := strconv.Atoi(strings.TrimSpace(fields[idx+1])); err == nil && port > 0 {
-					return port
-				}
-			default:
-				if strings.HasPrefix(fields[idx], "-p") && len(fields[idx]) > 2 {
-					if port, err := strconv.Atoi(strings.TrimPrefix(fields[idx], "-p")); err == nil && port > 0 {
-						return port
-					}
-				}
-				if strings.HasPrefix(fields[idx], "--port=") {
-					if port, err := strconv.Atoi(strings.TrimPrefix(fields[idx], "--port=")); err == nil && port > 0 {
-						return port
-					}
-				}
-			}
-		}
-	}
-	return 0
-}
-
-func usesThrust(text string) bool {
-	return strings.Contains(text, "bin/thrust") || strings.Contains(text, "\"thrust\"") || strings.Contains(text, "'thrust'")
+	return firstExposePort(string(data))
 }
 
 func firstExposePort(text string) int {

--- a/cli/internal/discovery/discovery_test.go
+++ b/cli/internal/discovery/discovery_test.go
@@ -6,74 +6,7 @@ import (
 	"testing"
 )
 
-func TestDiscoverFindsRailsRootAndModule(t *testing.T) {
-	t.Parallel()
-
-	root := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(root, "config"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(root, "Gemfile"), []byte("source 'https://rubygems.org'\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	content := "module ShopApp\n  class Application < Rails::Application\n  end\nend\n"
-	if err := os.WriteFile(filepath.Join(root, "config", "application.rb"), []byte(content), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	start := filepath.Join(root, "app", "models")
-	if err := os.MkdirAll(start, 0o755); err != nil {
-		t.Fatal(err)
-	}
-
-	result, err := Discover(start)
-	if err != nil {
-		t.Fatalf("Discover() error = %v", err)
-	}
-	if result.AppType != "rails" {
-		t.Fatalf("AppType = %q, want rails", result.AppType)
-	}
-	if result.RailsRoot != root {
-		t.Fatalf("RailsRoot = %q, want %q", result.RailsRoot, root)
-	}
-	if result.WorkspaceRoot != root {
-		t.Fatalf("WorkspaceRoot = %q, want %q", result.WorkspaceRoot, root)
-	}
-	if result.ProjectName != "ShopApp" || result.ProjectSlug != "shop-app" {
-		t.Fatalf("project discovery mismatch: %#v", result)
-	}
-	if result.FallbackUsed {
-		t.Fatalf("FallbackUsed = true, want false")
-	}
-}
-
-func TestDiscoverFallsBackToDirectoryName(t *testing.T) {
-	t.Parallel()
-
-	root := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(root, "config"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(root, "Gemfile"), []byte(""), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(root, "config", "application.rb"), []byte("class Application < Rails::Application\nend\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	result, err := Discover(root)
-	if err != nil {
-		t.Fatalf("Discover() error = %v", err)
-	}
-	if !result.FallbackUsed {
-		t.Fatalf("FallbackUsed = false, want true")
-	}
-	if result.ProjectSlug == "" {
-		t.Fatalf("ProjectSlug should not be empty")
-	}
-}
-
-func TestDiscoverFindsGenericWorkspaceFromConfig(t *testing.T) {
+func TestDiscoverFindsConfiguredWorkspace(t *testing.T) {
 	t.Parallel()
 
 	root := t.TempDir()
@@ -89,9 +22,6 @@ func TestDiscoverFindsGenericWorkspaceFromConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Discover() error = %v", err)
 	}
-	if result.AppType != "generic" {
-		t.Fatalf("AppType = %q, want generic", result.AppType)
-	}
 	if result.WorkspaceRoot != root {
 		t.Fatalf("WorkspaceRoot = %q, want %q", result.WorkspaceRoot, root)
 	}
@@ -100,7 +30,7 @@ func TestDiscoverFindsGenericWorkspaceFromConfig(t *testing.T) {
 	}
 }
 
-func TestDiscoverFallsBackToGenericWorkspaceCandidate(t *testing.T) {
+func TestDiscoverFallsBackToWorkspaceCandidate(t *testing.T) {
 	t.Parallel()
 
 	root := t.TempDir()
@@ -115,9 +45,6 @@ func TestDiscoverFallsBackToGenericWorkspaceCandidate(t *testing.T) {
 	result, err := Discover(start)
 	if err != nil {
 		t.Fatalf("Discover() error = %v", err)
-	}
-	if result.AppType != "generic" {
-		t.Fatalf("AppType = %q, want generic", result.AppType)
 	}
 	if result.WorkspaceRoot != root {
 		t.Fatalf("WorkspaceRoot = %q, want %q", result.WorkspaceRoot, root)
@@ -137,28 +64,16 @@ func TestDiscoverFallsBackToOriginalDirectoryWhenNothingDetected(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Discover() error = %v", err)
 	}
-	if result.AppType != "generic" {
-		t.Fatalf("AppType = %q, want generic", result.AppType)
-	}
 	if result.WorkspaceRoot != start {
 		t.Fatalf("WorkspaceRoot = %q, want %q", result.WorkspaceRoot, start)
 	}
 }
 
-func TestDiscoverInfersWebPortFromThrustDockerfile(t *testing.T) {
+func TestDiscoverInfersWebPortFromDockerfileExpose(t *testing.T) {
 	t.Parallel()
 
 	root := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(root, "config"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(root, "Gemfile"), []byte(""), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(root, "config", "application.rb"), []byte("module Smoke\n  class Application < Rails::Application\n  end\nend\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(root, "Dockerfile"), []byte("FROM ruby:4.0.0-slim\nEXPOSE 80\nCMD [\"./bin/thrust\", \"./bin/rails\", \"server\"]\n"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(root, "Dockerfile"), []byte("FROM scratch\nEXPOSE 8080/tcp\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -166,33 +81,7 @@ func TestDiscoverInfersWebPortFromThrustDockerfile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Discover() error = %v", err)
 	}
-	if result.InferredWebPort != 80 {
-		t.Fatalf("InferredWebPort = %d, want 80", result.InferredWebPort)
-	}
-}
-
-func TestDiscoverInfersExplicitRailsServerPortFromDockerfile(t *testing.T) {
-	t.Parallel()
-
-	root := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(root, "config"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(root, "Gemfile"), []byte(""), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(root, "config", "application.rb"), []byte("module Smoke\n  class Application < Rails::Application\n  end\nend\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(root, "Dockerfile"), []byte("FROM ruby:4.0.0-slim\nEXPOSE 3000\nCMD [\"./bin/rails\", \"server\", \"-b\", \"0.0.0.0\", \"-p\", \"3000\"]\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	result, err := Discover(root)
-	if err != nil {
-		t.Fatalf("Discover() error = %v", err)
-	}
-	if result.InferredWebPort != 3000 {
-		t.Fatalf("InferredWebPort = %d, want 3000", result.InferredWebPort)
+	if result.InferredWebPort != 8080 {
+		t.Fatalf("InferredWebPort = %d, want 8080", result.InferredWebPort)
 	}
 }

--- a/cli/internal/solo/state.go
+++ b/cli/internal/solo/state.go
@@ -184,7 +184,6 @@ func buildDeploySnapshot(cfg *config.ProjectConfig, workspaceRoot, configPath, i
 		Revision:      strings.TrimSpace(revision),
 		Image:         strings.TrimSpace(imageTag),
 		Metadata: desiredstate.SnapshotMetadata{
-			AppType:    strings.TrimSpace(cfg.App.Type),
 			ConfigPath: strings.TrimSpace(configPath),
 			Project:    strings.TrimSpace(cfg.Project),
 			UpdatedAt:  time.Now().UTC().Format(time.RFC3339),

--- a/cli/internal/solo/state_test.go
+++ b/cli/internal/solo/state_test.go
@@ -682,7 +682,7 @@ func TestRedactDeploySnapshotSecretsRemovesSecretValues(t *testing.T) {
 			Port: 3000,
 		},
 	}
-	cfg.Tasks.Release = &config.TaskConfig{Service: "web", Command: []string{"bin/rails", "db:migrate"}}
+	cfg.Tasks.Release = &config.TaskConfig{Service: "web", Command: []string{"bin/migrate"}}
 
 	snapshot, err := BuildDeploySnapshot(&cfg, "/workspace/demo", "/workspace/demo/devopsellence.yml", "demo:abc1234", "abc1234", map[string]string{"DATABASE_URL": "postgres://secret"})
 	if err != nil {

--- a/cli/internal/workflow/app.go
+++ b/cli/internal/workflow/app.go
@@ -514,8 +514,6 @@ func (a *App) Init(ctx context.Context, opts InitOptions) error {
 			"environment_created":  initialized.CreatedEnv,
 			"config_path":          initialized.ConfigPath,
 			"project_slug":         initialized.Discovered.ProjectSlug,
-			"app_type":             initialized.Discovered.AppType,
-			"fallback_used":        initialized.Discovered.FallbackUsed,
 			"config":               initialized.Config,
 		}
 		return nil
@@ -766,7 +764,7 @@ func deployPreflightConfig(discovered discovery.Result, existing *config.Project
 	if existing != nil {
 		return *existing
 	}
-	return config.DefaultProjectConfigForType("", discovered.ProjectName, firstNonEmpty(opts.Environment, config.DefaultEnvironment), discovered.AppType)
+	return config.DefaultProjectConfig("", discovered.ProjectName, firstNonEmpty(opts.Environment, config.DefaultEnvironment))
 }
 
 func (a *App) runDeployReadOnlyPreflight(ctx context.Context, opts DeployOptions, workspaceRoot string, cfg config.ProjectConfig, update func(string)) (deployReadOnlyPreflight, error) {
@@ -891,7 +889,7 @@ func initGeneratedFilesCommitMessage(discovered discovery.Result, entries []stri
 		return ""
 	}
 
-	configPath := config.PathForType(discovered.WorkspaceRoot, discovered.AppType)
+	configPath := filepath.Join(discovered.WorkspaceRoot, config.FilePath)
 	relativeConfigPath, err := filepath.Rel(discovered.WorkspaceRoot, configPath)
 	if err != nil {
 		return ""
@@ -927,7 +925,7 @@ func deployDirtyIgnorePaths(store config.Store, discovered discovery.Result, exi
 		return paths
 	}
 
-	configPath := store.PathForType(discovered.WorkspaceRoot, discovered.AppType)
+	configPath := store.PathFor(discovered.WorkspaceRoot)
 	relativePath, err := filepath.Rel(discovered.WorkspaceRoot, configPath)
 	if err == nil {
 		paths = append(paths, relativePath)
@@ -1041,7 +1039,7 @@ func (a *App) Doctor(ctx context.Context) error {
 		if discoveryErr != nil {
 			return "", discoveryErr
 		}
-		return discovered.AppType + " @ " + discovered.WorkspaceRoot, nil
+		return discovered.WorkspaceRoot, nil
 	})
 	addCheck("git", func() (string, error) {
 		if discoveryErr != nil {
@@ -2764,7 +2762,7 @@ func (a *App) initializeWorkspace(ctx context.Context, callAuth authCall, opts I
 	environment := target.Environment
 
 	update("Writing config…")
-	projectConfig := config.DefaultProjectConfigForType(org.Name, project.Name, environment.Name, discovered.AppType)
+	projectConfig := config.DefaultProjectConfig(org.Name, project.Name, environment.Name)
 	if existing == nil && discovered.InferredWebPort > 0 {
 		projectConfig = setPrimaryWebServicePort(projectConfig, discovered.InferredWebPort)
 	}
@@ -2776,7 +2774,6 @@ func (a *App) initializeWorkspace(ctx context.Context, callAuth authCall, opts I
 		projectConfig.Services = existing.Services
 		projectConfig.Tasks = existing.Tasks
 		projectConfig.Ingress = existing.Ingress
-		projectConfig.App = existing.App
 		projectConfig.Organization = org.Name
 		projectConfig.Project = project.Name
 		projectConfig.DefaultEnvironment = environment.Name
@@ -3069,9 +3066,6 @@ func inferredHealthcheckPath(cfg config.ProjectConfig) string {
 	service, ok := primaryWebService(cfg)
 	if ok && service.Healthcheck != nil && strings.TrimSpace(service.Healthcheck.Path) != "" {
 		return service.Healthcheck.Path
-	}
-	if cfg.App.Type == config.AppTypeGeneric {
-		return "/"
 	}
 	return config.DefaultHealthcheckPath
 }

--- a/cli/internal/workflow/management_test.go
+++ b/cli/internal/workflow/management_test.go
@@ -28,7 +28,7 @@ import (
 func TestInitWritesConfigOnly(t *testing.T) {
 	t.Parallel()
 
-	root := makeRailsRoot(t, "ShopApp")
+	root := makeRubyRoot(t, "ShopApp")
 	app := newTestApp(t, root, roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/cli/organizations":
@@ -60,7 +60,7 @@ func TestInitWritesConfigOnly(t *testing.T) {
 func TestInitLeavesExistingAgentsFileAlone(t *testing.T) {
 	t.Parallel()
 
-	root := makeRailsRoot(t, "ShopApp")
+	root := makeRubyRoot(t, "ShopApp")
 	path := filepath.Join(root, "AGENTS.md")
 	existing := strings.Join([]string{
 		"# Team Conventions",
@@ -132,26 +132,26 @@ func TestInitWritesGenericConfigAtRepoRoot(t *testing.T) {
 		t.Fatalf("Init() error = %v", err)
 	}
 
-	if _, err := os.Stat(filepath.Join(root, config.GenericFilePath)); err != nil {
+	if _, err := os.Stat(filepath.Join(root, config.FilePath)); err != nil {
 		t.Fatalf("generic config missing: %v", err)
 	}
 	loaded, err := config.LoadFromRoot(root)
 	if err != nil {
 		t.Fatalf("LoadFromRoot() error = %v", err)
 	}
-	if loaded == nil || loaded.App.Type != config.AppTypeGeneric {
-		t.Fatalf("loaded generic config mismatch: %#v", loaded)
+	if loaded == nil {
+		t.Fatal("loaded config is nil")
 	}
 	web := webService(t, loaded)
-	if web.Healthcheck == nil || web.Healthcheck.Path != "/" {
-		t.Fatalf("generic healthcheck path = %#v, want /", web.Healthcheck)
+	if web.Healthcheck == nil || web.Healthcheck.Path != config.DefaultHealthcheckPath {
+		t.Fatalf("healthcheck path = %#v, want %s", web.Healthcheck, config.DefaultHealthcheckPath)
 	}
 }
 
 func TestInitBootstrapsSharedIngressFromCanonicalDomain(t *testing.T) {
 	t.Parallel()
 
-	root := makeRailsRoot(t, "ShopApp")
+	root := makeRubyRoot(t, "ShopApp")
 	app := newTestAppWithDeployTarget(t, root, roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		switch {
 		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/cli/deploy_target":
@@ -219,7 +219,7 @@ func TestInitBootstrapsSharedIngressFromCanonicalDomain(t *testing.T) {
 func TestInitLeavesSharedIngressUnsetUntilCanonicalDomainExists(t *testing.T) {
 	t.Parallel()
 
-	root := makeRailsRoot(t, "ShopApp")
+	root := makeRubyRoot(t, "ShopApp")
 	app := newTestAppWithDeployTarget(t, root, roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		switch {
 		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/cli/deploy_target":
@@ -261,7 +261,7 @@ func TestInitLeavesSharedIngressUnsetUntilCanonicalDomainExists(t *testing.T) {
 func TestContextShowJSONIncludesWorkspaceContext(t *testing.T) {
 	t.Parallel()
 
-	root := makeRailsRoot(t, "ShopApp")
+	root := makeRubyRoot(t, "ShopApp")
 	if _, err := config.Write(root, config.DefaultProjectConfig("default", "ShopApp", "staging")); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
@@ -306,7 +306,7 @@ func TestContextShowJSONIncludesWorkspaceContext(t *testing.T) {
 func TestOrganizationUseUpdatesConfig(t *testing.T) {
 	t.Parallel()
 
-	root := makeRailsRoot(t, "ShopApp")
+	root := makeRubyRoot(t, "ShopApp")
 	if _, err := config.Write(root, config.DefaultProjectConfig("default", "ShopApp", "staging")); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
@@ -340,7 +340,7 @@ func TestOrganizationUseUpdatesConfig(t *testing.T) {
 func TestProjectUseUpdatesConfig(t *testing.T) {
 	t.Parallel()
 
-	root := makeRailsRoot(t, "ShopApp")
+	root := makeRubyRoot(t, "ShopApp")
 	if _, err := config.Write(root, config.DefaultProjectConfig("default", "ShopApp", "staging")); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
@@ -376,7 +376,7 @@ func TestProjectUseUpdatesConfig(t *testing.T) {
 func TestEnvironmentUseUpdatesWorkspaceStateNotConfig(t *testing.T) {
 	t.Parallel()
 
-	root := makeRailsRoot(t, "ShopApp")
+	root := makeRubyRoot(t, "ShopApp")
 	if _, err := config.Write(root, config.DefaultProjectConfig("default", "ShopApp", "staging")); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
@@ -422,7 +422,7 @@ func TestEnvironmentUseUpdatesWorkspaceStateNotConfig(t *testing.T) {
 func TestConfigResolvePrintsResolvedEnvironmentConfig(t *testing.T) {
 	t.Parallel()
 
-	root := makeRailsRoot(t, "ShopApp")
+	root := makeRubyRoot(t, "ShopApp")
 	project := config.DefaultProjectConfig("default", "ShopApp", "production")
 	project.Ingress = &config.IngressConfig{
 		Hosts: []string{"app.example.test"},
@@ -442,7 +442,7 @@ func TestConfigResolvePrintsResolvedEnvironmentConfig(t *testing.T) {
 			},
 			Services: map[string]config.ServiceConfigOverlay{
 				"web": {
-					Env: map[string]string{"RAILS_ENV": "staging"},
+					Env: map[string]string{"APP_ENV": "staging"},
 				},
 			},
 		},
@@ -484,7 +484,7 @@ func TestConfigResolvePrintsResolvedEnvironmentConfig(t *testing.T) {
 func TestStatusUsesSavedWorkspaceEnvironment(t *testing.T) {
 	t.Parallel()
 
-	root := makeRailsRoot(t, "ShopApp")
+	root := makeRubyRoot(t, "ShopApp")
 	if _, err := config.Write(root, config.DefaultProjectConfig("default", "ShopApp", "staging")); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
@@ -540,7 +540,7 @@ func TestStatusUsesSavedWorkspaceEnvironment(t *testing.T) {
 func TestNodeBootstrapUsesWorkspaceEnvironment(t *testing.T) {
 	t.Parallel()
 
-	root := makeRailsRoot(t, "ShopApp")
+	root := makeRubyRoot(t, "ShopApp")
 	if _, err := config.Write(root, config.DefaultProjectConfig("default", "ShopApp", "staging")); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
@@ -623,7 +623,7 @@ func TestNodeBootstrapAutoInitializesWorkspaceWhenConfigMissing(t *testing.T) {
 func TestNodeBootstrapUnassignedUsesOrganizationOnly(t *testing.T) {
 	t.Parallel()
 
-	root := makeRailsRoot(t, "ShopApp")
+	root := makeRubyRoot(t, "ShopApp")
 	if _, err := config.Write(root, config.DefaultProjectConfig("default", "ShopApp", "staging")); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
@@ -659,7 +659,7 @@ func TestNodeBootstrapUnassignedUsesOrganizationOnly(t *testing.T) {
 func TestNodeBootstrapRejectsTrialOrganizationsBeforeAPICall(t *testing.T) {
 	t.Parallel()
 
-	root := makeRailsRoot(t, "ShopApp")
+	root := makeRubyRoot(t, "ShopApp")
 	if _, err := config.Write(root, config.DefaultProjectConfig("trial-org", "ShopApp", "staging")); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
@@ -693,7 +693,7 @@ func TestNodeBootstrapRejectsTrialOrganizationsBeforeAPICall(t *testing.T) {
 func TestStatusPrintsWarningWhenPresent(t *testing.T) {
 	t.Parallel()
 
-	root := makeRailsRoot(t, "ShopApp")
+	root := makeRubyRoot(t, "ShopApp")
 	if _, err := config.Write(root, config.DefaultProjectConfig("default", "ShopApp", "staging")); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
@@ -735,7 +735,7 @@ func TestStatusPrintsWarningWhenPresent(t *testing.T) {
 func TestNodeAssignUsesWorkspaceEnvironmentAndNodeID(t *testing.T) {
 	t.Parallel()
 
-	root := makeRailsRoot(t, "ShopApp")
+	root := makeRubyRoot(t, "ShopApp")
 	if _, err := config.Write(root, config.DefaultProjectConfig("default", "ShopApp", "staging")); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
@@ -768,7 +768,7 @@ func TestNodeAssignUsesWorkspaceEnvironmentAndNodeID(t *testing.T) {
 func TestNodeAssignRequiresExplicitNodeID(t *testing.T) {
 	t.Parallel()
 
-	root := makeRailsRoot(t, "ShopApp")
+	root := makeRubyRoot(t, "ShopApp")
 	app := newTestApp(t, root, roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		t.Fatalf("unexpected request without explicit node ID: %s %s", r.Method, r.URL.Path)
 		return nil, nil
@@ -786,7 +786,7 @@ func TestNodeAssignRequiresExplicitNodeID(t *testing.T) {
 func TestNodeUnassignDeletesAssignment(t *testing.T) {
 	t.Parallel()
 
-	root := makeRailsRoot(t, "ShopApp")
+	root := makeRubyRoot(t, "ShopApp")
 	var stdout bytes.Buffer
 	app := newTestApp(t, root, roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		switch {
@@ -810,7 +810,7 @@ func TestNodeUnassignDeletesAssignment(t *testing.T) {
 func TestNodeUnassignManagedNodeSignalsDelete(t *testing.T) {
 	t.Parallel()
 
-	root := makeRailsRoot(t, "ShopApp")
+	root := makeRubyRoot(t, "ShopApp")
 	var stdout bytes.Buffer
 	app := newTestApp(t, root, roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		switch {
@@ -834,7 +834,7 @@ func TestNodeUnassignManagedNodeSignalsDelete(t *testing.T) {
 func TestNodeDeleteDeletesUnassignedManagedNode(t *testing.T) {
 	t.Parallel()
 
-	root := makeRailsRoot(t, "ShopApp")
+	root := makeRubyRoot(t, "ShopApp")
 	var stdout bytes.Buffer
 	app := newTestApp(t, root, roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		switch {
@@ -858,7 +858,7 @@ func TestNodeDeleteDeletesUnassignedManagedNode(t *testing.T) {
 func TestNodeDeleteDeletesUnassignedCustomerManagedNode(t *testing.T) {
 	t.Parallel()
 
-	root := makeRailsRoot(t, "ShopApp")
+	root := makeRubyRoot(t, "ShopApp")
 	var stdout bytes.Buffer
 	app := newTestApp(t, root, roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		switch {
@@ -882,7 +882,7 @@ func TestNodeDeleteDeletesUnassignedCustomerManagedNode(t *testing.T) {
 func TestSecretSetUsesWorkspaceEnvironment(t *testing.T) {
 	t.Parallel()
 
-	root := makeRailsRoot(t, "ShopApp")
+	root := makeRubyRoot(t, "ShopApp")
 	if _, err := config.Write(root, config.DefaultProjectConfig("default", "ShopApp", "staging")); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
@@ -926,7 +926,7 @@ func TestSecretSetUsesWorkspaceEnvironment(t *testing.T) {
 func TestSecretSetReadsValueFromStdin(t *testing.T) {
 	t.Parallel()
 
-	root := makeRailsRoot(t, "ShopApp")
+	root := makeRubyRoot(t, "ShopApp")
 	if _, err := config.Write(root, config.DefaultProjectConfig("default", "ShopApp", "staging")); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
@@ -960,7 +960,7 @@ func TestSecretSetReadsValueFromStdin(t *testing.T) {
 func TestSecretListUsesWorkspaceEnvironment(t *testing.T) {
 	t.Parallel()
 
-	root := makeRailsRoot(t, "ShopApp")
+	root := makeRubyRoot(t, "ShopApp")
 	project := config.DefaultProjectConfig("default", "ShopApp", "staging")
 	web := project.Services["web"]
 	web.SecretRefs = []config.SecretRef{
@@ -984,7 +984,7 @@ func TestSecretListUsesWorkspaceEnvironment(t *testing.T) {
 		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/cli/environments/99/secrets":
 			return jsonResponse(t, map[string]any{"secrets": []map[string]any{
 				{"service_name": "web", "name": "SECRET_KEY_BASE", "secret_ref": "gsm://projects/test/secrets/abc/versions/latest"},
-				{"service_name": "web", "name": "RAILS_MASTER_KEY", "secret_ref": "gsm://projects/test/secrets/rails/versions/latest"},
+				{"service_name": "web", "name": "API_TOKEN", "secret_ref": "gsm://projects/test/secrets/api-token/versions/latest"},
 			}}), nil
 		default:
 			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
@@ -1003,9 +1003,9 @@ func TestSecretListUsesWorkspaceEnvironment(t *testing.T) {
 		seen[stringValueAny(item["name"])] = item
 	}
 	for name, want := range map[string]map[string]any{
-		"SECRET_KEY_BASE":  {"configured": true, "stored": true, "available_to_service": true, "store": "managed"},
-		"ONLY_IN_CONFIG":   {"configured": true, "stored": false, "available_to_service": true, "store": "managed"},
-		"RAILS_MASTER_KEY": {"configured": false, "stored": true, "available_to_service": false, "store": "managed"},
+		"SECRET_KEY_BASE": {"configured": true, "stored": true, "available_to_service": true, "store": "managed"},
+		"ONLY_IN_CONFIG":  {"configured": true, "stored": false, "available_to_service": true, "store": "managed"},
+		"API_TOKEN":       {"configured": false, "stored": true, "available_to_service": false, "store": "managed"},
 	} {
 		item := seen[name]
 		if item == nil {
@@ -1022,7 +1022,7 @@ func TestSecretListUsesWorkspaceEnvironment(t *testing.T) {
 func TestSecretDeleteUsesWorkspaceEnvironment(t *testing.T) {
 	t.Parallel()
 
-	root := makeRailsRoot(t, "ShopApp")
+	root := makeRubyRoot(t, "ShopApp")
 	project := config.DefaultProjectConfig("default", "ShopApp", "staging")
 	web := project.Services["web"]
 	web.SecretRefs = []config.SecretRef{{Name: "SECRET_KEY_BASE", Secret: "gsm://projects/test/secrets/abc/versions/latest"}}
@@ -1148,7 +1148,7 @@ func TestAliasLFGRefusesWhenCommandAlreadyExists(t *testing.T) {
 func TestNodeListAndLabelSet(t *testing.T) {
 	t.Parallel()
 
-	root := makeRailsRoot(t, "ShopApp")
+	root := makeRubyRoot(t, "ShopApp")
 	var labelCaptured map[string]any
 	var stdout bytes.Buffer
 	app := newTestApp(t, root, roundTripFunc(func(r *http.Request) (*http.Response, error) {
@@ -1197,7 +1197,7 @@ func TestNodeListAndLabelSet(t *testing.T) {
 func TestNodeDiagnose(t *testing.T) {
 	t.Parallel()
 
-	root := makeRailsRoot(t, "ShopApp")
+	root := makeRubyRoot(t, "ShopApp")
 	var stdout bytes.Buffer
 	polls := 0
 	app := newTestApp(t, root, roundTripFunc(func(r *http.Request) (*http.Response, error) {
@@ -1280,7 +1280,7 @@ func TestNodeDiagnose(t *testing.T) {
 func TestNodeDiagnoseFailedStatusReturnsExitErrorAfterPrintingJSON(t *testing.T) {
 	t.Parallel()
 
-	root := makeRailsRoot(t, "ShopApp")
+	root := makeRubyRoot(t, "ShopApp")
 	var stdout bytes.Buffer
 	app := newTestApp(t, root, roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		switch {
@@ -1318,7 +1318,7 @@ func TestNodeDiagnoseFailedStatusReturnsExitErrorAfterPrintingJSON(t *testing.T)
 func TestDeployWaitsForRolloutProgress(t *testing.T) {
 	t.Parallel()
 
-	root := makeGitRailsRoot(t, "ShopApp")
+	root := makeGitRubyRoot(t, "ShopApp")
 	if _, err := config.Write(root, config.DefaultProjectConfig("default", "ShopApp", "production")); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
@@ -1337,7 +1337,7 @@ func TestDeployWaitsForRolloutProgress(t *testing.T) {
 		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/cli/environments/44/secrets":
 			return jsonResponse(t, map[string]any{"secrets": []map[string]any{}}), nil
 		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/cli/environments/44/secrets":
-			return jsonResponse(t, map[string]any{"name": "RAILS_MASTER_KEY", "service_name": "web", "secret_ref": "gsm://projects/test/secrets/abc/versions/latest"}), nil
+			return jsonResponse(t, map[string]any{"name": "API_TOKEN", "service_name": "web", "secret_ref": "gsm://projects/test/secrets/abc/versions/latest"}), nil
 		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/cli/projects/11/releases":
 			return jsonResponseWithStatus(t, http.StatusCreated, map[string]any{"id": 22}), nil
 		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/cli/releases/22/publish":
@@ -1437,7 +1437,7 @@ func TestDeployUsesResolveDeployTargetWhenAvailable(t *testing.T) {
 	t.Parallel()
 
 	root := makeGitGenericRoot(t)
-	project := config.DefaultProjectConfigForType("default", filepath.Base(root), "production", config.AppTypeGeneric)
+	project := config.DefaultProjectConfig("default", filepath.Base(root), "production")
 	project.Ingress = &config.IngressConfig{
 		Hosts: []string{"app.example.com"},
 		Rules: []config.IngressRuleConfig{{
@@ -1530,7 +1530,7 @@ func TestDeployUsesResolveDeployTargetWhenAvailable(t *testing.T) {
 
 func TestDeployAppliesGitHubActionEnvVarOverrides(t *testing.T) {
 	root := makeGitGenericRoot(t)
-	project := config.DefaultProjectConfigForType("default", filepath.Base(root), "production", config.AppTypeGeneric)
+	project := config.DefaultProjectConfig("default", filepath.Base(root), "production")
 	web := project.Services[config.DefaultWebServiceName]
 	web.Env = map[string]string{"FROM_CONFIG": "1"}
 	project.Services[config.DefaultWebServiceName] = web
@@ -1543,7 +1543,7 @@ func TestDeployAppliesGitHubActionEnvVarOverrides(t *testing.T) {
 	}
 	commitAll(t, root, "add config")
 
-	t.Setenv(deployEnvVarsOverrideEnv, `{"all":{"RAILS_ENV":"production"},"web":{"WEB_ONLY":"true"},"worker":{"QUEUE":"critical"}}`)
+	t.Setenv(deployEnvVarsOverrideEnv, `{"all":{"APP_ENV":"production"},"web":{"WEB_ONLY":"true"},"worker":{"QUEUE":"critical"}}`)
 
 	var releaseCaptured api.ReleaseCreateRequest
 	app := newTestAppWithDeployTarget(t, root, roundTripFunc(func(r *http.Request) (*http.Response, error) {
@@ -1612,10 +1612,10 @@ func TestDeployAppliesGitHubActionEnvVarOverrides(t *testing.T) {
 	if _, ok := workerPayload["kind"]; ok {
 		t.Fatalf("worker payload unexpectedly includes kind: %#v", workerPayload)
 	}
-	if got, want := webPayload["env"], map[string]any{"FROM_CONFIG": "1", "RAILS_ENV": "production", "WEB_ONLY": "true"}; !equalJSONMap(got, want) {
+	if got, want := webPayload["env"], map[string]any{"FROM_CONFIG": "1", "APP_ENV": "production", "WEB_ONLY": "true"}; !equalJSONMap(got, want) {
 		t.Fatalf("web env = %#v, want %#v", got, want)
 	}
-	if got, want := workerPayload["env"], map[string]any{"WORKER_FROM_CONFIG": "1", "RAILS_ENV": "production", "QUEUE": "critical"}; !equalJSONMap(got, want) {
+	if got, want := workerPayload["env"], map[string]any{"WORKER_FROM_CONFIG": "1", "APP_ENV": "production", "QUEUE": "critical"}; !equalJSONMap(got, want) {
 		t.Fatalf("worker env = %#v, want %#v", got, want)
 	}
 }
@@ -1623,7 +1623,7 @@ func TestDeployAppliesGitHubActionEnvVarOverrides(t *testing.T) {
 func TestDeployShowsSchedulingStatusWhileManagedNodeBoots(t *testing.T) {
 	t.Parallel()
 
-	root := makeGitRailsRoot(t, "ShopApp")
+	root := makeGitRubyRoot(t, "ShopApp")
 	if _, err := config.Write(root, config.DefaultProjectConfig("default", "ShopApp", "production")); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
@@ -1642,7 +1642,7 @@ func TestDeployShowsSchedulingStatusWhileManagedNodeBoots(t *testing.T) {
 		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/cli/environments/44/secrets":
 			return jsonResponse(t, map[string]any{"secrets": []map[string]any{}}), nil
 		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/cli/environments/44/secrets":
-			return jsonResponse(t, map[string]any{"name": "RAILS_MASTER_KEY", "service_name": "web", "secret_ref": "gsm://projects/test/secrets/abc/versions/latest"}), nil
+			return jsonResponse(t, map[string]any{"name": "API_TOKEN", "service_name": "web", "secret_ref": "gsm://projects/test/secrets/abc/versions/latest"}), nil
 		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/cli/projects/11/releases":
 			return jsonResponseWithStatus(t, http.StatusCreated, map[string]any{"id": 22}), nil
 		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/cli/releases/22/publish":
@@ -1722,7 +1722,7 @@ func TestDeployShowsSchedulingStatusWhileManagedNodeBoots(t *testing.T) {
 func TestDeployShowsWarmCapacityMilestones(t *testing.T) {
 	t.Parallel()
 
-	root := makeGitRailsRoot(t, "ShopApp")
+	root := makeGitRubyRoot(t, "ShopApp")
 	if _, err := config.Write(root, config.DefaultProjectConfig("default", "ShopApp", "production")); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
@@ -1741,7 +1741,7 @@ func TestDeployShowsWarmCapacityMilestones(t *testing.T) {
 		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/cli/environments/44/secrets":
 			return jsonResponse(t, map[string]any{"secrets": []map[string]any{}}), nil
 		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/cli/environments/44/secrets":
-			return jsonResponse(t, map[string]any{"name": "RAILS_MASTER_KEY", "service_name": "web", "secret_ref": "gsm://projects/test/secrets/abc/versions/latest"}), nil
+			return jsonResponse(t, map[string]any{"name": "API_TOKEN", "service_name": "web", "secret_ref": "gsm://projects/test/secrets/abc/versions/latest"}), nil
 		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/cli/projects/11/releases":
 			return jsonResponseWithStatus(t, http.StatusCreated, map[string]any{"id": 22}), nil
 		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/cli/releases/22/publish":
@@ -1832,7 +1832,7 @@ func TestDeployShowsWarmCapacityMilestones(t *testing.T) {
 func TestDeployReportsManagedCapacityFallback(t *testing.T) {
 	t.Parallel()
 
-	root := makeGitRailsRoot(t, "ShopApp")
+	root := makeGitRubyRoot(t, "ShopApp")
 	if _, err := config.Write(root, config.DefaultProjectConfig("default", "ShopApp", "production")); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
@@ -1852,7 +1852,7 @@ func TestDeployReportsManagedCapacityFallback(t *testing.T) {
 		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/cli/environments/44/secrets":
 			return jsonResponse(t, map[string]any{"secrets": []map[string]any{}}), nil
 		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/cli/environments/44/secrets":
-			return jsonResponse(t, map[string]any{"name": "RAILS_MASTER_KEY", "service_name": "web", "secret_ref": "gsm://projects/test/secrets/abc/versions/latest"}), nil
+			return jsonResponse(t, map[string]any{"name": "API_TOKEN", "service_name": "web", "secret_ref": "gsm://projects/test/secrets/abc/versions/latest"}), nil
 		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/cli/projects/11/releases":
 			return jsonResponseWithStatus(t, http.StatusCreated, map[string]any{"id": 22}), nil
 		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/cli/releases/22/publish":
@@ -1908,7 +1908,7 @@ func TestDeployReportsManagedCapacityFallback(t *testing.T) {
 func TestDeployRetriesPublishAfter524WithSameRequestToken(t *testing.T) {
 	t.Parallel()
 
-	root := makeGitRailsRoot(t, "ShopApp")
+	root := makeGitRubyRoot(t, "ShopApp")
 	if _, err := config.Write(root, config.DefaultProjectConfig("default", "ShopApp", "production")); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
@@ -1927,7 +1927,7 @@ func TestDeployRetriesPublishAfter524WithSameRequestToken(t *testing.T) {
 		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/cli/environments/44/secrets":
 			return jsonResponse(t, map[string]any{"secrets": []map[string]any{}}), nil
 		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/cli/environments/44/secrets":
-			return jsonResponse(t, map[string]any{"name": "RAILS_MASTER_KEY", "service_name": "web", "secret_ref": "gsm://projects/test/secrets/abc/versions/latest"}), nil
+			return jsonResponse(t, map[string]any{"name": "API_TOKEN", "service_name": "web", "secret_ref": "gsm://projects/test/secrets/abc/versions/latest"}), nil
 		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/cli/projects/11/releases":
 			return jsonResponseWithStatus(t, http.StatusCreated, map[string]any{"id": 22}), nil
 		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/cli/releases/22/publish":
@@ -1991,7 +1991,7 @@ func TestDeployRetriesPublishAfter524WithSameRequestToken(t *testing.T) {
 func TestDeployBuildsAndPushesMultiArchImage(t *testing.T) {
 	t.Parallel()
 
-	root := makeGitRailsRoot(t, "ShopApp")
+	root := makeGitRubyRoot(t, "ShopApp")
 	project := config.DefaultProjectConfig("default", "ShopApp", "production")
 	project.Build.Platforms = []string{"linux/amd64", "linux/arm64"}
 	if _, err := config.Write(root, project); err != nil {
@@ -2016,7 +2016,7 @@ func TestDeployBuildsAndPushesMultiArchImage(t *testing.T) {
 		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/cli/environments/44/secrets":
 			return jsonResponse(t, map[string]any{"secrets": []map[string]any{}}), nil
 		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/cli/environments/44/secrets":
-			return jsonResponse(t, map[string]any{"name": "RAILS_MASTER_KEY", "service_name": "web", "secret_ref": "gsm://projects/test/secrets/abc/versions/latest"}), nil
+			return jsonResponse(t, map[string]any{"name": "API_TOKEN", "service_name": "web", "secret_ref": "gsm://projects/test/secrets/abc/versions/latest"}), nil
 		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/cli/projects/11/registry/push_auth":
 			return jsonResponse(t, map[string]any{
 				"registry_host":    "northamerica-northeast1-docker.pkg.dev",
@@ -2098,7 +2098,7 @@ func TestDeployBuildsAndPushesMultiArchImage(t *testing.T) {
 func TestDeleteUsesWorkspaceEnvironment(t *testing.T) {
 	t.Parallel()
 
-	root := makeRailsRoot(t, "ShopApp")
+	root := makeRubyRoot(t, "ShopApp")
 	if _, err := config.Write(root, config.DefaultProjectConfig("default", "ShopApp", "production")); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
@@ -2135,10 +2135,10 @@ func TestDeleteUsesWorkspaceEnvironment(t *testing.T) {
 	}
 }
 
-func TestDeployRailsAllowsMissingMasterKey(t *testing.T) {
+func TestDeployDoesNotSyncImplicitMasterKey(t *testing.T) {
 	t.Parallel()
 
-	root := makeGitRailsRoot(t, "ShopApp")
+	root := makeGitRubyRoot(t, "ShopApp")
 	if err := os.Remove(filepath.Join(root, "config", "master.key")); err != nil {
 		t.Fatalf("remove master.key: %v", err)
 	}
@@ -2157,10 +2157,10 @@ func TestDeployRailsAllowsMissingMasterKey(t *testing.T) {
 		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/cli/projects/11/environments":
 			return jsonResponse(t, map[string]any{"environments": []map[string]any{{"id": 44, "name": "production"}}}), nil
 		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/cli/environments/44/secrets":
-			t.Fatalf("unexpected secret lookup for Rails app without master.key")
+			t.Fatalf("unexpected secret lookup without configured secret refs")
 			return nil, nil
 		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/cli/environments/44/secrets":
-			t.Fatalf("unexpected secret sync for Rails app without master.key")
+			t.Fatalf("unexpected secret sync without configured secret refs")
 			return nil, nil
 		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/cli/projects/11/releases":
 			return jsonResponseWithStatus(t, http.StatusCreated, map[string]any{"id": 22}), nil
@@ -2211,7 +2211,7 @@ func TestDeployBuildsGenericWorkspaceImage(t *testing.T) {
 	t.Parallel()
 
 	root := makeGitGenericRoot(t)
-	project := config.DefaultProjectConfigForType("default", filepath.Base(root), "production", config.AppTypeGeneric)
+	project := config.DefaultProjectConfig("default", filepath.Base(root), "production")
 	web := project.Services[config.DefaultWebServiceName]
 	for i := range web.Ports {
 		if web.Ports[i].Name == "http" {
@@ -2298,8 +2298,8 @@ func TestDeployBuildsGenericWorkspaceImage(t *testing.T) {
 	if !ok {
 		t.Fatalf("web env payload type = %T", webPayload["env"])
 	}
-	if _, exists := envMap["RAILS_MASTER_KEY"]; exists {
-		t.Fatalf("generic deploy should not inject RAILS_MASTER_KEY: %#v", envMap)
+	if _, exists := envMap["API_TOKEN"]; exists {
+		t.Fatalf("deploy should not inject unconfigured API_TOKEN: %#v", envMap)
 	}
 }
 
@@ -2493,7 +2493,7 @@ func TestDeployRecoversFromUnauthorizedAPIResponse(t *testing.T) {
 	t.Parallel()
 
 	root := makeGitGenericRoot(t)
-	project := config.DefaultProjectConfigForType("default", filepath.Base(root), "production", config.AppTypeGeneric)
+	project := config.DefaultProjectConfig("default", filepath.Base(root), "production")
 	if _, err := config.Write(root, project); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
@@ -2581,16 +2581,7 @@ func TestInitInfersThrustPortForFirstGeneratedConfig(t *testing.T) {
 	t.Parallel()
 
 	root := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(root, "config"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(root, "Gemfile"), []byte("source 'https://rubygems.org'\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(root, "config", "application.rb"), []byte("module SmokePort\n  class Application < Rails::Application\n  end\nend\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(root, "Dockerfile"), []byte("FROM ruby:4.0.0-slim\nEXPOSE 80\nCMD [\"./bin/thrust\", \"./bin/rails\", \"server\"]\n"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(root, "Dockerfile"), []byte("FROM scratch\nEXPOSE 80\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2636,7 +2627,7 @@ func TestDeployBootstrapsAnonymousTrialWhenStateMissing(t *testing.T) {
 	t.Parallel()
 
 	root := makeGitGenericRoot(t)
-	project := config.DefaultProjectConfigForType("default", filepath.Base(root), "production", config.AppTypeGeneric)
+	project := config.DefaultProjectConfig("default", filepath.Base(root), "production")
 	if _, err := config.Write(root, project); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
@@ -2843,7 +2834,7 @@ func TestDeployClaimReminderPrintsOncePerAnonymousAccount(t *testing.T) {
 	t.Parallel()
 
 	root := makeGitGenericRoot(t)
-	project := config.DefaultProjectConfigForType("default", filepath.Base(root), "production", config.AppTypeGeneric)
+	project := config.DefaultProjectConfig("default", filepath.Base(root), "production")
 	if _, err := config.Write(root, project); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
@@ -2932,7 +2923,7 @@ func TestDeployFailsFastWhenDockerDaemonUnavailable(t *testing.T) {
 	t.Parallel()
 
 	root := makeGitGenericRoot(t)
-	project := config.DefaultProjectConfigForType("default", filepath.Base(root), "production", config.AppTypeGeneric)
+	project := config.DefaultProjectConfig("default", filepath.Base(root), "production")
 	if _, err := config.Write(root, project); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
@@ -2961,7 +2952,7 @@ func TestDeployFailsFastWhenDockerDaemonUnavailable(t *testing.T) {
 func TestDeployFailsBeforeRemoteWritesWhenBuildInputsInvalid(t *testing.T) {
 	t.Parallel()
 
-	root := makeGitRailsRoot(t, "ShopApp")
+	root := makeGitRubyRoot(t, "ShopApp")
 	project := config.DefaultProjectConfig("default", "ShopApp", "production")
 	if _, err := config.Write(root, project); err != nil {
 		t.Fatalf("write config: %v", err)
@@ -2991,11 +2982,11 @@ func TestDeployFailsFastWhenWorkspaceDirty(t *testing.T) {
 	t.Parallel()
 
 	root := makeGitGenericRoot(t)
-	project := config.DefaultProjectConfigForType("default", filepath.Base(root), "production", config.AppTypeGeneric)
+	project := config.DefaultProjectConfig("default", filepath.Base(root), "production")
 	if _, err := config.Write(root, project); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
-	runGit(t, root, "add", config.GenericFilePath)
+	runGit(t, root, "add", config.FilePath)
 	runGit(t, root, "commit", "-m", "add config")
 	if err := os.WriteFile(filepath.Join(root, "notes.txt"), []byte("dirty\n"), 0o644); err != nil {
 		t.Fatalf("write notes: %v", err)
@@ -3025,7 +3016,7 @@ func TestDeployFailsWhenExistingConfigIsUncommitted(t *testing.T) {
 	t.Parallel()
 
 	root := makeGitGenericRoot(t)
-	project := config.DefaultProjectConfigForType("default", filepath.Base(root), "production", config.AppTypeGeneric)
+	project := config.DefaultProjectConfig("default", filepath.Base(root), "production")
 	if _, err := config.Write(root, project); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
@@ -3045,7 +3036,7 @@ func TestDeployFailsWhenExistingConfigIsUncommitted(t *testing.T) {
 	if !strings.Contains(err.Error(), "workspace contains devopsellence init files that are not committed yet") {
 		t.Fatalf("Deploy() error = %v", err)
 	}
-	if !strings.Contains(err.Error(), "git add "+config.GenericFilePath) {
+	if !strings.Contains(err.Error(), "git add "+config.FilePath) {
 		t.Fatalf("Deploy() error = %v", err)
 	}
 }
@@ -3109,11 +3100,11 @@ func TestDeployTreatsAgentsMarkdownAsUserChange(t *testing.T) {
 	t.Parallel()
 
 	root := makeGitGenericRoot(t)
-	project := config.DefaultProjectConfigForType("default", filepath.Base(root), "production", config.AppTypeGeneric)
+	project := config.DefaultProjectConfig("default", filepath.Base(root), "production")
 	if _, err := config.Write(root, project); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
-	runGit(t, root, "add", config.GenericFilePath)
+	runGit(t, root, "add", config.FilePath)
 	runGit(t, root, "commit", "-m", "add config")
 	if err := os.WriteFile(filepath.Join(root, "AGENTS.md"), []byte("# local notes\n"), 0o644); err != nil {
 		t.Fatalf("write AGENTS.md: %v", err)
@@ -3251,9 +3242,12 @@ func (d *dockerUnavailableStub) ImageMetadata(_ context.Context, _ string) (dock
 	panic("unexpected ImageMetadata call")
 }
 
-func makeRailsRoot(t *testing.T, moduleName string) string {
+func makeRubyRoot(t *testing.T, moduleName string) string {
 	t.Helper()
-	root := t.TempDir()
+	root := filepath.Join(t.TempDir(), moduleName)
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("mkdir root: %v", err)
+	}
 	if err := os.WriteFile(filepath.Join(root, "Gemfile"), []byte("source 'https://rubygems.org'\n"), 0o644); err != nil {
 		t.Fatalf("write Gemfile: %v", err)
 	}
@@ -3266,19 +3260,15 @@ func makeRailsRoot(t *testing.T, moduleName string) string {
 	if err := os.MkdirAll(filepath.Join(root, "config"), 0o755); err != nil {
 		t.Fatalf("mkdir config: %v", err)
 	}
-	content := "module " + moduleName + "\n  class Application < Rails::Application\n  end\nend\n"
-	if err := os.WriteFile(filepath.Join(root, "config", "application.rb"), []byte(content), 0o644); err != nil {
-		t.Fatalf("write application.rb: %v", err)
-	}
 	if err := os.WriteFile(filepath.Join(root, "config", "master.key"), []byte("test-master-key\n"), 0o600); err != nil {
 		t.Fatalf("write master.key: %v", err)
 	}
 	return root
 }
 
-func makeGitRailsRoot(t *testing.T, moduleName string) string {
+func makeGitRubyRoot(t *testing.T, moduleName string) string {
 	t.Helper()
-	root := makeRailsRoot(t, moduleName)
+	root := makeRubyRoot(t, moduleName)
 	runGit(t, root, "init")
 	runGit(t, root, "config", "user.email", "test@example.com")
 	runGit(t, root, "config", "user.name", "Test User")

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -2760,7 +2760,7 @@ func (a *App) SoloDoctor(ctx context.Context) error {
 		if discoveryErr != nil {
 			return "", discoveryErr
 		}
-		return discovered.AppType + " @ " + discovered.WorkspaceRoot, nil
+		return discovered.WorkspaceRoot, nil
 	})
 	addCheck("git", func() (string, error) {
 		if discoveryErr != nil {
@@ -3300,8 +3300,6 @@ func (a *App) SoloInit(context.Context, SoloInitOptions) error {
 		"mode":             string(ModeSolo),
 		"workspace_root":   discovered.WorkspaceRoot,
 		"project_slug":     discovered.ProjectSlug,
-		"app_type":         discovered.AppType,
-		"fallback_used":    discovered.FallbackUsed,
 		"runtime_contract": soloInitRuntimeContract(*cfg, discovered, created),
 		"config": map[string]any{
 			"path":           configPath,
@@ -3551,7 +3549,7 @@ func soloAffectedNodesForNode(current solo.State, nodeName string) []string {
 }
 
 func soloDefaultProjectConfig(discovered discovery.Result) *config.ProjectConfig {
-	cfg := config.DefaultProjectConfigForType("solo", discovered.ProjectName, config.DefaultEnvironment, discovered.AppType)
+	cfg := config.DefaultProjectConfig("solo", discovered.ProjectName, config.DefaultEnvironment)
 	if discovered.InferredWebPort > 0 {
 		if serviceName, ok := cfg.PrimaryWebServiceName(); ok {
 			service := cfg.Services[serviceName]

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -220,7 +220,6 @@ func TestSoloDefaultProjectConfigBootstrapsExplicitCatchAllIngress(t *testing.T)
 
 	cfg := soloDefaultProjectConfig(discovery.Result{
 		ProjectName:     "shop-app",
-		AppType:         config.AppTypeRails,
 		InferredWebPort: 3001,
 	})
 
@@ -277,7 +276,7 @@ func TestValidateNodeScheduleSelectsReleaseNode(t *testing.T) {
 		Tasks: config.TasksConfig{
 			Release: &config.TaskConfig{
 				Service: config.DefaultWebServiceName,
-				Command: []string{"rails", "db:migrate"},
+				Command: []string{"bin/migrate"},
 			},
 		},
 	}
@@ -335,7 +334,7 @@ func TestValidateNodeScheduleInfersKindsWithoutStoredConfigKind(t *testing.T) {
 		Tasks: config.TasksConfig{
 			Release: &config.TaskConfig{
 				Service: config.DefaultWebServiceName,
-				Command: []string{"rails", "db:migrate"},
+				Command: []string{"bin/migrate"},
 			},
 		},
 	}
@@ -656,7 +655,7 @@ func TestSoloNodeCreateProviderReportsMetadataAndProgress(t *testing.T) {
 
 func TestReleaseNodeForSnapshotSelectsSortedEligibleNode(t *testing.T) {
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")
-	cfg.Tasks.Release = &config.TaskConfig{Service: "web", Command: []string{"bin/rails", "db:migrate"}}
+	cfg.Tasks.Release = &config.TaskConfig{Service: "web", Command: []string{"bin/migrate"}}
 	snapshot, err := solo.BuildDeploySnapshot(&cfg, "/workspace/demo", "/workspace/demo/devopsellence.yml", "demo:abc1234", "abc1234", map[string]string{})
 	if err != nil {
 		t.Fatal(err)
@@ -2031,7 +2030,7 @@ func TestSoloDeployWaitsForSettledStatusBeforeSuccess(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cfg := config.DefaultProjectConfigForType("solo", "demo", "production", config.AppTypeGeneric)
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
 	cfg.Ingress = &config.IngressConfig{
 		Hosts: []string{"*"},
 		Rules: []config.IngressRuleConfig{{
@@ -2118,7 +2117,7 @@ func TestSoloDeployWaitsForSettledStatusBeforeSuccess(t *testing.T) {
 
 func TestSoloReleaseListReturnsCurrentReleaseHistory(t *testing.T) {
 	workspaceRoot := t.TempDir()
-	cfg := config.DefaultProjectConfigForType("solo", "demo", "production", config.AppTypeGeneric)
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
 	if _, err := config.Write(workspaceRoot, cfg); err != nil {
 		t.Fatal(err)
 	}
@@ -2168,7 +2167,7 @@ func TestSoloReleaseListReturnsCurrentReleaseHistory(t *testing.T) {
 
 func TestSoloReleaseRollbackUsesSelectedReleaseTargets(t *testing.T) {
 	workspaceRoot := t.TempDir()
-	cfg := config.DefaultProjectConfigForType("solo", "demo", "production", config.AppTypeGeneric)
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
 	if _, err := config.Write(workspaceRoot, cfg); err != nil {
 		t.Fatal(err)
 	}
@@ -2227,7 +2226,7 @@ func TestSoloReleaseRollbackUsesSelectedReleaseTargets(t *testing.T) {
 
 func TestSoloReleaseRollbackPersistsSelectedReleaseOnRolloutFailure(t *testing.T) {
 	workspaceRoot := t.TempDir()
-	cfg := config.DefaultProjectConfigForType("solo", "demo", "production", config.AppTypeGeneric)
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
 	if _, err := config.Write(workspaceRoot, cfg); err != nil {
 		t.Fatal(err)
 	}
@@ -3086,8 +3085,8 @@ func TestSoloInitCreatesWorkspaceConfig(t *testing.T) {
 	if runtimeContract["web_service"] != true {
 		t.Fatalf("runtime_contract.web_service = %#v, want true", runtimeContract["web_service"])
 	}
-	if runtimeContract["healthcheck_path"] != "/" || runtimeContract["healthcheck_port"] != float64(3000) {
-		t.Fatalf("runtime_contract healthcheck = %#v, want / on port 3000", runtimeContract)
+	if runtimeContract["healthcheck_path"] != config.DefaultHealthcheckPath || runtimeContract["healthcheck_port"] != float64(3000) {
+		t.Fatalf("runtime_contract healthcheck = %#v, want %s on port 3000", runtimeContract, config.DefaultHealthcheckPath)
 	}
 	requirement := stringValueAny(runtimeContract["requirement"])
 	if !strings.Contains(requirement, "EXPOSE") || !strings.Contains(requirement, "devopsellence.yml") {
@@ -3100,7 +3099,7 @@ func TestSoloInitReportsConfigPortContract(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(workspaceRoot, "Dockerfile"), []byte("FROM nginx:1.27-alpine\nEXPOSE 8080\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	cfg := config.DefaultProjectConfigForType("solo", "demo", "production", config.AppTypeGeneric)
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
 	web := cfg.Services["web"]
 	web.Ports = []config.ServicePort{{Name: "http", Port: 8080}}
 	web.Healthcheck = &config.HTTPHealthcheck{Path: "/health", Port: 8080}
@@ -3131,7 +3130,7 @@ func TestSoloInitReportsConfigPortContract(t *testing.T) {
 
 func TestSoloInitReportsNoWebServicePortContract(t *testing.T) {
 	workspaceRoot := t.TempDir()
-	cfg := config.DefaultProjectConfigForType("solo", "demo", "production", config.AppTypeGeneric)
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
 	cfg.Services = map[string]config.ServiceConfig{
 		"worker": {
 			Command: []string{"bin/worker"},
@@ -3253,14 +3252,10 @@ func TestWaitForSoloSSHWithProbeBoundsSingleAttempt(t *testing.T) {
 func TestSoloDefaultProjectConfigUsesDiscovery(t *testing.T) {
 	cfg := soloDefaultProjectConfig(discovery.Result{
 		ProjectName:     "ShopApp",
-		AppType:         config.AppTypeGeneric,
 		InferredWebPort: 8080,
 	})
 	if cfg.Organization != "solo" || cfg.Project != "ShopApp" {
 		t.Fatalf("config identity = org %q project %q", cfg.Organization, cfg.Project)
-	}
-	if cfg.App.Type != config.AppTypeGeneric {
-		t.Fatalf("app.type = %q", cfg.App.Type)
 	}
 	web := cfg.Services[config.DefaultWebServiceName]
 	if web.HTTPPort(0) != 8080 || web.Healthcheck.Port != 8080 {
@@ -3272,7 +3267,7 @@ func TestIngressSetInfersPrimaryWebService(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	cfg := config.DefaultProjectConfigForType("solo", "demo", config.DefaultEnvironment, config.AppTypeGeneric)
+	cfg := config.DefaultProjectConfig("solo", "demo", config.DefaultEnvironment)
 	if _, err := config.Write(dir, cfg); err != nil {
 		t.Fatal(err)
 	}
@@ -3560,7 +3555,7 @@ func TestIngressSetPreservesExistingServiceWhenFlagOmitted(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	cfg := config.DefaultProjectConfigForType("solo", "demo", config.DefaultEnvironment, config.AppTypeGeneric)
+	cfg := config.DefaultProjectConfig("solo", "demo", config.DefaultEnvironment)
 	cfg.Services["frontend"] = cfg.Services[config.DefaultWebServiceName]
 	delete(cfg.Services, config.DefaultWebServiceName)
 	cfg.Ingress = &config.IngressConfig{

--- a/control-plane/app/views/marketing/docs.html.erb
+++ b/control-plane/app/views/marketing/docs.html.erb
@@ -353,8 +353,6 @@
       </div>
       <div class="terminal-body">
         <pre class="config-pre"><code>schema_version: 1
-app:
-  type: rails
 organization: solo
 project: myapp
 default_environment: production
@@ -579,9 +577,6 @@ jobs:
       <div class="terminal-body">
         <pre class="config-pre"><code>schema_version: 1
 
-app:
-  type: rails
-
 organization: acme
 project: myapp
 default_environment: production
@@ -630,10 +625,6 @@ tasks:
       <div class="docs-field">
         <dt><code>schema_version</code></dt>
         <dd>Required. Currently <code>1</code>.</dd>
-      </div>
-      <div class="docs-field">
-        <dt><code>app.type</code></dt>
-        <dd>Application type. Used for defaults and display. Example: <code>rails</code>.</dd>
       </div>
       <div class="docs-field">
         <dt><code>organization</code></dt>

--- a/deployment-core/pkg/deploycore/config/config.go
+++ b/deployment-core/pkg/deploycore/config/config.go
@@ -14,15 +14,12 @@ import (
 
 const (
 	FilePath               = "devopsellence.yml"
-	GenericFilePath        = FilePath
 	SchemaVersion          = 1
 	DefaultEnvironment     = "production"
 	DefaultBuildContext    = "."
 	DefaultDockerfile      = "Dockerfile"
 	DefaultHealthcheckPath = "/up"
 	DefaultWebPort         = 3000
-	AppTypeRails           = "rails"
-	AppTypeGeneric         = "generic"
 	DefaultWebRole         = "web"
 	DefaultWorkerRole      = "worker"
 	DefaultWebServiceName  = "web"
@@ -80,10 +77,6 @@ type BuildConfig struct {
 	Context    string   `yaml:"context" json:"context"`
 	Dockerfile string   `yaml:"dockerfile" json:"dockerfile"`
 	Platforms  []string `yaml:"platforms" json:"platforms"`
-}
-
-type AppConfig struct {
-	Type string `yaml:"type,omitempty" json:"type,omitempty"`
 }
 
 type IngressTLSConfig struct {
@@ -176,7 +169,6 @@ type Node struct {
 
 type ProjectConfig struct {
 	SchemaVersion      int                           `yaml:"schema_version" json:"schema_version"`
-	App                AppConfig                     `yaml:"app,omitempty" json:"app,omitempty"`
 	Organization       string                        `yaml:"organization" json:"organization"`
 	Project            string                        `yaml:"project" json:"project"`
 	DefaultEnvironment string                        `yaml:"default_environment" json:"default_environment"`
@@ -200,10 +192,6 @@ func (Store) PathFor(workspaceRoot string) string {
 	return filepath.Join(workspaceRoot, FilePath)
 }
 
-func (Store) PathForType(workspaceRoot, appType string) string {
-	return PathForType(workspaceRoot, appType)
-}
-
 func (s Store) Read(workspaceRoot string) (*ProjectConfig, error) {
 	return LoadFromRoot(workspaceRoot)
 }
@@ -221,9 +209,6 @@ func Load(path string) (*ProjectConfig, error) {
 	decoder.KnownFields(true)
 	if err := decoder.Decode(&cfg); err != nil {
 		return nil, fmt.Errorf("invalid %s: %w", filepath.Base(path), err)
-	}
-	if strings.TrimSpace(cfg.App.Type) == "" && filepath.Base(path) == GenericFilePath {
-		cfg.App.Type = AppTypeGeneric
 	}
 	if cfg.SchemaVersion == 0 {
 		return nil, fmt.Errorf("invalid %s in %s: schema_version must be %d; re-run `devopsellence init --mode solo|shared`", filepath.Base(path), path, SchemaVersion)
@@ -245,10 +230,6 @@ func ExistingPath(workspaceRoot string) (string, bool) {
 		}
 	}
 	return "", false
-}
-
-func PathForType(workspaceRoot, _ string) string {
-	return filepath.Join(workspaceRoot, FilePath)
 }
 
 func LoadFromRoot(workspaceRoot string) (*ProjectConfig, error) {
@@ -283,7 +264,7 @@ func Write(workspaceRoot string, cfg ProjectConfig) (ProjectConfig, error) {
 		return ProjectConfig{}, err
 	}
 
-	path := PathForType(workspaceRoot, cfg.App.Type)
+	path := filepath.Join(workspaceRoot, FilePath)
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return ProjectConfig{}, err
 	}
@@ -298,17 +279,8 @@ func Write(workspaceRoot string, cfg ProjectConfig) (ProjectConfig, error) {
 }
 
 func DefaultProjectConfig(organization, project, environment string) ProjectConfig {
-	return DefaultProjectConfigForType(organization, project, environment, AppTypeRails)
-}
-
-func DefaultProjectConfigForType(organization, project, environment, appType string) ProjectConfig {
-	healthcheckPath := DefaultHealthcheckPath
-	if appType == AppTypeGeneric {
-		healthcheckPath = "/"
-	}
 	cfg := ProjectConfig{
 		SchemaVersion:      SchemaVersion,
-		App:                AppConfig{Type: appType},
 		Organization:       organization,
 		Project:            project,
 		DefaultEnvironment: environment,
@@ -327,7 +299,7 @@ func DefaultProjectConfigForType(organization, project, environment, appType str
 					Port: DefaultWebPort,
 				}},
 				Healthcheck: &HTTPHealthcheck{
-					Path: healthcheckPath,
+					Path: DefaultHealthcheckPath,
 					Port: DefaultWebPort,
 				},
 			},
@@ -343,9 +315,6 @@ func Validate(cfg *ProjectConfig) error {
 	}
 	if cfg.SchemaVersion != SchemaVersion {
 		return fmt.Errorf("schema_version must be %d; re-run `devopsellence init --mode solo|shared`", SchemaVersion)
-	}
-	if cfg.App.Type != AppTypeRails && cfg.App.Type != AppTypeGeneric {
-		return fmt.Errorf("app.type must be %q or %q", AppTypeRails, AppTypeGeneric)
 	}
 	if strings.TrimSpace(cfg.Organization) == "" {
 		return errors.New("organization is required")
@@ -427,9 +396,6 @@ func applyDefaults(cfg *ProjectConfig) {
 	if cfg.SchemaVersion == 0 {
 		cfg.SchemaVersion = SchemaVersion
 	}
-	if strings.TrimSpace(cfg.App.Type) == "" {
-		cfg.App.Type = AppTypeRails
-	}
 	if strings.TrimSpace(cfg.DefaultEnvironment) == "" {
 		cfg.DefaultEnvironment = DefaultEnvironment
 	}
@@ -462,11 +428,7 @@ func applyDefaults(cfg *ProjectConfig) {
 		if service.Healthcheck != nil {
 			service.Healthcheck.Path = strings.TrimSpace(service.Healthcheck.Path)
 			if strings.TrimSpace(service.Healthcheck.Path) == "" {
-				if cfg.App.Type == AppTypeGeneric {
-					service.Healthcheck.Path = "/"
-				} else {
-					service.Healthcheck.Path = DefaultHealthcheckPath
-				}
+				service.Healthcheck.Path = DefaultHealthcheckPath
 			}
 			if service.Healthcheck.Port == 0 {
 				service.Healthcheck.Port = service.HTTPPort(DefaultWebPort)

--- a/deployment-core/pkg/deploycore/config/config_test.go
+++ b/deployment-core/pkg/deploycore/config/config_test.go
@@ -19,9 +19,9 @@ func TestWriteAndLoadFromRoot(t *testing.T) {
 		Command:    []string{"./bin/jobs"},
 		Env:        map[string]string{"QUEUE": "default"},
 		SecretRefs: []SecretRef{{Name: "API_KEY", Secret: "gsm://projects/test/secrets/api-key"}},
-		Volumes:    []Volume{{Source: "app_storage", Target: "/rails/storage"}},
+		Volumes:    []Volume{{Source: "app_storage", Target: "/app/storage"}},
 	}
-	project.Tasks.Release = &TaskConfig{Service: "web", Command: []string{"bundle", "exec", "rails", "db:migrate"}}
+	project.Tasks.Release = &TaskConfig{Service: "web", Command: []string{"./bin/migrate"}}
 
 	written, err := Write(root, project)
 	if err != nil {
@@ -53,7 +53,7 @@ func TestWriteAndLoadFromRoot(t *testing.T) {
 	if strings.Join(loaded.Build.Platforms, ",") != strings.Join(DefaultBuildPlatforms, ",") {
 		t.Fatalf("build platforms = %#v, want %#v", loaded.Build.Platforms, DefaultBuildPlatforms)
 	}
-	if loaded.Tasks.Release == nil || strings.Join(loaded.Tasks.Release.Command, " ") != "bundle exec rails db:migrate" {
+	if loaded.Tasks.Release == nil || strings.Join(loaded.Tasks.Release.Command, " ") != "./bin/migrate" {
 		t.Fatalf("release task = %#v", loaded.Tasks.Release)
 	}
 	if _, err := os.Stat(filepath.Join(root, FilePath)); err != nil {
@@ -407,11 +407,11 @@ func TestValidateIngressRulesRejectsCaseInsensitiveDuplicateRoutes(t *testing.T)
 	}
 }
 
-func TestWriteGenericConfigUsesRepoRootPath(t *testing.T) {
+func TestWriteConfigUsesRepoRootPath(t *testing.T) {
 	t.Parallel()
 
 	root := t.TempDir()
-	project := DefaultProjectConfigForType("acme", "GenericApp", "production", AppTypeGeneric)
+	project := DefaultProjectConfig("acme", "GenericApp", "production")
 	web := project.Services[DefaultWebServiceName]
 	web.Ports = []ServicePort{{Name: "http", Port: 8080}}
 	web.Healthcheck.Path = "/"
@@ -421,15 +421,15 @@ func TestWriteGenericConfigUsesRepoRootPath(t *testing.T) {
 	if _, err := Write(root, project); err != nil {
 		t.Fatalf("Write() error = %v", err)
 	}
-	if _, err := os.Stat(filepath.Join(root, GenericFilePath)); err != nil {
-		t.Fatalf("generic config missing: %v", err)
+	if _, err := os.Stat(filepath.Join(root, FilePath)); err != nil {
+		t.Fatalf("config missing: %v", err)
 	}
 	loaded, err := LoadFromRoot(root)
 	if err != nil {
 		t.Fatalf("LoadFromRoot() error = %v", err)
 	}
-	if loaded == nil || loaded.App.Type != AppTypeGeneric {
-		t.Fatalf("loaded generic config mismatch: %#v", loaded)
+	if loaded == nil {
+		t.Fatal("loaded config is nil")
 	}
 }
 
@@ -489,18 +489,18 @@ func TestResolveEnvironmentConfigMergesOverlay(t *testing.T) {
 	project.Services["web"] = ServiceConfig{
 		Command:    []string{"bundle", "exec", "puma"},
 		Args:       []string{"-C", "config/puma.rb"},
-		Env:        map[string]string{"RAILS_ENV": "production", "BASE_ONLY": "1"},
+		Env:        map[string]string{"APP_ENV": "production", "BASE_ONLY": "1"},
 		SecretRefs: []SecretRef{{Name: "BASE_KEY", Secret: "gsm://base"}},
 		Ports:      []ServicePort{{Name: "http", Port: 3000}},
 		Healthcheck: &HTTPHealthcheck{
 			Path: "/up",
 			Port: 3000,
 		},
-		Volumes: []Volume{{Source: "storage", Target: "/rails/storage"}},
+		Volumes: []Volume{{Source: "storage", Target: "/app/storage"}},
 	}
 	project.Tasks.Release = &TaskConfig{
 		Service: "web",
-		Command: []string{"bundle", "exec", "rails", "db:migrate"},
+		Command: []string{"./bin/migrate"},
 		Env:     map[string]string{"RELEASE_ONLY": "base"},
 	}
 	redirectHTTP := false
@@ -525,17 +525,17 @@ func TestResolveEnvironmentConfigMergesOverlay(t *testing.T) {
 			Services: map[string]ServiceConfigOverlay{
 				"web": {
 					Command:     []string{"./bin/staging-web"},
-					Env:         map[string]string{"RAILS_ENV": "staging", "STAGING_ONLY": "1"},
+					Env:         map[string]string{"APP_ENV": "staging", "STAGING_ONLY": "1"},
 					SecretRefs:  []SecretRef{{Name: "STAGING_KEY", Secret: "gsm://staging"}},
 					Ports:       []ServicePort{{Name: "http", Port: 8080}},
-					Volumes:     []Volume{{Source: "staging-storage", Target: "/rails/storage"}},
+					Volumes:     []Volume{{Source: "staging-storage", Target: "/app/storage"}},
 					Healthcheck: &HTTPHealthcheckOverlay{Path: &stagingPath, Port: &stagingPort},
 				},
 			},
 			Tasks: &TasksConfigOverlay{
 				Release: &TaskConfigOverlay{
 					Env:     map[string]string{"RELEASE_ONLY": "staging", "MIGRATION_MODE": "online"},
-					Command: []string{"bundle", "exec", "rails", "db:prepare"},
+					Command: []string{"./bin/prepare"},
 				},
 			},
 		},
@@ -564,7 +564,7 @@ func TestResolveEnvironmentConfigMergesOverlay(t *testing.T) {
 	if web.Args[0] != "-C" {
 		t.Fatalf("args = %#v", web.Args)
 	}
-	if web.Env["RAILS_ENV"] != "staging" || web.Env["BASE_ONLY"] != "1" || web.Env["STAGING_ONLY"] != "1" {
+	if web.Env["APP_ENV"] != "staging" || web.Env["BASE_ONLY"] != "1" || web.Env["STAGING_ONLY"] != "1" {
 		t.Fatalf("env = %#v", web.Env)
 	}
 	if len(web.SecretRefs) != 1 || web.SecretRefs[0].Name != "STAGING_KEY" {
@@ -576,7 +576,7 @@ func TestResolveEnvironmentConfigMergesOverlay(t *testing.T) {
 	if resolved.Tasks.Release == nil {
 		t.Fatal("release task missing")
 	}
-	if got := strings.Join(resolved.Tasks.Release.Command, " "); got != "bundle exec rails db:prepare" {
+	if got := strings.Join(resolved.Tasks.Release.Command, " "); got != "./bin/prepare" {
 		t.Fatalf("release command = %q", got)
 	}
 	if resolved.Tasks.Release.Env["RELEASE_ONLY"] != "staging" || resolved.Tasks.Release.Env["MIGRATION_MODE"] != "online" {

--- a/deployment-core/pkg/deploycore/desiredstate/desiredstate.go
+++ b/deployment-core/pkg/deploycore/desiredstate/desiredstate.go
@@ -125,7 +125,6 @@ func (s ScopedSecrets) ValuesForService(serviceName string) map[string]string {
 }
 
 type SnapshotMetadata struct {
-	AppType    string `json:"app_type,omitempty"`
 	ConfigPath string `json:"config_path,omitempty"`
 	Project    string `json:"project,omitempty"`
 	UpdatedAt  string `json:"updated_at,omitempty"`

--- a/deployment-core/pkg/deploycore/desiredstate/desiredstate_test.go
+++ b/deployment-core/pkg/deploycore/desiredstate/desiredstate_test.go
@@ -17,8 +17,8 @@ func boolPtr(value bool) *bool {
 func baseProject() *config.ProjectConfig {
 	cfg := config.DefaultProjectConfig("solo", "myapp", config.DefaultEnvironment)
 	cfg.Services["web"] = config.ServiceConfig{
-		Command: []string{"rails", "server"},
-		Env:     map[string]string{"RAILS_ENV": "production"},
+		Command: []string{"./bin/server"},
+		Env:     map[string]string{"APP_ENV": "production"},
 		SecretRefs: []config.SecretRef{
 			{Name: "DATABASE_URL", Secret: "projects/x/secrets/db"},
 		},
@@ -57,7 +57,7 @@ func TestBuildDesiredState_WebOnly(t *testing.T) {
 	if web.Name != "web" || web.Kind != "web" || web.Image != "myapp:abc1234" {
 		t.Fatalf("web service = %#v", web)
 	}
-	if web.Env["RAILS_ENV"] != "production" || web.Env["DATABASE_URL"] != "postgres://localhost/mydb" {
+	if web.Env["APP_ENV"] != "production" || web.Env["DATABASE_URL"] != "postgres://localhost/mydb" {
 		t.Fatalf("env = %#v", web.Env)
 	}
 	if web.Healthcheck == nil || web.Healthcheck.Path != "/up" {
@@ -66,7 +66,7 @@ func TestBuildDesiredState_WebOnly(t *testing.T) {
 	if len(web.Ports) != 1 || web.Ports[0].Name != "http" || web.Ports[0].Port != 3000 {
 		t.Fatalf("ports = %#v", web.Ports)
 	}
-	if got, want := web.Entrypoint, []string{"rails", "server"}; !reflect.DeepEqual(got, want) {
+	if got, want := web.Entrypoint, []string{"./bin/server"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("entrypoint = %#v, want %#v", got, want)
 	}
 }
@@ -109,7 +109,7 @@ func TestBuildDesiredState_WithNamedWorkerAndReleaseTask(t *testing.T) {
 		Command: []string{"sidekiq"},
 		Env:     map[string]string{"QUEUE": "default"},
 	}
-	cfg.Tasks.Release = &config.TaskConfig{Service: "web", Command: []string{"rails", "db:migrate"}}
+	cfg.Tasks.Release = &config.TaskConfig{Service: "web", Command: []string{"./bin/migrate"}}
 
 	data, err := BuildDesiredState(cfg, "myapp:def5678", "def5678", map[string]string{"DATABASE_URL": "postgres://localhost/mydb"})
 	if err != nil {
@@ -176,7 +176,7 @@ func TestBuildDesiredStateForLabelsFiltersServicesByKindLabel(t *testing.T) {
 	cfg.Services["jobs"] = config.ServiceConfig{
 		Command: []string{"sidekiq"},
 	}
-	cfg.Tasks.Release = &config.TaskConfig{Service: "web", Command: []string{"rails", "db:migrate"}}
+	cfg.Tasks.Release = &config.TaskConfig{Service: "web", Command: []string{"./bin/migrate"}}
 
 	data, err := BuildDesiredStateForLabels(cfg, "myapp:def5678", "def5678", map[string]string{"DATABASE_URL": "postgres://localhost/mydb"}, []string{config.DefaultWorkerRole}, false)
 	if err != nil {
@@ -197,7 +197,7 @@ func TestBuildDesiredStateForLabelsFiltersServicesByKindLabel(t *testing.T) {
 
 func TestBuildDesiredStateForLabelsIncludesReleaseWhenSelected(t *testing.T) {
 	cfg := baseProject()
-	cfg.Tasks.Release = &config.TaskConfig{Service: "web", Command: []string{"rails", "db:migrate"}}
+	cfg.Tasks.Release = &config.TaskConfig{Service: "web", Command: []string{"./bin/migrate"}}
 
 	data, err := BuildDesiredStateForLabels(cfg, "myapp:def5678", "def5678", map[string]string{"DATABASE_URL": "postgres://localhost/mydb"}, []string{config.DefaultWebRole}, true)
 	if err != nil {

--- a/deployment-core/pkg/deploycore/release/model_test.go
+++ b/deployment-core/pkg/deploycore/release/model_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestNewReleaseNormalizesImmutableSnapshot(t *testing.T) {
-	env := map[string]string{"RAILS_ENV": "production"}
+	env := map[string]string{"APP_ENV": "production"}
 	release, err := NewRelease(ReleaseCreateInput{
 		ID:            " rel-1 ",
 		EnvironmentID: " env-1 ",
@@ -44,8 +44,8 @@ func TestNewReleaseNormalizesImmutableSnapshot(t *testing.T) {
 	if got, want := strings.Join(release.TargetNodeIDs, ","), "web-a,worker-a"; got != want {
 		t.Fatalf("target nodes = %q, want %q", got, want)
 	}
-	env["RAILS_ENV"] = "staging"
-	if got := release.Snapshot.Services[0].Env["RAILS_ENV"]; got != "production" {
+	env["APP_ENV"] = "staging"
+	if got := release.Snapshot.Services[0].Env["APP_ENV"]; got != "production" {
 		t.Fatalf("release snapshot env = %q, want immutable production value", got)
 	}
 }


### PR DESCRIPTION
## Summary
- remove the app/type field from devopsellence.yml config parsing, defaults, docs, and generated examples
- default all generated/blank service healthchecks to /up
- drop app_type from solo deploy snapshot metadata while keeping CLI discovery metadata internal

## Tests
- mise run test:core
- mise run test:cli
