### PR TITLE
[codex] address dogfood findings

### DIFF
--- a/.agents/skills/dogfood/SKILL.md
+++ b/.agents/skills/dogfood/SKILL.md
@@ -26,7 +26,7 @@ Direct human UX matters only when it affects AI-agent-mediated use, for example 
 - Evaluate from the AI-agent-mediated perspective by default: the AI coding/operator agent receives a user goal, operates devopsellence, asks the user for approvals or missing facts, and reports back with evidence.
 - Do not score direct human terminal ergonomics as the primary product experience unless the user explicitly asks for human-direct QA.
 - Prefer fresh temp apps and fresh state.
-- For ordinary solo-mode node tests, prefer `zirk` VMs when available. Use `zirk health`, `zirk flavors`, `zirk create <run-scoped-name> --flavor <flavor>`, `zirk show <run-scoped-name>`, and `zirk exec <run-scoped-name> ...` as setup evidence.
+- For ordinary solo-mode node tests, prefer `zirk` VMs when available. Use `zirk health`, `zirk flavors`, `zirk create --flavor <flavor> <run-scoped-name>`, `zirk show <run-scoped-name>`, and `zirk exec <run-scoped-name> ...` as setup evidence. For cleanup of a running VM, use `zirk delete --force <run-scoped-name>`.
 - Use run-scoped names for external resources, for example `dogfood-<timestamp>` or the run slug. Do not use generic production-like names unless the scenario specifically requires testing that name.
 - Start with a blind pass unless the user explicitly asks for code review first.
 - During blind pass, use only context an external AI coding/operator agent could use: public website docs, README/docs that match the target version when available, installed CLI help, API/JSON output, web UI state when unavoidable, generated errors, logs surfaced by the product, and ordinary tools exposed to the operator.

--- a/agent/internal/engine/docker/docker.go
+++ b/agent/internal/engine/docker/docker.go
@@ -311,6 +311,16 @@ func (e *Engine) Inspect(ctx context.Context, name string) (engine.ContainerInfo
 		NetworkIP:       map[string]string{},
 		LogPath:         res.Container.LogPath,
 	}
+	if res.Container.Config != nil {
+		info.Entrypoint = append([]string(nil), res.Container.Config.Entrypoint...)
+		info.Command = append([]string(nil), res.Container.Config.Cmd...)
+	}
+	if res.Container.State != nil {
+		info.StateStatus = string(res.Container.State.Status)
+		info.ExitCode = res.Container.State.ExitCode
+		info.StateError = res.Container.State.Error
+		info.FinishedAt = res.Container.State.FinishedAt
+	}
 	if res.Container.HostConfig != nil {
 		info.LogDriver = res.Container.HostConfig.LogConfig.Type
 		info.LogOptions = cloneStringMap(res.Container.HostConfig.LogConfig.Config)

--- a/agent/internal/engine/engine.go
+++ b/agent/internal/engine/engine.go
@@ -186,6 +186,12 @@ type ContainerInfo struct {
 	Name            string
 	Running         bool
 	Health          string
+	StateStatus     string
+	ExitCode        int
+	StateError      string
+	FinishedAt      string
+	Entrypoint      []string
+	Command         []string
 	HasHealthcheck  bool
 	PublishHostPort bool
 	PublishedPorts  []PortBinding

--- a/agent/internal/reconcile/reconcile.go
+++ b/agent/internal/reconcile/reconcile.go
@@ -537,6 +537,15 @@ func (r *Reconciler) tearDownFailedContainer(name string) {
 			"container", name,
 			"output", lines,
 		)
+	} else if info, inspectErr := r.engine.Inspect(ctx, name); inspectErr == nil {
+		logger := r.opts.Logger
+		if logger == nil {
+			logger = slog.Default()
+		}
+		logger.Warn("web container failed health checks — no log output; inspect details",
+			"container", name,
+			"state", containerInspectSummary(info),
+		)
 	}
 
 	_ = r.engine.Remove(ctx, name)
@@ -569,7 +578,7 @@ func (r *Reconciler) webContainerIP(ctx context.Context, name string, desired de
 		return "", fmt.Errorf("inspect container %s: %w", name, err)
 	}
 	if !info.Running {
-		return "", fmt.Errorf("container %s not running", name)
+		return "", fmt.Errorf("container %s not running (%s)", name, containerInspectSummary(info))
 	}
 
 	network, err := r.environmentNetwork(desired.EnvironmentName)
@@ -620,7 +629,7 @@ func (r *Reconciler) waitHealthy(ctx context.Context, name string, desired desir
 			return "", fmt.Errorf("inspect container %s: %w", name, err)
 		}
 		if !info.Running {
-			return "", fmt.Errorf("container %s not running", name)
+			return "", fmt.Errorf("container %s not running (%s)", name, containerInspectSummary(info))
 		}
 
 		network, err := r.environmentNetwork(desired.EnvironmentName)
@@ -657,6 +666,35 @@ func (r *Reconciler) waitHealthy(ctx context.Context, name string, desired desir
 		lastErr = fmt.Errorf("healthcheck failed for %s", name)
 	}
 	return "", lastErr
+}
+
+func containerInspectSummary(info engine.ContainerInfo) string {
+	parts := []string{}
+	if status := strings.TrimSpace(info.StateStatus); status != "" {
+		parts = append(parts, "status="+status)
+	}
+	if !info.Running {
+		parts = append(parts, fmt.Sprintf("exit_code=%d", info.ExitCode))
+	}
+	if stateErr := strings.TrimSpace(info.StateError); stateErr != "" {
+		parts = append(parts, "error="+stateErr)
+	}
+	if finishedAt := strings.TrimSpace(info.FinishedAt); finishedAt != "" {
+		parts = append(parts, "finished_at="+finishedAt)
+	}
+	if len(info.Entrypoint) > 0 {
+		parts = append(parts, "entrypoint="+strings.Join(info.Entrypoint, " "))
+	}
+	if len(info.Command) > 0 {
+		parts = append(parts, "cmd="+strings.Join(info.Command, " "))
+	}
+	if len(parts) == 0 {
+		if info.Running {
+			return "running=true"
+		}
+		return "running=false"
+	}
+	return strings.Join(parts, " ")
 }
 
 func (r *Reconciler) specForService(runtime desiredstate.RuntimeService) (string, string, engine.ContainerSpec, error) {

--- a/agent/internal/reconcile/reconcile.go
+++ b/agent/internal/reconcile/reconcile.go
@@ -682,12 +682,6 @@ func containerInspectSummary(info engine.ContainerInfo) string {
 	if finishedAt := strings.TrimSpace(info.FinishedAt); finishedAt != "" {
 		parts = append(parts, "finished_at="+finishedAt)
 	}
-	if len(info.Entrypoint) > 0 {
-		parts = append(parts, "entrypoint="+strings.Join(info.Entrypoint, " "))
-	}
-	if len(info.Command) > 0 {
-		parts = append(parts, "cmd="+strings.Join(info.Command, " "))
-	}
 	if len(parts) == 0 {
 		if info.Running {
 			return "running=true"

--- a/agent/internal/reconcile/reconcile_test.go
+++ b/agent/internal/reconcile/reconcile_test.go
@@ -481,8 +481,6 @@ func TestWaitHealthyIncludesContainerInspectDetailsWhenContainerExited(t *testin
 			ExitCode:    127,
 			StateError:  "exec: missing command",
 			FinishedAt:  "2026-04-28T20:25:07Z",
-			Entrypoint:  []string{"/bin/sh"},
-			Command:     []string{"-c", "missing"},
 			NetworkIP:   map[string]string{"devopsellence-env-production": "172.19.0.2"},
 		},
 	}
@@ -497,9 +495,14 @@ func TestWaitHealthyIncludesContainerInspectDetailsWhenContainerExited(t *testin
 		t.Fatal("expected waitHealthy error")
 	}
 	msg := err.Error()
-	for _, want := range []string{"container web not running", "status=exited", "exit_code=127", "error=exec: missing command", "finished_at=2026-04-28T20:25:07Z", "entrypoint=/bin/sh", "cmd=-c missing"} {
+	for _, want := range []string{"container web not running", "status=exited", "exit_code=127", "error=exec: missing command", "finished_at=2026-04-28T20:25:07Z"} {
 		if !strings.Contains(msg, want) {
 			t.Fatalf("error = %q, want %q", msg, want)
+		}
+	}
+	for _, leaked := range []string{"entrypoint=", "cmd="} {
+		if strings.Contains(msg, leaked) {
+			t.Fatalf("error = %q, did not expect argv field %q", msg, leaked)
 		}
 	}
 }
@@ -513,7 +516,6 @@ func TestTearDownFailedContainerLogsInspectDetailsWhenLogsAreEmpty(t *testing.T)
 			Running:     false,
 			StateStatus: "exited",
 			ExitCode:    1,
-			Command:     []string{"python", "server.py"},
 			NetworkIP:   map[string]string{},
 		},
 	}
@@ -526,10 +528,13 @@ func TestTearDownFailedContainerLogsInspectDetailsWhenLogsAreEmpty(t *testing.T)
 	rec.tearDownFailedContainer("web")
 
 	output := logs.String()
-	for _, want := range []string{"no log output", "status=exited", "exit_code=1", "cmd=python server.py"} {
+	for _, want := range []string{"no log output", "status=exited", "exit_code=1"} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("log output = %q, want %q", output, want)
 		}
+	}
+	if strings.Contains(output, "cmd=") || strings.Contains(output, "entrypoint=") {
+		t.Fatalf("log output = %q, did not expect argv fields", output)
 	}
 }
 

--- a/agent/internal/reconcile/reconcile_test.go
+++ b/agent/internal/reconcile/reconcile_test.go
@@ -1,8 +1,10 @@
 package reconcile
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"log/slog"
 	"reflect"
 	"strings"
 	"testing"
@@ -27,6 +29,7 @@ type fakeEngine struct {
 	ops          []string
 	waitExitCode int64
 	logsOutput   []byte
+	inspectInfo  map[string]engine.ContainerInfo
 }
 
 func newFakeEngine() *fakeEngine {
@@ -110,11 +113,28 @@ func (f *fakeEngine) Inspect(_ context.Context, name string) (engine.ContainerIn
 			networkIP[environmentNetwork] = "172.19.0.2"
 		}
 	}
-	return engine.ContainerInfo{
+	info := engine.ContainerInfo{
 		Name:      c.Name,
 		Running:   c.Running,
 		NetworkIP: networkIP,
-	}, nil
+	}
+	if override, ok := f.inspectInfo[name]; ok {
+		if override.Name != "" {
+			info.Name = override.Name
+		}
+		info.Running = override.Running
+		if override.NetworkIP != nil {
+			info.NetworkIP = override.NetworkIP
+		}
+		info.Health = override.Health
+		info.StateStatus = override.StateStatus
+		info.ExitCode = override.ExitCode
+		info.StateError = override.StateError
+		info.FinishedAt = override.FinishedAt
+		info.Entrypoint = override.Entrypoint
+		info.Command = override.Command
+	}
+	return info, nil
 }
 
 func (f *fakeEngine) EnsureNetwork(_ context.Context, name string) error {
@@ -447,6 +467,69 @@ func TestRunTaskTruncatesLogOutput(t *testing.T) {
 	}
 	if len(msg) > 650 {
 		t.Fatalf("expected bounded error length, got %d chars", len(msg))
+	}
+}
+
+func TestWaitHealthyIncludesContainerInspectDetailsWhenContainerExited(t *testing.T) {
+	eng := newFakeEngine()
+	eng.containers["web"] = engine.ContainerState{Name: "web", Environment: desiredstate.DefaultEnvironmentName}
+	eng.inspectInfo = map[string]engine.ContainerInfo{
+		"web": {
+			Name:        "web",
+			Running:     false,
+			StateStatus: "exited",
+			ExitCode:    127,
+			StateError:  "exec: missing command",
+			FinishedAt:  "2026-04-28T20:25:07Z",
+			Entrypoint:  []string{"/bin/sh"},
+			Command:     []string{"-c", "missing"},
+			NetworkIP:   map[string]string{"devopsellence-env-production": "172.19.0.2"},
+		},
+	}
+	rec := New(eng, Options{Network: "devopsellence", HTTPProber: &fakeHTTPProber{}})
+
+	_, err := rec.waitHealthy(context.Background(), "web", desiredstate.RuntimeService{
+		EnvironmentName: desiredstate.DefaultEnvironmentName,
+		ServiceName:     "web",
+		Service:         webService(3000, "/up"),
+	})
+	if err == nil {
+		t.Fatal("expected waitHealthy error")
+	}
+	msg := err.Error()
+	for _, want := range []string{"container web not running", "status=exited", "exit_code=127", "error=exec: missing command", "finished_at=2026-04-28T20:25:07Z", "entrypoint=/bin/sh", "cmd=-c missing"} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("error = %q, want %q", msg, want)
+		}
+	}
+}
+
+func TestTearDownFailedContainerLogsInspectDetailsWhenLogsAreEmpty(t *testing.T) {
+	eng := newFakeEngine()
+	eng.containers["web"] = engine.ContainerState{Name: "web", Environment: desiredstate.DefaultEnvironmentName}
+	eng.inspectInfo = map[string]engine.ContainerInfo{
+		"web": {
+			Name:        "web",
+			Running:     false,
+			StateStatus: "exited",
+			ExitCode:    1,
+			Command:     []string{"python", "server.py"},
+			NetworkIP:   map[string]string{},
+		},
+	}
+	var logs bytes.Buffer
+	rec := New(eng, Options{
+		Network: "devopsellence",
+		Logger:  slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug})),
+	})
+
+	rec.tearDownFailedContainer("web")
+
+	output := logs.String()
+	for _, want := range []string{"no log output", "status=exited", "exit_code=1", "cmd=python server.py"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("log output = %q, want %q", output, want)
+		}
 	}
 }
 

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -3678,7 +3678,7 @@ func (a *App) SoloInit(context.Context, SoloInitOptions) error {
 		"git init # if this app is not already a git checkout",
 		"git add . # include devopsellence.yml and app files",
 		"git commit -m 'initial deploy' # devopsellence deploys the current commit",
-		"devopsellence node list # solo node names are global on this machine",
+		"devopsellence node list --all # solo node names are global on this machine",
 		"devopsellence node create <node-name> --host <host> --user root --ssh-key <path>",
 		"devopsellence agent install <node-name>",
 		"devopsellence node attach <node-name>",

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1499,7 +1499,10 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 
 	}
 
-	payload := map[string]any{"nodes": jsonResults}
+	payload := map[string]any{
+		"schema_version": outputSchemaVersion,
+		"nodes":          jsonResults,
+	}
 	if urls := soloStatusPublicURLs(cfg, nodes); len(urls) > 0 {
 		if allSettled {
 			payload["public_urls"] = urls
@@ -3675,13 +3678,14 @@ func (a *App) SoloInit(context.Context, SoloInitOptions) error {
 		"git init # if this app is not already a git checkout",
 		"git add . # include devopsellence.yml and app files",
 		"git commit -m 'initial deploy' # devopsellence deploys the current commit",
-		"devopsellence node create prod-1 --host <host> --user root --ssh-key <path>",
-		"devopsellence agent install prod-1",
-		"devopsellence node attach prod-1",
+		"devopsellence node list # solo node names are global on this machine",
+		"devopsellence node create <node-name> --host <host> --user root --ssh-key <path>",
+		"devopsellence agent install <node-name>",
+		"devopsellence node attach <node-name>",
 		"# or let devopsellence create a Hetzner node:",
 		"devopsellence provider login hetzner --token <token>",
 		"devopsellence provider status hetzner",
-		"devopsellence node create prod-1 --provider hetzner --install --attach",
+		"devopsellence node create <node-name> --provider hetzner --install --attach",
 		"devopsellence doctor",
 		"devopsellence deploy",
 	}

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -763,6 +763,9 @@ func TestSoloStatusIncludesPublicURLs(t *testing.T) {
 		t.Fatalf("SoloStatus() error = %v", err)
 	}
 	payload := decodeJSONOutput(t, &stdout)
+	if payload["schema_version"] != float64(outputSchemaVersion) {
+		t.Fatalf("schema_version = %#v, want %d", payload["schema_version"], outputSchemaVersion)
+	}
 	urls := jsonArrayFromMap(t, payload, "public_urls")
 	if len(urls) != 1 || urls[0] != "http://203.0.113.10/" {
 		t.Fatalf("public_urls = %#v, want web node URL only", urls)
@@ -814,6 +817,9 @@ func TestSoloStatusUsesConfiguredPublicURLsWhenNodeIsNotSettled(t *testing.T) {
 		t.Fatalf("SoloStatus() error = %v", err)
 	}
 	payload := decodeJSONOutput(t, &stdout)
+	if payload["schema_version"] != float64(outputSchemaVersion) {
+		t.Fatalf("schema_version = %#v, want %d", payload["schema_version"], outputSchemaVersion)
+	}
 	if _, ok := payload["public_urls"]; ok {
 		t.Fatalf("payload = %#v, did not expect public_urls while node is errored", payload)
 	}
@@ -1391,6 +1397,9 @@ func TestSoloStatusReturnsFailureWhenNodeStatusReadFails(t *testing.T) {
 		t.Fatalf("exit error = %#v, want RenderedError", exitErr.Err)
 	}
 	payload := decodeJSONOutput(t, &stdout)
+	if payload["schema_version"] != float64(outputSchemaVersion) {
+		t.Fatalf("schema_version = %#v, want %d", payload["schema_version"], outputSchemaVersion)
+	}
 	nodes := jsonArrayFromMap(t, payload, "nodes")
 	node := jsonMapFromAny(t, nodes[0])
 	if node["node"] != "node-a" || !strings.Contains(stringValueAny(node["error"]), "ssh root@203.0.113.10:") {
@@ -3479,7 +3488,10 @@ func TestSoloInitCreatesWorkspaceConfig(t *testing.T) {
 		steps = append(steps, stringValueAny(value))
 	}
 	nextSteps := strings.Join(steps, "\n")
-	if !strings.Contains(nextSteps, "devopsellence node create prod-1 --provider hetzner --install --attach") {
+	if !strings.Contains(nextSteps, "devopsellence node list # solo node names are global on this machine") {
+		t.Fatalf("next_steps = %q, want node-list collision guidance", nextSteps)
+	}
+	if !strings.Contains(nextSteps, "devopsellence node create <node-name> --provider hetzner --install --attach") {
 		t.Fatalf("next_steps = %q, want provider-created node path", nextSteps)
 	}
 	runtimeContract := jsonMapFromAny(t, payload["runtime_contract"])

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -3488,7 +3488,7 @@ func TestSoloInitCreatesWorkspaceConfig(t *testing.T) {
 		steps = append(steps, stringValueAny(value))
 	}
 	nextSteps := strings.Join(steps, "\n")
-	if !strings.Contains(nextSteps, "devopsellence node list # solo node names are global on this machine") {
+	if !strings.Contains(nextSteps, "devopsellence node list --all # solo node names are global on this machine") {
 		t.Fatalf("next_steps = %q, want node-list collision guidance", nextSteps)
 	}
 	if !strings.Contains(nextSteps, "devopsellence node create <node-name> --provider hetzner --install --attach") {


### PR DESCRIPTION
## What changed

- Added `schema_version` to solo `devopsellence status` JSON payloads.
- Replaced `prod-1` init guidance with `<node-name>` plus `node list` guidance about solo-global node names.
- Added bounded Docker inspect details to agent container-not-running errors and empty-log healthcheck teardown logs.
- Updated the dogfood skill's zirk create/delete examples to match the installed flag order.

## Why

The v0.2.0-preview dogfood run showed three AI-agent-mediated operability gaps: inconsistent status payload contracts, collision-prone init guidance, and weak diagnostics when a failed container exits without logs. The zirk skill instructions also used flag order that the installed zirk CLI rejected.

## Validation

- `cd cli && go test ./internal/workflow`
- `cd agent && go test ./internal/reconcile ./internal/engine/docker`
- `mise run test:agent`
- `mise run test:cli`
