### PR TITLE
fix: redact solo support bundle state secrets

### DIFF
--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -4155,6 +4155,26 @@ func (a *App) SoloSupportBundle(_ context.Context, opts SoloSupportBundleOptions
 }
 
 func redactSoloStateForSupport(current solo.State) solo.State {
+	data, err := json.Marshal(current)
+	if err == nil {
+		var clone solo.State
+		if err := json.Unmarshal(data, &clone); err == nil {
+			current = clone
+		}
+	}
+	for key, node := range current.Nodes {
+		if strings.TrimSpace(node.SSHKey) != "" {
+			node.SSHKey = "[REDACTED]"
+		}
+		current.Nodes[key] = node
+	}
+	for key, snapshot := range current.Snapshots {
+		current.Snapshots[key] = redactDeploySnapshotForSupport(snapshot)
+	}
+	for key, release := range current.Releases {
+		release.Snapshot = redactDeploySnapshotForSupport(release.Snapshot)
+		current.Releases[key] = release
+	}
 	for key, record := range current.Secrets {
 		record.Value = "[REDACTED]"
 		if strings.TrimSpace(record.Reference) != "" {
@@ -4163,6 +4183,16 @@ func redactSoloStateForSupport(current solo.State) solo.State {
 		current.Secrets[key] = record
 	}
 	return current
+}
+
+func redactDeploySnapshotForSupport(snapshot desiredstate.DeploySnapshot) desiredstate.DeploySnapshot {
+	for i := range snapshot.Services {
+		snapshot.Services[i].Env = redactStringMapValues(snapshot.Services[i].Env)
+	}
+	if snapshot.ReleaseTask != nil {
+		snapshot.ReleaseTask.Env = redactStringMapValues(snapshot.ReleaseTask.Env)
+	}
+	return snapshot
 }
 
 func redactProjectConfigForSupport(cfg *config.ProjectConfig) *config.ProjectConfig {

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -2848,13 +2848,47 @@ func TestSoloSupportBundleWritesRedactedEvidence(t *testing.T) {
 	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
 	current := solo.State{
 		Nodes: map[string]config.Node{
-			"node-a": {Host: "203.0.113.10", User: "root", Port: 22, Labels: []string{config.DefaultWebRole}},
+			"node-a": {Host: "203.0.113.10", User: "root", Port: 22, SSHKey: "-----BEGIN OPENSSH PRIVATE KEY-----private-key-material", Labels: []string{config.DefaultWebRole}},
 		},
 		Attachments: map[string]solo.AttachmentRecord{},
+		Snapshots:   map[string]desiredstate.DeploySnapshot{},
+		Releases:    map[string]corerelease.Release{},
 		Secrets:     map[string]solo.SecretRecord{},
 	}
 	if _, _, err := current.AttachNode(workspaceRoot, "production", "node-a"); err != nil {
 		t.Fatal(err)
+	}
+	stateKey, err := solo.EnvironmentStateKey(workspaceRoot, "production")
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot := desiredstate.DeploySnapshot{
+		WorkspaceRoot: workspaceRoot,
+		Environment:   "production",
+		Revision:      "abc1234",
+		Image:         "demo:abc1234",
+		Services: []desiredstate.ServiceJSON{{
+			Name:  config.DefaultWebServiceName,
+			Image: "demo:abc1234",
+			Env: map[string]string{
+				"APP_REVISION":        "snapshot-inline-value",
+				"SNAPSHOT_SECRET_ENV": "snapshot-secret-value",
+			},
+		}},
+		ReleaseTask: &desiredstate.TaskJSON{
+			Name:  "release",
+			Image: "demo:abc1234",
+			Env:   map[string]string{"RELEASE_INLINE": "snapshot-release-value"},
+		},
+	}
+	current.Snapshots[stateKey] = snapshot
+	current.Releases["rel-abc1234"] = corerelease.Release{
+		ID:            "rel-abc1234",
+		EnvironmentID: stateKey,
+		Revision:      "abc1234",
+		Snapshot:      snapshot,
+		Image:         corerelease.ImageRef{Reference: "demo:abc1234"},
+		CreatedAt:     time.Now().UTC().Format(time.RFC3339Nano),
 	}
 	if _, err := current.SetSecret(workspaceRoot, "production", config.DefaultWebServiceName, "DEMO_SECRET", solo.SecretMaterial{Store: solo.SecretStorePlaintext, Value: "super-secret-value"}); err != nil {
 		t.Fatal(err)
@@ -2877,7 +2911,18 @@ func TestSoloSupportBundleWritesRedactedEvidence(t *testing.T) {
 		t.Fatal(err)
 	}
 	text := string(data)
-	for _, forbidden := range []string{"super-secret-value", "op://vault/item/field", "inline-config-secret", "op://config/item/field", "release-config-secret", "staging-config-secret"} {
+	for _, forbidden := range []string{
+		"super-secret-value",
+		"op://vault/item/field",
+		"inline-config-secret",
+		"op://config/item/field",
+		"release-config-secret",
+		"staging-config-secret",
+		"-----BEGIN OPENSSH PRIVATE KEY-----private-key-material",
+		"snapshot-inline-value",
+		"snapshot-secret-value",
+		"snapshot-release-value",
+	} {
 		if strings.Contains(text, forbidden) {
 			t.Fatalf("support bundle leaked %q: %s", forbidden, text)
 		}


### PR DESCRIPTION
## Summary

Fixes #98.

Redacts additional sensitive fields from solo support bundles:

- `solo_state.nodes.*.ssh_key`
- `solo_state.snapshots.*.services[].env.*`
- `solo_state.snapshots.*.release_task.env.*`
- `solo_state.releases.*.snapshot.services[].env.*`
- `solo_state.releases.*.snapshot.release_task.env.*`

The support bundle still preserves topology/release metadata needed for debugging, but no longer emits raw env values or inline SSH key material while claiming `redacted: true`.

## Test plan

- Watched regression fail before implementation:
  - `mise exec -- go test ./internal/workflow -run TestSoloSupportBundleWritesRedactedEvidence -count=1 -v`
- Focused support bundle tests:
  - `mise exec -- go test ./internal/workflow -run 'TestSoloSupportBundle' -count=1 -v`
- Relevant CLI suites:
  - `mise exec -- go test ./internal/...`
  - `mise exec -- go test ./...`
- Local CLI release:
  - `cli/scripts/release-local.sh`
  - `devopsellence --version` => `dev (e0dfa5a, 2026-04-29T12:51:59Z)`
- Focused local-release dogfood:
  - sample API support bundle scan: 72 sensitive/env fields, 0 violations
  - sample app support bundle scan: 75 sensitive/env fields, 0 violations
  - known inline marker scan: 0 hits

## Dogfood evidence

Run directory:

`/tmp/devopsellence-dogfood-solo/20260429T125209895062Z-support-bundle-redaction-local`

Report:

`/tmp/devopsellence-dogfood-solo/20260429T125209895062Z-support-bundle-redaction-local/report.md`
