### PR TITLE
[codex] Improve agent install and SSH setup guidance

### DIFF
--- a/cli/internal/workflow/root.go
+++ b/cli/internal/workflow/root.go
@@ -829,6 +829,7 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 			"Create or register a node for the selected workspace mode.",
 			"Solo --host nodes must be reachable over SSH with the selected key. devopsellence stores SSH host keys in its own state directory and uses StrictHostKeyChecking=accept-new, so first contact does not write to ~/.ssh/known_hosts.",
 			"The solo agent install can install Docker on supported Ubuntu VMs when Docker is missing; otherwise install Docker yourself or make the SSH user able to run docker via passwordless sudo.",
+			"If SSH validation fails as root, retry with the image default user such as ubuntu, debian, or ec2-user, and verify passwordless sudo with `ssh <user>@<host> sudo -n true` before installing the agent.",
 		}, "\n"),
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -3765,7 +3765,7 @@ func (a *App) SoloNodeCreate(ctx context.Context, opts SoloNodeCreateOptions) er
 			return err
 		}
 		if err := validateSoloNodeSSH(ctx, node); err != nil {
-			return fmt.Errorf("node create could not validate SSH for %s@%s:%d; fix --host/--user/--ssh-key or SSH access, then retry: %w", node.User, node.Host, node.Port, err)
+			return fmt.Errorf("node create could not validate SSH for %s@%s:%d; fix --host/--user/--ssh-key or SSH access, then retry. If root login is disabled, try the image default user such as ubuntu, debian, or ec2-user and verify passwordless sudo with `ssh <user>@<host> sudo -n true`: %w", node.User, node.Host, node.Port, err)
 		}
 		result["source"] = "existing_ssh"
 		result["ssh_checked"] = true

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -765,6 +765,9 @@ func TestSoloNodeCreateValidatesExistingSSHBeforeWritingState(t *testing.T) {
 	if !strings.Contains(err.Error(), "node create could not validate SSH") || !strings.Contains(err.Error(), "Permission denied") {
 		t.Fatalf("error = %v, want SSH validation context", err)
 	}
+	if !strings.Contains(err.Error(), "try the image default user") || !strings.Contains(err.Error(), "sudo -n true") {
+		t.Fatalf("error = %v, want non-root SSH recovery guidance", err)
+	}
 	loaded, err := soloState.Read()
 	if err != nil {
 		t.Fatal(err)

--- a/cli/scripts/release-local.sh
+++ b/cli/scripts/release-local.sh
@@ -38,6 +38,14 @@ TMP_BIN="$(mktemp "$BUILD_DIR/devopsellence.XXXXXX")"
 cleanup() { rm -f "$TMP_BIN"; }
 trap cleanup EXIT
 
+json_string() {
+  local value="$1"
+  value="${value//\\/\\\\}"
+  value="${value//\"/\\\"}"
+  value="${value//$'\n'/\\n}"
+  printf '"%s"' "$value"
+}
+
 COMMIT="$(git -C "$ROOT_DIR" rev-parse --short HEAD)"
 BUILD_TIME="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
 MODULE_PATH="github.com/devopsellence/cli/internal/version"
@@ -106,6 +114,11 @@ case "$INSTALL_AGENT_SKILL" in
     if command -v npx >/dev/null 2>&1; then
       echo "installing devopsellence agent skill..."
       npx --yes skills add devopsellence/devopsellence --skill devopsellence -g --yes
+      printf '{"schema_version":1,"event":"result","operation":"devopsellence release-local","cli_installed":true,"cli_path":'
+      json_string "$INSTALL_DIR/$TARGET_NAME"
+      printf ',"commit":'
+      json_string "$COMMIT"
+      printf ',"agent_skill_requested":true,"agent_skill_installed":true,"agent_skill":"devopsellence"}\n'
     else
       echo "devopsellence CLI installed. Agent skill install requested, but npx was not found." >&2
       echo "Install the skill later with:" >&2

--- a/control-plane/app/controllers/cli_installs_controller.rb
+++ b/control-plane/app/controllers/cli_installs_controller.rb
@@ -153,6 +153,14 @@ class CliInstallsController < ActionController::Base
         fi
       }
 
+      json_string() {
+        local value="$1"
+        value="${value//\\\\/\\\\\\\\}"
+        value="${value//\\"/\\\\\\"}"
+        value="${value//$'\\n'/\\\\n}"
+        printf '"%s"' "$value"
+      }
+
       echo "downloading devopsellence CLI..."
       curl -fsSL "$DOWNLOAD_URL" -o "$TMP_BIN"
       curl -fsSL "$CHECKSUM_URL" -o "$TMP_SUMS"
@@ -211,6 +219,9 @@ class CliInstallsController < ActionController::Base
           if command -v npx >/dev/null 2>&1; then
             echo "installing devopsellence agent skill..."
             npx --yes skills add devopsellence/devopsellence --skill devopsellence -g --yes
+            printf '{"schema_version":1,"event":"result","operation":"devopsellence install","cli_installed":true,"cli_path":'
+            json_string "$INSTALL_DIR/$TARGET_NAME"
+            printf ',"agent_skill_requested":true,"agent_skill_installed":true,"agent_skill":"devopsellence"}\\n'
           else
             echo "devopsellence CLI installed. Agent skill install requested, but npx was not found." >&2
             echo "Install the skill later with:" >&2

--- a/control-plane/test/integration/installs_test.rb
+++ b/control-plane/test/integration/installs_test.rb
@@ -134,6 +134,9 @@ class InstallsTest < ActionDispatch::IntegrationTest
 
     assert_predicate status, :success?, -> { "stdout:\n#{stdout}\nstderr:\n#{stderr}" }
     assert_includes stdout, "installing devopsellence agent skill"
+    assert_includes stdout, '"operation":"devopsellence install"'
+    assert_includes stdout, '"agent_skill_installed":true'
+    assert_includes stdout, '"agent_skill":"devopsellence"'
     assert_equal "prerelease build\n", installed_cli
     assert_equal [ "--yes", "skills", "add", "devopsellence/devopsellence", "--skill", "devopsellence", "-g", "--yes" ], skill_args
   end


### PR DESCRIPTION
## Summary

- emit a final structured JSON result when the installer is asked to install the devopsellence agent skill
- emit the same structured JSON result from the local release installer when `DEVOPSELLENCE_INSTALL_AGENT_SKILL=1` succeeds
- add AI-agent-friendly SSH recovery guidance for existing-node registration failures
- cover both paths with focused installer and solo node tests / smoke validation

## Why

Dogfood of `v0.2.0-preview` found the core CLI deploy path is strong and JSON-first, but the agent skill install path still ended in styled terminal output and SSH setup required guessing when root login was disabled.

## Validation

- `cd cli && mise run test -- ./internal/workflow -run 'TestSoloNodeCreateValidatesExistingSSHBeforeWritingState|TestRootHelp|TestSolo'`
- `cd control-plane && mise run test:cp -- test/integration/installs_test.rb`
- `git diff --check && bash -n cli/scripts/release-local.sh`
- local `DEVOPSELLENCE_INSTALL_AGENT_SKILL=1 ./cli/scripts/release-local.sh` smoke with temp install dir and fake `npx`; parsed final JSON result and verified installed binary + skill args
