### PR TITLE
Fix solo dogfood findings

### DIFF
--- a/agent/internal/envoy/manager.go
+++ b/agent/internal/envoy/manager.go
@@ -53,15 +53,16 @@ type Config struct {
 }
 
 type Manager struct {
-	engine          engine.Engine
-	config          Config
-	logger          *slog.Logger
-	xds             *xdsServer
-	http            *http.Client
-	lastIngress     *desiredstatepb.Ingress
-	lastEndpoint    *endpointState
-	lastEndpoints   map[string]*endpointState
-	snapshotVersion atomic.Int64
+	engine               engine.Engine
+	config               Config
+	logger               *slog.Logger
+	xds                  *xdsServer
+	http                 *http.Client
+	lastIngress          *desiredstatepb.Ingress
+	lastEndpoint         *endpointState
+	lastEndpoints        map[string]*endpointState
+	lastWorkloadNetworks []string
+	snapshotVersion      atomic.Int64
 }
 
 func New(engine engine.Engine, config Config, logger *slog.Logger) *Manager {
@@ -114,6 +115,7 @@ func New(engine engine.Engine, config Config, logger *slog.Logger) *Manager {
 }
 
 func (m *Manager) Ensure(ctx context.Context, ingress *desiredstatepb.Ingress, workloadNetworks ...string) error {
+	m.lastWorkloadNetworks = cloneStrings(workloadNetworks)
 	publicIngressListener, err := m.publicIngressListenerConfig(ingress)
 	if err != nil {
 		return err
@@ -220,6 +222,7 @@ func (m *Manager) Ensure(ctx context.Context, ingress *desiredstatepb.Ingress, w
 // creating Envoy when it is absent. It is used to drop stale environment
 // networks after a node stops hosting web services.
 func (m *Manager) SyncWorkloadNetworks(ctx context.Context, workloadNetworks ...string) error {
+	m.lastWorkloadNetworks = cloneStrings(workloadNetworks)
 	_, err := m.engine.Inspect(ctx, m.config.ContainerName)
 	if err != nil {
 		if cerrdefs.IsNotFound(err) {
@@ -485,11 +488,21 @@ func (m *Manager) restart(ctx context.Context) error {
 	if err := m.createEnvoy(ctx, m.lastIngress, desiredPorts, publicIngressListener != nil); err != nil {
 		return err
 	}
+	if err := m.syncWorkloadNetworks(ctx, m.lastWorkloadNetworks); err != nil {
+		return err
+	}
 	if err := m.waitReady(ctx); err != nil {
 		return err
 	}
 	m.logger.Info("envoy restarted", "name", m.config.ContainerName, "port", m.config.Port)
 	return nil
+}
+
+func cloneStrings(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	return append([]string(nil), values...)
 }
 
 func defaultHealthcheck() *engine.Healthcheck {

--- a/agent/internal/envoy/manager_test.go
+++ b/agent/internal/envoy/manager_test.go
@@ -1078,6 +1078,54 @@ func TestWaitForRoute(t *testing.T) {
 	}
 }
 
+func TestWaitForRouteReconnectsWorkloadNetworksAfterRestart(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "no healthy upstream", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	host, portString, err := net.SplitHostPort(strings.TrimPrefix(server.URL, "http://"))
+	if err != nil {
+		t.Fatalf("split host/port: %v", err)
+	}
+	port, err := strconv.Atoi(portString)
+	if err != nil {
+		t.Fatalf("atoi port: %v", err)
+	}
+
+	eng := &fakeEngine{inspectErr: cerrdefs.ErrNotFound}
+	logger := slog.New(slog.NewJSONHandler(io.Discard, &slog.HandlerOptions{}))
+	mgr := New(eng, Config{
+		Image:          "docker.io/envoyproxy/envoy:v1.37.0",
+		ContainerName:  "devopsellence-envoy",
+		NetworkName:    "devopsellence",
+		BootstrapPath:  tempBootstrapPath(t),
+		Port:           uint16(port),
+		ClusterName:    "devopsellence_web",
+		HTTPClient:     server.Client(),
+		RouteTimeout:   20 * time.Millisecond,
+		RouteInterval:  10 * time.Millisecond,
+		StartupTimeout: time.Second,
+	}, logger)
+
+	if err := mgr.Ensure(context.Background(), nil, "devopsellence-env-production"); err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+	eng.inspectInfo.NetworkIP["devopsellence"] = host
+	if err := mgr.WaitForRoute(context.Background(), "/up"); err == nil {
+		t.Fatal("expected route probe to fail after restart")
+	}
+	connections := 0
+	for _, network := range eng.connectedNetworks {
+		if network == "devopsellence-env-production" {
+			connections++
+		}
+	}
+	if connections != 2 {
+		t.Fatalf("workload network connections = %d, want 2 (initial ensure and post-restart reconnect); all connections: %#v", connections, eng.connectedNetworks)
+	}
+}
+
 func TestWaitForRouteRestartsAndIncludesBody(t *testing.T) {
 	requests := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cli/internal/workflow/root.go
+++ b/cli/internal/workflow/root.go
@@ -773,6 +773,8 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 	var nodeRemoveSharedOpts NodeDeleteOptions
 	var nodeLabelSharedOpts NodeLabelSetOptions
 	var nodeLabelSoloOpts SoloNodeLabelSetOptions
+	var nodeLabelListSoloOpts SoloNodeLabelListOptions
+	var nodeLabelRemoveSoloOpts SoloNodeLabelRemoveOptions
 	var nodeDiagnoseOpts NodeDiagnoseOptions
 	var soloNodeDiagnoseOpts SoloNodeDiagnoseOptions
 	var nodeLogsOpts SoloLogsOptions
@@ -932,8 +934,35 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 		},
 	}
 	nodeLabelSetCommand.Flags().StringVar(&nodeLabels, "labels", "", "Comma-separated labels")
+	nodeLabelListCommand := &cobra.Command{
+		Use:   "list [target]",
+		Short: "List node labels",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			nodeLabelListSoloOpts.Node = ""
+			if len(args) > 0 {
+				nodeLabelListSoloOpts.Node = args[0]
+			}
+			return runSoloOnly("node label list", func(ctx context.Context) error {
+				return app.SoloNodeLabelList(ctx, nodeLabelListSoloOpts)
+			})(cmd, args)
+		},
+	}
+	nodeLabelRemoveCommand := &cobra.Command{
+		Use:   "remove <target>",
+		Short: "Remove labels from a node",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			nodeLabelRemoveSoloOpts.Node = args[0]
+			nodeLabelRemoveSoloOpts.Labels = nodeLabels
+			return runSoloOnly("node label remove", func(ctx context.Context) error {
+				return app.SoloNodeLabelRemove(ctx, nodeLabelRemoveSoloOpts)
+			})(cmd, args)
+		},
+	}
+	nodeLabelRemoveCommand.Flags().StringVar(&nodeLabels, "labels", "", "Comma-separated labels to remove")
 	nodeLabelCommand := &cobra.Command{Use: "label", Short: "Manage node labels"}
-	nodeLabelCommand.AddCommand(nodeLabelSetCommand)
+	nodeLabelCommand.AddCommand(nodeLabelSetCommand, nodeLabelListCommand, nodeLabelRemoveCommand)
 	nodeDiagnoseCommand := &cobra.Command{
 		Use:   "diagnose <name|id>",
 		Short: "Collect a runtime snapshot from a node",

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1547,6 +1547,10 @@ func (a *App) SoloReleaseList(ctx context.Context, opts SoloReleaseListOptions) 
 	if err != nil {
 		return err
 	}
+	displayEnvironmentID, err := soloDisplayEnvironmentID(workspaceRoot, environmentName)
+	if err != nil {
+		return err
+	}
 	limit := opts.Limit
 	if limit > 0 && len(releases) > limit {
 		releases = releases[:limit]
@@ -1566,7 +1570,7 @@ func (a *App) SoloReleaseList(ctx context.Context, opts SoloReleaseListOptions) 
 	return a.Printer.PrintJSON(map[string]any{
 		"schema_version": outputSchemaVersion,
 		"environment":    environmentName,
-		"environment_id": soloDisplayEnvironmentID(workspaceRoot, environmentName),
+		"environment_id": displayEnvironmentID,
 		"current_release_id": func() string {
 			if hasCurrent {
 				return currentRelease.ID
@@ -3956,16 +3960,12 @@ func soloEnvironmentName(cfg *config.ProjectConfig, override string) string {
 	return strings.TrimSpace(cfg.DefaultEnvironment)
 }
 
-func soloDisplayEnvironmentID(workspaceRoot, environment string) string {
-	workspaceRoot = strings.TrimSpace(workspaceRoot)
-	environment = strings.TrimSpace(environment)
-	if environment == "" {
-		environment = config.DefaultEnvironment
+func soloDisplayEnvironmentID(workspaceRoot, environment string) (string, error) {
+	key, err := solo.EnvironmentStateKey(workspaceRoot, environment)
+	if err != nil {
+		return "", err
 	}
-	if workspaceRoot == "" {
-		return environment
-	}
-	return workspaceRoot + "#" + environment
+	return strings.Replace(key, "\n", "#", 1), nil
 }
 
 func (a *App) soloStatusNodes(opts SoloStatusOptions) (map[string]config.Node, error) {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -120,6 +120,15 @@ type SoloNodeLabelSetOptions struct {
 	Labels string
 }
 
+type SoloNodeLabelListOptions struct {
+	Node string
+}
+
+type SoloNodeLabelRemoveOptions struct {
+	Node   string
+	Labels string
+}
+
 type SoloAgentInstallOptions struct {
 	Node        string
 	AgentBinary string
@@ -1530,7 +1539,7 @@ func (a *App) SoloReleaseList(ctx context.Context, opts SoloReleaseListOptions) 
 		return err
 	}
 	environmentName := soloEnvironmentName(cfg, "")
-	environmentID, currentRelease, hasCurrent, err := current.CurrentRelease(workspaceRoot, environmentName)
+	_, currentRelease, hasCurrent, err := current.CurrentRelease(workspaceRoot, environmentName)
 	if err != nil {
 		return err
 	}
@@ -1557,7 +1566,7 @@ func (a *App) SoloReleaseList(ctx context.Context, opts SoloReleaseListOptions) 
 	return a.Printer.PrintJSON(map[string]any{
 		"schema_version": outputSchemaVersion,
 		"environment":    environmentName,
-		"environment_id": environmentID,
+		"environment_id": soloDisplayEnvironmentID(workspaceRoot, environmentName),
 		"current_release_id": func() string {
 			if hasCurrent {
 				return currentRelease.ID
@@ -1812,6 +1821,9 @@ func (a *App) SoloSecretsSet(_ context.Context, opts SoloSecretsSetOptions) erro
 	}
 	if strings.TrimSpace(record.Reference) != "" {
 		payload["reference"] = record.Reference
+	}
+	if record.Store == solo.SecretStorePlaintext {
+		payload["warnings"] = []string{"solo plaintext secrets are stored locally in the devopsellence solo state file; use --store 1password --op-ref for production secrets"}
 	}
 	if a.SoloState != nil && strings.TrimSpace(a.SoloState.Path) != "" {
 		payload["state_path"] = a.SoloState.Path
@@ -2082,13 +2094,13 @@ func (a *App) SoloNodeAttach(ctx context.Context, opts SoloNodeAttachOptions) er
 	if err != nil {
 		return err
 	}
-	if err := a.writeSoloState(current); err != nil {
-		return err
-	}
 	if soloAttachmentHasReleaseState(current, attachment) {
 		if _, err := a.republishNodes(ctx, current, attachment.NodeNames); err != nil {
 			return err
 		}
+	}
+	if err := a.writeSoloState(current); err != nil {
+		return err
 	}
 
 	return a.Printer.PrintJSON(map[string]any{
@@ -3024,6 +3036,60 @@ func (a *App) SoloNodeLabelSet(ctx context.Context, opts SoloNodeLabelSetOptions
 
 }
 
+func (a *App) SoloNodeLabelList(_ context.Context, opts SoloNodeLabelListOptions) error {
+	current, err := a.readSoloState()
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(opts.Node) != "" {
+		node, ok := current.Nodes[opts.Node]
+		if !ok {
+			return fmt.Errorf("node %q not found", opts.Node)
+		}
+		return a.Printer.PrintJSON(map[string]any{"node": opts.Node, "labels": solo.NormalizeNode(node).Labels})
+	}
+	items := make([]map[string]any, 0, len(current.Nodes))
+	for name, node := range current.Nodes {
+		items = append(items, map[string]any{"node": name, "labels": solo.NormalizeNode(node).Labels})
+	}
+	sort.Slice(items, func(i, j int) bool { return items[i]["node"].(string) < items[j]["node"].(string) })
+	return a.Printer.PrintJSON(map[string]any{"nodes": items})
+}
+
+func (a *App) SoloNodeLabelRemove(ctx context.Context, opts SoloNodeLabelRemoveOptions) error {
+	current, err := a.readSoloState()
+	if err != nil {
+		return err
+	}
+	node, ok := current.Nodes[opts.Node]
+	if !ok {
+		return fmt.Errorf("node %q not found", opts.Node)
+	}
+	labels, err := parseSoloLabels(opts.Labels)
+	if err != nil {
+		return err
+	}
+	remove := map[string]bool{}
+	for _, label := range labels {
+		remove[label] = true
+	}
+	kept := make([]string, 0, len(node.Labels))
+	for _, label := range node.Labels {
+		if !remove[label] {
+			kept = append(kept, label)
+		}
+	}
+	node.Labels = kept
+	current.Nodes[opts.Node] = solo.NormalizeNode(node)
+	if _, err := a.republishNodes(ctx, current, soloAffectedNodesForNode(current, opts.Node)); err != nil {
+		return err
+	}
+	if err := a.writeSoloState(current); err != nil {
+		return err
+	}
+	return a.Printer.PrintJSON(map[string]any{"node": opts.Node, "labels": current.Nodes[opts.Node].Labels, "removed": labels})
+}
+
 func (a *App) SoloAgentInstall(ctx context.Context, opts SoloAgentInstallOptions) error {
 	current, err := a.readSoloState()
 	if err != nil {
@@ -3888,6 +3954,18 @@ func soloEnvironmentName(cfg *config.ProjectConfig, override string) string {
 		return config.DefaultEnvironment
 	}
 	return strings.TrimSpace(cfg.DefaultEnvironment)
+}
+
+func soloDisplayEnvironmentID(workspaceRoot, environment string) string {
+	workspaceRoot = strings.TrimSpace(workspaceRoot)
+	environment = strings.TrimSpace(environment)
+	if environment == "" {
+		environment = config.DefaultEnvironment
+	}
+	if workspaceRoot == "" {
+		return environment
+	}
+	return workspaceRoot + "#" + environment
 }
 
 func (a *App) soloStatusNodes(opts SoloStatusOptions) (map[string]config.Node, error) {

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -2581,6 +2581,42 @@ func TestSoloReleaseListReturnsCurrentReleaseHistory(t *testing.T) {
 	}
 }
 
+func TestSoloReleaseListEnvironmentIDUsesCanonicalWorkspaceKey(t *testing.T) {
+	realWorkspace := filepath.Join(t.TempDir(), "real")
+	if err := os.Mkdir(realWorkspace, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	if _, err := config.Write(realWorkspace, cfg); err != nil {
+		t.Fatal(err)
+	}
+	linkWorkspace := filepath.Join(t.TempDir(), "link")
+	if err := os.Symlink(realWorkspace, linkWorkspace); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := soloReleaseWorkflowState(realWorkspace)
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{
+		Printer:     output.New(&stdout, io.Discard),
+		SoloState:   soloState,
+		ConfigStore: config.NewStore(),
+		Cwd:         linkWorkspace,
+	}
+	if err := app.SoloReleaseList(context.Background(), SoloReleaseListOptions{Limit: 1}); err != nil {
+		t.Fatal(err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	want := realWorkspace + "#production"
+	if payload["environment_id"] != want {
+		t.Fatalf("environment_id = %#v, want canonical %q", payload["environment_id"], want)
+	}
+}
+
 func TestSoloReleaseRollbackUsesSelectedReleaseTargets(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -2386,7 +2386,7 @@ func TestDesiredStateRevisionReadsRevision(t *testing.T) {
 	}
 }
 
-func TestNodeAttachPersistsDesiredStateOnRepublishError(t *testing.T) {
+func TestNodeAttachDoesNotPersistDesiredStateOnRepublishError(t *testing.T) {
 	t.Parallel()
 
 	workspaceRoot := t.TempDir()
@@ -2432,8 +2432,8 @@ func TestNodeAttachPersistsDesiredStateOnRepublishError(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(loaded.Attachments) != 1 {
-		t.Fatalf("attachments = %#v, want persisted desired attachment", loaded.Attachments)
+	if len(loaded.Attachments) != 0 {
+		t.Fatalf("attachments = %#v, want no persisted attachment after failed republish", loaded.Attachments)
 	}
 }
 
@@ -2551,6 +2551,9 @@ func TestSoloReleaseListReturnsCurrentReleaseHistory(t *testing.T) {
 		t.Fatal(err)
 	}
 	payload := decodeJSONOutput(t, &stdout)
+	if environmentID, ok := payload["environment_id"].(string); !ok || strings.Contains(environmentID, "\n") || !strings.Contains(environmentID, "#production") {
+		t.Fatalf("environment_id = %#v, want newline-free workspace/environment identifier", payload["environment_id"])
+	}
 	if payload["current_release_id"] != "rel-2" {
 		t.Fatalf("payload = %#v, want current release rel-2", payload)
 	}


### PR DESCRIPTION
## Summary

Addresses follow-up issues from the solo-mode dogfood pass:

- Reconnect Envoy to remembered workload networks after an automatic route-health restart, fixing the 503-until-agent-restart failure mode.
- Make `node attach` transactional when republishing desired state fails, so failed attaches no longer persist partial local state.
- Clean up `release list` JSON by returning a newline-free `environment_id` display value.
- Add an explicit plaintext-secret warning to `secret set` output.
- Add `node label list` and `node label remove` so `node label list/remove --help` no longer falls back to parent help and labels can be inspected/edited incrementally.

Note: the rollback issue from the dogfood report was already covered on upstream master by targeting rollbacks to the selected release's target-node intersection; this PR preserves that behavior and adds the remaining fixes.

## Tests

- `cd cli && mise run test -- ./...`
- `cd agent && mise run test -- ./...`
- `cd cli && mise run build >/dev/null`
- Manual help verification:
  - `./bin/devopsellence node label --help`
  - `./bin/devopsellence node label list --help`
  - `./bin/devopsellence node label remove --help`
