### PR TITLE
fix: retain detached solo images for reattach

### DIFF
--- a/agent/internal/diskcare/diskcare.go
+++ b/agent/internal/diskcare/diskcare.go
@@ -413,20 +413,20 @@ func retainedReleaseKeys(releases []releaseRecord, current []releaseRecord, keep
 		keepPerEnvironment = 0
 	}
 	retained := map[string]struct{}{}
-	currentEnvironments := map[string]struct{}{}
 	for _, release := range current {
 		retained[releaseKey(release.Environment, release.Revision)] = struct{}{}
-		currentEnvironments[strings.TrimSpace(release.Environment)] = struct{}{}
 	}
 	byEnvironment := map[string][]releaseRecord{}
 	for _, release := range releases {
 		environment := strings.TrimSpace(release.Environment)
 		byEnvironment[environment] = append(byEnvironment[environment], release)
 	}
-	for environment, envReleases := range byEnvironment {
-		if _, ok := currentEnvironments[environment]; !ok {
-			continue
-		}
+	for _, envReleases := range byEnvironment {
+		// Retain the newest local releases even when an environment is absent
+		// from the current desired state. A solo detach publishes an empty
+		// desired state to clear containers; pruning the image immediately makes
+		// a later reattach + same-revision deploy race with cleanup and fail
+		// before the CLI has a chance to republish that exact image.
 		sort.SliceStable(envReleases, func(i, j int) bool {
 			return envReleases[i].LastSeenAt.After(envReleases[j].LastSeenAt)
 		})

--- a/agent/internal/diskcare/diskcare_test.go
+++ b/agent/internal/diskcare/diskcare_test.go
@@ -221,14 +221,46 @@ func TestRetainedReleaseKeysNormalizesEnvironmentNames(t *testing.T) {
 	}
 }
 
-func TestRetainedReleaseKeysDropsDeletedEnvironments(t *testing.T) {
+func TestRetainedReleaseKeysPrunesOlderAbsentEnvironmentReleases(t *testing.T) {
+	older := time.Now().Add(-time.Hour)
+	newer := time.Now()
 	releases := []releaseRecord{
-		{Environment: "deleted", Revision: "rev-1", Images: []string{"app:rev1"}, LastSeenAt: time.Now()},
+		{Environment: "deleted", Revision: "rev-1", Images: []string{"app:rev1"}, LastSeenAt: older},
+		{Environment: "deleted", Revision: "rev-2", Images: []string{"app:rev2"}, LastSeenAt: newer},
 	}
 
 	retained := retainedReleaseKeys(releases, nil, 1)
-	if len(retained) != 0 {
-		t.Fatalf("retained = %#v, want none for deleted environments", retained)
+	if _, ok := retained[releaseKey("deleted", "rev-2")]; !ok {
+		t.Fatal("expected newest absent-environment release to stay inside retention")
+	}
+	if _, ok := retained[releaseKey("deleted", "rev-1")]; ok {
+		t.Fatal("expected older absent-environment release to fall outside retention")
+	}
+}
+
+func TestRunRetainsDetachedEnvironmentImagesInsideRetentionWindow(t *testing.T) {
+	dir := t.TempDir()
+	statePath := filepath.Join(dir, "disk-care-state.json")
+	initial := &store{Releases: []releaseRecord{
+		{Environment: "production", Revision: "rev-1", Images: []string{"app:rev1"}, LastSeenAt: time.Now().Add(-time.Minute)},
+	}}
+	eng := &fakeEngine{
+		images:        []engine.ImageState{{ID: "sha256:1", RepoTags: []string{"app:rev1"}, Size: 100}},
+		containers:    []engine.ContainerState{},
+		logPaths:      map[string]string{},
+		removeResults: map[string][]engine.ImageDelete{"app:rev1": {{Deleted: "sha256:1"}}},
+	}
+	mgr := New(eng, Config{StatePath: statePath, RetainedPreviousReleases: 1}, nil)
+	if err := mgr.saveStore(initial); err != nil {
+		t.Fatalf("save store: %v", err)
+	}
+
+	_, err := mgr.Run(context.Background(), &desiredstatepb.DesiredState{SchemaVersion: 2, Revision: "empty"})
+	if err != nil {
+		t.Fatalf("run detached state: %v", err)
+	}
+	if len(eng.removed) != 0 {
+		t.Fatalf("removed = %#v, want none; detached environments must retain recent images so reattach + same-revision deploy can recover", eng.removed)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fixes solo detach -> attach -> same-revision deploy failures caused by node-agent disk-care pruning detached environment images too aggressively.
- Retains the newest local release records per known environment even when that environment is temporarily absent from desired state.
- Adds regression coverage proving detached-environment images stay inside retention while older absent-environment releases remain prunable.

Closes #100

## Root cause
A solo `node detach` publishes desired state without the detached environment so the node clears containers. Disk-care previously only retained releases for environments present in the current desired state, so it could remove the detached environment's image. A later `node attach` + same-revision `deploy` could then fail during rollout with `image not found locally`.

## Test plan
- [x] `cd agent && mise exec -- go test ./internal/diskcare -run 'TestRetainedReleaseKeysPrunesOlderAbsentEnvironmentReleases|TestRunRetainsDetachedEnvironmentImagesInsideRetentionWindow|TestRetainedReleaseKeysNormalizesEnvironmentNames' -count=1 -v`
- [x] `cd agent && mise exec -- go test ./...`
- [x] `cd deployment-core && mise exec -- go test ./...`
- [x] `cd cli && mise exec -- go test ./...`
- [x] `cli/scripts/release-local.sh`
- [x] Local agent release build: `DEVOPSELLENCE_RELEASE_VERSION=dev-issue-100 ... mise run release:build:agent`

## Dogfood
Focused run: `/tmp/devopsellence-dogfood-solo/20260429T150030355173Z-issue-100-local-agent-fix`

Evidence:
- `tests.txt`
- `install-fixed-agent.txt`
- `detach-attach-same-revision-fixed.txt`
- `report.md`

Live validation on existing solo node `hcloud-1` with a locally built fixed agent:
- Verified current API image existed before detach.
- Ran `devopsellence node detach hcloud-1` for sample API production.
- Waited for detach reconciliation / disk-care pass.
- Verified the same remote Docker image still existed after detach.
- Verified co-hosted sample app prod/staging endpoints stayed healthy (`200`).
- Ran `devopsellence node attach hcloud-1`.
- Ran same-revision `devopsellence deploy` with no source/config revision change.
- Deploy settled and API `/up` returned `200`.

## Caveat
This PR changes the node-agent. Local dogfood installed a locally built `dev-issue-100` agent on `hcloud-1`; official preview validation still requires rebuilding/publishing official artifacts and reinstalling the released agent before claiming `v0.2.0-preview` includes this fix.