### PR TITLE
docs: add solo dogfood agent skill

### DIFF
--- a/.agents/skills/dogfood-solo/SKILL.md
+++ b/.agents/skills/dogfood-solo/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: dogfood-solo
+description: >-
+  Use when asked to dogfood or release-validate devopsellence solo mode from an AI-agent-mediated operator perspective. Focuses on official-artifact validation, co-hosted projects/environments, TLS/ACME, secrets, rollback, diagnostics, cleanup, and evidence-backed readiness decisions.
+---
+
+# Dogfood Solo
+
+## Purpose
+
+Run devopsellence **solo mode** as an AI coding/operator agent acting for a delegating user. The goal is not just to prove that one happy-path deploy works; it is to find runtime, state, release, and operability gaps that would cause an AI agent to report false confidence to a user.
+
+Use this skill when validating solo-mode PRs, release candidates, GA readiness, or a suspected solo-mode regression. For broad product dogfood that is not solo-specific, use the generic `dogfood` skill. Future shared-mode validation should live in a separate `dogfood-shared` skill rather than diluting this one.
+
+Terminology: "AI agent" means the coding/operator agent doing the dogfood run. "devopsellence node agent" means the runtime reconciler installed on the VM.
+
+## Core Rules
+
+- Scope this skill to `devopsellence init --mode solo` and solo node workflows.
+- Evaluate from the AI-agent-mediated perspective: can an AI agent deploy, diagnose, recover, and explain without guessing?
+- Prefer proof over CLI optimism. A command reporting success is not enough when a URL, container, node, secret, cert, or release can be checked directly.
+- For release/RC validation, use **official CLI and agent artifacts from the exact commit/version**. A local CLI build does not prove the deployed node agent is current.
+- Keep secrets out of terminal history, command logs, reports, PR bodies, and chat. Use stdin and redact values as `[REDACTED]`.
+- Reuse existing dogfood nodes when the user approves and that better matches the scenario; otherwise prefer run-scoped disposable resources.
+- Record every meaningful command and outcome in `commands.log` as the run proceeds.
+- Every material finding must ratchet into at least one durable artifact: regression test, product issue, docs update, skill update, or follow-up PR.
+
+## When to Use
+
+Use this skill for:
+
+- Solo-mode GA/release-readiness validation.
+- PRs touching solo deploy, status, logs, exec, ingress, secrets, release history, rollback, node attach/detach, desired state, or agent reconciliation.
+- Live validation of TLS auto/ACME, co-hosted projects, multiple environments on one node, secret isolation, rollback, dry-run boundaries, restart/reboot recovery, and cleanup.
+- Investigating whether an AI agent can safely operate devopsellence solo without source-code knowledge.
+
+Do not use this skill for:
+
+- Shared/control-plane-first validation. Create/use `dogfood-shared` later.
+- Pure browser UI QA.
+- Unit-test-only verification with no live/runtime claim.
+
+## Run Types
+
+Pick the smallest run type that answers the user’s request.
+
+### PR-focused solo probe
+
+Use when a PR touches one solo-mode surface. Run focused tests plus the relevant live probe(s). It is acceptable to use a local CLI build if the PR only changes CLI-side behavior and the report clearly says so.
+
+### RC/release solo validation
+
+Use before calling a solo release candidate validated. Requirements:
+
+1. Build or download official CLI and agent artifacts from the target commit/version.
+2. Install the official CLI locally.
+3. Install the official devopsellence node agent on every dogfood node.
+4. Verify both binaries report the expected version/commit.
+5. Force at least one fresh workload revision after artifact install.
+6. Run the full high-value solo probe matrix.
+
+### Incident/regression reproduction
+
+Use when a user reports a solo-mode bug. Reproduce with evidence, isolate root cause after blind evidence is captured, add a regression test when fixing, and re-run the narrow live probe.
+
+## Workflow
+
+1. Create run artifact.
+   - Prefer `mise exec -- ruby .agents/skills/dogfood-solo/scripts/new_run.rb <scenario>` from repo root when Ruby is managed by mise; plain `ruby ...` is fine when Ruby is already on `PATH`.
+   - Use the printed run directory for `commands.log`, `report.md`, and evidence files.
+   - If validating a version, pass `--version <version>`.
+   - If validating a commit/PR, include the SHA/PR in the scenario name or report header.
+
+2. Preflight.
+   - Record repo branch/SHA, PR URL if any, target devopsellence version, and whether this is local-build or official-artifact validation.
+   - Check `devopsellence --version` and, for live nodes, `/usr/local/bin/devopsellence-agent --version` or equivalent.
+   - Identify the node strategy: existing approved node, zirk VM, provider-created VM, or user-provided SSH host.
+   - Record resource names, expected cost/blast radius, approval state, and cleanup command before provisioning or destructive cleanup.
+
+3. Prepare solo apps/environments.
+   - At minimum use one app in `production`.
+   - For co-hosting readiness, use a second project on the same node with a distinct hostname.
+   - For multi-env readiness, use `production` and `staging` for one project on the same node with distinct hostnames.
+   - Use hostnames that genuinely resolve to the node for TLS/DNS tests. IP-based wildcard DNS such as `x-x-x-x.sslip.io` is acceptable.
+
+4. Run the high-value solo probe matrix.
+   - Use `references/checklist.md` as the scenario checklist.
+   - Prefer structured CLI output when available.
+   - Verify runtime truth with curls, SSH/Docker observations, status/logs, and node-agent logs when appropriate.
+
+5. Expert pass and fixes.
+   - Only after blind/operator evidence is captured, inspect implementation, tests, state files, desired-state payloads, and node logs.
+   - If fixing code, add regression coverage before or with the fix.
+   - Re-run focused tests, broader relevant suites, and the narrow live probe that failed.
+
+6. Report.
+   - Use `references/report-template.md`.
+   - Lead with verdict: ready, ready-with-known-gaps, blocked, or inconclusive.
+   - Include what was actually verified, what was skipped, and why.
+   - Link PRs/issues and evidence files.
+
+## High-Value Solo Probe Areas
+
+Treat these as the core solo readiness surfaces:
+
+- **Official artifact reality:** CLI and node agent must both come from the intended version/commit for release validation.
+- **TLS auto/ACME:** DNS correctness, HTTP-01 issuance, HTTPS curl success, HTTP→HTTPS redirect, restart/reuse, reboot recovery.
+- **Manual TLS honesty:** do not count `tls.mode: manual` as dogfooded unless there is a documented cert/key provisioning path and live HTTPS proof.
+- **Co-hosted projects:** two projects on one node with distinct hosts; verify routing, status, logs, exec, release list, rollback, detach/reattach.
+- **Multiple environments:** production and staging on one node; verify env-specific ingress, secrets, releases, exec, status, and rollback.
+- **Secret isolation:** same secret name across production, staging, and another project; verify values stay isolated without printing them.
+- **Rollback semantics:** rollback should republish the stored historical release snapshot and should not mark the selected release current until publication succeeds.
+- **Rollout freshness:** a settled status for the same desired-state revision can be stale; require fresh status evidence when available.
+- **Dry-run boundary:** deploy/rollback dry-run must not build, publish, SSH, mutate release state, or write local state.
+- **DNS honesty:** bad hostnames should produce clear structured missing-IP evidence rather than false readiness.
+- **Diagnostics:** `status`, `logs`, `exec`, `node logs`, `node diagnose`, and `release list` should target the selected logical environment even when runtime environment names are project-scoped.
+- **Cleanup/recovery:** detach/remove one co-hosted project without breaking others; restart agent; reboot node; verify all expected endpoints after recovery.
+
+## Release Blockers
+
+Block a solo release or mark the PR not ready if any of these are true:
+
+- CLI reports success while endpoint/container/node status proves the deploy failed.
+- HTTPS URLs are presented as ready before TLS is actually reachable.
+- Current/effective environment is ignored by solo commands.
+- Co-hosted projects/environments collide in runtime names, routes, secrets, status, logs, exec, releases, or rollback.
+- Rollback mutates persistent current-release state before successful publication.
+- Stale node-agent status can satisfy a fresh rollout.
+- Dry-run performs side effects.
+- Secret values leak in output, logs, release snapshots, reports, or command history.
+- Cleanup cannot identify or remove resources created during the run.
+
+## Finding Handling
+
+For each finding, classify it as one of:
+
+- **Bug:** implementation contradicts expected behavior; add or request regression coverage.
+- **Product gap:** behavior may be intentional but blocks safe AI-agent operation; open an issue with acceptance criteria.
+- **Docs gap:** workflow works but cannot be discovered from public docs/help/output.
+- **Test gap:** behavior works now but lacks coverage for a class of regression.
+- **Skill/process gap:** the dogfood process missed something; update this skill or references.
+
+## Output Shape
+
+Final response to the user should be concise:
+
+- run path
+- verdict
+- top findings/blockers
+- fixes/tests, if any
+- live evidence summary
+- PR/issue links
+- remaining risks
+
+Write the full report to the run artifact.

--- a/.agents/skills/dogfood-solo/agents/openai.yaml
+++ b/.agents/skills/dogfood-solo/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Dogfood Solo"
+  short_description: "Solo-mode devopsellence dogfood and release-readiness runs"
+  default_prompt: "Dogfood devopsellence solo mode from the perspective of an AI coding/operator agent: validate official artifacts when release-readiness matters, probe TLS/ACME, co-hosted projects/environments, secrets, rollback, diagnostics, restart/reboot recovery, cleanup, and write an evidence-backed report with blockers and ratchet follow-ups."

--- a/.agents/skills/dogfood-solo/references/checklist.md
+++ b/.agents/skills/dogfood-solo/references/checklist.md
@@ -1,0 +1,220 @@
+# Solo Dogfood Checklist
+
+Use this checklist as a menu, not a bureaucracy. For PR-focused probes, run only the affected sections plus any adjacent high-risk surfaces. For RC/release validation, run the full checklist with official artifacts.
+
+## 0. Preflight
+
+- [ ] Create run artifact with `mise exec -- ruby .agents/skills/dogfood-solo/scripts/new_run.rb <scenario>` when Ruby is managed by mise; use plain `ruby ...` if Ruby is already on `PATH`.
+- [ ] Record branch, SHA, PR, target version, and validation mode.
+- [ ] Confirm whether this is local-build validation or official-artifact validation.
+- [ ] Record node strategy: existing approved node, zirk VM, provider VM, or user-provided SSH host.
+- [ ] Record cleanup plan before creating/deleting resources.
+- [ ] Confirm no secrets will be printed or persisted in reports.
+
+Useful commands:
+
+```sh
+git status --short --branch
+git rev-parse HEAD
+gh pr view <number> --json number,url,headRefOid,reviewDecision,statusCheckRollup || true
+devopsellence --version || true
+devopsellence mode show || true
+devopsellence context show || true
+```
+
+## 1. Official Artifact Reality
+
+Required for RC/release validation.
+
+- [ ] Download/install official CLI artifact for the exact target version/commit.
+- [ ] Download/install official node-agent artifact on every dogfood node.
+- [ ] Verify CLI version/commit.
+- [ ] Verify node-agent version/commit.
+- [ ] Force a fresh workload revision after artifact install.
+
+Do not treat `cli/scripts/release-local.sh` as proof of node-agent behavior; it builds/installs the CLI only.
+
+## 2. Solo Deploy Baseline
+
+- [ ] Initialize or verify solo mode.
+- [ ] Attach/create/install a node.
+- [ ] Run `doctor` before deploy.
+- [ ] Deploy a fresh revision.
+- [ ] Verify CLI-reported status and runtime endpoint health.
+- [ ] Verify logs and exec for the deployed service.
+
+Useful commands:
+
+```sh
+devopsellence init --mode solo
+devopsellence doctor
+devopsellence deploy
+devopsellence status
+devopsellence logs --node <node> --lines 100
+devopsellence exec <service> -- <command>
+curl -fsS <url>/up
+```
+
+## 3. TLS Auto / ACME
+
+- [ ] Use a real hostname resolving to the node; `sslip.io` hostnames are acceptable.
+- [ ] Configure `tls.mode: auto`, TLS email, and `redirect_http` when testing redirect.
+- [ ] Run ingress check and record DNS result.
+- [ ] Deploy and wait for settled status.
+- [ ] Verify HTTPS with `curl`.
+- [ ] Verify HTTP redirects to HTTPS when enabled.
+- [ ] Scan node-agent logs from the relevant time for ACME success/failure.
+- [ ] Restart devopsellence node agent and verify cert reuse/endpoints.
+- [ ] Reboot node and verify endpoints recover.
+
+Evidence markers:
+
+```text
+acme certificate ready
+curl https://<host>/up -> success
+curl -I http://<host>/... -> 301/308 Location: https://...
+```
+
+## 4. Manual TLS Honesty
+
+- [ ] Check whether the CLI/docs expose a cert/key provisioning path.
+- [ ] If no cert/key install path exists, mark as known product gap; do not claim dogfood success.
+- [ ] If a path exists, install cert/key material without logging secrets/private key data.
+- [ ] Deploy and verify `curl https://<host>/up` succeeds.
+- [ ] Verify missing/invalid cert material produces clear status/warnings.
+
+Known gap from 2026-04 dogfood: `tls.mode: manual` was exposed, but no clear solo cert/key provisioning path was found. See issue #95.
+
+## 5. Multi-Project Co-hosting
+
+- [ ] Deploy project A to node with hostname A.
+- [ ] Deploy project B to same node with hostname B.
+- [ ] Verify both HTTPS endpoints return the expected app.
+- [ ] Verify `status` shows settled state without route/env collision.
+- [ ] Verify `logs` and `exec` target the right project's containers.
+- [ ] Verify `release list` and rollback for at least one co-hosted project.
+- [ ] Detach/remove one project and verify the other remains healthy.
+- [ ] Reattach/redeploy removed project and verify all endpoints recover.
+
+Failure classes to watch:
+
+- duplicate route validation
+- ingress TLS/redirect merge mismatch
+- raw `production` runtime-name collisions
+- logs/exec selecting no or wrong containers
+- stale rollout status accepted after reattach/redeploy
+
+## 6. Multi-Environment on One Node
+
+- [ ] Configure production and staging for one project with distinct hostnames.
+- [ ] Attach both environments to the same node.
+- [ ] Set environment-specific secrets.
+- [ ] Deploy production and staging.
+- [ ] Verify each host routes to the expected environment.
+- [ ] Verify `DEVOPSELLENCE_ENVIRONMENT=staging` or current context is honored by status/logs/exec/secrets/release list/rollback.
+- [ ] Roll back staging and verify production is unaffected.
+
+Failure classes to watch:
+
+- commands defaulting to production when staging is selected
+- duplicate route from unresolved/default hostname
+- secrets stored/listed/deleted in wrong environment
+- release list or rollback using default config instead of current env
+
+## 7. Secret Isolation
+
+- [ ] Use the same secret name across production, staging, and a second project.
+- [ ] Set secrets via stdin; never put values directly in shell history.
+- [ ] Deploy after secret changes.
+- [ ] Verify inside each environment that the value is the expected redacted category, without printing raw values to the report.
+- [ ] Re-check earlier environments after deploying another project.
+
+Useful pattern:
+
+```sh
+printf '%s' "$VALUE" | devopsellence secret set DOGFOOD_SECRET --service web --stdin --env staging
+devopsellence secret list --env staging
+devopsellence deploy
+devopsellence exec web -- printenv DOGFOOD_SECRET
+```
+
+Report values as `[REDACTED: app production]`, not plaintext.
+
+## 8. Release List and Rollback
+
+- [ ] Create at least two releases in the target environment.
+- [ ] Confirm `release list` reports the selected logical environment.
+- [ ] Roll back one environment while another environment/project is co-hosted.
+- [ ] Verify current release changed only after successful publication.
+- [ ] Verify endpoints stay healthy.
+- [ ] If inducing failure, verify previous current release remains current.
+
+Watch for rollback rebuilding from current `devopsellence.yml` instead of the stored historical snapshot.
+
+## 9. Dry-Run / Plan Boundary
+
+- [ ] Run deploy dry-run and rollback dry-run where available.
+- [ ] Verify no build, publish, SSH, release mutation, deployment mutation, or state write occurred.
+- [ ] Compare release list/state before and after.
+
+Evidence marker from prior run:
+
+```text
+build: false
+publish: false
+ssh: false
+state_write: false
+```
+
+## 10. DNS Honesty
+
+- [ ] Run ingress check for a valid hostname.
+- [ ] Run ingress check for an intentionally bad hostname such as `example.com` when safe.
+- [ ] Verify output shows resolved IPs and missing expected node IP.
+- [ ] Ensure deploy/status does not imply ready HTTPS when DNS/TLS is not ready.
+
+Evidence shape:
+
+```json
+{
+  "ok": false,
+  "missing": ["<node-ip>"]
+}
+```
+
+## 11. Restart / Reboot Recovery
+
+- [ ] Capture status and endpoint health before restart.
+- [ ] Restart `devopsellence-agent` or equivalent node-agent service.
+- [ ] Verify all co-hosted endpoints recover.
+- [ ] Trigger full node reboot only with user approval.
+- [ ] Poll node reachability/status after reboot.
+- [ ] Verify every expected endpoint and selected secrets/releases after reboot.
+
+A reboot command timing out is inconclusive; the proof is post-reboot status and endpoint health.
+
+## 12. Diagnostics and Agent-Primary Output
+
+- [ ] Check whether bounded commands produce one machine-readable result where expected.
+- [ ] Check whether long commands produce parseable event streams.
+- [ ] Check structured error shape: code, message, exit code, suggested next action/evidence fields.
+- [ ] Avoid making decisions from prose-only spinners/styled text when structured output should exist.
+
+Commands to probe:
+
+```sh
+devopsellence status
+devopsellence logs --node <node> --lines 100
+devopsellence node logs <node> --lines 100
+devopsellence node diagnose <node>
+devopsellence release list --limit 5
+devopsellence exec <service> -- <command>
+```
+
+## 13. Report and Ratchet
+
+- [ ] Summarize verdict and confidence.
+- [ ] Link evidence files.
+- [ ] Convert every material finding into a regression test, issue, docs update, skill update, or follow-up PR.
+- [ ] Confirm cleanup state.
+- [ ] If PR-related, update PR body/comment with tests and dogfood evidence.

--- a/.agents/skills/dogfood-solo/references/commands-log-template.md
+++ b/.agents/skills/dogfood-solo/references/commands-log-template.md
@@ -1,0 +1,33 @@
+# Commands Log
+
+Scenario: {{scenario}}
+Target version/commit: {{target_version}}
+Validation mode: <local-build | official-artifact | installed-stable | unknown>
+Run started: <UTC timestamp>
+Run directory: <path>
+
+Keep this file redacted. Never paste raw tokens, secret values, private SSH keys, or plaintext secret outputs.
+
+## Step Template
+
+### <step number>. <short title>
+
+- Time: <UTC timestamp>
+- Working directory: `<path>`
+- AI-agent intent: <what this command proves or changes>
+- Approval state: <not required | approved by user | blocked waiting approval>
+- Command:
+
+```sh
+<redacted command>
+```
+
+- Exit code: `<code>`
+- Evidence excerpt:
+
+```text
+<minimal redacted output or JSON excerpt>
+```
+
+- Interpretation: <what the AI agent can conclude, and what remains uncertain>
+- Follow-up: <none | command/test/issue/fix>

--- a/.agents/skills/dogfood-solo/references/report-template.md
+++ b/.agents/skills/dogfood-solo/references/report-template.md
@@ -1,0 +1,95 @@
+# devopsellence Solo Dogfood Report
+
+Scenario:
+Target version/commit:
+Validation mode:
+Date:
+Commit:
+Run path:
+Node(s):
+Hostnames:
+PR/issue links:
+
+## Verdict
+
+- Verdict: <ready | ready with known gaps | blocked | inconclusive>
+- One-line reason:
+
+## Executive Summary
+
+<What was validated, what failed, what changed, and what remains.>
+
+## Evidence Index
+
+- Commands log: `commands.log`
+- Versions/artifacts:
+- Deploy/status evidence:
+- Endpoint checks:
+- Logs/diagnostics:
+- Issues/PRs:
+
+## Probe Matrix
+
+| Probe | Result | Evidence | Notes |
+| --- | --- | --- | --- |
+| Official CLI artifact/version | PASS/FAIL/SKIPPED |  |  |
+| Official node-agent artifact/version | PASS/FAIL/SKIPPED |  |  |
+| Solo deploy fresh revision | PASS/FAIL/SKIPPED |  |  |
+| TLS auto / ACME | PASS/FAIL/SKIPPED |  |  |
+| HTTP -> HTTPS redirect | PASS/FAIL/SKIPPED |  |  |
+| Manual TLS operability | PASS/FAIL/SKIPPED/KNOWN GAP |  |  |
+| Multi-project co-hosting | PASS/FAIL/SKIPPED |  |  |
+| Multi-env co-hosting | PASS/FAIL/SKIPPED |  |  |
+| Secret isolation | PASS/FAIL/SKIPPED |  |  |
+| status/logs/exec diagnostics | PASS/FAIL/SKIPPED |  |  |
+| release list / rollback | PASS/FAIL/SKIPPED |  |  |
+| Dry-run side-effect boundary | PASS/FAIL/SKIPPED |  |  |
+| DNS honesty | PASS/FAIL/SKIPPED |  |  |
+| Detach/reattach | PASS/FAIL/SKIPPED |  |  |
+| Agent restart recovery | PASS/FAIL/SKIPPED |  |  |
+| Full node reboot recovery | PASS/FAIL/SKIPPED |  |  |
+| Cleanup verified | PASS/FAIL/SKIPPED |  |  |
+
+## Findings
+
+### 1. <title>
+
+- Severity: <blocker | high | medium | low>
+- Type: <bug | product gap | docs gap | test gap | skill/process gap>
+- Surface: <CLI | node agent | deploy core | state | docs | installer | diagnostics | cleanup>
+- Expected:
+- Actual:
+- Reproduction/evidence:
+- Suggested fix:
+- Ratchet artifact: <test | issue | docs | skill update | PR>
+
+## Fixes Made During Run
+
+- <commit/test/PR summary or none>
+
+## Tests Run
+
+```text
+<commands and outcomes>
+```
+
+## Live Runtime Verification
+
+```text
+<endpoint/status/log summaries, redacted>
+```
+
+## Skipped / Not Probed
+
+- <probe>: <why skipped and whether it matters>
+
+## Cleanup
+
+- Resources created:
+- Cleanup commands:
+- Cleanup verification:
+- Remaining resources/risk:
+
+## Release Decision Notes
+
+<Whether this should block merge/release, what can be follow-up, and why.>

--- a/.agents/skills/dogfood-solo/scripts/new_run.rb
+++ b/.agents/skills/dogfood-solo/scripts/new_run.rb
@@ -1,0 +1,137 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "fileutils"
+require "open3"
+require "optparse"
+require "time"
+require "tmpdir"
+
+options = {
+  root: Dir.pwd,
+  out: File.join(Dir.tmpdir, "devopsellence-dogfood-solo"),
+  version: nil,
+  mode: nil
+}
+
+parser = OptionParser.new do |opts|
+  opts.banner = "Usage: new_run.rb SCENARIO [--version VERSION] [--mode MODE] [--root PATH] [--out PATH]"
+  opts.on("--version VERSION", "devopsellence version/commit/PR to dogfood; omit when unknown") { |value| options[:version] = value }
+  opts.on("--mode MODE", "validation mode: local-build, official-artifact, installed-stable, or unknown") { |value| options[:mode] = value }
+  opts.on("--root PATH", "Repository root used for git metadata") { |value| options[:root] = value }
+  opts.on("--out PATH", "Parent output directory") { |value| options[:out] = value }
+end
+
+begin
+  parser.parse!
+rescue OptionParser::ParseError => e
+  warn e.message
+  warn parser
+  exit 64
+end
+
+options[:out] = File.expand_path(options[:out])
+options[:root] = File.expand_path(options[:root])
+
+scenario = ARGV.join(" ").strip
+if scenario.empty?
+  warn parser
+  exit 64
+end
+if scenario.match?(/[[:cntrl:]]/)
+  warn "SCENARIO must not contain control characters"
+  warn parser
+  exit 64
+end
+
+slug = scenario.downcase.gsub(/[^a-z0-9]+/, "-").gsub(/\A-|-+\z/, "")
+if slug.empty?
+  warn "SCENARIO must contain at least one letter or digit after normalization"
+  warn parser
+  exit 64
+end
+
+def clean_option!(name, value, pattern)
+  return nil if value.nil?
+
+  value = value.strip
+  if value.empty?
+    warn "#{name} must not be empty"
+    exit 64
+  end
+  if value.match?(/[[:cntrl:]]/) || !value.match?(pattern)
+    warn "#{name} contains unsupported characters"
+    exit 64
+  end
+  value
+end
+
+version = clean_option!("VERSION", options[:version], /\A[A-Za-z0-9][A-Za-z0-9._\/-]*\z/)
+mode = clean_option!("MODE", options[:mode], /\A[A-Za-z0-9][A-Za-z0-9._-]*\z/) || "unknown"
+target_version = version || "unspecified"
+
+now = Time.now.utc
+timestamp = now.strftime("%Y%m%dT%H%M%S%6NZ")
+run_dir = File.expand_path("#{timestamp}-#{slug}", options[:out])
+
+def git_value(root, *args)
+  stdout, status = Open3.capture2("git", *args, chdir: root)
+  status.success? ? stdout.strip : "unknown"
+rescue SystemCallError
+  "unknown"
+end
+
+def exit_filesystem_error(action, path, error)
+  warn "#{action} #{path}: #{error.message}"
+  exit 73
+end
+
+commit = git_value(options[:root], "rev-parse", "--short", "HEAD")
+branch = git_value(options[:root], "branch", "--show-current")
+branch = "detached" if branch.empty?
+
+skill_root = File.expand_path("..", __dir__)
+report_template_path = File.join(skill_root, "references", "report-template.md")
+commands_template_path = File.join(skill_root, "references", "commands-log-template.md")
+
+begin
+  report = File.read(report_template_path)
+rescue SystemCallError => e
+  exit_filesystem_error("failed to read", report_template_path, e)
+end
+
+report = report
+  .sub("Scenario:", "Scenario: #{scenario}")
+  .sub("Target version/commit:", "Target version/commit: #{target_version}")
+  .sub("Validation mode:", "Validation mode: #{mode}")
+  .sub("Date:", "Date: #{now.iso8601}")
+  .sub("Commit:", "Commit: #{commit} (#{branch})")
+  .sub("Run path:", "Run path: #{run_dir}")
+
+begin
+  commands_template = File.read(commands_template_path)
+rescue SystemCallError => e
+  exit_filesystem_error("failed to read", commands_template_path, e)
+end
+
+commands_log = commands_template
+  .gsub("{{scenario}}", scenario)
+  .gsub("{{target_version}}", target_version)
+  .sub("Validation mode: <local-build | official-artifact | installed-stable | unknown>", "Validation mode: #{mode}")
+  .sub("Run started: <UTC timestamp>", "Run started: #{now.iso8601}")
+  .sub("Run directory: <path>", "Run directory: #{run_dir}")
+
+begin
+  FileUtils.mkdir_p(options[:out])
+  Dir.mkdir(run_dir)
+  File.write(File.join(run_dir, "report.md"), report)
+  File.write(File.join(run_dir, "commands.log"), commands_log)
+  FileUtils.mkdir_p(File.join(run_dir, "evidence"))
+rescue Errno::EEXIST
+  warn "run directory already exists: #{run_dir}"
+  exit 73
+rescue SystemCallError => e
+  exit_filesystem_error("failed to create dogfood run", run_dir, e)
+end
+
+puts run_dir


### PR DESCRIPTION
## Summary

Adds a focused `.agents/skills/dogfood-solo` skill for solo-mode devopsellence dogfood and release-readiness runs.

This is intentionally separate from the generic `.agents/skills/dogfood` skill. It captures the high-value process and pitfalls from the solo GA dogfood work in #94, while keeping the scope focused on solo mode. A future `dogfood-shared` skill can use the same pattern for shared/control-plane flows.

## What is included

- `SKILL.md` with the solo-mode dogfood operating model:
  - AI-agent-mediated solo validation
  - PR-focused probes vs RC/release validation
  - official-artifact reality checks
  - release blockers and finding handling
- `references/checklist.md` with a repeatable solo probe matrix:
  - official CLI/node-agent artifacts
  - TLS auto / ACME
  - manual TLS honesty
  - multi-project co-hosting
  - multi-env co-hosting
  - secret isolation
  - release list / rollback
  - dry-run boundaries
  - DNS honesty
  - restart/reboot recovery
  - diagnostics and cleanup
- `references/report-template.md`
- `references/commands-log-template.md`
- `scripts/new_run.rb` to create a run artifact under `/tmp/devopsellence-dogfood-solo`
- `agents/openai.yaml` metadata for agent launchers

## Relationship to #94

Stacked on top of #94 because this skill is derived from that dogfood session, but it is process/documentation only and should be reviewable independently.

## Validation

- Validated `SKILL.md` frontmatter with Ruby/YAML.
- Smoke-tested the run artifact helper using `mise exec -- ruby .agents/skills/dogfood-solo/scripts/new_run.rb ...`.

No product code changes.