### PR TITLE
fix: add solo manual tls provisioning and exec env selection

### DIFF
--- a/cli/internal/workflow/root.go
+++ b/cli/internal/workflow/root.go
@@ -562,6 +562,7 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 
 	var ingressSetOpts IngressSetOptions
 	var ingressCheckOpts IngressCheckOptions
+	var ingressCertInstallOpts SoloIngressCertInstallOptions
 	ingressCommand := &cobra.Command{
 		Use:   "ingress",
 		Short: "Manage public hostnames and TLS",
@@ -594,7 +595,27 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 		}),
 	}
 	ingressCheckCommand.Flags().DurationVar(&ingressCheckOpts.Wait, "wait", 0, "Poll until DNS is ready or this timeout elapses")
-	ingressCommand.AddCommand(ingressSetCommand, ingressCheckCommand)
+	ingressCertCommand := &cobra.Command{
+		Use:   "cert",
+		Short: "Manage manual ingress TLS certificates",
+	}
+	ingressCertInstallCommand := &cobra.Command{
+		Use:   "install",
+		Short: "Install manual TLS certificate files on solo nodes",
+		Long: strings.Join([]string{
+			"Install manual TLS certificate files on selected solo nodes.",
+			"The devopsellence solo agent reads manual TLS files from /var/lib/devopsellence/ingress-cert.pem and /var/lib/devopsellence/ingress-key.pem by default.",
+			"After installing the files, configure ingress with `devopsellence ingress set --tls-mode manual --host <hostname>` and deploy/redeploy so the agent reconciles Envoy with HTTPS enabled.",
+		}, "\n"),
+		RunE: runSoloOnly("ingress cert install", func(ctx context.Context) error {
+			return app.SoloIngressCertInstall(ctx, ingressCertInstallOpts)
+		}),
+	}
+	ingressCertInstallCommand.Flags().StringVar(&ingressCertInstallOpts.CertFile, "cert-file", "", "Local PEM certificate chain file to install")
+	ingressCertInstallCommand.Flags().StringVar(&ingressCertInstallOpts.KeyFile, "key-file", "", "Local PEM private key file to install")
+	ingressCertInstallCommand.Flags().StringSliceVar(&ingressCertInstallOpts.Nodes, "node", nil, "Solo node name to install on (repeatable or comma-separated)")
+	ingressCertCommand.AddCommand(ingressCertInstallCommand)
+	ingressCommand.AddCommand(ingressSetCommand, ingressCheckCommand, ingressCertCommand)
 	root.AddCommand(ingressCommand)
 
 	var statusSharedOpts StatusOptions
@@ -1073,6 +1094,7 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 			})(cmd, args)
 		},
 	}
+	execCommand.Flags().StringVar(&workloadExecOpts.Environment, "env", "", "Environment name override")
 	execCommand.Flags().StringSliceVar(&workloadExecOpts.Nodes, "node", nil, "Solo node name to run exec on (repeatable or comma-separated)")
 	root.AddCommand(execCommand)
 

--- a/cli/internal/workflow/root_test.go
+++ b/cli/internal/workflow/root_test.go
@@ -612,3 +612,48 @@ func TestIngressSetHelpShowsServiceFlag(t *testing.T) {
 		}
 	}
 }
+
+func TestIngressCertInstallHelpDocumentsManualTLSProvisioning(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, t.TempDir())
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{"ingress", "cert", "install", "--help"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	for _, snippet := range []string{
+		"Install manual TLS certificate files",
+		"--cert-file string",
+		"--key-file string",
+		"--node strings",
+		"/var/lib/devopsellence/ingress-cert.pem",
+		"devopsellence ingress set --tls-mode manual",
+	} {
+		if !strings.Contains(stdout.String(), snippet) {
+			t.Fatalf("help output = %q, want %q", stdout.String(), snippet)
+		}
+	}
+}
+
+func TestExecHelpDocumentsEnvironmentOverride(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, t.TempDir())
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{"exec", "--help"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	for _, snippet := range []string{"--env string", "Environment name override"} {
+		if !strings.Contains(stdout.String(), snippet) {
+			t.Fatalf("help output = %q, want %q", stdout.String(), snippet)
+		}
+	}
+}

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -105,8 +105,15 @@ type SoloWorkloadLogsOptions struct {
 
 type SoloExecOptions struct {
 	ServiceName string
+	Environment string
 	Nodes       []string
 	Command     []string
+}
+
+type SoloIngressCertInstallOptions struct {
+	CertFile string
+	KeyFile  string
+	Nodes    []string
 }
 
 type SoloNodeExecOptions struct {
@@ -2711,27 +2718,30 @@ func (a *App) SoloExec(ctx context.Context, opts SoloExecOptions) error {
 	if _, err := remoteUserCommand(opts.Command); err != nil {
 		return err
 	}
-	nodes, cfg, err := a.soloStatusSelection(SoloStatusOptions{Nodes: opts.Nodes})
+	cfg, workspaceRoot, environmentName, err := a.loadResolvedSoloProjectConfig(opts.Environment)
 	if err != nil {
 		return err
-	}
-	if len(nodes) == 0 {
-		return fmt.Errorf("no nodes selected; attach a node or pass --node")
-	}
-	if cfg == nil {
-		return fmt.Errorf("no workspace selected; attach a workspace or run this command from a workspace")
 	}
 	if _, ok := cfg.Services[serviceName]; !ok {
 		return ExitError{Code: 2, Err: fmt.Errorf("service %q not found in devopsellence.yml", serviceName)}
 	}
-	environmentName := soloEnvironmentName(cfg, "")
-	workspaceRoot, err := a.soloCurrentWorkspaceRoot()
-	if err != nil {
-		return err
-	}
 	current, err := a.readSoloState()
 	if err != nil {
 		return err
+	}
+	nodeNames := append([]string(nil), opts.Nodes...)
+	if len(nodeNames) == 0 {
+		nodeNames, err = current.AttachedNodeNames(workspaceRoot, environmentName)
+		if err != nil {
+			return err
+		}
+	}
+	nodes, err := a.resolveNodes(current, nodeNames)
+	if err != nil {
+		return err
+	}
+	if len(nodes) == 0 {
+		return fmt.Errorf("no nodes selected for environment %s; attach a node or pass --node", environmentName)
 	}
 	candidates := []soloExecTarget{}
 	for _, nodeName := range sortedNodeNames(nodes) {
@@ -4479,6 +4489,132 @@ func (a *App) IngressSet(_ context.Context, opts IngressSetOptions) error {
 		"config_path":    a.ConfigStore.PathFor(discovered.WorkspaceRoot),
 	})
 
+}
+
+func (a *App) SoloIngressCertInstall(ctx context.Context, opts SoloIngressCertInstallOptions) error {
+	certFile := strings.TrimSpace(opts.CertFile)
+	keyFile := strings.TrimSpace(opts.KeyFile)
+	if certFile == "" {
+		return ExitError{Code: 2, Err: errors.New("--cert-file is required")}
+	}
+	if keyFile == "" {
+		return ExitError{Code: 2, Err: errors.New("--key-file is required")}
+	}
+	if err := validateReadableFile(certFile, "cert-file"); err != nil {
+		return err
+	}
+	if err := validateReadableFile(keyFile, "key-file"); err != nil {
+		return err
+	}
+
+	current, err := a.readSoloState()
+	if err != nil {
+		return err
+	}
+	nodeNames := append([]string(nil), opts.Nodes...)
+	if len(nodeNames) == 0 {
+		_, workspaceRoot, environmentName, resolveErr := a.loadResolvedSoloProjectConfig("")
+		if resolveErr != nil {
+			return resolveErr
+		}
+		nodeNames, err = current.AttachedNodeNames(workspaceRoot, environmentName)
+		if err != nil {
+			return err
+		}
+	}
+	nodes, err := a.resolveNodes(current, nodeNames)
+	if err != nil {
+		return err
+	}
+	if len(nodes) == 0 {
+		return fmt.Errorf("no nodes selected; attach a node or pass --node")
+	}
+
+	installed := make([]map[string]any, 0, len(nodes))
+	for _, nodeName := range sortedNodeNames(nodes) {
+		node := nodes[nodeName]
+		certPath, keyPath, err := installSoloIngressCert(ctx, node, certFile, keyFile)
+		if err != nil {
+			return fmt.Errorf("[%s] install ingress cert: %w", nodeName, err)
+		}
+		installed = append(installed, map[string]any{
+			"node":      nodeName,
+			"cert_path": certPath,
+			"key_path":  keyPath,
+		})
+	}
+	return a.Printer.PrintJSON(map[string]any{
+		"schema_version": outputSchemaVersion,
+		"nodes":          installed,
+		"next_steps": []string{
+			"devopsellence ingress set --tls-mode manual --host <hostname>",
+			"devopsellence deploy",
+			"curl -vk https://<hostname>/",
+		},
+	})
+}
+
+func validateReadableFile(filePath, label string) error {
+	info, err := os.Stat(filePath)
+	if err != nil {
+		return fmt.Errorf("%s: %w", label, err)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("%s %q is a directory", label, filePath)
+	}
+	file, err := os.Open(filePath)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", label, err)
+	}
+	return file.Close()
+}
+
+func installSoloIngressCert(ctx context.Context, node config.Node, certFile, keyFile string) (string, string, error) {
+	stateDir := firstNonEmpty(node.AgentStateDir, "/var/lib/devopsellence")
+	certPath := path.Join(stateDir, "ingress-cert.pem")
+	keyPath := path.Join(stateDir, "ingress-key.pem")
+	nonce := time.Now().UnixNano()
+	remoteCert := fmt.Sprintf("/tmp/devopsellence-ingress-cert-%d.pem", nonce)
+	remoteKey := fmt.Sprintf("/tmp/devopsellence-ingress-key-%d.pem", nonce)
+	if err := uploadSoloFile(ctx, node, certFile, remoteCert); err != nil {
+		return certPath, keyPath, fmt.Errorf("upload cert: %w", err)
+	}
+	defer solo.RunSSHInteractive(ctx, node, "rm -f "+shellQuote(remoteCert), io.Discard, io.Discard)
+	if err := uploadSoloFile(ctx, node, keyFile, remoteKey); err != nil {
+		return certPath, keyPath, fmt.Errorf("upload key: %w", err)
+	}
+	defer solo.RunSSHInteractive(ctx, node, "rm -f "+shellQuote(remoteKey), io.Discard, io.Discard)
+	script := fmt.Sprintf(`set -euo pipefail
+if [ "$(id -u)" -ne 0 ]; then
+  SUDO=sudo
+else
+  SUDO=
+fi
+run_root() {
+  if [ -n "$SUDO" ]; then
+    "$SUDO" "$@"
+  else
+    "$@"
+  fi
+}
+run_root install -d -m 0755 %s
+run_root install -m 0644 %s %s
+run_root install -m 0600 %s %s
+run_root systemctl restart devopsellence-agent || true
+`, shellQuote(stateDir), shellQuote(remoteCert), shellQuote(certPath), shellQuote(remoteKey), shellQuote(keyPath))
+	if err := solo.RunSSHInteractiveWithStdin(ctx, node, "bash -s", strings.NewReader(script), io.Discard, io.Discard); err != nil {
+		return certPath, keyPath, err
+	}
+	return certPath, keyPath, nil
+}
+
+func uploadSoloFile(ctx context.Context, node config.Node, localPath, remotePath string) error {
+	file, err := os.Open(localPath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	return solo.RunSSHStream(ctx, node, "cat > "+shellQuote(remotePath), file)
 }
 
 func (a *App) IngressCheck(ctx context.Context, opts IngressCheckOptions) error {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -4606,7 +4606,7 @@ run_root() {
 run_root install -d -m 0755 %s
 run_root install -m 0644 %s %s
 run_root install -m 0600 %s %s
-run_root systemctl restart devopsellence-agent || true
+run_root systemctl restart devopsellence-agent
 `, shellQuote(stateDir), shellQuote(remoteCert), shellQuote(certPath), shellQuote(remoteKey), shellQuote(keyPath))
 	if err := solo.RunSSHInteractiveWithStdin(ctx, node, "bash -s", strings.NewReader(script), io.Discard, io.Discard); err != nil {
 		return certPath, keyPath, err

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -4576,11 +4576,11 @@ func installSoloIngressCert(ctx context.Context, node config.Node, certFile, key
 	nonce := time.Now().UnixNano()
 	remoteCert := fmt.Sprintf("/tmp/devopsellence-ingress-cert-%d.pem", nonce)
 	remoteKey := fmt.Sprintf("/tmp/devopsellence-ingress-key-%d.pem", nonce)
-	if err := uploadSoloFile(ctx, node, certFile, remoteCert); err != nil {
+	if err := uploadSoloFile(ctx, node, certFile, remoteCert, false); err != nil {
 		return certPath, keyPath, fmt.Errorf("upload cert: %w", err)
 	}
 	defer solo.RunSSHInteractive(ctx, node, "rm -f "+shellQuote(remoteCert), io.Discard, io.Discard)
-	if err := uploadSoloFile(ctx, node, keyFile, remoteKey); err != nil {
+	if err := uploadSoloFile(ctx, node, keyFile, remoteKey, true); err != nil {
 		return certPath, keyPath, fmt.Errorf("upload key: %w", err)
 	}
 	defer solo.RunSSHInteractive(ctx, node, "rm -f "+shellQuote(remoteKey), io.Discard, io.Discard)
@@ -4608,13 +4608,17 @@ run_root systemctl restart devopsellence-agent || true
 	return certPath, keyPath, nil
 }
 
-func uploadSoloFile(ctx context.Context, node config.Node, localPath, remotePath string) error {
+func uploadSoloFile(ctx context.Context, node config.Node, localPath, remotePath string, private bool) error {
 	file, err := os.Open(localPath)
 	if err != nil {
 		return err
 	}
 	defer file.Close()
-	return solo.RunSSHStream(ctx, node, "cat > "+shellQuote(remotePath), file)
+	command := "cat > " + shellQuote(remotePath)
+	if private {
+		command = "umask 077; " + command
+	}
+	return solo.RunSSHStream(ctx, node, command, file)
 }
 
 func (a *App) IngressCheck(ctx context.Context, opts IngressCheckOptions) error {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -2735,6 +2735,9 @@ func (a *App) SoloExec(ctx context.Context, opts SoloExecOptions) error {
 		if err != nil {
 			return err
 		}
+		if len(nodeNames) == 0 {
+			return fmt.Errorf("no nodes selected for environment %s; attach a node or pass --node", environmentName)
+		}
 	}
 	nodes, err := a.resolveNodes(current, nodeNames)
 	if err != nil {
@@ -4520,6 +4523,9 @@ func (a *App) SoloIngressCertInstall(ctx context.Context, opts SoloIngressCertIn
 		nodeNames, err = current.AttachedNodeNames(workspaceRoot, environmentName)
 		if err != nil {
 			return err
+		}
+		if len(nodeNames) == 0 {
+			return fmt.Errorf("no nodes selected for environment %s; attach a node or pass --node", environmentName)
 		}
 	}
 	nodes, err := a.resolveNodes(current, nodeNames)

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -1962,6 +1962,96 @@ func TestSoloExecUsesProjectScopedRuntimeEnvironmentForCoHostedNode(t *testing.T
 	}
 }
 
+func TestRootExecEnvSelectsAttachedEnvironment(t *testing.T) {
+	cwd := rootTestSoloWorkspace(t)
+	cfg, err := config.LoadFromRoot(cwd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.Environments = map[string]config.EnvironmentOverlay{"staging": {}}
+	if _, err := config.Write(cwd, *cfg); err != nil {
+		t.Fatal(err)
+	}
+	status := `{"revision":"abc","phase":"settled","environments":[{"name":"production","services":[{"name":"web","state":"running","container":"wrong-container"}]},{"name":"staging","services":[{"name":"web","state":"running","container":"svc-production-web-abc"}]}]}` + "\n"
+	installFakeSoloCommands(t, []fakeSSHResponse{{stdout: status}})
+	current := solo.State{}
+	if err := current.SetNode("node-a", config.Node{Host: "203.0.113.10", User: "root"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := current.AttachNode(cwd, "staging", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	if err := solo.NewStateStore(solo.DefaultStatePath()).Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, io.Discard, cwd)
+	cmd.SetOut(&stdout)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{"exec", "--env", "staging", "web", "--", "bin/rails", "runner", "puts Rails.env"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	events := decodeNDJSONOutput(t, &stdout)
+	if len(events) == 0 || events[0]["environment"] != "staging" || events[0]["container"] != "svc-production-web-abc" {
+		t.Fatalf("started event = %#v, want staging container", events[0])
+	}
+}
+
+func TestSoloIngressCertInstallUploadsManualTLSFilesToAttachedNode(t *testing.T) {
+	cwd := rootTestSoloWorkspace(t)
+	uploadsPath := filepath.Join(t.TempDir(), "uploads")
+	scriptPath := filepath.Join(t.TempDir(), "script")
+	t.Setenv("DEVOPSELLENCE_FAKE_SSH_UPLOADS", uploadsPath)
+	t.Setenv("DEVOPSELLENCE_FAKE_SSH_SCRIPT", scriptPath)
+	installFakeSoloCommands(t, nil)
+	certFile := filepath.Join(t.TempDir(), "cert.pem")
+	keyFile := filepath.Join(t.TempDir(), "key.pem")
+	if err := os.WriteFile(certFile, []byte("cert"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyFile, []byte("key"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	current := solo.State{}
+	if err := current.SetNode("node-a", config.Node{Host: "203.0.113.10", User: "root"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := current.AttachNode(cwd, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	if err := solo.NewStateStore(solo.DefaultStatePath()).Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := NewApp(bytes.NewBuffer(nil), &stdout, io.Discard, cwd)
+	if err := app.SoloIngressCertInstall(context.Background(), SoloIngressCertInstallOptions{CertFile: certFile, KeyFile: keyFile}); err != nil {
+		t.Fatalf("SoloIngressCertInstall() error = %v", err)
+	}
+	uploads, err := os.ReadFile(uploadsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Count(string(uploads), "/tmp/devopsellence-ingress-"); got != 2 {
+		t.Fatalf("uploads = %q, want two ingress TLS uploads", string(uploads))
+	}
+	script, err := os.ReadFile(scriptPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, snippet := range []string{"/var/lib/devopsellence/ingress-cert.pem", "/var/lib/devopsellence/ingress-key.pem", "systemctl restart devopsellence-agent"} {
+		if !strings.Contains(string(script), snippet) {
+			t.Fatalf("script = %q, want %q", string(script), snippet)
+		}
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	if intValueAny(payload["schema_version"]) != outputSchemaVersion {
+		t.Fatalf("output = %#v, want JSON payload", payload)
+	}
+}
+
 func TestSoloExecPreservesRemoteExitCodeInErrorEvent(t *testing.T) {
 	installFakeSoloCommands(t, nil)
 	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
@@ -4807,6 +4897,29 @@ set -euo pipefail
 command="${!#}"
 
 if [[ "$command" == "true" ]]; then
+  exit 0
+fi
+
+if [[ "$command" == cat\ \>* ]]; then
+  target="${command#cat > }"
+  target="${target#\'}"
+  target="${target%\'}"
+  cat >"$target"
+  if [[ -n "${DEVOPSELLENCE_FAKE_SSH_UPLOADS:-}" ]]; then
+    printf '%s\n' "$target" >>"$DEVOPSELLENCE_FAKE_SSH_UPLOADS"
+  fi
+  exit 0
+fi
+
+if [[ "$command" == "bash -s" ]]; then
+  script="$(cat)"
+  if [[ -n "${DEVOPSELLENCE_FAKE_SSH_SCRIPT:-}" ]]; then
+    printf '%s' "$script" >"$DEVOPSELLENCE_FAKE_SSH_SCRIPT"
+  fi
+  exit 0
+fi
+
+if [[ "$command" == rm\ -f\ * ]]; then
   exit 0
 fi
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -2037,6 +2037,9 @@ func TestSoloIngressCertInstallUploadsManualTLSFilesToAttachedNode(t *testing.T)
 	if got := strings.Count(string(uploads), "/tmp/devopsellence-ingress-"); got != 2 {
 		t.Fatalf("uploads = %q, want two ingress TLS uploads", string(uploads))
 	}
+	if !strings.Contains(string(uploads), "umask 077; cat > '/tmp/devopsellence-ingress-key-") {
+		t.Fatalf("uploads = %q, want private key upload to use restrictive umask", string(uploads))
+	}
 	script, err := os.ReadFile(scriptPath)
 	if err != nil {
 		t.Fatal(err)
@@ -4900,13 +4903,17 @@ if [[ "$command" == "true" ]]; then
   exit 0
 fi
 
-if [[ "$command" == cat\ \>* ]]; then
-  target="${command#cat > }"
+if [[ "$command" == "umask 077; cat > "* || "$command" == cat\ \>* ]]; then
+  if [[ "$command" == "umask 077; cat > "* ]]; then
+    target="${command#umask 077; cat > }"
+  else
+    target="${command#cat > }"
+  fi
   target="${target#\'}"
   target="${target%\'}"
   cat >"$target"
   if [[ -n "${DEVOPSELLENCE_FAKE_SSH_UPLOADS:-}" ]]; then
-    printf '%s\n' "$target" >>"$DEVOPSELLENCE_FAKE_SSH_UPLOADS"
+    printf '%s\n' "$command" >>"$DEVOPSELLENCE_FAKE_SSH_UPLOADS"
   fi
   exit 0
 fi

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -1999,6 +1999,36 @@ func TestRootExecEnvSelectsAttachedEnvironment(t *testing.T) {
 	}
 }
 
+func TestRootExecEnvFailsWhenSelectedEnvironmentHasNoAttachedNodes(t *testing.T) {
+	cwd := rootTestSoloWorkspace(t)
+	cfg, err := config.LoadFromRoot(cwd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.Environments = map[string]config.EnvironmentOverlay{"staging": {}}
+	if _, err := config.Write(cwd, *cfg); err != nil {
+		t.Fatal(err)
+	}
+	installFakeSoloCommands(t, nil)
+	current := solo.State{}
+	if err := current.SetNode("unrelated", config.Node{Host: "203.0.113.10", User: "root"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := solo.NewStateStore(solo.DefaultStatePath()).Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, io.Discard, cwd)
+	cmd.SetOut(&stdout)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{"exec", "--env", "staging", "web", "--", "true"})
+	err = cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "no nodes selected for environment staging") {
+		t.Fatalf("Execute() error = %v, want no nodes selected for staging", err)
+	}
+}
+
 func TestSoloIngressCertInstallUploadsManualTLSFilesToAttachedNode(t *testing.T) {
 	cwd := rootTestSoloWorkspace(t)
 	uploadsPath := filepath.Join(t.TempDir(), "uploads")
@@ -2052,6 +2082,33 @@ func TestSoloIngressCertInstallUploadsManualTLSFilesToAttachedNode(t *testing.T)
 	payload := decodeJSONOutput(t, &stdout)
 	if intValueAny(payload["schema_version"]) != outputSchemaVersion {
 		t.Fatalf("output = %#v, want JSON payload", payload)
+	}
+}
+
+func TestSoloIngressCertInstallFailsWhenCurrentEnvironmentHasNoAttachedNodes(t *testing.T) {
+	cwd := rootTestSoloWorkspace(t)
+	installFakeSoloCommands(t, nil)
+	certFile := filepath.Join(t.TempDir(), "cert.pem")
+	keyFile := filepath.Join(t.TempDir(), "key.pem")
+	if err := os.WriteFile(certFile, []byte("cert"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyFile, []byte("key"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	current := solo.State{}
+	if err := current.SetNode("unrelated", config.Node{Host: "203.0.113.10", User: "root"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := solo.NewStateStore(solo.DefaultStatePath()).Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := NewApp(bytes.NewBuffer(nil), &stdout, io.Discard, cwd)
+	err := app.SoloIngressCertInstall(context.Background(), SoloIngressCertInstallOptions{CertFile: certFile, KeyFile: keyFile})
+	if err == nil || !strings.Contains(err.Error(), "no nodes selected for environment production") {
+		t.Fatalf("SoloIngressCertInstall() error = %v, want no nodes selected for production", err)
 	}
 }
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -2079,9 +2079,43 @@ func TestSoloIngressCertInstallUploadsManualTLSFilesToAttachedNode(t *testing.T)
 			t.Fatalf("script = %q, want %q", string(script), snippet)
 		}
 	}
+	if strings.Contains(string(script), "systemctl restart devopsellence-agent || true") {
+		t.Fatalf("script = %q, want restart failures to be propagated", string(script))
+	}
 	payload := decodeJSONOutput(t, &stdout)
 	if intValueAny(payload["schema_version"]) != outputSchemaVersion {
 		t.Fatalf("output = %#v, want JSON payload", payload)
+	}
+}
+
+func TestSoloIngressCertInstallFailsWhenAgentRestartFails(t *testing.T) {
+	cwd := rootTestSoloWorkspace(t)
+	t.Setenv("DEVOPSELLENCE_FAKE_SSH_RESTART_FAIL", "1")
+	installFakeSoloCommands(t, nil)
+	certFile := filepath.Join(t.TempDir(), "cert.pem")
+	keyFile := filepath.Join(t.TempDir(), "key.pem")
+	if err := os.WriteFile(certFile, []byte("cert"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyFile, []byte("key"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	current := solo.State{}
+	if err := current.SetNode("node-a", config.Node{Host: "203.0.113.10", User: "root"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := current.AttachNode(cwd, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	if err := solo.NewStateStore(solo.DefaultStatePath()).Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := NewApp(bytes.NewBuffer(nil), &stdout, io.Discard, cwd)
+	err := app.SoloIngressCertInstall(context.Background(), SoloIngressCertInstallOptions{CertFile: certFile, KeyFile: keyFile})
+	if err == nil || !strings.Contains(err.Error(), "[node-a] install ingress cert") {
+		t.Fatalf("SoloIngressCertInstall() error = %v, want node install failure", err)
 	}
 }
 
@@ -4979,6 +5013,10 @@ if [[ "$command" == "bash -s" ]]; then
   script="$(cat)"
   if [[ -n "${DEVOPSELLENCE_FAKE_SSH_SCRIPT:-}" ]]; then
     printf '%s' "$script" >"$DEVOPSELLENCE_FAKE_SSH_SCRIPT"
+  fi
+  if [[ -n "${DEVOPSELLENCE_FAKE_SSH_RESTART_FAIL:-}" && "$script" == *"systemctl restart devopsellence-agent"* && "$script" != *"systemctl restart devopsellence-agent || true"* ]]; then
+    printf 'systemctl restart devopsellence-agent failed\n' >&2
+    exit 1
   fi
   exit 0
 fi


### PR DESCRIPTION
## Summary

- Add `devopsellence ingress cert install` as a discoverable solo manual TLS cert/key provisioning path.
- Add/wire `devopsellence exec --env <environment>` so workload exec resolves the selected logical environment before choosing attached nodes/runtime containers.
- Add regression coverage for help/discoverability, manual TLS upload behavior, and env-scoped exec target selection.

## Findings addressed

1. Manual TLS provisioning/discoverability gap from #95
   - `ingress cert install --help` now documents cert/key flags, default remote paths, and the follow-up `ingress set --tls-mode manual` + deploy/curl flow.
   - The command uploads the cert/key to selected solo nodes and restarts the agent so Envoy can reconcile with manual TLS files.

2. `exec --env` environment selection/discoverability
   - `exec --help` now exposes `--env string`.
   - `SoloExec` resolves project config and attachments for the requested logical environment, then maps to the matching runtime container from node status.

## Test plan

Passed locally from `cli/`:

```sh
mise exec -- go test ./internal/workflow -run 'TestIngressCertInstallHelpDocumentsManualTLSProvisioning|TestExecHelpDocumentsEnvironmentOverride|TestRootExecEnvSelectsAttachedEnvironment|TestSoloIngressCertInstallUploadsManualTLSFilesToAttachedNode' -count=1
mise exec -- go test ./... -count=1
./scripts/release-local.sh
```

Focused local dogfood using the branch-built CLI:

- Run/report: `/tmp/devopsellence-dogfood-solo/20260429T161954678509Z-focused-manual-tls-exec-env/report.md`
- Captured help for `ingress cert install` and `exec --help`.
- Verified `devopsellence exec --env staging web -- ...` selected `environment: staging` and the staging runtime container.
- Verified `ingress cert install --cert-file <dummy-cert> --key-file <dummy-key> --node hcloud-1` returned structured success with the expected manual TLS paths. Dummy key contents were not logged and local dummy files were removed after upload.
- Verified existing HTTPS endpoints still returned healthy responses after the agent restart.

## Caveats

- This was a PR-focused local CLI dogfood because the branch is CLI-only. It is not official `v0.2.0-preview` artifact validation.
- I did not switch the live co-hosted dogfood node fully to manual TLS mode; full manual HTTPS serving proof should use a disposable/manual-TLS-specific hostname or node to avoid destabilizing current auto-TLS apps.

Addresses #95.
