### PR TITLE
Add sslip.io ingress hints for solo

### DIFF
--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -4165,7 +4165,7 @@ func temporaryDNSHostname(cfg *config.ProjectConfig, ip string) string {
 }
 
 func temporaryDNSCommand(cfg *config.ProjectConfig, hostname string) string {
-	return "devopsellence ingress set --host " + hostname + " --tls-mode " + temporaryDNSTLSMode(cfg)
+	return "devopsellence ingress set --host " + shellQuote(hostname) + " --tls-mode " + shellQuote(temporaryDNSTLSMode(cfg))
 }
 
 func temporaryDNSTLSMode(cfg *config.ProjectConfig) string {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -4166,10 +4166,17 @@ func temporaryDNSHostname(cfg *config.ProjectConfig, ip string) string {
 
 func isTemporaryDNSIPv4(value string) bool {
 	ip := net.ParseIP(strings.TrimSpace(value))
-	if ip == nil || ip.To4() == nil {
+	if ip == nil {
 		return false
 	}
-	return !ip.IsUnspecified() && !ip.IsLoopback() && !ip.IsPrivate() && !ip.IsLinkLocalUnicast()
+	ip4 := ip.To4()
+	if ip4 == nil {
+		return false
+	}
+	if !ip4.IsGlobalUnicast() || ip4.Equal(net.IPv4bcast) {
+		return false
+	}
+	return !ip4.IsUnspecified() && !ip4.IsLoopback() && !ip4.IsPrivate() && !ip4.IsLinkLocalUnicast()
 }
 
 func normalizeIngressHosts(values []string) []string {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -4151,21 +4151,8 @@ func temporaryDNSHints(cfg *config.ProjectConfig, expectedIPs []string) []ingres
 	return hints
 }
 
-func temporaryDNSHostname(cfg *config.ProjectConfig, ip string) string {
-	labels := []string{}
-	if cfg != nil {
-		if project := discovery.Slugify(cfg.Project); project != "" {
-			labels = append(labels, project)
-		}
-		if environment := discovery.Slugify(soloEnvironmentName(cfg, "")); environment != "" {
-			labels = append(labels, environment)
-		}
-	}
-	if len(labels) == 0 {
-		labels = append(labels, "app")
-	}
-	encodedIP := strings.ReplaceAll(strings.TrimSpace(ip), ".", "-")
-	return encodedIP + "." + strings.Join(labels, "-") + ".sslip.io"
+func temporaryDNSHostname(_ *config.ProjectConfig, ip string) string {
+	return strings.TrimSpace(ip) + ".sslip.io"
 }
 
 func temporaryDNSCommand(cfg *config.ProjectConfig, hostname string) string {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -3968,6 +3968,7 @@ type ingressDNSReportResult struct {
 	PublicURLs    []string               `json:"public_urls,omitempty"`
 	ExpectedIPs   []string               `json:"expected_ips"`
 	Hosts         []ingressDNSHostResult `json:"hosts"`
+	Hints         []ingressHint          `json:"hints,omitempty"`
 	NextSteps     []string               `json:"next_steps,omitempty"`
 }
 
@@ -3977,6 +3978,48 @@ type ingressDNSHostResult struct {
 	Resolved []string `json:"resolved,omitempty"`
 	Missing  []string `json:"missing,omitempty"`
 	Error    string   `json:"error,omitempty"`
+}
+
+type ingressHint struct {
+	Code            string            `json:"code"`
+	Severity        string            `json:"severity"`
+	Message         string            `json:"message"`
+	SuggestedAction ingressHintAction `json:"suggested_action"`
+}
+
+type ingressHintAction struct {
+	Kind     string   `json:"kind"`
+	Provider string   `json:"provider"`
+	Hostname string   `json:"hostname"`
+	Command  string   `json:"command"`
+	Risks    []string `json:"risks"`
+}
+
+type ingressDNSReadinessError struct {
+	report  ingressDNSReportResult
+	message string
+}
+
+func (e ingressDNSReadinessError) Error() string {
+	return e.message
+}
+
+func (e ingressDNSReadinessError) ErrorFields() map[string]any {
+	fields := map[string]any{
+		"kind":         "ingress_dns_not_ready",
+		"ok":           e.report.OK,
+		"expected_ips": e.report.ExpectedIPs,
+	}
+	if len(e.report.Hosts) > 0 {
+		fields["hosts"] = e.report.Hosts
+	}
+	if len(e.report.Hints) > 0 {
+		fields["hints"] = e.report.Hints
+	}
+	if len(e.report.NextSteps) > 0 {
+		fields["next_steps"] = e.report.NextSteps
+	}
+	return fields
 }
 
 const soloStatusMissingSentinel = "__DEVOPSELLENCE_STATUS_MISSING__"
@@ -3994,10 +4037,12 @@ func (a *App) checkIngressBeforeDeploy(ctx context.Context, cfg *config.ProjectC
 	}
 	reportErr := ingressDNSReportError(report)
 	if len(report.Hosts) == 0 {
-		return fmt.Errorf("%w; configure ingress hostnames or pass --skip-dns-check", reportErr)
+		message := fmt.Sprintf("%s; configure ingress hostnames or pass --skip-dns-check", reportErr)
+		return ingressDNSReadinessError{report: report, message: message}
 	}
 
-	return fmt.Errorf("%w; update DNS or pass --skip-dns-check", reportErr)
+	message := fmt.Sprintf("%s; update DNS or pass --skip-dns-check", reportErr)
+	return ingressDNSReadinessError{report: report, message: message}
 }
 
 func ingressDNSReportRetryable(report ingressDNSReportResult) bool {
@@ -4026,6 +4071,7 @@ func ingressDNSReport(ctx context.Context, cfg *config.ProjectConfig, selected m
 	}
 	if len(hosts) == 0 {
 		report.OK = false
+		report.Hints = temporaryDNSHints(cfg, expected)
 		report.NextSteps = []string{"devopsellence status", "devopsellence ingress set --host <hostname> --service <service>", "devopsellence ingress check --wait 5m"}
 		return report, nil
 	}
@@ -4073,6 +4119,57 @@ func webNodeIPs(cfg *config.ProjectConfig, selected map[string]config.Node) []st
 	}
 	sort.Strings(ips)
 	return ips
+}
+
+func temporaryDNSHints(cfg *config.ProjectConfig, expectedIPs []string) []ingressHint {
+	hints := []ingressHint{}
+	for _, ip := range expectedIPs {
+		if !isTemporaryDNSIPv4(ip) {
+			continue
+		}
+		hostname := temporaryDNSHostname(cfg, ip)
+		hints = append(hints, ingressHint{
+			Code:     "solo_ingress_no_hostname",
+			Severity: "suggestion",
+			Message:  "No concrete ingress hostname is configured. For day-0 HTTPS, an operator agent can use a temporary sslip.io hostname that points at this node IP.",
+			SuggestedAction: ingressHintAction{
+				Kind:     "use_temporary_dns_hostname",
+				Provider: "sslip.io",
+				Hostname: hostname,
+				Command:  "devopsellence ingress set --host " + hostname + " --tls-mode auto",
+				Risks: []string{
+					"third_party_dns_dependency",
+					"breaks_if_public_ip_changes",
+					"not_recommended_as_long_term_production_domain",
+				},
+			},
+		})
+	}
+	return hints
+}
+
+func temporaryDNSHostname(cfg *config.ProjectConfig, ip string) string {
+	labels := []string{}
+	if cfg != nil {
+		if project := discovery.Slugify(cfg.Project); project != "" {
+			labels = append(labels, project)
+		}
+		if environment := discovery.Slugify(soloEnvironmentName(cfg, "")); environment != "" {
+			labels = append(labels, environment)
+		}
+	}
+	if len(labels) == 0 {
+		labels = append(labels, "app")
+	}
+	return strings.Join(labels, "-") + "." + strings.TrimSpace(ip) + ".sslip.io"
+}
+
+func isTemporaryDNSIPv4(value string) bool {
+	ip := net.ParseIP(strings.TrimSpace(value))
+	if ip == nil || ip.To4() == nil {
+		return false
+	}
+	return !ip.IsUnspecified() && !ip.IsLoopback() && !ip.IsPrivate() && !ip.IsLinkLocalUnicast()
 }
 
 func normalizeIngressHosts(values []string) []string {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -4131,12 +4131,12 @@ func temporaryDNSHints(cfg *config.ProjectConfig, expectedIPs []string) []ingres
 		hints = append(hints, ingressHint{
 			Code:     "solo_ingress_no_hostname",
 			Severity: "suggestion",
-			Message:  "No concrete ingress hostname is configured. For day-0 HTTPS, an operator agent can use a temporary sslip.io hostname that points at this node IP.",
+			Message:  "No concrete ingress hostname is configured. For day-0 ingress, an operator agent can use a temporary sslip.io hostname that points at this node IP.",
 			SuggestedAction: ingressHintAction{
 				Kind:     "use_temporary_dns_hostname",
 				Provider: "sslip.io",
 				Hostname: hostname,
-				Command:  "devopsellence ingress set --host " + hostname + " --tls-mode auto",
+				Command:  temporaryDNSCommand(cfg, hostname),
 				Risks: []string{
 					"third_party_dns_dependency",
 					"breaks_if_public_ip_changes",
@@ -4162,6 +4162,21 @@ func temporaryDNSHostname(cfg *config.ProjectConfig, ip string) string {
 		labels = append(labels, "app")
 	}
 	return strings.Join(labels, "-") + "." + strings.TrimSpace(ip) + ".sslip.io"
+}
+
+func temporaryDNSCommand(cfg *config.ProjectConfig, hostname string) string {
+	return "devopsellence ingress set --host " + hostname + " --tls-mode " + temporaryDNSTLSMode(cfg)
+}
+
+func temporaryDNSTLSMode(cfg *config.ProjectConfig) string {
+	if cfg != nil && cfg.Ingress != nil {
+		mode := strings.TrimSpace(cfg.Ingress.TLS.Mode)
+		switch mode {
+		case "auto", "manual", "off":
+			return mode
+		}
+	}
+	return "auto"
 }
 
 func isTemporaryDNSIPv4(value string) bool {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -4161,7 +4161,7 @@ func temporaryDNSHostname(cfg *config.ProjectConfig, ip string) string {
 	if len(labels) == 0 {
 		labels = append(labels, "app")
 	}
-	return strings.Join(labels, "-") + "." + strings.TrimSpace(ip) + ".sslip.io"
+	return strings.TrimSpace(ip) + "." + strings.Join(labels, "-") + ".sslip.io"
 }
 
 func temporaryDNSCommand(cfg *config.ProjectConfig, hostname string) string {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -4122,6 +4122,9 @@ func webNodeIPs(cfg *config.ProjectConfig, selected map[string]config.Node) []st
 }
 
 func temporaryDNSHints(cfg *config.ProjectConfig, expectedIPs []string) []ingressHint {
+	if len(expectedIPs) != 1 {
+		return nil
+	}
 	hints := []ingressHint{}
 	for _, ip := range expectedIPs {
 		if !isTemporaryDNSIPv4(ip) {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -4164,7 +4164,8 @@ func temporaryDNSHostname(cfg *config.ProjectConfig, ip string) string {
 	if len(labels) == 0 {
 		labels = append(labels, "app")
 	}
-	return strings.TrimSpace(ip) + "." + strings.Join(labels, "-") + ".sslip.io"
+	encodedIP := strings.ReplaceAll(strings.TrimSpace(ip), ".", "-")
+	return encodedIP + "." + strings.Join(labels, "-") + ".sslip.io"
 }
 
 func temporaryDNSCommand(cfg *config.ProjectConfig, hostname string) string {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -4170,7 +4170,7 @@ func temporaryDNSCommand(cfg *config.ProjectConfig, hostname string) string {
 
 func temporaryDNSTLSMode(cfg *config.ProjectConfig) string {
 	if cfg != nil && cfg.Ingress != nil {
-		mode := strings.TrimSpace(cfg.Ingress.TLS.Mode)
+		mode := strings.ToLower(strings.TrimSpace(cfg.Ingress.TLS.Mode))
 		switch mode {
 		case "auto", "manual", "off":
 			return mode

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -4025,7 +4025,7 @@ func (e ingressDNSReadinessError) ErrorFields() map[string]any {
 const soloStatusMissingSentinel = "__DEVOPSELLENCE_STATUS_MISSING__"
 
 func (a *App) checkIngressBeforeDeploy(ctx context.Context, cfg *config.ProjectConfig, nodes map[string]config.Node, skip bool) error {
-	if skip || cfg == nil || cfg.Ingress == nil || cfg.Ingress.TLS.Mode != "auto" {
+	if skip || cfg == nil || cfg.Ingress == nil || !strings.EqualFold(strings.TrimSpace(cfg.Ingress.TLS.Mode), "auto") {
 		return nil
 	}
 	report, err := ingressDNSReport(ctx, cfg, nodes)

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -4176,7 +4176,39 @@ func isTemporaryDNSIPv4(value string) bool {
 	if !ip4.IsGlobalUnicast() || ip4.Equal(net.IPv4bcast) {
 		return false
 	}
-	return !ip4.IsUnspecified() && !ip4.IsLoopback() && !ip4.IsPrivate() && !ip4.IsLinkLocalUnicast()
+	return !isSpecialUseIPv4(ip4)
+}
+
+func isSpecialUseIPv4(ip net.IP) bool {
+	if ip.IsUnspecified() || ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() {
+		return true
+	}
+	ip4 := ip.To4()
+	if ip4 == nil {
+		return true
+	}
+	switch {
+	case ip4[0] == 0:
+		return true
+	case ip4[0] == 100 && ip4[1]&0xc0 == 64:
+		return true
+	case ip4[0] == 192 && ip4[1] == 0 && ip4[2] == 0:
+		return true
+	case ip4[0] == 192 && ip4[1] == 0 && ip4[2] == 2:
+		return true
+	case ip4[0] == 192 && ip4[1] == 88 && ip4[2] == 99:
+		return true
+	case ip4[0] == 198 && (ip4[1] == 18 || ip4[1] == 19):
+		return true
+	case ip4[0] == 198 && ip4[1] == 51 && ip4[2] == 100:
+		return true
+	case ip4[0] == 203 && ip4[1] == 0 && ip4[2] == 113:
+		return true
+	case ip4[0] >= 240:
+		return true
+	default:
+		return false
+	}
 }
 
 func normalizeIngressHosts(values []string) []string {

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -1043,6 +1043,25 @@ func TestIngressDNSReportIncludesSSLIPHintForPublicIPWithoutConcreteHostnames(t 
 	}
 }
 
+func TestTemporaryDNSIPv4RejectsNonPublicAddresses(t *testing.T) {
+	tests := map[string]bool{
+		"203.0.113.10":    true,
+		"10.0.0.1":        false,
+		"127.0.0.1":       false,
+		"169.254.1.1":     false,
+		"224.0.0.1":       false,
+		"255.255.255.255": false,
+		"2001:db8::1":     false,
+	}
+	for value, want := range tests {
+		t.Run(value, func(t *testing.T) {
+			if got := isTemporaryDNSIPv4(value); got != want {
+				t.Fatalf("isTemporaryDNSIPv4(%q) = %v, want %v", value, got, want)
+			}
+		})
+	}
+}
+
 func TestCheckIngressBeforeDeployIncludesSSLIPHintFields(t *testing.T) {
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")
 	cfg.Ingress = &config.IngressConfig{

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -1005,6 +1005,75 @@ func TestIngressCheckDoesNotWaitForMissingConcreteHostnames(t *testing.T) {
 	}
 }
 
+func TestIngressDNSReportIncludesSSLIPHintForPublicIPWithoutConcreteHostnames(t *testing.T) {
+	cfg := config.DefaultProjectConfig("solo", "My App", "production")
+	cfg.Ingress = &config.IngressConfig{
+		Hosts: []string{"*"},
+		Rules: []config.IngressRuleConfig{{Target: config.IngressTargetConfig{Service: config.DefaultWebServiceName}}},
+		TLS:   config.IngressTLSConfig{Mode: "auto"},
+	}
+
+	report, err := ingressDNSReport(context.Background(), &cfg, map[string]config.Node{
+		"node-a": {Host: "203.0.113.10", User: "root", Labels: []string{config.DefaultWebRole}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.OK {
+		t.Fatalf("OK = true, want hostname configuration guidance")
+	}
+	if len(report.Hints) != 1 {
+		t.Fatalf("hints = %#v, want one sslip.io hint", report.Hints)
+	}
+	hint := report.Hints[0]
+	if hint.Code != "solo_ingress_no_hostname" || hint.Severity != "suggestion" {
+		t.Fatalf("hint = %#v, want no-hostname suggestion", hint)
+	}
+	if hint.SuggestedAction.Kind != "use_temporary_dns_hostname" || hint.SuggestedAction.Provider != "sslip.io" {
+		t.Fatalf("suggested_action = %#v, want sslip.io temporary hostname", hint.SuggestedAction)
+	}
+	if got, want := hint.SuggestedAction.Hostname, "my-app-production.203.0.113.10.sslip.io"; got != want {
+		t.Fatalf("suggested hostname = %q, want %q", got, want)
+	}
+	if !strings.Contains(hint.SuggestedAction.Command, "devopsellence ingress set --host my-app-production.203.0.113.10.sslip.io --tls-mode auto") {
+		t.Fatalf("command = %q, want ingress set command", hint.SuggestedAction.Command)
+	}
+	if len(hint.SuggestedAction.Risks) == 0 {
+		t.Fatalf("risks = %#v, want explicit caveats", hint.SuggestedAction.Risks)
+	}
+}
+
+func TestCheckIngressBeforeDeployIncludesSSLIPHintFields(t *testing.T) {
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	cfg.Ingress = &config.IngressConfig{
+		Hosts: []string{"*"},
+		Rules: []config.IngressRuleConfig{{Target: config.IngressTargetConfig{Service: config.DefaultWebServiceName}}},
+		TLS:   config.IngressTLSConfig{Mode: "auto"},
+	}
+
+	err := (&App{}).checkIngressBeforeDeploy(context.Background(), &cfg, map[string]config.Node{
+		"node-a": {Host: "203.0.113.10", User: "root", Labels: []string{config.DefaultWebRole}},
+	}, false)
+	if err == nil {
+		t.Fatal("checkIngressBeforeDeploy() error = nil, want missing hostname failure")
+	}
+	var structured StructuredError
+	if !errors.As(err, &structured) {
+		t.Fatalf("error = %#v, want structured error", err)
+	}
+	fields := structured.ErrorFields()
+	if fields["kind"] != "ingress_dns_not_ready" {
+		t.Fatalf("kind = %v, want ingress_dns_not_ready", fields["kind"])
+	}
+	hints, ok := fields["hints"].([]ingressHint)
+	if !ok || len(hints) != 1 {
+		t.Fatalf("hints = %#v, want one ingress hint", fields["hints"])
+	}
+	if got, want := hints[0].SuggestedAction.Hostname, "demo-production.203.0.113.10.sslip.io"; got != want {
+		t.Fatalf("suggested hostname = %q, want %q", got, want)
+	}
+}
+
 func TestIngressDNSReportBootstrapWildcardHostPromptsForRealHostnames(t *testing.T) {
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")
 	cfg.Ingress = &config.IngressConfig{

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -1035,7 +1035,7 @@ func TestIngressDNSReportIncludesSSLIPHintForPublicIPWithoutConcreteHostnames(t 
 	if got, want := hint.SuggestedAction.Hostname, "my-app-production.8.8.8.8.sslip.io"; got != want {
 		t.Fatalf("suggested hostname = %q, want %q", got, want)
 	}
-	if !strings.Contains(hint.SuggestedAction.Command, "devopsellence ingress set --host my-app-production.8.8.8.8.sslip.io --tls-mode auto") {
+	if !strings.Contains(hint.SuggestedAction.Command, "devopsellence ingress set --host 'my-app-production.8.8.8.8.sslip.io' --tls-mode 'auto'") {
 		t.Fatalf("command = %q, want ingress set command", hint.SuggestedAction.Command)
 	}
 	if len(hint.SuggestedAction.Risks) == 0 {
@@ -1048,7 +1048,7 @@ func TestTemporaryDNSCommandPreservesConfiguredTLSMode(t *testing.T) {
 	cfg.Ingress = &config.IngressConfig{TLS: config.IngressTLSConfig{Mode: "off"}}
 
 	got := temporaryDNSCommand(&cfg, "demo-production.8.8.8.8.sslip.io")
-	want := "devopsellence ingress set --host demo-production.8.8.8.8.sslip.io --tls-mode off"
+	want := "devopsellence ingress set --host 'demo-production.8.8.8.8.sslip.io' --tls-mode 'off'"
 	if got != want {
 		t.Fatalf("temporaryDNSCommand() = %q, want %q", got, want)
 	}

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -1045,7 +1045,7 @@ func TestIngressDNSReportIncludesSSLIPHintForPublicIPWithoutConcreteHostnames(t 
 
 func TestTemporaryDNSCommandPreservesConfiguredTLSMode(t *testing.T) {
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")
-	cfg.Ingress = &config.IngressConfig{TLS: config.IngressTLSConfig{Mode: "off"}}
+	cfg.Ingress = &config.IngressConfig{TLS: config.IngressTLSConfig{Mode: " OFF "}}
 
 	got := temporaryDNSCommand(&cfg, "demo-production.8.8.8.8.sslip.io")
 	want := "devopsellence ingress set --host 'demo-production.8.8.8.8.sslip.io' --tls-mode 'off'"

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -1032,10 +1032,10 @@ func TestIngressDNSReportIncludesSSLIPHintForPublicIPWithoutConcreteHostnames(t 
 	if hint.SuggestedAction.Kind != "use_temporary_dns_hostname" || hint.SuggestedAction.Provider != "sslip.io" {
 		t.Fatalf("suggested_action = %#v, want sslip.io temporary hostname", hint.SuggestedAction)
 	}
-	if got, want := hint.SuggestedAction.Hostname, "8-8-8-8.my-app-production.sslip.io"; got != want {
+	if got, want := hint.SuggestedAction.Hostname, "8.8.8.8.sslip.io"; got != want {
 		t.Fatalf("suggested hostname = %q, want %q", got, want)
 	}
-	if !strings.Contains(hint.SuggestedAction.Command, "devopsellence ingress set --host '8-8-8-8.my-app-production.sslip.io' --tls-mode 'auto'") {
+	if !strings.Contains(hint.SuggestedAction.Command, "devopsellence ingress set --host '8.8.8.8.sslip.io' --tls-mode 'auto'") {
 		t.Fatalf("command = %q, want ingress set command", hint.SuggestedAction.Command)
 	}
 	if len(hint.SuggestedAction.Risks) == 0 {
@@ -1063,11 +1063,11 @@ func TestIngressDNSReportOmitsSSLIPHintForMultipleIngressIPs(t *testing.T) {
 	}
 }
 
-func TestTemporaryDNSHostnamePutsNodeIPBeforeSlugLabels(t *testing.T) {
+func TestTemporaryDNSHostnameUsesPlainIPHost(t *testing.T) {
 	cfg := config.DefaultProjectConfig("solo", "10.0.0.1", "production")
 
 	got := temporaryDNSHostname(&cfg, "8.8.8.8")
-	want := "8-8-8-8.10-0-0-1-production.sslip.io"
+	want := "8.8.8.8.sslip.io"
 	if got != want {
 		t.Fatalf("temporaryDNSHostname() = %q, want %q", got, want)
 	}
@@ -1077,8 +1077,8 @@ func TestTemporaryDNSCommandPreservesConfiguredTLSMode(t *testing.T) {
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")
 	cfg.Ingress = &config.IngressConfig{TLS: config.IngressTLSConfig{Mode: " OFF "}}
 
-	got := temporaryDNSCommand(&cfg, "8-8-8-8.demo-production.sslip.io")
-	want := "devopsellence ingress set --host '8-8-8-8.demo-production.sslip.io' --tls-mode 'off'"
+	got := temporaryDNSCommand(&cfg, "8.8.8.8.sslip.io")
+	want := "devopsellence ingress set --host '8.8.8.8.sslip.io' --tls-mode 'off'"
 	if got != want {
 		t.Fatalf("temporaryDNSCommand() = %q, want %q", got, want)
 	}
@@ -1154,7 +1154,7 @@ func TestCheckIngressBeforeDeployIncludesSSLIPHintFields(t *testing.T) {
 	if !ok || len(hints) != 1 {
 		t.Fatalf("hints = %#v, want one ingress hint", fields["hints"])
 	}
-	if got, want := hints[0].SuggestedAction.Hostname, "8-8-8-8.demo-production.sslip.io"; got != want {
+	if got, want := hints[0].SuggestedAction.Hostname, "8.8.8.8.sslip.io"; got != want {
 		t.Fatalf("suggested hostname = %q, want %q", got, want)
 	}
 }

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -1043,6 +1043,17 @@ func TestIngressDNSReportIncludesSSLIPHintForPublicIPWithoutConcreteHostnames(t 
 	}
 }
 
+func TestTemporaryDNSCommandPreservesConfiguredTLSMode(t *testing.T) {
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	cfg.Ingress = &config.IngressConfig{TLS: config.IngressTLSConfig{Mode: "off"}}
+
+	got := temporaryDNSCommand(&cfg, "demo-production.8.8.8.8.sslip.io")
+	want := "devopsellence ingress set --host demo-production.8.8.8.8.sslip.io --tls-mode off"
+	if got != want {
+		t.Fatalf("temporaryDNSCommand() = %q, want %q", got, want)
+	}
+}
+
 func TestTemporaryDNSIPv4AcceptsOnlyPubliclyRoutableAddresses(t *testing.T) {
 	tests := map[string]bool{
 		"8.8.8.8":         true,

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -1032,10 +1032,10 @@ func TestIngressDNSReportIncludesSSLIPHintForPublicIPWithoutConcreteHostnames(t 
 	if hint.SuggestedAction.Kind != "use_temporary_dns_hostname" || hint.SuggestedAction.Provider != "sslip.io" {
 		t.Fatalf("suggested_action = %#v, want sslip.io temporary hostname", hint.SuggestedAction)
 	}
-	if got, want := hint.SuggestedAction.Hostname, "my-app-production.8.8.8.8.sslip.io"; got != want {
+	if got, want := hint.SuggestedAction.Hostname, "8.8.8.8.my-app-production.sslip.io"; got != want {
 		t.Fatalf("suggested hostname = %q, want %q", got, want)
 	}
-	if !strings.Contains(hint.SuggestedAction.Command, "devopsellence ingress set --host 'my-app-production.8.8.8.8.sslip.io' --tls-mode 'auto'") {
+	if !strings.Contains(hint.SuggestedAction.Command, "devopsellence ingress set --host '8.8.8.8.my-app-production.sslip.io' --tls-mode 'auto'") {
 		t.Fatalf("command = %q, want ingress set command", hint.SuggestedAction.Command)
 	}
 	if len(hint.SuggestedAction.Risks) == 0 {
@@ -1043,12 +1043,22 @@ func TestIngressDNSReportIncludesSSLIPHintForPublicIPWithoutConcreteHostnames(t 
 	}
 }
 
+func TestTemporaryDNSHostnamePutsNodeIPBeforeSlugLabels(t *testing.T) {
+	cfg := config.DefaultProjectConfig("solo", "10.0.0.1", "production")
+
+	got := temporaryDNSHostname(&cfg, "8.8.8.8")
+	want := "8.8.8.8.10-0-0-1-production.sslip.io"
+	if got != want {
+		t.Fatalf("temporaryDNSHostname() = %q, want %q", got, want)
+	}
+}
+
 func TestTemporaryDNSCommandPreservesConfiguredTLSMode(t *testing.T) {
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")
 	cfg.Ingress = &config.IngressConfig{TLS: config.IngressTLSConfig{Mode: " OFF "}}
 
-	got := temporaryDNSCommand(&cfg, "demo-production.8.8.8.8.sslip.io")
-	want := "devopsellence ingress set --host 'demo-production.8.8.8.8.sslip.io' --tls-mode 'off'"
+	got := temporaryDNSCommand(&cfg, "8.8.8.8.demo-production.sslip.io")
+	want := "devopsellence ingress set --host '8.8.8.8.demo-production.sslip.io' --tls-mode 'off'"
 	if got != want {
 		t.Fatalf("temporaryDNSCommand() = %q, want %q", got, want)
 	}
@@ -1124,7 +1134,7 @@ func TestCheckIngressBeforeDeployIncludesSSLIPHintFields(t *testing.T) {
 	if !ok || len(hints) != 1 {
 		t.Fatalf("hints = %#v, want one ingress hint", fields["hints"])
 	}
-	if got, want := hints[0].SuggestedAction.Hostname, "demo-production.8.8.8.8.sslip.io"; got != want {
+	if got, want := hints[0].SuggestedAction.Hostname, "8.8.8.8.demo-production.sslip.io"; got != want {
 		t.Fatalf("suggested hostname = %q, want %q", got, want)
 	}
 }

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -1014,7 +1014,7 @@ func TestIngressDNSReportIncludesSSLIPHintForPublicIPWithoutConcreteHostnames(t 
 	}
 
 	report, err := ingressDNSReport(context.Background(), &cfg, map[string]config.Node{
-		"node-a": {Host: "203.0.113.10", User: "root", Labels: []string{config.DefaultWebRole}},
+		"node-a": {Host: "8.8.8.8", User: "root", Labels: []string{config.DefaultWebRole}},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -1032,10 +1032,10 @@ func TestIngressDNSReportIncludesSSLIPHintForPublicIPWithoutConcreteHostnames(t 
 	if hint.SuggestedAction.Kind != "use_temporary_dns_hostname" || hint.SuggestedAction.Provider != "sslip.io" {
 		t.Fatalf("suggested_action = %#v, want sslip.io temporary hostname", hint.SuggestedAction)
 	}
-	if got, want := hint.SuggestedAction.Hostname, "my-app-production.203.0.113.10.sslip.io"; got != want {
+	if got, want := hint.SuggestedAction.Hostname, "my-app-production.8.8.8.8.sslip.io"; got != want {
 		t.Fatalf("suggested hostname = %q, want %q", got, want)
 	}
-	if !strings.Contains(hint.SuggestedAction.Command, "devopsellence ingress set --host my-app-production.203.0.113.10.sslip.io --tls-mode auto") {
+	if !strings.Contains(hint.SuggestedAction.Command, "devopsellence ingress set --host my-app-production.8.8.8.8.sslip.io --tls-mode auto") {
 		t.Fatalf("command = %q, want ingress set command", hint.SuggestedAction.Command)
 	}
 	if len(hint.SuggestedAction.Risks) == 0 {
@@ -1043,12 +1043,18 @@ func TestIngressDNSReportIncludesSSLIPHintForPublicIPWithoutConcreteHostnames(t 
 	}
 }
 
-func TestTemporaryDNSIPv4RejectsNonPublicAddresses(t *testing.T) {
+func TestTemporaryDNSIPv4AcceptsOnlyPubliclyRoutableAddresses(t *testing.T) {
 	tests := map[string]bool{
-		"203.0.113.10":    true,
+		"8.8.8.8":         true,
+		"0.1.2.3":         false,
 		"10.0.0.1":        false,
+		"100.64.0.1":      false,
 		"127.0.0.1":       false,
 		"169.254.1.1":     false,
+		"192.0.2.10":      false,
+		"198.18.0.1":      false,
+		"198.51.100.10":   false,
+		"203.0.113.10":    false,
 		"224.0.0.1":       false,
 		"255.255.255.255": false,
 		"2001:db8::1":     false,
@@ -1071,7 +1077,7 @@ func TestCheckIngressBeforeDeployIncludesSSLIPHintFields(t *testing.T) {
 	}
 
 	err := (&App{}).checkIngressBeforeDeploy(context.Background(), &cfg, map[string]config.Node{
-		"node-a": {Host: "203.0.113.10", User: "root", Labels: []string{config.DefaultWebRole}},
+		"node-a": {Host: "8.8.8.8", User: "root", Labels: []string{config.DefaultWebRole}},
 	}, false)
 	if err == nil {
 		t.Fatal("checkIngressBeforeDeploy() error = nil, want missing hostname failure")
@@ -1088,7 +1094,7 @@ func TestCheckIngressBeforeDeployIncludesSSLIPHintFields(t *testing.T) {
 	if !ok || len(hints) != 1 {
 		t.Fatalf("hints = %#v, want one ingress hint", fields["hints"])
 	}
-	if got, want := hints[0].SuggestedAction.Hostname, "demo-production.203.0.113.10.sslip.io"; got != want {
+	if got, want := hints[0].SuggestedAction.Hostname, "demo-production.8.8.8.8.sslip.io"; got != want {
 		t.Fatalf("suggested hostname = %q, want %q", got, want)
 	}
 }

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -1043,6 +1043,26 @@ func TestIngressDNSReportIncludesSSLIPHintForPublicIPWithoutConcreteHostnames(t 
 	}
 }
 
+func TestIngressDNSReportOmitsSSLIPHintForMultipleIngressIPs(t *testing.T) {
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	cfg.Ingress = &config.IngressConfig{
+		Hosts: []string{"*"},
+		Rules: []config.IngressRuleConfig{{Target: config.IngressTargetConfig{Service: config.DefaultWebServiceName}}},
+		TLS:   config.IngressTLSConfig{Mode: "auto"},
+	}
+
+	report, err := ingressDNSReport(context.Background(), &cfg, map[string]config.Node{
+		"node-a": {Host: "8.8.8.8", User: "root", Labels: []string{config.DefaultWebRole}},
+		"node-b": {Host: "1.1.1.1", User: "root", Labels: []string{config.DefaultWebRole}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(report.Hints) != 0 {
+		t.Fatalf("hints = %#v, want no sslip.io hint for multiple expected ingress IPs", report.Hints)
+	}
+}
+
 func TestTemporaryDNSHostnamePutsNodeIPBeforeSlugLabels(t *testing.T) {
 	cfg := config.DefaultProjectConfig("solo", "10.0.0.1", "production")
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -1032,10 +1032,10 @@ func TestIngressDNSReportIncludesSSLIPHintForPublicIPWithoutConcreteHostnames(t 
 	if hint.SuggestedAction.Kind != "use_temporary_dns_hostname" || hint.SuggestedAction.Provider != "sslip.io" {
 		t.Fatalf("suggested_action = %#v, want sslip.io temporary hostname", hint.SuggestedAction)
 	}
-	if got, want := hint.SuggestedAction.Hostname, "8.8.8.8.my-app-production.sslip.io"; got != want {
+	if got, want := hint.SuggestedAction.Hostname, "8-8-8-8.my-app-production.sslip.io"; got != want {
 		t.Fatalf("suggested hostname = %q, want %q", got, want)
 	}
-	if !strings.Contains(hint.SuggestedAction.Command, "devopsellence ingress set --host '8.8.8.8.my-app-production.sslip.io' --tls-mode 'auto'") {
+	if !strings.Contains(hint.SuggestedAction.Command, "devopsellence ingress set --host '8-8-8-8.my-app-production.sslip.io' --tls-mode 'auto'") {
 		t.Fatalf("command = %q, want ingress set command", hint.SuggestedAction.Command)
 	}
 	if len(hint.SuggestedAction.Risks) == 0 {
@@ -1067,7 +1067,7 @@ func TestTemporaryDNSHostnamePutsNodeIPBeforeSlugLabels(t *testing.T) {
 	cfg := config.DefaultProjectConfig("solo", "10.0.0.1", "production")
 
 	got := temporaryDNSHostname(&cfg, "8.8.8.8")
-	want := "8.8.8.8.10-0-0-1-production.sslip.io"
+	want := "8-8-8-8.10-0-0-1-production.sslip.io"
 	if got != want {
 		t.Fatalf("temporaryDNSHostname() = %q, want %q", got, want)
 	}
@@ -1077,8 +1077,8 @@ func TestTemporaryDNSCommandPreservesConfiguredTLSMode(t *testing.T) {
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")
 	cfg.Ingress = &config.IngressConfig{TLS: config.IngressTLSConfig{Mode: " OFF "}}
 
-	got := temporaryDNSCommand(&cfg, "8.8.8.8.demo-production.sslip.io")
-	want := "devopsellence ingress set --host '8.8.8.8.demo-production.sslip.io' --tls-mode 'off'"
+	got := temporaryDNSCommand(&cfg, "8-8-8-8.demo-production.sslip.io")
+	want := "devopsellence ingress set --host '8-8-8-8.demo-production.sslip.io' --tls-mode 'off'"
 	if got != want {
 		t.Fatalf("temporaryDNSCommand() = %q, want %q", got, want)
 	}
@@ -1154,7 +1154,7 @@ func TestCheckIngressBeforeDeployIncludesSSLIPHintFields(t *testing.T) {
 	if !ok || len(hints) != 1 {
 		t.Fatalf("hints = %#v, want one ingress hint", fields["hints"])
 	}
-	if got, want := hints[0].SuggestedAction.Hostname, "8.8.8.8.demo-production.sslip.io"; got != want {
+	if got, want := hints[0].SuggestedAction.Hostname, "8-8-8-8.demo-production.sslip.io"; got != want {
 		t.Fatalf("suggested hostname = %q, want %q", got, want)
 	}
 }

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -1079,6 +1079,25 @@ func TestTemporaryDNSIPv4AcceptsOnlyPubliclyRoutableAddresses(t *testing.T) {
 	}
 }
 
+func TestCheckIngressBeforeDeployTreatsAutoTLSModeCaseInsensitively(t *testing.T) {
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	cfg.Ingress = &config.IngressConfig{
+		Hosts: []string{"*"},
+		Rules: []config.IngressRuleConfig{{Target: config.IngressTargetConfig{Service: config.DefaultWebServiceName}}},
+		TLS:   config.IngressTLSConfig{Mode: " AUTO "},
+	}
+
+	err := (&App{}).checkIngressBeforeDeploy(context.Background(), &cfg, map[string]config.Node{
+		"node-a": {Host: "8.8.8.8", User: "root", Labels: []string{config.DefaultWebRole}},
+	}, false)
+	if err == nil {
+		t.Fatal("checkIngressBeforeDeploy() error = nil, want DNS readiness failure")
+	}
+	if !strings.Contains(err.Error(), "no ingress hostnames configured") {
+		t.Fatalf("error = %q, want DNS readiness check to run", err.Error())
+	}
+}
+
 func TestCheckIngressBeforeDeployIncludesSSLIPHintFields(t *testing.T) {
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")
 	cfg.Ingress = &config.IngressConfig{


### PR DESCRIPTION
## Summary
- add machine-readable ingress hints for solo deployments with no concrete hostnames
- suggest explicit sslip.io temporary DNS commands without changing desired state automatically
- include the hints in deploy DNS readiness error fields for AI/operator agents

## Tests
- GOCACHE=$(pwd)/.gocache go test ./... (from cli/ in a clean worktree)
