### PR TITLE
Install pinned agent skill without npx

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ curl -fsSL https://www.devopsellence.com/lfg.sh | bash
 
 The installer writes to `~/.local/bin` by default. If that directory is not already on your `PATH`, it prints the shell command to add it.
 
-devopsellence is agent-first. The installer prints the agent skill command; to install the CLI and skill together:
+devopsellence is agent-first. The installer can also install the matching version of the devopsellence agent skill into `~/.agents/skills/devopsellence`:
 
 ```bash
 curl -fsSL https://www.devopsellence.com/lfg.sh | bash -s -- --install-agent-skill
@@ -86,7 +86,7 @@ devopsellence node create prod-1 --provider hetzner --install --attach
 devopsellence doctor
 ```
 
-For provider-created solo nodes, `devopsellence node create` can generate a workspace-scoped SSH keypair under `$XDG_STATE_HOME/devopsellence/solo/keys/` (default: `~/.local/state/devopsellence/solo/keys/`) and reuse it for later node creation from the same workspace.
+For provider-created solo nodes, `devopsellence node create` can generate a workspace-scoped SSH keypair under the devopsellence state home (`$DEVOPSELLENCE_STATE_HOME`, then `$XDG_STATE_HOME`, then `~/.local/state`) and reuse it for later node creation from the same workspace.
 
 Deploy over SSH:
 
@@ -126,7 +126,7 @@ devopsellence node remove prod-1 --yes
 
 `agent uninstall --yes` stops and disables `devopsellence-agent`, removes devopsellence-managed containers, removes the `devopsellence-envoy` container and `devopsellence` Docker network, deletes agent state, and removes `/usr/local/bin/devopsellence-agent`. Use `--keep-workloads` only when you intentionally want to stop the agent without cleaning remote runtime resources.
 
-Solo mode keeps app config workload-only. Solo nodes, local environment attachments, and the latest desired environment snapshots live in `$XDG_STATE_HOME/devopsellence/solo/state.json` (default: `~/.local/state/devopsellence/solo/state.json` when `XDG_STATE_HOME` is unset). Generated solo SSH keys stay local under `$XDG_STATE_HOME/devopsellence/solo/keys/`.
+Solo mode keeps app config workload-only. Solo nodes, local environment attachments, and the latest desired environment snapshots live in `$DEVOPSELLENCE_STATE_HOME/devopsellence/solo/state.json`, then `$XDG_STATE_HOME/devopsellence/solo/state.json`, and default to `~/.local/state/devopsellence/solo/state.json` when neither env var is set. Generated solo SSH keys stay local under the same state home. Use `DEVOPSELLENCE_STATE_HOME` for run-scoped AI-agent/operator sessions that must not see ambient local node state.
 
 ## Shared mode
 

--- a/cli/internal/agentskill/agentskill.go
+++ b/cli/internal/agentskill/agentskill.go
@@ -1,0 +1,70 @@
+package agentskill
+
+import (
+	"embed"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+const Name = "devopsellence"
+
+//go:embed all:devopsellence
+var bundled embed.FS
+
+type InstallResult struct {
+	Name    string
+	Path    string
+	Version string
+	Source  string
+}
+
+func DefaultSkillsDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".agents", "skills"), nil
+}
+
+func Install(skillsDir string, version string) (InstallResult, error) {
+	if skillsDir == "" {
+		defaultDir, err := DefaultSkillsDir()
+		if err != nil {
+			return InstallResult{}, err
+		}
+		skillsDir = defaultDir
+	}
+	dest := filepath.Join(skillsDir, Name)
+	if err := os.RemoveAll(dest); err != nil {
+		return InstallResult{}, fmt.Errorf("remove existing skill: %w", err)
+	}
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		return InstallResult{}, fmt.Errorf("create skill dir: %w", err)
+	}
+	if err := fs.WalkDir(bundled, Name, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		rel, err := filepath.Rel(Name, path)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return nil
+		}
+		target := filepath.Join(dest, rel)
+		if entry.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		data, err := bundled.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(target, data, 0o644)
+	}); err != nil {
+		return InstallResult{}, fmt.Errorf("write bundled skill: %w", err)
+	}
+	return InstallResult{Name: Name, Path: dest, Version: version, Source: "embedded"}, nil
+}

--- a/cli/internal/agentskill/agentskill_test.go
+++ b/cli/internal/agentskill/agentskill_test.go
@@ -1,0 +1,40 @@
+package agentskill
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestInstallWritesBundledSkill(t *testing.T) {
+	dir := t.TempDir()
+	result, err := Install(dir, "v1-test")
+	if err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+	if result.Name != Name || result.Version != "v1-test" || result.Source != "embedded" {
+		t.Fatalf("result = %#v, want bundled devopsellence skill", result)
+	}
+	path := filepath.Join(dir, Name, "SKILL.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", path, err)
+	}
+	if len(data) == 0 {
+		t.Fatalf("%s is empty", path)
+	}
+}
+
+func TestBundledSkillMatchesPublicSkill(t *testing.T) {
+	bundled, err := os.ReadFile(filepath.Join("devopsellence", "SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	public, err := os.ReadFile(filepath.Join("..", "..", "..", "skills", "devopsellence", "SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(bundled) != string(public) {
+		t.Fatal("bundled devopsellence skill differs from skills/devopsellence/SKILL.md")
+	}
+}

--- a/cli/internal/agentskill/devopsellence/SKILL.md
+++ b/cli/internal/agentskill/devopsellence/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: devopsellence
+description: Use the devopsellence CLI to choose solo or shared workspace mode, deploy the current app, inspect status, and manage secrets or nodes.
+homepage: https://www.devopsellence.com
+---
+
+# devopsellence
+
+Use this skill when the user wants to deploy an app with devopsellence, check deployment state, manage secrets, register and attach their own nodes, or edit the main lifecycle-hook config.
+
+## Default flow
+
+1. Work in the app directory the user wants to deploy.
+2. Check whether the CLI is already available:
+
+```sh
+command -v devopsellence
+```
+
+If the command is missing, tell the user the devopsellence CLI is required and point them to the official docs. Do not run setup scripts from this skill.
+
+3. Choose the workspace mode before initializing. First inspect any existing mode/context:
+
+```sh
+devopsellence mode show || true
+devopsellence context show || true
+```
+
+If a mode is already configured, use it. If no mode is configured and the user has not explicitly chosen one, do not default silently. Ask a short mode-selection question, make a recommendation, and wait for confirmation before running `devopsellence init`:
+
+> devopsellence has two workspace modes:
+>
+> - `solo`: SSH-first, single-operator, existing or provider-created VMs, local node state, local secrets, direct Docker image streaming over SSH.
+> - `shared`: hosted sign-in, org/project/env context, team workflows, shared encrypted secrets, and control-plane-managed nodes.
+>
+> Based on what you’ve told me, I recommend `<solo|shared>` because `<reason>`. Should I initialize this repo in `<solo|shared>` mode?
+
+Recommend `solo` when the user mentions their own VM/server, SSH, single-operator usage, local secrets, direct image streaming, or avoiding hosted/team workflows.
+
+Recommend `shared` when the user mentions teams, org/project/env context, browser sign-in, hosted control plane, shared encrypted secrets, managed nodes, auditability, or collaboration.
+
+If intent is still ambiguous, ask whether they are deploying SSH-first to their own VM as one operator or want the hosted/team workflow.
+
+4. Initialize the workspace before the first deploy only after mode confirmation. For solo:
+
+```sh
+devopsellence init --mode solo
+```
+
+For shared:
+
+```sh
+devopsellence auth whoami || devopsellence auth login
+devopsellence init --mode shared
+```
+
+If the user already knows the shared target workspace values, prefer explicit flags:
+
+```sh
+devopsellence init --mode shared --org acme --project shop --env staging
+```
+
+5. Validate local state after initialization and before deploy:
+
+```sh
+devopsellence doctor
+```
+
+6. Deploy the app:
+
+```sh
+devopsellence deploy
+```
+
+In shared mode, if the user wants to deploy an existing image digest instead of building locally:
+
+```sh
+devopsellence deploy --image docker.io/example/app@sha256:...
+```
+
+7. Verify the result:
+
+```sh
+devopsellence status
+```
+
+## CLI output contract
+
+The devopsellence CLI is agent-primary. Treat stdout as the primary machine-readable contract.
+
+- Bounded successful commands emit one JSON document on stdout.
+- Long-running commands typically emit newline-delimited JSON events on stdout.
+- Some commands may also emit optional structured progress or diagnostic events on stderr, for example during auth flows. Treat stderr events as supplemental rather than the primary contract, and do not scrape human prose from stderr unless diagnosing a CLI/runtime failure.
+- On command failure, stdout uses a structured `event: "error"` envelope with `ok: false` and `error` details even for otherwise bounded commands.
+- Streaming event envelopes always include `schema_version`; bounded JSON results often include it, but some legacy bounded results may omit it.
+- When `schema_version` is present, check it before relying on command-specific fields; if it is missing from a bounded result, be tolerant and treat command-specific fields cautiously.
+- For schema version 1, streaming events use a common envelope:
+  - `event`: `started`, `progress`, `result`, or `error`
+  - `operation`: stable operation name when available
+  - final success events include `ok: true`
+  - final failure events include `ok: false` and `error`
+- Structured errors use `error.code`, `error.message`, and `error.exit_code`.
+- Command-specific fields are top-level. Tolerate unknown fields, but do not assume undocumented fields are stable.
+- Prefer explaining failures from structured `code`, `message`, evidence fields, and suggested next actions when present.
+- If `schema_version` is unsupported, do not make high-risk decisions from command-specific fields; summarize the raw structured output and ask for updated docs or skill guidance. If `schema_version` is missing from a bounded result, treat common fields cautiously and avoid assuming undocumented command-specific fields are stable.
+- Keep secret values out of logs and chat output.
+
+## Secrets
+
+Prefer stdin over literal secret values in prompts or shell history:
+
+```sh
+printf '%s' "$VALUE" | devopsellence secret set NAME --service web --stdin
+devopsellence secret list --env production
+devopsellence secret delete NAME --service web
+```
+
+In solo mode, 1Password references are also supported:
+
+```sh
+devopsellence secret set NAME --service web --store 1password --op-ref op://vault/item/field
+```
+
+## Bring your own node
+
+Use these in shared mode for a provider-created node. By default, `node create` registers and attaches the node to the current environment:
+
+```sh
+devopsellence init --mode shared
+printf '%s' "$HCLOUD_TOKEN" | devopsellence provider login hetzner --stdin
+# or: devopsellence provider login hetzner --token "$HCLOUD_TOKEN"
+devopsellence node create prod-1 --provider hetzner
+devopsellence node list
+devopsellence node detach <id>
+devopsellence node remove <id>
+```
+
+If you intentionally create an unassigned shared node, attach it later:
+
+```sh
+devopsellence node create prod-1 --provider hetzner --unassigned
+devopsellence node attach <id>
+```
+
+Use this in shared mode for an existing server that you will install manually:
+
+```sh
+devopsellence node register
+```
+
+Use these in solo mode when the user wants SSH-first workflows without the control plane on an existing VM:
+
+```sh
+devopsellence init --mode solo
+devopsellence node create prod-1 --host <ip> --user root --ssh-key ~/.ssh/id_ed25519
+devopsellence agent install prod-1
+devopsellence node attach prod-1
+devopsellence doctor
+devopsellence deploy
+```
+
+Use these in solo mode for a provider-created node:
+
+```sh
+devopsellence init --mode solo
+printf '%s' "$HCLOUD_TOKEN" | devopsellence provider login hetzner --stdin
+# or: devopsellence provider login hetzner --token "$HCLOUD_TOKEN"
+devopsellence node create prod-1 --provider hetzner --install --attach
+devopsellence doctor
+devopsellence deploy
+```
+
+For solo diagnostics:
+
+```sh
+devopsellence status
+devopsellence logs --node prod-1 --lines 100
+devopsellence node diagnose prod-1
+devopsellence node logs prod-1 --lines 100
+```
+
+For solo cleanup:
+
+```sh
+devopsellence node detach prod-1
+devopsellence agent uninstall prod-1 --yes
+devopsellence node remove prod-1 --yes
+```
+
+## Lifecycle hooks
+
+When the user is editing `devopsellence.yml`, recognize these deploy-time hooks:
+
+- `tasks.release`: one-shot task that runs before rollout. Good for migrations. It reuses the configured service image, env, secrets, and volumes.
+- For per-node prep work, prefer the image entrypoint or boot-time scripts; the config-level `init` hook is no longer supported.
+
+## Heuristics
+
+- Prefer `devopsellence doctor` after init and before `devopsellence deploy`.
+- If Docker is missing or not running, surface the problem clearly. In shared mode, switch to `devopsellence deploy --image ...` when the user already has a pushed image digest.
+- If the workspace is not a git checkout and the CLI needs git metadata, stop and ask before creating a repo or commit.
+- Keep secrets out of logs and chat output. Use environment variables plus `--stdin`.

--- a/cli/internal/state/store.go
+++ b/cli/internal/state/store.go
@@ -16,7 +16,10 @@ func New(path string) *Store {
 }
 
 func DefaultPath(rel string) string {
-	base := os.Getenv("XDG_STATE_HOME")
+	base := os.Getenv("DEVOPSELLENCE_STATE_HOME")
+	if base == "" {
+		base = os.Getenv("XDG_STATE_HOME")
+	}
 	if base == "" {
 		home, err := os.UserHomeDir()
 		if err != nil {

--- a/cli/internal/state/store_test.go
+++ b/cli/internal/state/store_test.go
@@ -40,3 +40,15 @@ func TestStoreWriteReadDelete(t *testing.T) {
 		t.Fatal("Delete() = false, want true")
 	}
 }
+
+func TestDefaultPathHonorsDevopsellenceStateHome(t *testing.T) {
+	stateHome := t.TempDir()
+	t.Setenv("DEVOPSELLENCE_STATE_HOME", stateHome)
+	t.Setenv("XDG_STATE_HOME", filepath.Join(t.TempDir(), "xdg-state"))
+
+	got := DefaultPath(filepath.Join("devopsellence", "solo", "state.json"))
+	want := filepath.Join(stateHome, "devopsellence", "solo", "state.json")
+	if got != want {
+		t.Fatalf("DefaultPath() = %q, want %q", got, want)
+	}
+}

--- a/cli/internal/workflow/mode.go
+++ b/cli/internal/workflow/mode.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/devopsellence/cli/internal/discovery"
 	"github.com/devopsellence/cli/internal/solo"
+	"github.com/devopsellence/cli/internal/state"
 	"github.com/devopsellence/devopsellence/deployment-core/pkg/deploycore/config"
 )
 
@@ -43,6 +44,20 @@ func (a *App) modeWorkspaceKey() string {
 		return path
 	}
 	return a.Cwd
+}
+
+func storePath(store *state.Store) string {
+	if store == nil {
+		return ""
+	}
+	return store.Path
+}
+
+func soloStorePath(store *solo.StateStore) string {
+	if store == nil {
+		return ""
+	}
+	return store.Path
 }
 
 func (a *App) savedMode() (Mode, bool, error) {
@@ -193,9 +208,13 @@ func (a *App) ModeShow() error {
 	}
 
 	payload := map[string]any{
-		"schema_version": outputSchemaVersion,
-		"workspace_key":  a.modeWorkspaceKey(),
-		"set":            ok,
+		"schema_version":          outputSchemaVersion,
+		"workspace_key":           a.modeWorkspaceKey(),
+		"set":                     ok,
+		"workspace_state_path":    storePath(a.WorkspaceState),
+		"solo_state_path":         soloStorePath(a.SoloState),
+		"state_home_env":          "DEVOPSELLENCE_STATE_HOME",
+		"state_home_fallback_env": "XDG_STATE_HOME",
 	}
 	if ok {
 		payload["mode"] = string(mode)
@@ -216,9 +235,13 @@ func (a *App) ContextShow() error {
 		return ExitError{Code: 1, Err: modeErr}
 	}
 	result := map[string]any{
-		"schema_version": outputSchemaVersion,
-		"workspace_root": discovered.WorkspaceRoot,
-		"mode_set":       ok,
+		"schema_version":          outputSchemaVersion,
+		"workspace_root":          discovered.WorkspaceRoot,
+		"mode_set":                ok,
+		"workspace_state_path":    storePath(a.WorkspaceState),
+		"solo_state_path":         soloStorePath(a.SoloState),
+		"state_home_env":          "DEVOPSELLENCE_STATE_HOME",
+		"state_home_fallback_env": "XDG_STATE_HOME",
 	}
 	if ok {
 		result["mode"] = string(mode)

--- a/cli/internal/workflow/root.go
+++ b/cli/internal/workflow/root.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/devopsellence/cli/internal/agentskill"
 	"github.com/devopsellence/cli/internal/version"
 
 	"github.com/spf13/cobra"
@@ -503,6 +504,30 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 		RunE:  withTimeout(app.AliasLFG),
 	})
 	root.AddCommand(aliasCommand)
+
+	var skillInstallDir string
+	skillCommand := &cobra.Command{Use: "skill", Short: "Manage bundled AI agent skill"}
+	skillInstallCommand := &cobra.Command{
+		Use:   "install",
+		Short: "Install the bundled devopsellence agent skill",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			result, installErr := agentskill.Install(skillInstallDir, version.String())
+			if installErr != nil {
+				return ExitError{Code: 1, Err: installErr}
+			}
+			return app.Printer.PrintJSON(map[string]any{
+				"schema_version": outputSchemaVersion,
+				"action":         "installed",
+				"skill":          result.Name,
+				"path":           result.Path,
+				"version":        result.Version,
+				"source":         result.Source,
+			})
+		},
+	}
+	skillInstallCommand.Flags().StringVar(&skillInstallDir, "dir", "", "Parent skills directory (default ~/.agents/skills)")
+	skillCommand.AddCommand(skillInstallCommand)
+	root.AddCommand(skillCommand)
 
 	var initSharedOpts InitOptions
 	var initMode string

--- a/cli/internal/workflow/root.go
+++ b/cli/internal/workflow/root.go
@@ -142,9 +142,13 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 				return ExitError{Code: 1, Err: err}
 			}
 			return app.Printer.PrintJSON(map[string]any{
-				"schema_version": outputSchemaVersion,
-				"mode":           string(mode),
-				"workspace_key":  app.modeWorkspaceKey(),
+				"schema_version":          outputSchemaVersion,
+				"mode":                    string(mode),
+				"workspace_key":           app.modeWorkspaceKey(),
+				"workspace_state_path":    storePath(app.WorkspaceState),
+				"solo_state_path":         soloStorePath(app.SoloState),
+				"state_home_env":          "DEVOPSELLENCE_STATE_HOME",
+				"state_home_fallback_env": "XDG_STATE_HOME",
 			})
 		},
 	})

--- a/cli/internal/workflow/root_test.go
+++ b/cli/internal/workflow/root_test.go
@@ -40,6 +40,31 @@ func TestRootVersionCommand(t *testing.T) {
 	}
 }
 
+func TestRootSkillInstallWritesBundledSkill(t *testing.T) {
+	var stdout bytes.Buffer
+	skillsDir := t.TempDir()
+	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, t.TempDir())
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{"skill", "install", "--dir", skillsDir})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	if payload["skill"] != "devopsellence" || payload["source"] != "embedded" {
+		t.Fatalf("payload = %#v, want embedded devopsellence skill", payload)
+	}
+	path := filepath.Join(skillsDir, "devopsellence", "SKILL.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", path, err)
+	}
+	if !strings.Contains(string(data), "# devopsellence") {
+		t.Fatalf("SKILL.md = %q, want devopsellence skill", string(data))
+	}
+}
+
 func TestRootModeFlagIsNotGlobal(t *testing.T) {
 	t.Parallel()
 

--- a/cli/internal/workflow/root_test.go
+++ b/cli/internal/workflow/root_test.go
@@ -87,6 +87,8 @@ func TestInitModeFlagPersistsWorkspaceModeAndWritesConfig(t *testing.T) {
 
 func TestModeCommandDefaultsToShow(t *testing.T) {
 	var stdout bytes.Buffer
+	stateHome := t.TempDir()
+	t.Setenv("DEVOPSELLENCE_STATE_HOME", stateHome)
 	cwd := rootTestWorkspaceWithMode(t, ModeSolo)
 	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, cwd)
 	cmd.SetOut(&stdout)
@@ -99,6 +101,15 @@ func TestModeCommandDefaultsToShow(t *testing.T) {
 	payload := decodeJSONOutput(t, &stdout)
 	if payload["mode"] != "solo" || payload["set"] != true {
 		t.Fatalf("payload = %#v, want current solo mode", payload)
+	}
+	if payload["workspace_state_path"] != filepath.Join(stateHome, "devopsellence", "workspace.json") {
+		t.Fatalf("workspace_state_path = %#v, want state home path", payload["workspace_state_path"])
+	}
+	if payload["solo_state_path"] != filepath.Join(stateHome, "devopsellence", "solo", "state.json") {
+		t.Fatalf("solo_state_path = %#v, want state home path", payload["solo_state_path"])
+	}
+	if payload["state_home_env"] != "DEVOPSELLENCE_STATE_HOME" {
+		t.Fatalf("state_home_env = %#v, want DEVOPSELLENCE_STATE_HOME", payload["state_home_env"])
 	}
 }
 

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -4160,7 +4160,16 @@ func temporaryDNSHostname(_ *config.ProjectConfig, ip string) string {
 }
 
 func temporaryDNSCommand(cfg *config.ProjectConfig, hostname string) string {
-	return "devopsellence ingress set --host " + shellQuote(hostname) + " --tls-mode " + shellQuote(temporaryDNSTLSMode(cfg))
+	return "devopsellence ingress set --service " + shellQuote(temporaryDNSIngressService(cfg)) + " --host " + shellQuote(hostname) + " --tls-mode " + shellQuote(temporaryDNSTLSMode(cfg))
+}
+
+func temporaryDNSIngressService(cfg *config.ProjectConfig) string {
+	if cfg != nil {
+		if serviceName, ok := cfg.PrimaryWebServiceName(); ok && strings.TrimSpace(serviceName) != "" {
+			return strings.TrimSpace(serviceName)
+		}
+	}
+	return "<service>"
 }
 
 func temporaryDNSTLSMode(cfg *config.ProjectConfig) string {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -2057,10 +2057,12 @@ func (a *App) SoloNodeList(_ context.Context, opts SoloNodeListOptions) error {
 	}
 
 	return a.Printer.PrintJSON(map[string]any{
-		"schema_version": outputSchemaVersion,
-		"scope":          scope,
-		"nodes":          nodes,
-		"node_items":     items,
+		"schema_version":  outputSchemaVersion,
+		"scope":           scope,
+		"nodes":           nodes,
+		"node_items":      items,
+		"solo_state_path": soloStorePath(a.SoloState),
+		"state_home_env":  "DEVOPSELLENCE_STATE_HOME",
 	})
 
 }
@@ -3691,6 +3693,8 @@ func (a *App) SoloInit(context.Context, SoloInitOptions) error {
 		"workspace_root":   discovered.WorkspaceRoot,
 		"project_slug":     discovered.ProjectSlug,
 		"runtime_contract": soloInitRuntimeContract(*cfg, discovered, created),
+		"solo_state_path":  soloStorePath(a.SoloState),
+		"state_home_env":   "DEVOPSELLENCE_STATE_HOME",
 		"config": map[string]any{
 			"path":           configPath,
 			"created":        created,

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -1078,7 +1078,7 @@ func TestTemporaryDNSCommandPreservesConfiguredTLSMode(t *testing.T) {
 	cfg.Ingress = &config.IngressConfig{TLS: config.IngressTLSConfig{Mode: " OFF "}}
 
 	got := temporaryDNSCommand(&cfg, "8.8.8.8.sslip.io")
-	want := "devopsellence ingress set --host '8.8.8.8.sslip.io' --tls-mode 'off'"
+	want := "devopsellence ingress set --service 'web' --host '8.8.8.8.sslip.io' --tls-mode 'off'"
 	if got != want {
 		t.Fatalf("temporaryDNSCommand() = %q, want %q", got, want)
 	}

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -1035,7 +1035,7 @@ func TestIngressDNSReportIncludesSSLIPHintForPublicIPWithoutConcreteHostnames(t 
 	if got, want := hint.SuggestedAction.Hostname, "8.8.8.8.sslip.io"; got != want {
 		t.Fatalf("suggested hostname = %q, want %q", got, want)
 	}
-	if !strings.Contains(hint.SuggestedAction.Command, "devopsellence ingress set --host '8.8.8.8.sslip.io' --tls-mode 'auto'") {
+	if !strings.Contains(hint.SuggestedAction.Command, "devopsellence ingress set --service 'web' --host '8.8.8.8.sslip.io' --tls-mode 'auto'") {
 		t.Fatalf("command = %q, want ingress set command", hint.SuggestedAction.Command)
 	}
 	if len(hint.SuggestedAction.Risks) == 0 {

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -1427,6 +1427,12 @@ func TestSoloNodeListDefaultsToCurrentEnvironmentAndRedactsPrivateFields(t *test
 	if payload["scope"] != "current_environment" {
 		t.Fatalf("scope = %v, want current_environment", payload["scope"])
 	}
+	if payload["solo_state_path"] != soloState.Path {
+		t.Fatalf("solo_state_path = %#v, want %q", payload["solo_state_path"], soloState.Path)
+	}
+	if payload["state_home_env"] != "DEVOPSELLENCE_STATE_HOME" {
+		t.Fatalf("state_home_env = %#v, want DEVOPSELLENCE_STATE_HOME", payload["state_home_env"])
+	}
 	nodes := jsonMapFromAny(t, payload["nodes"])
 	if _, ok := nodes["node-b"]; ok {
 		t.Fatalf("nodes = %#v, want node-b omitted", nodes)

--- a/cli/scripts/release-local.sh
+++ b/cli/scripts/release-local.sh
@@ -6,6 +6,7 @@ CLI_DIR="$ROOT_DIR/cli"
 TARGET_NAME="devopsellence"
 INSTALL_DIR="${DEVOPSELLENCE_CLI_INSTALL_DIR:-}"
 INSTALL_AGENT_SKILL="${DEVOPSELLENCE_INSTALL_AGENT_SKILL:-}"
+AGENT_SKILLS_DIR="${DEVOPSELLENCE_AGENT_SKILLS_DIR:-}"
 
 OS_RAW="$(uname -s | tr '[:upper:]' '[:lower:]')"
 ARCH_RAW="$(uname -m)"
@@ -101,21 +102,36 @@ case ":$PATH:" in
     ;;
 esac
 
+install_agent_skill_from_checkout() {
+  local skills_dir skill_dest source_dir
+
+  skills_dir="$AGENT_SKILLS_DIR"
+  if [[ -z "$skills_dir" ]]; then
+    skills_dir="$HOME/.agents/skills"
+  fi
+  skill_dest="$skills_dir/devopsellence"
+  source_dir="$ROOT_DIR/skills/devopsellence"
+
+  if [[ ! -f "$source_dir/SKILL.md" ]]; then
+    echo "devopsellence CLI installed, but agent skill install failed: missing $source_dir/SKILL.md" >&2
+    exit 1
+  fi
+
+  echo "installing devopsellence agent skill..."
+  mkdir -p "$skills_dir"
+  rm -rf "$skill_dest"
+  cp -R "$source_dir" "$skill_dest"
+  echo "devopsellence agent skill installed"
+  echo "  version: local-head ($COMMIT)"
+  echo "  source: $source_dir"
+  echo "  path: $skill_dest"
+}
+
 case "$INSTALL_AGENT_SKILL" in
   1|true|TRUE|yes|YES)
-    if command -v npx >/dev/null 2>&1; then
-      echo "installing devopsellence agent skill..."
-      npx --yes skills add devopsellence/devopsellence --skill devopsellence -g --yes
-    else
-      echo "devopsellence CLI installed. Agent skill install requested, but npx was not found." >&2
-      echo "Install the skill later with:" >&2
-      echo "  npx --yes skills add devopsellence/devopsellence --skill devopsellence -g --yes" >&2
-      exit 1
-    fi
+    install_agent_skill_from_checkout
     ;;
   *)
-    echo "agent skill available:"
-    echo "  npx --yes skills add devopsellence/devopsellence --skill devopsellence -g --yes"
-    echo "or rerun installer with DEVOPSELLENCE_INSTALL_AGENT_SKILL=1"
+    echo "agent skill available; rerun installer with DEVOPSELLENCE_INSTALL_AGENT_SKILL=1"
     ;;
 esac

--- a/cli/scripts/release-local.sh
+++ b/cli/scripts/release-local.sh
@@ -102,34 +102,20 @@ case ":$PATH:" in
     ;;
 esac
 
-install_agent_skill_from_checkout() {
-  local skills_dir skill_dest source_dir
+install_agent_skill() {
+  local skill_args=()
 
-  skills_dir="$AGENT_SKILLS_DIR"
-  if [[ -z "$skills_dir" ]]; then
-    skills_dir="$HOME/.agents/skills"
-  fi
-  skill_dest="$skills_dir/devopsellence"
-  source_dir="$ROOT_DIR/skills/devopsellence"
-
-  if [[ ! -f "$source_dir/SKILL.md" ]]; then
-    echo "devopsellence CLI installed, but agent skill install failed: missing $source_dir/SKILL.md" >&2
-    exit 1
+  if [[ -n "$AGENT_SKILLS_DIR" ]]; then
+    skill_args+=(--dir "$AGENT_SKILLS_DIR")
   fi
 
   echo "installing devopsellence agent skill..."
-  mkdir -p "$skills_dir"
-  rm -rf "$skill_dest"
-  cp -R "$source_dir" "$skill_dest"
-  echo "devopsellence agent skill installed"
-  echo "  version: local-head ($COMMIT)"
-  echo "  source: $source_dir"
-  echo "  path: $skill_dest"
+  "$INSTALL_DIR/$TARGET_NAME" skill install "${skill_args[@]}"
 }
 
 case "$INSTALL_AGENT_SKILL" in
   1|true|TRUE|yes|YES)
-    install_agent_skill_from_checkout
+    install_agent_skill
     ;;
   *)
     echo "agent skill available; rerun installer with DEVOPSELLENCE_INSTALL_AGENT_SKILL=1"

--- a/control-plane/app/controllers/cli_installs_controller.rb
+++ b/control-plane/app/controllers/cli_installs_controller.rb
@@ -30,6 +30,8 @@ class CliInstallsController < ActionController::Base
       CLI_CHECKSUM_URL="${DEVOPSELLENCE_CLI_CHECKSUM_URL:-}"
       INSTALL_DIR="${DEVOPSELLENCE_CLI_INSTALL_DIR:-}"
       INSTALL_AGENT_SKILL="${DEVOPSELLENCE_INSTALL_AGENT_SKILL:-}"
+      AGENT_SKILLS_DIR="${DEVOPSELLENCE_AGENT_SKILLS_DIR:-}"
+      AGENT_SKILL_ARCHIVE_URL="${DEVOPSELLENCE_AGENT_SKILL_ARCHIVE_URL:-}"
       TARGET_NAME="devopsellence"
 
       while [[ $# -gt 0 ]]; do
@@ -118,7 +120,9 @@ class CliInstallsController < ActionController::Base
       ARTIFACT_NAME="cli-$OS-$ARCH"
       TMP_BIN="$(mktemp)"
       TMP_SUMS="$(mktemp)"
-      cleanup() { rm -f "$TMP_BIN" "$TMP_SUMS"; }
+      TMP_SKILL_ARCHIVE="$(mktemp)"
+      TMP_SKILL_DIR="$(mktemp -d)"
+      cleanup() { rm -f "$TMP_BIN" "$TMP_SUMS" "$TMP_SKILL_ARCHIVE"; rm -rf "$TMP_SKILL_DIR"; }
       trap cleanup EXIT
 
       checksum_value() {
@@ -151,6 +155,46 @@ class CliInstallsController < ActionController::Base
           echo "checksum mismatch for downloaded CLI" >&2
           exit 1
         fi
+      }
+
+      install_agent_skill() {
+        local skills_dir skill_dest archive_url
+
+        skills_dir="$AGENT_SKILLS_DIR"
+        if [[ -z "$skills_dir" ]]; then
+          skills_dir="$HOME/.agents/skills"
+        fi
+        skill_dest="$skills_dir/devopsellence"
+        archive_url="$AGENT_SKILL_ARCHIVE_URL"
+        if [[ -z "$archive_url" ]]; then
+          archive_url="https://codeload.github.com/devopsellence/devopsellence/tar.gz/refs/tags/$CLI_VERSION"
+        fi
+
+        if ! command -v tar >/dev/null 2>&1; then
+          echo "devopsellence CLI installed, but agent skill install failed: tar was not found" >&2
+          exit 1
+        fi
+
+        echo "installing devopsellence agent skill..."
+        curl -fsSL "$archive_url" -o "$TMP_SKILL_ARCHIVE"
+        tar -xzf "$TMP_SKILL_ARCHIVE" -C "$TMP_SKILL_DIR"
+
+        shopt -s nullglob
+        local skill_sources=("$TMP_SKILL_DIR"/*/skills/devopsellence)
+        shopt -u nullglob
+        if [[ "${#skill_sources[@]}" -ne 1 || ! -f "${skill_sources[0]}/SKILL.md" ]]; then
+          echo "devopsellence CLI installed, but agent skill install failed: missing skills/devopsellence/SKILL.md in tag $CLI_VERSION" >&2
+          exit 1
+        fi
+
+        mkdir -p "$skills_dir"
+        rm -rf "$skill_dest"
+        cp -R "${skill_sources[0]}" "$skill_dest"
+
+        echo "devopsellence agent skill installed"
+        echo "  version: $CLI_VERSION"
+        echo "  source: https://github.com/devopsellence/devopsellence/tree/$CLI_VERSION/skills/devopsellence"
+        echo "  path: $skill_dest"
       }
 
       echo "downloading devopsellence CLI..."
@@ -208,20 +252,10 @@ class CliInstallsController < ActionController::Base
 
       case "$INSTALL_AGENT_SKILL" in
         1|true|TRUE|yes|YES)
-          if command -v npx >/dev/null 2>&1; then
-            echo "installing devopsellence agent skill..."
-            npx --yes skills add devopsellence/devopsellence --skill devopsellence -g --yes
-          else
-            echo "devopsellence CLI installed. Agent skill install requested, but npx was not found." >&2
-            echo "Install the skill later with:" >&2
-            echo "  npx --yes skills add devopsellence/devopsellence --skill devopsellence -g --yes" >&2
-            exit 1
-          fi
+          install_agent_skill
           ;;
         *)
-          echo "agent skill available:"
-          echo "  npx --yes skills add devopsellence/devopsellence --skill devopsellence -g --yes"
-          echo "or install CLI + skill together with:"
+          echo "agent skill available; install CLI + skill together with:"
           echo "  curl -fsSL \"$INSTALL_SCRIPT_URL?version=$CLI_VERSION\" | bash -s -- --install-agent-skill"
           ;;
       esac

--- a/control-plane/app/controllers/cli_installs_controller.rb
+++ b/control-plane/app/controllers/cli_installs_controller.rb
@@ -31,7 +31,6 @@ class CliInstallsController < ActionController::Base
       INSTALL_DIR="${DEVOPSELLENCE_CLI_INSTALL_DIR:-}"
       INSTALL_AGENT_SKILL="${DEVOPSELLENCE_INSTALL_AGENT_SKILL:-}"
       AGENT_SKILLS_DIR="${DEVOPSELLENCE_AGENT_SKILLS_DIR:-}"
-      AGENT_SKILL_ARCHIVE_URL="${DEVOPSELLENCE_AGENT_SKILL_ARCHIVE_URL:-}"
       TARGET_NAME="devopsellence"
 
       while [[ $# -gt 0 ]]; do
@@ -120,9 +119,7 @@ class CliInstallsController < ActionController::Base
       ARTIFACT_NAME="cli-$OS-$ARCH"
       TMP_BIN="$(mktemp)"
       TMP_SUMS="$(mktemp)"
-      TMP_SKILL_ARCHIVE="$(mktemp)"
-      TMP_SKILL_DIR="$(mktemp -d)"
-      cleanup() { rm -f "$TMP_BIN" "$TMP_SUMS" "$TMP_SKILL_ARCHIVE"; rm -rf "$TMP_SKILL_DIR"; }
+      cleanup() { rm -f "$TMP_BIN" "$TMP_SUMS"; }
       trap cleanup EXIT
 
       checksum_value() {
@@ -158,43 +155,14 @@ class CliInstallsController < ActionController::Base
       }
 
       install_agent_skill() {
-        local skills_dir skill_dest archive_url
+        local skill_args=()
 
-        skills_dir="$AGENT_SKILLS_DIR"
-        if [[ -z "$skills_dir" ]]; then
-          skills_dir="$HOME/.agents/skills"
-        fi
-        skill_dest="$skills_dir/devopsellence"
-        archive_url="$AGENT_SKILL_ARCHIVE_URL"
-        if [[ -z "$archive_url" ]]; then
-          archive_url="https://codeload.github.com/devopsellence/devopsellence/tar.gz/refs/tags/$CLI_VERSION"
-        fi
-
-        if ! command -v tar >/dev/null 2>&1; then
-          echo "devopsellence CLI installed, but agent skill install failed: tar was not found" >&2
-          exit 1
+        if [[ -n "$AGENT_SKILLS_DIR" ]]; then
+          skill_args+=(--dir "$AGENT_SKILLS_DIR")
         fi
 
         echo "installing devopsellence agent skill..."
-        curl -fsSL "$archive_url" -o "$TMP_SKILL_ARCHIVE"
-        tar -xzf "$TMP_SKILL_ARCHIVE" -C "$TMP_SKILL_DIR"
-
-        shopt -s nullglob
-        local skill_sources=("$TMP_SKILL_DIR"/*/skills/devopsellence)
-        shopt -u nullglob
-        if [[ "${#skill_sources[@]}" -ne 1 || ! -f "${skill_sources[0]}/SKILL.md" ]]; then
-          echo "devopsellence CLI installed, but agent skill install failed: missing skills/devopsellence/SKILL.md in tag $CLI_VERSION" >&2
-          exit 1
-        fi
-
-        mkdir -p "$skills_dir"
-        rm -rf "$skill_dest"
-        cp -R "${skill_sources[0]}" "$skill_dest"
-
-        echo "devopsellence agent skill installed"
-        echo "  version: $CLI_VERSION"
-        echo "  source: https://github.com/devopsellence/devopsellence/tree/$CLI_VERSION/skills/devopsellence"
-        echo "  path: $skill_dest"
+        "$INSTALL_DIR/$TARGET_NAME" skill install "${skill_args[@]}"
       }
 
       echo "downloading devopsellence CLI..."

--- a/control-plane/app/views/marketing/docs.html.erb
+++ b/control-plane/app/views/marketing/docs.html.erb
@@ -164,7 +164,7 @@
         <div class="tl"><span class="tp">$</span> <%= @cli_install_command %></div>
       </div>
     </div>
-    <p>This installs the <code>devopsellence</code> binary to <code>~/.local/bin</code> by default and prints the shell command to add that directory to your <code>PATH</code> when needed. devopsellence is agent-first; the installer also prints the agent skill command, and accepts <code>--install-agent-skill</code> when you want the CLI and skill installed together. Run <code>devopsellence doctor</code> to verify your setup.</p>
+    <p>This installs the <code>devopsellence</code> binary to <code>~/.local/bin</code> by default and prints the shell command to add that directory to your <code>PATH</code> when needed. devopsellence is agent-first; pass <code>--install-agent-skill</code> when you want the CLI and the matching devopsellence agent skill installed together under <code>~/.agents/skills/devopsellence</code>. Run <code>devopsellence doctor</code> to verify your setup.</p>
 
     <h3>2. Choose a workspace mode</h3>
     <div class="terminal">
@@ -340,10 +340,10 @@
         <div class="tl"><span class="tp">$</span> devopsellence node attach prod-1</div>
       </div>
     </div>
-    <p>If no default SSH public key exists, <code>node create</code> generates and reuses a workspace-scoped keypair under local state. Pass <code>--ssh-public-key</code> when you want to use a specific key. Provider-managed nodes record non-secret metadata like provider name, server ID, region, size, public host, SSH user, and labels in local solo state at <code>$XDG_STATE_HOME/devopsellence/solo/state.json</code> (default: <code>~/.local/state/devopsellence/solo/state.json</code> when <code>XDG_STATE_HOME</code> is unset). The provider API token and SSH private key value are not written to app config.</p>
+    <p>If no default SSH public key exists, <code>node create</code> generates and reuses a workspace-scoped keypair under local state. Pass <code>--ssh-public-key</code> when you want to use a specific key. Provider-managed nodes record non-secret metadata like provider name, server ID, region, size, public host, SSH user, and labels in local solo state at <code>$DEVOPSELLENCE_STATE_HOME/devopsellence/solo/state.json</code>, then <code>$XDG_STATE_HOME/devopsellence/solo/state.json</code>, defaulting to <code>~/.local/state/devopsellence/solo/state.json</code> when neither env var is set. The provider API token and SSH private key value are not written to app config.</p>
 
     <h3>Solo config</h3>
-    <p><code>devopsellence.yml</code> stays workload-only in solo mode. Solo nodes, workspace/environment attachments, and the latest desired environment snapshots live in <code>$XDG_STATE_HOME/devopsellence/solo/state.json</code> (default: <code>~/.local/state/devopsellence/solo/state.json</code> when <code>XDG_STATE_HOME</code> is unset). Generated solo SSH keys stay local under <code>$XDG_STATE_HOME/devopsellence/solo/keys/</code>; SSH private key material is still never written into app config.</p>
+    <p><code>devopsellence.yml</code> stays workload-only in solo mode. Solo nodes, workspace/environment attachments, and the latest desired environment snapshots live under the devopsellence state home: <code>$DEVOPSELLENCE_STATE_HOME</code>, then <code>$XDG_STATE_HOME</code>, defaulting to <code>~/.local/state</code> when neither env var is set. Generated solo SSH keys stay local under the same state home; SSH private key material is still never written into app config. Use <code>DEVOPSELLENCE_STATE_HOME</code> for run-scoped AI-agent/operator sessions that must not see ambient local node state.</p>
     <div class="terminal">
       <div class="terminal-bar">
         <span class="dot dot-red"></span>
@@ -675,8 +675,8 @@ tasks:
         <dd>Runs once on a node matching its configured service before the rollout proceeds. Use for migrations. Failure stops the deploy.</dd>
       </div>
       <div class="docs-field">
-        <dt><code>$XDG_STATE_HOME/devopsellence/solo/state.json</code></dt>
-        <dd>Solo mode local state. Stores the global node registry, workspace/environment attachments, and the latest desired environment snapshots. Defaults to <code>~/.local/state/devopsellence/solo/state.json</code> when <code>XDG_STATE_HOME</code> is not set.</dd>
+        <dt><code>$DEVOPSELLENCE_STATE_HOME/devopsellence/solo/state.json</code></dt>
+        <dd>Solo mode local state. Stores the global node registry, workspace/environment attachments, and the latest desired environment snapshots. Falls back to <code>$XDG_STATE_HOME/devopsellence/solo/state.json</code>, then <code>~/.local/state/devopsellence/solo/state.json</code> when neither env var is set.</dd>
       </div>
     </dl>
   </section>

--- a/control-plane/test/integration/installs_test.rb
+++ b/control-plane/test/integration/installs_test.rb
@@ -58,6 +58,8 @@ class InstallsTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "BASE_URL='https://dev.devopsellence.com'"
     assert_includes response.body, 'INSTALL_DIR="${DEVOPSELLENCE_CLI_INSTALL_DIR:-}"'
     assert_includes response.body, 'INSTALL_AGENT_SKILL="${DEVOPSELLENCE_INSTALL_AGENT_SKILL:-}"'
+    assert_includes response.body, 'AGENT_SKILLS_DIR="${DEVOPSELLENCE_AGENT_SKILLS_DIR:-}"'
+    assert_includes response.body, 'AGENT_SKILL_ARCHIVE_URL="${DEVOPSELLENCE_AGENT_SKILL_ARCHIVE_URL:-}"'
     assert_includes response.body, "INSTALL_SCRIPT_URL='https://dev.devopsellence.com/lfg.sh'"
     assert_includes response.body, "--install-agent-skill"
     assert_includes response.body, 'INSTALL_DIR="$HOME/.local/bin"'
@@ -65,8 +67,10 @@ class InstallsTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "PATH_EXPORT='export PATH=\"'\"$INSTALL_DIR\"':$PATH\"'"
     assert_includes response.body, "echo '$PATH_EXPORT' >> $RC_FILE"
     assert_includes response.body, "source $RC_FILE"
-    assert_includes response.body, "npx --yes skills add devopsellence/devopsellence --skill devopsellence -g --yes"
+    assert_includes response.body, "https://codeload.github.com/devopsellence/devopsellence/tar.gz/refs/tags/$CLI_VERSION"
+    assert_includes response.body, 'skills_dir="$HOME/.agents/skills"'
     assert_includes response.body, 'curl -fsSL "$INSTALL_SCRIPT_URL?version=$CLI_VERSION" | bash -s -- --install-agent-skill'
+    refute_includes response.body, "npx --yes skills add"
   end
 
   test "cli install script ignores configured public base url when choosing default download host" do
@@ -121,12 +125,12 @@ class InstallsTest < ActionDispatch::IntegrationTest
     assert_equal "prerelease build\n", installed_cli
   end
 
-  test "cli install script can install the agent skill when requested" do
+  test "cli install script can install the pinned agent skill when requested" do
     get "/lfg.sh", params: { version: "master-0053792f6aec" }
 
     assert_response :success
 
-    stdout, stderr, status, installed_cli, skill_args = run_cli_install_script(
+    stdout, stderr, status, installed_cli, installed_skill = run_cli_install_script(
       response.body,
       version: "master-0053792f6aec",
       install_agent_skill: true
@@ -134,26 +138,29 @@ class InstallsTest < ActionDispatch::IntegrationTest
 
     assert_predicate status, :success?, -> { "stdout:\n#{stdout}\nstderr:\n#{stderr}" }
     assert_includes stdout, "installing devopsellence agent skill"
+    assert_includes stdout, "devopsellence agent skill installed"
+    assert_includes stdout, "version: master-0053792f6aec"
+    assert_includes stdout, "source: https://github.com/devopsellence/devopsellence/tree/master-0053792f6aec/skills/devopsellence"
     assert_equal "prerelease build\n", installed_cli
-    assert_equal [ "--yes", "skills", "add", "devopsellence/devopsellence", "--skill", "devopsellence", "-g", "--yes" ], skill_args
+    assert_equal "skill for master-0053792f6aec\n", installed_skill
   end
 
-  test "cli install script fails when requested agent skill cannot install without npx" do
+  test "cli install script installs requested agent skill without npx" do
     get "/lfg.sh", params: { version: "master-0053792f6aec" }
 
     assert_response :success
 
-    stdout, stderr, status, installed_cli, skill_args = run_cli_install_script(
+    stdout, stderr, status, installed_cli, installed_skill = run_cli_install_script(
       response.body,
       version: "master-0053792f6aec",
       install_agent_skill: true,
       include_npx: false
     )
 
-    refute_predicate status, :success?, -> { "stdout:\n#{stdout}\nstderr:\n#{stderr}" }
-    assert_includes stderr, "Agent skill install requested, but npx was not found"
+    assert_predicate status, :success?, -> { "stdout:\n#{stdout}\nstderr:\n#{stderr}" }
+    assert_includes stdout, "devopsellence agent skill installed"
     assert_equal "prerelease build\n", installed_cli
-    assert_nil skill_args
+    assert_equal "skill for master-0053792f6aec\n", installed_skill
   end
 
   test "cli install script defaults to user local bin on linux" do
@@ -280,7 +287,9 @@ class InstallsTest < ActionDispatch::IntegrationTest
       script_path = File.join(tmpdir, "lfg.sh")
       artifact_path = File.join(fixtures_dir, "cli-linux-amd64")
       checksums_path = File.join(fixtures_dir, "cli-SHA256SUMS")
-      skill_args_path = File.join(tmpdir, "skill-args")
+      skill_archive_path = File.join(fixtures_dir, "skill.tar.gz")
+      skill_source_root = File.join(tmpdir, "skill-src", "devopsellence-master-0053792f6aec")
+      installed_skill_path = File.join(tmpdir, ".agents", "skills", "devopsellence", "SKILL.md")
 
       FileUtils.mkdir_p(fixtures_dir)
       FileUtils.mkdir_p(fakebin_dir)
@@ -293,7 +302,7 @@ class InstallsTest < ActionDispatch::IntegrationTest
 
         FileUtils.ln_s(File.join(path, name), File.join(safebin_dir, name))
       end
-      %w[bash tr mktemp rm awk chmod mkdir mv cp].each(&link_host_command)
+      %w[bash tr mktemp rm awk chmod mkdir mv cp tar gzip].each(&link_host_command)
 
       sha256sum_path = host_path.find { |entry| File.executable?(File.join(entry, "sha256sum")) }
       shasum_path = host_path.find { |entry| File.executable?(File.join(entry, "shasum")) }
@@ -335,6 +344,16 @@ class InstallsTest < ActionDispatch::IntegrationTest
       File.write(artifact_path, "prerelease build\n")
       digest = Digest::SHA256.file(artifact_path).hexdigest
       File.write(checksums_path, "#{digest}  cli-linux-amd64\n")
+      FileUtils.mkdir_p(File.join(skill_source_root, "skills", "devopsellence"))
+      File.write(
+        File.join(skill_source_root, "skills", "devopsellence", "SKILL.md"),
+        "skill for #{version}\n"
+      )
+      system(
+        "tar", "-czf", skill_archive_path,
+        "-C", File.dirname(skill_source_root), File.basename(skill_source_root),
+        exception: true
+      )
       File.write(script_path, script_body)
       FileUtils.chmod("u+x", script_path)
 
@@ -367,6 +386,9 @@ class InstallsTest < ActionDispatch::IntegrationTest
             ;;
           *"/cli/checksums?"*)
             cp #{checksums_path.inspect} "$output"
+            ;;
+          *"/devopsellence/devopsellence/tar.gz/refs/tags/"*)
+            cp #{skill_archive_path.inspect} "$output"
             ;;
           *)
             echo "unexpected curl url: $url" >&2
@@ -401,7 +423,8 @@ class InstallsTest < ActionDispatch::IntegrationTest
           #!/usr/bin/env bash
           set -euo pipefail
 
-          printf '%s\\n' "$@" > #{skill_args_path.inspect}
+          echo "unexpected npx invocation" >&2
+          exit 1
         SH
         FileUtils.chmod("u+x", npx_path)
       end
@@ -422,8 +445,8 @@ class InstallsTest < ActionDispatch::IntegrationTest
       stdout, stderr, status = Open3.capture3(env, script_path)
       expected_install_dir = effective_install_dir || File.join(tmpdir, ".local", "bin")
       installed_cli = File.exist?(File.join(expected_install_dir, "devopsellence")) ? File.read(File.join(expected_install_dir, "devopsellence")) : nil
-      skill_args = File.exist?(skill_args_path) ? File.readlines(skill_args_path, chomp: true) : nil
-      [ stdout, stderr, status, installed_cli, skill_args ]
+      installed_skill = File.exist?(installed_skill_path) ? File.read(installed_skill_path) : nil
+      [ stdout, stderr, status, installed_cli, installed_skill ]
     end
   end
 end

--- a/control-plane/test/integration/installs_test.rb
+++ b/control-plane/test/integration/installs_test.rb
@@ -59,7 +59,6 @@ class InstallsTest < ActionDispatch::IntegrationTest
     assert_includes response.body, 'INSTALL_DIR="${DEVOPSELLENCE_CLI_INSTALL_DIR:-}"'
     assert_includes response.body, 'INSTALL_AGENT_SKILL="${DEVOPSELLENCE_INSTALL_AGENT_SKILL:-}"'
     assert_includes response.body, 'AGENT_SKILLS_DIR="${DEVOPSELLENCE_AGENT_SKILLS_DIR:-}"'
-    assert_includes response.body, 'AGENT_SKILL_ARCHIVE_URL="${DEVOPSELLENCE_AGENT_SKILL_ARCHIVE_URL:-}"'
     assert_includes response.body, "INSTALL_SCRIPT_URL='https://dev.devopsellence.com/lfg.sh'"
     assert_includes response.body, "--install-agent-skill"
     assert_includes response.body, 'INSTALL_DIR="$HOME/.local/bin"'
@@ -67,8 +66,7 @@ class InstallsTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "PATH_EXPORT='export PATH=\"'\"$INSTALL_DIR\"':$PATH\"'"
     assert_includes response.body, "echo '$PATH_EXPORT' >> $RC_FILE"
     assert_includes response.body, "source $RC_FILE"
-    assert_includes response.body, "https://codeload.github.com/devopsellence/devopsellence/tar.gz/refs/tags/$CLI_VERSION"
-    assert_includes response.body, 'skills_dir="$HOME/.agents/skills"'
+    assert_includes response.body, '"$INSTALL_DIR/$TARGET_NAME" skill install'
     assert_includes response.body, 'curl -fsSL "$INSTALL_SCRIPT_URL?version=$CLI_VERSION" | bash -s -- --install-agent-skill'
     refute_includes response.body, "npx --yes skills add"
   end
@@ -122,10 +120,10 @@ class InstallsTest < ActionDispatch::IntegrationTest
 
     assert_predicate status, :success?, -> { "stdout:\n#{stdout}\nstderr:\n#{stderr}" }
     assert_includes stdout, "devopsellence CLI installed"
-    assert_equal "prerelease build\n", installed_cli
+    assert_includes installed_cli, "prerelease build"
   end
 
-  test "cli install script can install the pinned agent skill when requested" do
+  test "cli install script can install the embedded agent skill when requested" do
     get "/lfg.sh", params: { version: "master-0053792f6aec" }
 
     assert_response :success
@@ -138,10 +136,9 @@ class InstallsTest < ActionDispatch::IntegrationTest
 
     assert_predicate status, :success?, -> { "stdout:\n#{stdout}\nstderr:\n#{stderr}" }
     assert_includes stdout, "installing devopsellence agent skill"
-    assert_includes stdout, "devopsellence agent skill installed"
-    assert_includes stdout, "version: master-0053792f6aec"
-    assert_includes stdout, "source: https://github.com/devopsellence/devopsellence/tree/master-0053792f6aec/skills/devopsellence"
-    assert_equal "prerelease build\n", installed_cli
+    assert_includes stdout, '"action":"installed"'
+    assert_includes stdout, '"source":"embedded"'
+    assert_includes installed_cli, "prerelease build"
     assert_equal "skill for master-0053792f6aec\n", installed_skill
   end
 
@@ -158,8 +155,9 @@ class InstallsTest < ActionDispatch::IntegrationTest
     )
 
     assert_predicate status, :success?, -> { "stdout:\n#{stdout}\nstderr:\n#{stderr}" }
-    assert_includes stdout, "devopsellence agent skill installed"
-    assert_equal "prerelease build\n", installed_cli
+    assert_includes stdout, '"action":"installed"'
+    assert_includes stdout, '"source":"embedded"'
+    assert_includes installed_cli, "prerelease build"
     assert_equal "skill for master-0053792f6aec\n", installed_skill
   end
 
@@ -176,7 +174,7 @@ class InstallsTest < ActionDispatch::IntegrationTest
 
     assert_predicate status, :success?, -> { "stdout:\n#{stdout}\nstderr:\n#{stderr}" }
     assert_includes stdout, "/.local/bin/devopsellence"
-    assert_equal "prerelease build\n", installed_cli
+    assert_includes installed_cli, "prerelease build"
   end
 
   test "cli install script derives checksum url after parsing base url overrides" do
@@ -287,8 +285,6 @@ class InstallsTest < ActionDispatch::IntegrationTest
       script_path = File.join(tmpdir, "lfg.sh")
       artifact_path = File.join(fixtures_dir, "cli-linux-amd64")
       checksums_path = File.join(fixtures_dir, "cli-SHA256SUMS")
-      skill_archive_path = File.join(fixtures_dir, "skill.tar.gz")
-      skill_source_root = File.join(tmpdir, "skill-src", "devopsellence-master-0053792f6aec")
       installed_skill_path = File.join(tmpdir, ".agents", "skills", "devopsellence", "SKILL.md")
 
       FileUtils.mkdir_p(fixtures_dir)
@@ -302,7 +298,7 @@ class InstallsTest < ActionDispatch::IntegrationTest
 
         FileUtils.ln_s(File.join(path, name), File.join(safebin_dir, name))
       end
-      %w[bash tr mktemp rm awk chmod mkdir mv cp tar gzip].each(&link_host_command)
+      %w[bash tr mktemp rm awk chmod mkdir mv cp].each(&link_host_command)
 
       sha256sum_path = host_path.find { |entry| File.executable?(File.join(entry, "sha256sum")) }
       shasum_path = host_path.find { |entry| File.executable?(File.join(entry, "shasum")) }
@@ -341,19 +337,35 @@ class InstallsTest < ActionDispatch::IntegrationTest
         FileUtils.chmod("u+x", shasum_shim_path)
       end
 
-      File.write(artifact_path, "prerelease build\n")
+      File.write(artifact_path, <<~SH)
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        if [[ "${1:-}" == "skill" && "${2:-}" == "install" ]]; then
+          shift 2
+          skills_dir="$HOME/.agents/skills"
+          while [[ $# -gt 0 ]]; do
+            case "$1" in
+              --dir)
+                skills_dir="$2"
+                shift 2
+                ;;
+              *)
+                echo "unexpected skill arg: $1" >&2
+                exit 1
+                ;;
+            esac
+          done
+          mkdir -p "$skills_dir/devopsellence"
+          printf 'skill for #{version}\n' > "$skills_dir/devopsellence/SKILL.md"
+          printf '{"schema_version":1,"action":"installed","skill":"devopsellence","path":"%s","version":"%s","source":"embedded"}\n' "$skills_dir/devopsellence" #{version.inspect}
+          exit 0
+        fi
+
+        printf 'prerelease build\n'
+      SH
       digest = Digest::SHA256.file(artifact_path).hexdigest
       File.write(checksums_path, "#{digest}  cli-linux-amd64\n")
-      FileUtils.mkdir_p(File.join(skill_source_root, "skills", "devopsellence"))
-      File.write(
-        File.join(skill_source_root, "skills", "devopsellence", "SKILL.md"),
-        "skill for #{version}\n"
-      )
-      system(
-        "tar", "-czf", skill_archive_path,
-        "-C", File.dirname(skill_source_root), File.basename(skill_source_root),
-        exception: true
-      )
       File.write(script_path, script_body)
       FileUtils.chmod("u+x", script_path)
 
@@ -386,9 +398,6 @@ class InstallsTest < ActionDispatch::IntegrationTest
             ;;
           *"/cli/checksums?"*)
             cp #{checksums_path.inspect} "$output"
-            ;;
-          *"/devopsellence/devopsellence/tar.gz/refs/tags/"*)
-            cp #{skill_archive_path.inspect} "$output"
             ;;
           *)
             echo "unexpected curl url: $url" >&2


### PR DESCRIPTION
## Summary
- embed the devopsellence agent skill in the CLI and install it via `devopsellence skill install` instead of invoking npx or downloading a repo archive
- add DEVOPSELLENCE_STATE_HOME as an explicit state-home override and surface state paths in mode/context/node outputs
- update docs and installer tests for the embedded skill install flow
- include `--service` in temporary sslip.io ingress hints

## Tests
- cd control-plane && mise run test -- test/integration/installs_test.rb
- cd cli && mise run test -- ./internal/agentskill ./internal/state ./internal/workflow