### PR TITLE
Isolate co-hosted environments on Docker networks

### DIFF
--- a/agent/cmd/devopsellence/uninstall.go
+++ b/agent/cmd/devopsellence/uninstall.go
@@ -16,7 +16,6 @@ const (
 	stateDir    = "/var/lib/devopsellence"
 	authState   = "/var/lib/devopsellence/agent-auth-state.json"
 	statusFile  = "/var/lib/devopsellence/status.json"
-	networkName = "devopsellence"
 )
 
 func runUninstall(args []string) error {
@@ -84,8 +83,11 @@ func purgeDockerRuntime(run func(string, ...string)) error {
 		run("docker", append([]string{"rm", "-f"}, ids...)...)
 	}
 
-	fmt.Println("Removing devopsellence Docker network...")
-	run("docker", "network", "rm", networkName)
+	fmt.Println("Removing devopsellence Docker networks...")
+	networkIDs, _ := dockerOutput("docker", "network", "ls", "-q", "--filter", "label=devopsellence.managed=true")
+	if len(networkIDs) > 0 {
+		run("docker", append([]string{"network", "rm"}, networkIDs...)...)
+	}
 	return nil
 }
 

--- a/agent/internal/agent/agent.go
+++ b/agent/internal/agent/agent.go
@@ -249,7 +249,7 @@ func (a *Agent) ensureTaskSatisfied(ctx context.Context, sequence int64, environ
 		},
 	}, sequence)
 
-	taskResult, err := a.reconciler.RunTask(ctx, revision, task)
+	taskResult, err := a.reconciler.RunTask(ctx, environmentName, revision, task)
 	if err != nil {
 		a.reportStatus(ctx, report.Status{
 			Time:     start,

--- a/agent/internal/agent/agent_test.go
+++ b/agent/internal/agent/agent_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/devopsellence/devopsellence/agent/internal/authority"
+	"github.com/devopsellence/devopsellence/agent/internal/desiredstate"
 	"github.com/devopsellence/devopsellence/agent/internal/desiredstatepb"
 	"github.com/devopsellence/devopsellence/agent/internal/engine"
 	"github.com/devopsellence/devopsellence/agent/internal/lifecycle"
@@ -156,15 +157,27 @@ func (f *fakeEngine) PullImage(ctx context.Context, image string, auth *engine.R
 
 func (f *fakeEngine) Inspect(ctx context.Context, name string) (engine.ContainerInfo, error) {
 	c := f.containers[name]
+	networkIP := map[string]string{"devopsellence": "172.18.0.10"}
+	if environmentNetwork, err := desiredstate.EnvironmentNetworkName("devopsellence", c.Environment); err == nil {
+		networkIP[environmentNetwork] = "172.19.0.10"
+	}
 	return engine.ContainerInfo{
 		Name:      c.Name,
 		Running:   c.Running,
 		Health:    "healthy",
-		NetworkIP: map[string]string{"devopsellence": "172.18.0.10"},
+		NetworkIP: networkIP,
 	}, nil
 }
 
 func (f *fakeEngine) EnsureNetwork(ctx context.Context, name string) error {
+	return nil
+}
+
+func (f *fakeEngine) ConnectNetwork(ctx context.Context, networkName string, containerName string) error {
+	return nil
+}
+
+func (f *fakeEngine) DisconnectNetwork(ctx context.Context, networkName string, containerName string) error {
 	return nil
 }
 
@@ -185,7 +198,7 @@ type fakeEnvoy struct {
 	updated bool
 }
 
-func (f *fakeEnvoy) Ensure(ctx context.Context, ingress *desiredstatepb.Ingress) error {
+func (f *fakeEnvoy) Ensure(ctx context.Context, ingress *desiredstatepb.Ingress, workloadNetworks ...string) error {
 	return nil
 }
 

--- a/agent/internal/desiredstate/names.go
+++ b/agent/internal/desiredstate/names.go
@@ -1,6 +1,8 @@
 package desiredstate
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"regexp"
 	"strings"
@@ -50,6 +52,39 @@ func ServiceContainerName(environmentName, serviceName, revision, hash string) (
 		return "", fmt.Errorf("container name too long")
 	}
 	return name, nil
+}
+
+func EnvironmentNetworkPrefix(baseNetworkName string) string {
+	base := sanitize(baseNetworkName)
+	if base == "" {
+		base = "devopsellence"
+	}
+	return base + "-env-"
+}
+
+func EnvironmentNetworkName(baseNetworkName, environmentName string) (string, error) {
+	env := sanitize(environmentName)
+	if env == "" {
+		return "", fmt.Errorf("environment name sanitizes to empty")
+	}
+	name := EnvironmentNetworkPrefix(baseNetworkName) + env
+	if len(name) <= 255 {
+		return name, nil
+	}
+	sum := sha256.Sum256([]byte(environmentName))
+	suffix := hex.EncodeToString(sum[:4])
+	maxEnvLen := 255 - len(EnvironmentNetworkPrefix(baseNetworkName)) - len(suffix) - 1
+	if maxEnvLen <= 0 {
+		return "", fmt.Errorf("environment network name too long")
+	}
+	if len(env) > maxEnvLen {
+		env = env[:maxEnvLen]
+		env = strings.Trim(env, "-.")
+	}
+	if env == "" {
+		return "", fmt.Errorf("environment name sanitizes to empty")
+	}
+	return EnvironmentNetworkPrefix(baseNetworkName) + env + "-" + suffix, nil
 }
 
 func sanitize(input string) string {

--- a/agent/internal/desiredstate/names_test.go
+++ b/agent/internal/desiredstate/names_test.go
@@ -17,3 +17,19 @@ func TestContainerNameSanitizeEmpty(t *testing.T) {
 		t.Fatal("expected error")
 	}
 }
+
+func TestEnvironmentNetworkName(t *testing.T) {
+	name, err := EnvironmentNetworkName("devopsellence", "Shop Production")
+	if err != nil {
+		t.Fatalf("network name error: %v", err)
+	}
+	if name != "devopsellence-env-shop-production" {
+		t.Fatalf("unexpected network name: %s", name)
+	}
+}
+
+func TestEnvironmentNetworkNameSanitizeEmpty(t *testing.T) {
+	if _, err := EnvironmentNetworkName("devopsellence", "!!!"); err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/agent/internal/diagnose/collector_test.go
+++ b/agent/internal/diagnose/collector_test.go
@@ -54,6 +54,14 @@ func (f *fakeEngine) EnsureNetwork(ctx context.Context, name string) error {
 	return nil
 }
 
+func (f *fakeEngine) ConnectNetwork(ctx context.Context, networkName string, containerName string) error {
+	return nil
+}
+
+func (f *fakeEngine) DisconnectNetwork(ctx context.Context, networkName string, containerName string) error {
+	return nil
+}
+
 func (f *fakeEngine) Logs(ctx context.Context, name string, tail int) ([]byte, error) {
 	return f.logs[name], nil
 }

--- a/agent/internal/engine/docker/docker.go
+++ b/agent/internal/engine/docker/docker.go
@@ -347,6 +347,22 @@ func (e *Engine) EnsureNetwork(ctx context.Context, name string) error {
 	return err
 }
 
+func (e *Engine) ConnectNetwork(ctx context.Context, networkName string, containerName string) error {
+	_, err := e.client.NetworkConnect(ctx, networkName, client.NetworkConnectOptions{
+		Container:      containerName,
+		EndpointConfig: &network.EndpointSettings{},
+	})
+	return err
+}
+
+func (e *Engine) DisconnectNetwork(ctx context.Context, networkName string, containerName string) error {
+	_, err := e.client.NetworkDisconnect(ctx, networkName, client.NetworkDisconnectOptions{
+		Container: containerName,
+		Force:     false,
+	})
+	return err
+}
+
 func (e *Engine) Logs(ctx context.Context, name string, tail int) ([]byte, error) {
 	tailStr := "all"
 	if tail > 0 {

--- a/agent/internal/engine/engine.go
+++ b/agent/internal/engine/engine.go
@@ -30,6 +30,8 @@ type Engine interface {
 	PullImage(ctx context.Context, image string, auth *RegistryAuth) error
 	Inspect(ctx context.Context, name string) (ContainerInfo, error)
 	EnsureNetwork(ctx context.Context, name string) error
+	ConnectNetwork(ctx context.Context, networkName string, containerName string) error
+	DisconnectNetwork(ctx context.Context, networkName string, containerName string) error
 	// Logs returns the last tail lines of combined stdout+stderr for the
 	// named container. Pass tail=0 for all output.
 	Logs(ctx context.Context, name string, tail int) ([]byte, error)

--- a/agent/internal/envoy/manager.go
+++ b/agent/internal/envoy/manager.go
@@ -216,6 +216,20 @@ func (m *Manager) Ensure(ctx context.Context, ingress *desiredstatepb.Ingress, w
 	return nil
 }
 
+// SyncWorkloadNetworks reconciles Envoy's Docker network attachments without
+// creating Envoy when it is absent. It is used to drop stale environment
+// networks after a node stops hosting web services.
+func (m *Manager) SyncWorkloadNetworks(ctx context.Context, workloadNetworks ...string) error {
+	_, err := m.engine.Inspect(ctx, m.config.ContainerName)
+	if err != nil {
+		if cerrdefs.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("inspect envoy networks: %w", err)
+	}
+	return m.syncWorkloadNetworks(ctx, workloadNetworks)
+}
+
 func (m *Manager) syncWorkloadNetworks(ctx context.Context, workloadNetworks []string) error {
 	desired := map[string]bool{}
 	for _, networkName := range workloadNetworks {

--- a/agent/internal/envoy/manager.go
+++ b/agent/internal/envoy/manager.go
@@ -15,6 +15,7 @@ import (
 	"log/slog"
 
 	cerrdefs "github.com/containerd/errdefs"
+	"github.com/devopsellence/devopsellence/agent/internal/desiredstate"
 	"github.com/devopsellence/devopsellence/agent/internal/desiredstatepb"
 	"github.com/devopsellence/devopsellence/agent/internal/engine"
 	"google.golang.org/protobuf/proto"
@@ -112,7 +113,7 @@ func New(engine engine.Engine, config Config, logger *slog.Logger) *Manager {
 	}
 }
 
-func (m *Manager) Ensure(ctx context.Context, ingress *desiredstatepb.Ingress) error {
+func (m *Manager) Ensure(ctx context.Context, ingress *desiredstatepb.Ingress, workloadNetworks ...string) error {
 	publicIngressListener, err := m.publicIngressListenerConfig(ingress)
 	if err != nil {
 		return err
@@ -152,6 +153,9 @@ func (m *Manager) Ensure(ctx context.Context, ingress *desiredstatepb.Ingress) e
 		if err := m.createEnvoy(ctx, ingress, desiredPorts, publicIngressListener != nil); err != nil {
 			return err
 		}
+		if err := m.syncWorkloadNetworks(ctx, workloadNetworks); err != nil {
+			return err
+		}
 		if err := m.waitReady(ctx); err != nil {
 			return err
 		}
@@ -186,6 +190,9 @@ func (m *Manager) Ensure(ctx context.Context, ingress *desiredstatepb.Ingress) e
 	}
 
 	if info.Running {
+		if err := m.syncWorkloadNetworks(ctx, workloadNetworks); err != nil {
+			return err
+		}
 		m.lastIngress = cloneIngress(ingress)
 		return nil
 	}
@@ -198,11 +205,56 @@ func (m *Manager) Ensure(ctx context.Context, ingress *desiredstatepb.Ingress) e
 	if err := m.createEnvoy(ctx, ingress, desiredPorts, publicIngressListener != nil); err != nil {
 		return err
 	}
+	if err := m.syncWorkloadNetworks(ctx, workloadNetworks); err != nil {
+		return err
+	}
 	if err := m.waitReady(ctx); err != nil {
 		return err
 	}
 	m.lastIngress = cloneIngress(ingress)
 	m.logger.Info("envoy started", "name", m.config.ContainerName, "port", m.config.Port)
+	return nil
+}
+
+func (m *Manager) syncWorkloadNetworks(ctx context.Context, workloadNetworks []string) error {
+	desired := map[string]bool{}
+	for _, networkName := range workloadNetworks {
+		networkName = strings.TrimSpace(networkName)
+		if networkName == "" || networkName == m.config.NetworkName {
+			continue
+		}
+		desired[networkName] = true
+	}
+
+	info, err := m.engine.Inspect(ctx, m.config.ContainerName)
+	if err != nil {
+		return fmt.Errorf("inspect envoy networks: %w", err)
+	}
+	attached := info.NetworkIP
+	if attached == nil {
+		attached = map[string]string{}
+	}
+	for networkName := range desired {
+		if err := m.engine.EnsureNetwork(ctx, networkName); err != nil {
+			return fmt.Errorf("ensure workload network %s: %w", networkName, err)
+		}
+		if _, ok := attached[networkName]; ok {
+			continue
+		}
+		if err := m.engine.ConnectNetwork(ctx, networkName, m.config.ContainerName); err != nil {
+			return fmt.Errorf("connect envoy to workload network %s: %w", networkName, err)
+		}
+	}
+
+	managedPrefix := desiredstate.EnvironmentNetworkPrefix(m.config.NetworkName)
+	for networkName := range attached {
+		if networkName == m.config.NetworkName || desired[networkName] || !strings.HasPrefix(networkName, managedPrefix) {
+			continue
+		}
+		if err := m.engine.DisconnectNetwork(ctx, networkName, m.config.ContainerName); err != nil {
+			return fmt.Errorf("disconnect envoy from stale workload network %s: %w", networkName, err)
+		}
+	}
 	return nil
 }
 

--- a/agent/internal/envoy/manager_test.go
+++ b/agent/internal/envoy/manager_test.go
@@ -27,12 +27,15 @@ type fakeEngine struct {
 	inspectInfo engine.ContainerInfo
 	inspectErr  error
 
-	createdSpec  *engine.ContainerSpec
-	removed      []string
-	createHealth string
-	imageExists  bool
-	pulledImage  string
-	pullErr      error
+	createdSpec          *engine.ContainerSpec
+	removed              []string
+	createHealth         string
+	imageExists          bool
+	pulledImage          string
+	pullErr              error
+	ensuredNetworks      []string
+	connectedNetworks    []string
+	disconnectedNetworks []string
 }
 
 func (f *fakeEngine) ListManaged(ctx context.Context) ([]engine.ContainerState, error) {
@@ -106,6 +109,22 @@ func (f *fakeEngine) Logs(_ context.Context, _ string, _ int) ([]byte, error) {
 }
 
 func (f *fakeEngine) EnsureNetwork(ctx context.Context, name string) error {
+	f.ensuredNetworks = append(f.ensuredNetworks, name)
+	return nil
+}
+
+func (f *fakeEngine) ConnectNetwork(ctx context.Context, networkName string, containerName string) error {
+	f.connectedNetworks = append(f.connectedNetworks, networkName)
+	if f.inspectInfo.NetworkIP == nil {
+		f.inspectInfo.NetworkIP = map[string]string{}
+	}
+	f.inspectInfo.NetworkIP[networkName] = "172.19.0.2"
+	return nil
+}
+
+func (f *fakeEngine) DisconnectNetwork(ctx context.Context, networkName string, containerName string) error {
+	f.disconnectedNetworks = append(f.disconnectedNetworks, networkName)
+	delete(f.inspectInfo.NetworkIP, networkName)
 	return nil
 }
 
@@ -192,6 +211,72 @@ func TestEnsureCreatesEnvoyWithDefaults(t *testing.T) {
 	}
 	if !strings.Contains(contents, "pipe:") {
 		t.Fatalf("expected pipe address in bootstrap, got %s", contents)
+	}
+}
+
+func TestEnsureConnectsEnvoyToWorkloadNetworks(t *testing.T) {
+	eng := &fakeEngine{inspectErr: cerrdefs.ErrNotFound}
+	logger := slog.New(slog.NewJSONHandler(io.Discard, &slog.HandlerOptions{}))
+	mgr := New(eng, Config{
+		Image:          "docker.io/envoyproxy/envoy:v1.37.0",
+		ContainerName:  "devopsellence-envoy",
+		NetworkName:    "devopsellence",
+		BootstrapPath:  tempBootstrapPath(t),
+		Port:           8000,
+		ClusterName:    "devopsellence_web",
+		StartupTimeout: 2 * time.Second,
+	}, logger)
+
+	if err := mgr.Ensure(context.Background(), nil, "devopsellence-env-production"); err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+	if eng.createdSpec == nil || eng.createdSpec.Network != "devopsellence" {
+		t.Fatalf("expected envoy to start on edge network, got %#v", eng.createdSpec)
+	}
+	if len(eng.connectedNetworks) != 1 || eng.connectedNetworks[0] != "devopsellence-env-production" {
+		t.Fatalf("connected networks = %#v", eng.connectedNetworks)
+	}
+}
+
+func TestEnsureDisconnectsStaleWorkloadNetworks(t *testing.T) {
+	eng := &fakeEngine{
+		imageExists: true,
+		inspectInfo: engine.ContainerInfo{
+			Name:            "devopsellence-envoy",
+			Running:         true,
+			HasHealthcheck:  true,
+			PublishHostPort: true,
+			PublishedPorts:  []engine.PortBinding{{ContainerPort: 8000, HostPort: 8000, Protocol: "tcp"}},
+			NetworkIP: map[string]string{
+				"devopsellence":                 "172.18.0.2",
+				"devopsellence-env-old":         "172.19.0.2",
+				"operator-attached-diagnostics": "172.30.0.2",
+			},
+		},
+	}
+	logger := slog.New(slog.NewJSONHandler(io.Discard, &slog.HandlerOptions{}))
+	bootstrapPath := tempBootstrapPath(t)
+	if _, err := ensureBootstrap(bootstrapPath, "devopsellence"); err != nil {
+		t.Fatalf("bootstrap: %v", err)
+	}
+	mgr := New(eng, Config{
+		Image:          "docker.io/envoyproxy/envoy:v1.37.0",
+		ContainerName:  "devopsellence-envoy",
+		NetworkName:    "devopsellence",
+		BootstrapPath:  bootstrapPath,
+		Port:           8000,
+		ClusterName:    "devopsellence_web",
+		StartupTimeout: 2 * time.Second,
+	}, logger)
+
+	if err := mgr.Ensure(context.Background(), nil, "devopsellence-env-new"); err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+	if len(eng.connectedNetworks) != 1 || eng.connectedNetworks[0] != "devopsellence-env-new" {
+		t.Fatalf("connected networks = %#v", eng.connectedNetworks)
+	}
+	if len(eng.disconnectedNetworks) != 1 || eng.disconnectedNetworks[0] != "devopsellence-env-old" {
+		t.Fatalf("disconnected networks = %#v", eng.disconnectedNetworks)
 	}
 }
 

--- a/agent/internal/reconcile/reconcile.go
+++ b/agent/internal/reconcile/reconcile.go
@@ -496,12 +496,12 @@ func (r *Reconciler) environmentNetwork(environmentName string) (string, error) 
 	return desiredstate.EnvironmentNetworkName(r.opts.Network, environmentName)
 }
 
-func runtimeContainerHash(baseHash string, logConfig *engine.LogConfig) string {
+func runtimeContainerHash(baseHash string, logConfig *engine.LogConfig, network string) string {
 	logHash := engine.LogConfigHash(logConfig)
-	if logHash == "" {
+	if logHash == "" && network == "" {
 		return baseHash
 	}
-	sum := sha256.Sum256([]byte(baseHash + "\x00" + logHash))
+	sum := sha256.Sum256([]byte(baseHash + "\x00" + logHash + "\x00" + strings.TrimSpace(network)))
 	return hex.EncodeToString(sum[:])
 }
 
@@ -670,7 +670,7 @@ func (r *Reconciler) specForService(runtime desiredstate.RuntimeService) (string
 		return "", "", engine.ContainerSpec{}, fmt.Errorf("hash service %s/%s: %w", runtime.EnvironmentName, runtime.ServiceName, err)
 	}
 
-	hash = runtimeContainerHash(hash, r.opts.LogConfig)
+	hash = runtimeContainerHash(hash, r.opts.LogConfig, network)
 	name, err := desiredstate.ServiceContainerName(runtime.EnvironmentName, runtime.ServiceName, runtime.EnvironmentRevision, hash)
 	if err != nil {
 		return "", "", engine.ContainerSpec{}, err

--- a/agent/internal/reconcile/reconcile.go
+++ b/agent/internal/reconcile/reconcile.go
@@ -32,6 +32,10 @@ type EnvoyManager interface {
 	WaitForRoute(ctx context.Context, path string) error
 }
 
+type EnvoyWorkloadNetworkSyncer interface {
+	SyncWorkloadNetworks(ctx context.Context, workloadNetworks ...string) error
+}
+
 type ImagePullAuthProvider interface {
 	AuthForImage(ctx context.Context, image string) (*engine.RegistryAuth, error)
 }
@@ -87,6 +91,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, desired *desiredstatepb.Desi
 	workloadNetworks, err := r.ensureRuntimeNetworks(ctx, runtimeServices)
 	if err != nil {
 		return result, err
+	}
+	if len(workloadNetworks) == 0 {
+		if err := r.syncEnvoyWorkloadNetworks(ctx, workloadNetworks); err != nil {
+			return result, err
+		}
 	}
 
 	desiredByService := map[string]desiredstate.RuntimeService{}
@@ -418,6 +427,20 @@ func runtimeServiceKey(environmentName, serviceName string) string {
 
 func containerServiceKey(c engine.ContainerState) string {
 	return runtimeServiceKey(c.Environment, c.Service)
+}
+
+func (r *Reconciler) syncEnvoyWorkloadNetworks(ctx context.Context, workloadNetworks []string) error {
+	if r.opts.Envoy == nil {
+		return nil
+	}
+	syncer, ok := r.opts.Envoy.(EnvoyWorkloadNetworkSyncer)
+	if !ok {
+		return nil
+	}
+	if err := syncer.SyncWorkloadNetworks(ctx, workloadNetworks...); err != nil {
+		return fmt.Errorf("sync envoy workload networks: %w", err)
+	}
+	return nil
 }
 
 func (r *Reconciler) ensureRuntimeNetworks(ctx context.Context, services []desiredstate.RuntimeService) ([]string, error) {

--- a/agent/internal/reconcile/reconcile.go
+++ b/agent/internal/reconcile/reconcile.go
@@ -26,7 +26,7 @@ const webServiceName = "web"
 const ingressModePublic = "public"
 
 type EnvoyManager interface {
-	Ensure(ctx context.Context, ingress *desiredstatepb.Ingress) error
+	Ensure(ctx context.Context, ingress *desiredstatepb.Ingress, workloadNetworks ...string) error
 	UpdateEDS(ctx context.Context, address string, port uint16) error
 	UpdateClusterEDS(ctx context.Context, clusterName string, address string, port uint16) error
 	WaitForRoute(ctx context.Context, path string) error
@@ -83,14 +83,14 @@ func New(eng engine.Engine, opts Options) *Reconciler {
 
 func (r *Reconciler) Reconcile(ctx context.Context, desired *desiredstatepb.DesiredState) (Result, error) {
 	result := Result{}
-	if r.opts.Network != "" {
-		if err := r.engine.EnsureNetwork(ctx, r.opts.Network); err != nil {
-			return result, fmt.Errorf("ensure network: %w", err)
-		}
+	runtimeServices := desiredstate.RuntimeServices(desired)
+	workloadNetworks, err := r.ensureRuntimeNetworks(ctx, runtimeServices)
+	if err != nil {
+		return result, err
 	}
 
 	desiredByService := map[string]desiredstate.RuntimeService{}
-	for _, service := range desiredstate.RuntimeServices(desired) {
+	for _, service := range runtimeServices {
 		desiredByService[runtimeServiceKey(service.EnvironmentName, service.ServiceName)] = service
 	}
 
@@ -108,7 +108,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, desired *desiredstatepb.Desi
 	}
 
 	for serviceKey, c := range desiredByService {
-		serviceResult, err := r.reconcileService(ctx, desired.GetIngress(), desired.GetNodePeers(), c, existingByService[serviceKey])
+		serviceResult, err := r.reconcileService(ctx, desired.GetIngress(), desired.GetNodePeers(), c, existingByService[serviceKey], workloadNetworks)
 		result.Created += serviceResult.Created
 		result.Updated += serviceResult.Updated
 		result.Removed += serviceResult.Removed
@@ -133,18 +133,17 @@ func (r *Reconciler) Reconcile(ctx context.Context, desired *desiredstatepb.Desi
 	return result, nil
 }
 
-func (r *Reconciler) RunTask(ctx context.Context, revision string, task *desiredstatepb.Task) (TaskResult, error) {
+func (r *Reconciler) RunTask(ctx context.Context, environmentName string, revision string, task *desiredstatepb.Task) (TaskResult, error) {
 	result := TaskResult{}
 	if task == nil {
 		return result, nil
 	}
-	if r.opts.Network != "" {
-		if err := r.engine.EnsureNetwork(ctx, r.opts.Network); err != nil {
-			return result, fmt.Errorf("ensure network: %w", err)
-		}
+	network, err := r.ensureEnvironmentNetwork(ctx, environmentName)
+	if err != nil {
+		return result, err
 	}
 
-	name, _, spec, err := r.specForTask(task, revision)
+	name, _, spec, err := r.specForTask(environmentName, task, revision, network)
 	if err != nil {
 		return result, err
 	}
@@ -176,7 +175,7 @@ func (r *Reconciler) RunTask(ctx context.Context, revision string, task *desired
 	return result, nil
 }
 
-func (r *Reconciler) reconcileService(ctx context.Context, ingress *desiredstatepb.Ingress, nodePeers []*desiredstatepb.NodePeer, desired desiredstate.RuntimeService, existing []engine.ContainerState) (Result, error) {
+func (r *Reconciler) reconcileService(ctx context.Context, ingress *desiredstatepb.Ingress, nodePeers []*desiredstatepb.NodePeer, desired desiredstate.RuntimeService, existing []engine.ContainerState, workloadNetworks []string) (Result, error) {
 	result := Result{}
 	isWeb := desired.ServiceKind == desiredstate.ServiceKindWeb
 	name, hash, spec, err := r.specForService(desired)
@@ -192,7 +191,7 @@ func (r *Reconciler) reconcileService(ctx context.Context, ingress *desiredstate
 		if r.opts.Envoy == nil {
 			return result, fmt.Errorf("envoy manager required for web service")
 		}
-		if err := r.opts.Envoy.Ensure(ctx, ingress); err != nil {
+		if err := r.opts.Envoy.Ensure(ctx, ingress, workloadNetworks...); err != nil {
 			return result, fmt.Errorf("ensure envoy: %w", err)
 		}
 		if r.opts.IngressCert != nil {
@@ -208,7 +207,7 @@ func (r *Reconciler) reconcileService(ctx context.Context, ingress *desiredstate
 				}
 			}
 		}
-		if err := r.opts.Envoy.Ensure(ctx, ingress); err != nil {
+		if err := r.opts.Envoy.Ensure(ctx, ingress, workloadNetworks...); err != nil {
 			return result, fmt.Errorf("ensure envoy: %w", err)
 		}
 	}
@@ -421,6 +420,59 @@ func containerServiceKey(c engine.ContainerState) string {
 	return runtimeServiceKey(c.Environment, c.Service)
 }
 
+func (r *Reconciler) ensureRuntimeNetworks(ctx context.Context, services []desiredstate.RuntimeService) ([]string, error) {
+	if r.opts.Network == "" {
+		return nil, nil
+	}
+	if err := r.engine.EnsureNetwork(ctx, r.opts.Network); err != nil {
+		return nil, fmt.Errorf("ensure network %s: %w", r.opts.Network, err)
+	}
+	seen := map[string]bool{}
+	webSeen := map[string]bool{}
+	networks := []string{}
+	for _, service := range services {
+		network, err := r.environmentNetwork(service.EnvironmentName)
+		if err != nil {
+			return nil, err
+		}
+		if network == "" {
+			continue
+		}
+		if !seen[network] {
+			if err := r.engine.EnsureNetwork(ctx, network); err != nil {
+				return nil, fmt.Errorf("ensure network %s: %w", network, err)
+			}
+			seen[network] = true
+		}
+		if service.ServiceKind == desiredstate.ServiceKindWeb && !webSeen[network] {
+			networks = append(networks, network)
+			webSeen[network] = true
+		}
+	}
+	return networks, nil
+}
+
+func (r *Reconciler) ensureEnvironmentNetwork(ctx context.Context, environmentName string) (string, error) {
+	network, err := r.environmentNetwork(environmentName)
+	if err != nil {
+		return "", err
+	}
+	if network == "" {
+		return "", nil
+	}
+	if err := r.engine.EnsureNetwork(ctx, network); err != nil {
+		return "", fmt.Errorf("ensure network %s: %w", network, err)
+	}
+	return network, nil
+}
+
+func (r *Reconciler) environmentNetwork(environmentName string) (string, error) {
+	if r.opts.Network == "" {
+		return "", nil
+	}
+	return desiredstate.EnvironmentNetworkName(r.opts.Network, environmentName)
+}
+
 func runtimeContainerHash(baseHash string, logConfig *engine.LogConfig) string {
 	logHash := engine.LogConfigHash(logConfig)
 	if logHash == "" {
@@ -497,9 +549,13 @@ func (r *Reconciler) webContainerIP(ctx context.Context, name string, desired de
 		return "", fmt.Errorf("container %s not running", name)
 	}
 
-	ip := info.NetworkIP[r.opts.Network]
+	network, err := r.environmentNetwork(desired.EnvironmentName)
+	if err != nil {
+		return "", err
+	}
+	ip := info.NetworkIP[network]
 	if ip == "" {
-		return "", fmt.Errorf("container %s missing network ip on %s", name, r.opts.Network)
+		return "", fmt.Errorf("container %s missing network ip on %s", name, network)
 	}
 	return ip, nil
 }
@@ -544,9 +600,13 @@ func (r *Reconciler) waitHealthy(ctx context.Context, name string, desired desir
 			return "", fmt.Errorf("container %s not running", name)
 		}
 
-		ip := info.NetworkIP[r.opts.Network]
+		network, err := r.environmentNetwork(desired.EnvironmentName)
+		if err != nil {
+			return "", err
+		}
+		ip := info.NetworkIP[network]
 		if ip == "" {
-			lastErr = fmt.Errorf("container %s missing network ip on %s", name, r.opts.Network)
+			lastErr = fmt.Errorf("container %s missing network ip on %s", name, network)
 		} else {
 			target := probeTarget(ip, healthcheck.Port, healthcheck.Path)
 			status, probeErr := r.opts.HTTPProber.Get(ctx, target, timeout)
@@ -578,6 +638,10 @@ func (r *Reconciler) waitHealthy(ctx context.Context, name string, desired desir
 
 func (r *Reconciler) specForService(runtime desiredstate.RuntimeService) (string, string, engine.ContainerSpec, error) {
 	service := runtime.Service
+	network, err := r.environmentNetwork(runtime.EnvironmentName)
+	if err != nil {
+		return "", "", engine.ContainerSpec{}, err
+	}
 	hash, err := desiredstate.HashService(service)
 	if err != nil {
 		return "", "", engine.ContainerSpec{}, fmt.Errorf("hash service %s/%s: %w", runtime.EnvironmentName, runtime.ServiceName, err)
@@ -612,13 +676,13 @@ func (r *Reconciler) specForService(runtime desiredstate.RuntimeService) (string
 		Binds:      volumeBinds(service.VolumeMounts),
 		Labels:     labels,
 		Log:        engine.CloneLogConfig(r.opts.LogConfig),
-		Network:    r.opts.Network,
+		Network:    network,
 	}
 
 	return name, hash, spec, nil
 }
 
-func (r *Reconciler) specForTask(task *desiredstatepb.Task, revision string) (string, string, engine.ContainerSpec, error) {
+func (r *Reconciler) specForTask(environmentName string, task *desiredstatepb.Task, revision string, network string) (string, string, engine.ContainerSpec, error) {
 	hash, err := desiredstate.HashTask(task)
 	if err != nil {
 		return "", "", engine.ContainerSpec{}, fmt.Errorf("hash task %s: %w", task.GetName(), err)
@@ -642,13 +706,14 @@ func (r *Reconciler) specForTask(task *desiredstatepb.Task, revision string) (st
 		Env:        env,
 		Binds:      volumeBinds(task.VolumeMounts),
 		Labels: map[string]string{
-			engine.LabelManaged:  "true",
-			engine.LabelHash:     hash,
-			engine.LabelRevision: revision,
-			engine.LabelSystem:   task.GetName(),
+			engine.LabelManaged:     "true",
+			engine.LabelEnvironment: environmentName,
+			engine.LabelHash:        hash,
+			engine.LabelRevision:    revision,
+			engine.LabelSystem:      task.GetName(),
 		},
 		Log:     engine.CloneLogConfig(r.opts.LogConfig),
-		Network: r.opts.Network,
+		Network: network,
 	}
 
 	return name, hash, spec, nil

--- a/agent/internal/reconcile/reconcile_test.go
+++ b/agent/internal/reconcile/reconcile_test.go
@@ -23,6 +23,7 @@ type fakeEngine struct {
 	pulled       []string
 	inspectCalls int
 	networkIP    map[string]string
+	networks     []string
 	ops          []string
 	waitExitCode int64
 	logsOutput   []byte
@@ -101,11 +102,14 @@ func (f *fakeEngine) PullImage(_ context.Context, image string, _ *engine.Regist
 
 func (f *fakeEngine) Inspect(_ context.Context, name string) (engine.ContainerInfo, error) {
 	f.inspectCalls++
+	c := f.containers[name]
 	networkIP := f.networkIP
 	if networkIP == nil {
 		networkIP = map[string]string{"devopsellence": "172.18.0.2"}
+		if environmentNetwork, err := desiredstate.EnvironmentNetworkName("devopsellence", c.Environment); err == nil {
+			networkIP[environmentNetwork] = "172.19.0.2"
+		}
 	}
-	c := f.containers[name]
 	return engine.ContainerInfo{
 		Name:      c.Name,
 		Running:   c.Running,
@@ -113,7 +117,16 @@ func (f *fakeEngine) Inspect(_ context.Context, name string) (engine.ContainerIn
 	}, nil
 }
 
-func (f *fakeEngine) EnsureNetwork(context.Context, string) error {
+func (f *fakeEngine) EnsureNetwork(_ context.Context, name string) error {
+	f.networks = append(f.networks, name)
+	return nil
+}
+
+func (f *fakeEngine) ConnectNetwork(context.Context, string, string) error {
+	return nil
+}
+
+func (f *fakeEngine) DisconnectNetwork(context.Context, string, string) error {
 	return nil
 }
 
@@ -132,10 +145,12 @@ type fakeEnvoyManager struct {
 	waitPath           string
 	waitErr            error
 	ingress            *desiredstatepb.Ingress
+	workloadNetworks   []string
 }
 
-func (f *fakeEnvoyManager) Ensure(_ context.Context, ingress *desiredstatepb.Ingress) error {
+func (f *fakeEnvoyManager) Ensure(_ context.Context, ingress *desiredstatepb.Ingress, workloadNetworks ...string) error {
 	f.ingress = ingress
+	f.workloadNetworks = append([]string(nil), workloadNetworks...)
 	return nil
 }
 
@@ -257,11 +272,16 @@ func TestReconcileKeepsSameServiceNameInDifferentEnvironmentsSeparate(t *testing
 		t.Fatalf("expected created=2 got %d", result.Created)
 	}
 	seen := map[string]bool{}
+	networks := map[string]bool{}
 	for _, spec := range eng.created {
 		seen[spec.Labels[engine.LabelEnvironment]+"/"+spec.Labels[engine.LabelService]] = true
+		networks[spec.Network] = true
 	}
 	if !seen["blog-prod/worker"] || !seen["docs-prod/worker"] {
 		t.Fatalf("unexpected services: %#v", seen)
+	}
+	if !networks["devopsellence-env-blog-prod"] || !networks["devopsellence-env-docs-prod"] || networks["devopsellence"] {
+		t.Fatalf("unexpected container networks: %#v", networks)
 	}
 }
 
@@ -288,6 +308,9 @@ func TestReconcileWebUsesDesiredPortWhenPresent(t *testing.T) {
 	}
 	if envoyManager.waitPath != "/up" {
 		t.Fatalf("expected envoy wait path /up, got %q", envoyManager.waitPath)
+	}
+	if !reflect.DeepEqual(envoyManager.workloadNetworks, []string{"devopsellence-env-production"}) {
+		t.Fatalf("unexpected envoy workload networks: %#v", envoyManager.workloadNetworks)
 	}
 }
 
@@ -386,7 +409,7 @@ func TestRunTaskTruncatesLogOutput(t *testing.T) {
 	eng.logsOutput = []byte(strings.Repeat("x", 700))
 
 	rec := New(eng, Options{Network: "devopsellence"})
-	_, err := rec.RunTask(context.Background(), "rev-1", &desiredstatepb.Task{
+	_, err := rec.RunTask(context.Background(), desiredstate.DefaultEnvironmentName, "rev-1", &desiredstatepb.Task{
 		Name:  "init",
 		Image: "busybox",
 	})
@@ -596,7 +619,7 @@ func TestReconcileWebUnhealthyDoesNotUpdateEDS(t *testing.T) {
 func TestReconcileWebUpdateCutsOverBeforeRemovingOldContainer(t *testing.T) {
 	eng := newFakeEngine()
 	eng.images["httpbin"] = true
-	eng.networkIP = map[string]string{"devopsellence": "172.18.0.20"}
+	eng.networkIP = map[string]string{"devopsellence": "172.18.0.20", "devopsellence-env-production": "172.19.0.20"}
 
 	old := webService(80, "/up")
 	old.Env = map[string]string{"VERSION": "old"}

--- a/agent/internal/reconcile/reconcile_test.go
+++ b/agent/internal/reconcile/reconcile_test.go
@@ -146,11 +146,19 @@ type fakeEnvoyManager struct {
 	waitErr            error
 	ingress            *desiredstatepb.Ingress
 	workloadNetworks   []string
+	syncCalls          int
+	syncNetworks       []string
 }
 
 func (f *fakeEnvoyManager) Ensure(_ context.Context, ingress *desiredstatepb.Ingress, workloadNetworks ...string) error {
 	f.ingress = ingress
 	f.workloadNetworks = append([]string(nil), workloadNetworks...)
+	return nil
+}
+
+func (f *fakeEnvoyManager) SyncWorkloadNetworks(_ context.Context, workloadNetworks ...string) error {
+	f.syncCalls++
+	f.syncNetworks = append([]string(nil), workloadNetworks...)
 	return nil
 }
 
@@ -282,6 +290,23 @@ func TestReconcileKeepsSameServiceNameInDifferentEnvironmentsSeparate(t *testing
 	}
 	if !networks["devopsellence-env-blog-prod"] || !networks["devopsellence-env-docs-prod"] || networks["devopsellence"] {
 		t.Fatalf("unexpected container networks: %#v", networks)
+	}
+}
+
+func TestReconcileSyncsEnvoyNetworksWhenNoWebServicesRemain(t *testing.T) {
+	eng := newFakeEngine()
+	eng.images["busybox"] = true
+	envoyManager := &fakeEnvoyManager{}
+	rec := New(eng, Options{Network: "devopsellence", StopTimeout: 10 * time.Second, WebPort: 3000, Envoy: envoyManager})
+
+	if _, err := rec.Reconcile(context.Background(), desiredState(workerService("worker", nil))); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if envoyManager.syncCalls != 1 {
+		t.Fatalf("expected envoy network sync, got %d", envoyManager.syncCalls)
+	}
+	if len(envoyManager.syncNetworks) != 0 {
+		t.Fatalf("expected empty desired envoy workload networks, got %#v", envoyManager.syncNetworks)
 	}
 }
 

--- a/agent/internal/reconcile/reconcile_test.go
+++ b/agent/internal/reconcile/reconcile_test.go
@@ -479,6 +479,7 @@ func TestReconcileRestart(t *testing.T) {
 	if err != nil {
 		t.Fatalf("hash: %v", err)
 	}
+	hash = runtimeContainerHash(hash, nil, "devopsellence-env-production")
 	name, err := desiredstate.ServiceContainerName("production", "worker", "rev-1", hash)
 	if err != nil {
 		t.Fatalf("name: %v", err)
@@ -755,6 +756,45 @@ func TestReconcileAppliesLogConfigToRuntimeContainers(t *testing.T) {
 	}
 	if eng.created[0].Log == nil || eng.created[0].Log.Options["max-size"] != "10m" || eng.created[0].Log.Options["max-file"] != "5" {
 		t.Fatalf("unexpected log config: %#v", eng.created[0].Log)
+	}
+}
+
+func TestReconcileRecreatesRuntimeContainerWhenNetworkChanges(t *testing.T) {
+	eng := newFakeEngine()
+	eng.images["busybox"] = true
+	service := workerService("worker", nil)
+	oldHash, err := desiredstate.HashService(service)
+	if err != nil {
+		t.Fatalf("hash service: %v", err)
+	}
+	oldName, err := desiredstate.ServiceContainerName("production", "worker", "rev-1", oldHash)
+	if err != nil {
+		t.Fatalf("container name: %v", err)
+	}
+	eng.containers[oldName] = engine.ContainerState{
+		Name:        oldName,
+		Image:       "busybox",
+		Running:     true,
+		Managed:     true,
+		Hash:        oldHash,
+		Environment: "production",
+		Service:     "worker",
+		ServiceKind: "worker",
+	}
+
+	rec := New(eng, Options{Network: "devopsellence"})
+	result, err := rec.Reconcile(context.Background(), desiredState(service))
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if result.Updated != 1 || result.Removed != 1 {
+		t.Fatalf("result = %#v, want updated=1 removed=1", result)
+	}
+	if !containsString(eng.removed, oldName) {
+		t.Fatalf("expected old container removed; removed=%#v", eng.removed)
+	}
+	if len(eng.created) != 1 || eng.created[0].Name == oldName || eng.created[0].Network != "devopsellence-env-production" {
+		t.Fatalf("expected replacement container on environment network, created=%#v", eng.created)
 	}
 }
 


### PR DESCRIPTION
## Summary
- create per-environment Docker networks for workload and task containers
- keep Envoy on the node edge network and connect it to active web environment networks
- disconnect stale managed Envoy environment network attachments and purge all managed networks on uninstall

## Tests
- mise run test:agent
- cd agent && go vet ./...