### PR TITLE
Fix solo manual TLS and co-host detach safety

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,7 @@ cd control-plane && mise run test -- test/path/file_test.rb
 ## Review Handling
 
 - Explicit user product direction overrides reviewer suggestions.
-- The default product stance is clean slate: no legacy behavior and no backward-compatibility promises unless explicitly requested. Do not add backfills, shims, compat code, or rejection guards just to preserve or explicitly refute removed behavior; remove deleted surfaces cleanly and simplify the codepath instead.
+- The default product stance is clean slate: no legacy behavior and no backward-compatibility promises unless explicitly requested. Do not add backfills, shims, compat code, or rejection guards just to preserve or explicitly refute removed behavior; remove deleted surfaces cleanly and simplify the codepath instead. If a PR review asks to preserve backward compatibility, treat that suggestion as contrary to product direction by default: ignore it unless the user explicitly overrides this stance, and prefer a hard break with simpler implementation.
 - Open PRs as ready for review, not draft, unless the user explicitly asks for a draft.
 - After addressing a PR review thread, resolve the thread in GitHub so only remaining actionable feedback stays open.
 - Right after each PR is opened or updated with pushed fixes, request a fresh Copilot review with `gh pr edit <pr-number> --add-reviewer copilot-pull-request-reviewer`.

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -2640,26 +2640,18 @@ func (a *App) SoloWorkloadLogs(ctx context.Context, opts SoloWorkloadLogsOptions
 	results := make([]map[string]any, 0, len(nodes))
 	ok := true
 	for _, nodeName := range sortedNodeNames(nodes) {
-		runtimeEnvironmentNames, err := soloRuntimeEnvironmentNameCandidatesForNode(current, workspaceRoot, environmentName, nodeName)
+		runtimeEnvironmentName, err := soloRuntimeEnvironmentNameForNode(current, workspaceRoot, environmentName, nodeName)
 		if err != nil {
 			return err
 		}
-		diag := runRemoteDiagnostic(ctx, nodes[nodeName], remoteDockerLogsCommand(runtimeEnvironmentNames, serviceName, linesLimit))
+		diag := runRemoteDiagnostic(ctx, nodes[nodeName], remoteDockerLogsCommand(runtimeEnvironmentName, serviceName, linesLimit))
 		lines := splitNonFinalEmptyLines(diag.Stdout)
-		runtimeEnvironmentName := runtimeEnvironmentNames[0]
-		if selectedEnvironment, strippedLines := extractWorkloadLogsSelectedEnvironment(lines); selectedEnvironment != "" {
-			runtimeEnvironmentName = selectedEnvironment
-			lines = strippedLines
-		}
 		entry := map[string]any{
 			"node":                nodeName,
 			"service":             serviceName,
 			"runtime_environment": runtimeEnvironmentName,
 			"ok":                  diag.Err == nil && diag.ExitCode == 0,
 			"lines":               lines,
-		}
-		if len(runtimeEnvironmentNames) > 1 {
-			entry["runtime_environment_candidates"] = runtimeEnvironmentNames
 		}
 		if diag.Err != nil {
 			entry["error"] = diag.Err.Error()
@@ -2764,11 +2756,11 @@ func (a *App) SoloExec(ctx context.Context, opts SoloExecOptions) error {
 		if result.Missing {
 			continue
 		}
-		runtimeEnvironmentNames, err := soloRuntimeEnvironmentNameCandidatesForNode(current, workspaceRoot, environmentName, nodeName)
+		runtimeEnvironmentName, err := soloRuntimeEnvironmentNameForNode(current, workspaceRoot, environmentName, nodeName)
 		if err != nil {
 			return err
 		}
-		runtimeEnvironmentName, container := statusServiceContainerForRuntimeEnvironments(result.Status, runtimeEnvironmentNames, serviceName)
+		container := statusServiceContainer(result.Status, runtimeEnvironmentName, serviceName)
 		if container == "" {
 			continue
 		}
@@ -3068,16 +3060,6 @@ func soloExecFields(target soloExecTarget) map[string]any {
 	return payload
 }
 
-func statusServiceContainerForRuntimeEnvironments(status soloNodeStatus, environmentNames []string, serviceName string) (string, string) {
-	for _, environmentName := range environmentNames {
-		container := statusServiceContainer(status, environmentName, serviceName)
-		if container != "" {
-			return environmentName, container
-		}
-	}
-	return "", ""
-}
-
 func statusServiceContainer(status soloNodeStatus, environmentName, serviceName string) string {
 	for _, environment := range status.Environments {
 		if strings.TrimSpace(environment.Name) != environmentName {
@@ -3320,17 +3302,6 @@ func diagnosticErrorMessage(diag remoteDiagnosticResult) string {
 
 func noWorkloadContainers(diag remoteDiagnosticResult) bool {
 	return strings.Contains(diag.Stderr, soloNoWorkloadContainersSentinel)
-}
-
-func extractWorkloadLogsSelectedEnvironment(lines []string) (string, []string) {
-	if len(lines) == 0 {
-		return "", lines
-	}
-	selected := strings.TrimSpace(strings.TrimPrefix(lines[0], soloWorkloadLogsSelectedEnvironmentPrefix))
-	if selected == "" || !strings.HasPrefix(lines[0], soloWorkloadLogsSelectedEnvironmentPrefix) {
-		return "", lines
-	}
-	return selected, lines[1:]
 }
 
 func workloadLogsErrorMessage(diag remoteDiagnosticResult) string {
@@ -3982,15 +3953,14 @@ func (a *App) SharedSoloNodeCreate(ctx context.Context, opts SharedSoloNodeCreat
 const sshOutputTailLimit = 64 * 1024
 
 const (
-	soloLogsDefaultLines                      = 100
-	soloLogsMaxLines                          = 1000
-	soloWorkloadLogsContainerLimit            = 20
-	soloDiagnoseDockerItemLimit               = 100
-	soloDiagnosePortsLineLimit                = 200
-	soloDiagnoseTruncatedMarker               = "__DEVOPSELLENCE_TRUNCATED__"
-	soloNoWorkloadContainersSentinel          = "__DEVOPSELLENCE_NO_WORKLOAD_CONTAINERS__"
-	soloWorkloadLogsSelectedEnvironmentPrefix = "__DEVOPSELLENCE_SELECTED_ENVIRONMENT__="
-	soloRemoteAgentBinaryNotFoundMessage      = "devopsellence agent binary not found"
+	soloLogsDefaultLines                 = 100
+	soloLogsMaxLines                     = 1000
+	soloWorkloadLogsContainerLimit       = 20
+	soloDiagnoseDockerItemLimit          = 100
+	soloDiagnosePortsLineLimit           = 200
+	soloDiagnoseTruncatedMarker          = "__DEVOPSELLENCE_TRUNCATED__"
+	soloNoWorkloadContainersSentinel     = "__DEVOPSELLENCE_NO_WORKLOAD_CONTAINERS__"
+	soloRemoteAgentBinaryNotFoundMessage = "devopsellence agent binary not found"
 )
 
 type tailBuffer struct {
@@ -4868,48 +4838,21 @@ func (a *App) soloCurrentWorkspaceRoot() (string, error) {
 	return discovered.WorkspaceRoot, nil
 }
 
-func soloRuntimeEnvironmentNameForNode(current solo.State, workspaceRoot, logicalEnvironment, nodeName string) (string, error) {
-	candidates, err := soloRuntimeEnvironmentNameCandidatesForNode(current, workspaceRoot, logicalEnvironment, nodeName)
-	if err != nil {
-		return "", err
-	}
-	return candidates[0], nil
-}
-
-func soloRuntimeEnvironmentNameCandidatesForNode(current solo.State, workspaceRoot, logicalEnvironment, _ string) ([]string, error) {
+func soloRuntimeEnvironmentNameForNode(current solo.State, workspaceRoot, logicalEnvironment, _ string) (string, error) {
 	logicalEnvironment = strings.TrimSpace(logicalEnvironment)
 	if logicalEnvironment == "" {
 		logicalEnvironment = config.DefaultEnvironment
 	}
 	currentKey, err := solo.EnvironmentStateKey(workspaceRoot, logicalEnvironment)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 	currentSnapshot, ok := current.Snapshots[currentKey]
 	if !ok {
-		return []string{logicalEnvironment}, nil
+		return logicalEnvironment, nil
 	}
 	base := defaultSoloSnapshotEnvironment(currentSnapshot, logicalEnvironment)
-	// Prefer the stable project-scoped name emitted by deployment-core for new
-	// aggregated publications, but keep the logical/base environment as a
-	// compatibility fallback for nodes last deployed before this naming change.
-	return appendUniqueNonEmptyStrings(nil, uniqueSoloRuntimeEnvironmentName(currentSnapshot, base), base, logicalEnvironment), nil
-}
-
-func appendUniqueNonEmptyStrings(values []string, candidates ...string) []string {
-	seen := map[string]bool{}
-	for _, value := range values {
-		seen[value] = true
-	}
-	for _, candidate := range candidates {
-		candidate = strings.TrimSpace(candidate)
-		if candidate == "" || seen[candidate] {
-			continue
-		}
-		values = append(values, candidate)
-		seen[candidate] = true
-	}
-	return values
+	return uniqueSoloRuntimeEnvironmentName(currentSnapshot, base), nil
 }
 
 func defaultSoloSnapshotEnvironment(snapshot desiredstate.DeploySnapshot, fallback string) string {
@@ -6190,41 +6133,27 @@ func remoteDockerNetworksJSONCommand() string {
 	return withRemoteLineLimit("if docker info >/dev/null 2>&1; then docker network ls --format '{{json .}}'; elif command -v sudo >/dev/null 2>&1 && sudo -n docker info >/dev/null 2>&1; then sudo -n docker network ls --format '{{json .}}'; else echo 'Docker is not reachable' >&2; exit 1; fi", soloDiagnoseDockerItemLimit)
 }
 
-func remoteDockerLogsCommand(environmentNames []string, serviceName string, lines int) string {
-	environmentNames = appendUniqueNonEmptyStrings(nil, environmentNames...)
-	if len(environmentNames) == 0 {
-		environmentNames = []string{config.DefaultEnvironment}
+func remoteDockerLogsCommand(environmentName string, serviceName string, lines int) string {
+	environmentName = strings.TrimSpace(environmentName)
+	if environmentName == "" {
+		environmentName = config.DefaultEnvironment
 	}
-	envs := shellQuote(strings.Join(environmentNames, "\n"))
-	envDescription := shellQuote(strings.Join(environmentNames, ", "))
+	environment := shellQuote(environmentName)
 	service := shellQuote(serviceName)
 	return fmt.Sprintf(`if docker info >/dev/null 2>&1; then docker_cmd=docker; elif command -v sudo >/dev/null 2>&1 && sudo -n docker info >/dev/null 2>&1; then docker_cmd="sudo -n docker"; else echo 'Docker is not reachable' >&2; exit 1; fi
-env_candidates=%s
+environment=%s
 service=%s
-ids=""
-selected_env=""
-while IFS= read -r env || [ -n "$env" ]; do
-  [ -n "$env" ] || continue
-  candidate_ids=$($docker_cmd ps -a -q --filter label=devopsellence.managed=true --filter "label=devopsellence.environment=$env" --filter "label=devopsellence.service=$service" 2>&1)
-  ps_status=$?
-  if [ "$ps_status" -ne 0 ]; then
-    echo "Failed to list workload containers for service $service in environment $env" >&2
-    if [ -n "$candidate_ids" ]; then
-      printf '%%s\n' "$candidate_ids" >&2
-    fi
-    exit "$ps_status"
+ids=$($docker_cmd ps -a -q --filter label=devopsellence.managed=true --filter "label=devopsellence.environment=$environment" --filter "label=devopsellence.service=$service" 2>&1)
+ps_status=$?
+if [ "$ps_status" -ne 0 ]; then
+  echo "Failed to list workload containers for service $service in environment $environment" >&2
+  if [ -n "$ids" ]; then
+    printf '%%s\n' "$ids" >&2
   fi
-  candidate_ids=$(printf '%%s\n' "$candidate_ids" | sed '/^$/d' | head -n %d)
-  if [ -n "$candidate_ids" ]; then
-    ids="$candidate_ids"
-    selected_env="$env"
-    break
-  fi
-done <<__DEVOPSELLENCE_ENV_CANDIDATES__
-$env_candidates
-__DEVOPSELLENCE_ENV_CANDIDATES__
-if [ -z "$ids" ]; then echo "%s" >&2; echo "No workload containers found for service $service in environments %s" >&2; exit 1; fi
-printf '%%s%%s\n' %s "$selected_env"
+  exit "$ps_status"
+fi
+ids=$(printf '%%s\n' "$ids" | sed '/^$/d' | head -n %d)
+if [ -z "$ids" ]; then echo "%s" >&2; echo "No workload containers found for service $service in environment $environment" >&2; exit 1; fi
 rc=0
 for id in $ids; do
   name=$($docker_cmd inspect --format '{{.Name}}' "$id" 2>/dev/null | sed 's#^/##')
@@ -6240,7 +6169,7 @@ for id in $ids; do
     rc=$logs_status
   fi
 done
-	exit "$rc"`, envs, service, soloWorkloadLogsContainerLimit, soloNoWorkloadContainersSentinel, envDescription, shellQuote(soloWorkloadLogsSelectedEnvironmentPrefix), lines)
+	exit "$rc"`, environment, service, soloWorkloadLogsContainerLimit, soloNoWorkloadContainersSentinel, lines)
 }
 
 func remoteUserCommand(args []string) (string, error) {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -2645,12 +2645,18 @@ func (a *App) SoloWorkloadLogs(ctx context.Context, opts SoloWorkloadLogsOptions
 			return err
 		}
 		diag := runRemoteDiagnostic(ctx, nodes[nodeName], remoteDockerLogsCommand(runtimeEnvironmentNames, serviceName, linesLimit))
+		lines := splitNonFinalEmptyLines(diag.Stdout)
+		runtimeEnvironmentName := runtimeEnvironmentNames[0]
+		if selectedEnvironment, strippedLines := extractWorkloadLogsSelectedEnvironment(lines); selectedEnvironment != "" {
+			runtimeEnvironmentName = selectedEnvironment
+			lines = strippedLines
+		}
 		entry := map[string]any{
 			"node":                nodeName,
 			"service":             serviceName,
-			"runtime_environment": runtimeEnvironmentNames[0],
+			"runtime_environment": runtimeEnvironmentName,
 			"ok":                  diag.Err == nil && diag.ExitCode == 0,
-			"lines":               splitNonFinalEmptyLines(diag.Stdout),
+			"lines":               lines,
 		}
 		if len(runtimeEnvironmentNames) > 1 {
 			entry["runtime_environment_candidates"] = runtimeEnvironmentNames
@@ -3316,6 +3322,17 @@ func noWorkloadContainers(diag remoteDiagnosticResult) bool {
 	return strings.Contains(diag.Stderr, soloNoWorkloadContainersSentinel)
 }
 
+func extractWorkloadLogsSelectedEnvironment(lines []string) (string, []string) {
+	if len(lines) == 0 {
+		return "", lines
+	}
+	selected := strings.TrimSpace(strings.TrimPrefix(lines[0], soloWorkloadLogsSelectedEnvironmentPrefix))
+	if selected == "" || !strings.HasPrefix(lines[0], soloWorkloadLogsSelectedEnvironmentPrefix) {
+		return "", lines
+	}
+	return selected, lines[1:]
+}
+
 func workloadLogsErrorMessage(diag remoteDiagnosticResult) string {
 	if !noWorkloadContainers(diag) {
 		return diagnosticErrorMessage(diag)
@@ -3965,14 +3982,15 @@ func (a *App) SharedSoloNodeCreate(ctx context.Context, opts SharedSoloNodeCreat
 const sshOutputTailLimit = 64 * 1024
 
 const (
-	soloLogsDefaultLines                 = 100
-	soloLogsMaxLines                     = 1000
-	soloWorkloadLogsContainerLimit       = 20
-	soloDiagnoseDockerItemLimit          = 100
-	soloDiagnosePortsLineLimit           = 200
-	soloDiagnoseTruncatedMarker          = "__DEVOPSELLENCE_TRUNCATED__"
-	soloNoWorkloadContainersSentinel     = "__DEVOPSELLENCE_NO_WORKLOAD_CONTAINERS__"
-	soloRemoteAgentBinaryNotFoundMessage = "devopsellence agent binary not found"
+	soloLogsDefaultLines                      = 100
+	soloLogsMaxLines                          = 1000
+	soloWorkloadLogsContainerLimit            = 20
+	soloDiagnoseDockerItemLimit               = 100
+	soloDiagnosePortsLineLimit                = 200
+	soloDiagnoseTruncatedMarker               = "__DEVOPSELLENCE_TRUNCATED__"
+	soloNoWorkloadContainersSentinel          = "__DEVOPSELLENCE_NO_WORKLOAD_CONTAINERS__"
+	soloWorkloadLogsSelectedEnvironmentPrefix = "__DEVOPSELLENCE_SELECTED_ENVIRONMENT__="
+	soloRemoteAgentBinaryNotFoundMessage      = "devopsellence agent binary not found"
 )
 
 type tailBuffer struct {
@@ -4527,22 +4545,28 @@ func (a *App) SoloIngressCertInstall(ctx context.Context, opts SoloIngressCertIn
 	if err != nil {
 		return err
 	}
-	_, workspaceRoot, environmentName, err := a.loadResolvedSoloProjectConfig("")
-	if err != nil {
-		return err
-	}
-	currentKey, err := solo.EnvironmentStateKey(workspaceRoot, environmentName)
-	if err != nil {
-		return err
-	}
 	nodeNames := append([]string(nil), opts.Nodes...)
+	currentKey := ""
 	if len(nodeNames) == 0 {
+		_, workspaceRoot, environmentName, err := a.loadResolvedSoloProjectConfig("")
+		if err != nil {
+			return err
+		}
+		currentKey, err = solo.EnvironmentStateKey(workspaceRoot, environmentName)
+		if err != nil {
+			return err
+		}
 		nodeNames, err = current.AttachedNodeNames(workspaceRoot, environmentName)
 		if err != nil {
 			return err
 		}
 		if len(nodeNames) == 0 {
 			return fmt.Errorf("no nodes selected for environment %s; attach a node or pass --node", environmentName)
+		}
+	} else if _, workspaceRoot, environmentName, err := a.loadResolvedSoloProjectConfig(""); err == nil {
+		currentKey, err = solo.EnvironmentStateKey(workspaceRoot, environmentName)
+		if err != nil {
+			return err
 		}
 	}
 	nodes, err := a.resolveNodes(current, nodeNames)
@@ -6200,6 +6224,7 @@ done <<__DEVOPSELLENCE_ENV_CANDIDATES__
 $env_candidates
 __DEVOPSELLENCE_ENV_CANDIDATES__
 if [ -z "$ids" ]; then echo "%s" >&2; echo "No workload containers found for service $service in environments %s" >&2; exit 1; fi
+printf '%%s%%s\n' %s "$selected_env"
 rc=0
 for id in $ids; do
   name=$($docker_cmd inspect --format '{{.Name}}' "$id" 2>/dev/null | sed 's#^/##')
@@ -6215,7 +6240,7 @@ for id in $ids; do
     rc=$logs_status
   fi
 done
-	exit "$rc"`, envs, service, soloWorkloadLogsContainerLimit, soloNoWorkloadContainersSentinel, envDescription, lines)
+	exit "$rc"`, envs, service, soloWorkloadLogsContainerLimit, soloNoWorkloadContainersSentinel, envDescription, shellQuote(soloWorkloadLogsSelectedEnvironmentPrefix), lines)
 }
 
 func remoteUserCommand(args []string) (string, error) {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -6179,7 +6179,8 @@ env_candidates=%s
 service=%s
 ids=""
 selected_env=""
-for env in $env_candidates; do
+while IFS= read -r env || [ -n "$env" ]; do
+  [ -n "$env" ] || continue
   candidate_ids=$($docker_cmd ps -a -q --filter label=devopsellence.managed=true --filter "label=devopsellence.environment=$env" --filter "label=devopsellence.service=$service" 2>&1)
   ps_status=$?
   if [ "$ps_status" -ne 0 ]; then
@@ -6195,7 +6196,9 @@ for env in $env_candidates; do
     selected_env="$env"
     break
   fi
-done
+done <<__DEVOPSELLENCE_ENV_CANDIDATES__
+$env_candidates
+__DEVOPSELLENCE_ENV_CANDIDATES__
 if [ -z "$ids" ]; then echo "%s" >&2; echo "No workload containers found for service $service in environments %s" >&2; exit 1; fi
 rc=0
 for id in $ids; do

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -4514,12 +4514,16 @@ func (a *App) SoloIngressCertInstall(ctx context.Context, opts SoloIngressCertIn
 	if err != nil {
 		return err
 	}
+	_, workspaceRoot, environmentName, err := a.loadResolvedSoloProjectConfig("")
+	if err != nil {
+		return err
+	}
+	currentKey, err := solo.EnvironmentStateKey(workspaceRoot, environmentName)
+	if err != nil {
+		return err
+	}
 	nodeNames := append([]string(nil), opts.Nodes...)
 	if len(nodeNames) == 0 {
-		_, workspaceRoot, environmentName, resolveErr := a.loadResolvedSoloProjectConfig("")
-		if resolveErr != nil {
-			return resolveErr
-		}
 		nodeNames, err = current.AttachedNodeNames(workspaceRoot, environmentName)
 		if err != nil {
 			return err
@@ -4535,7 +4539,7 @@ func (a *App) SoloIngressCertInstall(ctx context.Context, opts SoloIngressCertIn
 	if len(nodes) == 0 {
 		return fmt.Errorf("no nodes selected; attach a node or pass --node")
 	}
-	if err := validateSoloManualTLSInstallSafe(current, sortedNodeNames(nodes)); err != nil {
+	if err := validateSoloManualTLSInstallSafe(current, currentKey, sortedNodeNames(nodes)); err != nil {
 		return err
 	}
 
@@ -4563,9 +4567,13 @@ func (a *App) SoloIngressCertInstall(ctx context.Context, opts SoloIngressCertIn
 	})
 }
 
-func validateSoloManualTLSInstallSafe(current solo.State, nodeNames []string) error {
+func validateSoloManualTLSInstallSafe(current solo.State, currentKey string, nodeNames []string) error {
+	currentKey = strings.TrimSpace(currentKey)
 	for _, nodeName := range normalizeSoloNames(nodeNames) {
 		for _, key := range current.AttachmentKeysForNode(nodeName) {
+			if strings.TrimSpace(key) == currentKey {
+				continue
+			}
 			snapshot, ok := current.Snapshots[key]
 			if !ok {
 				releaseID := strings.TrimSpace(current.Current[key])

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -2640,17 +2640,20 @@ func (a *App) SoloWorkloadLogs(ctx context.Context, opts SoloWorkloadLogsOptions
 	results := make([]map[string]any, 0, len(nodes))
 	ok := true
 	for _, nodeName := range sortedNodeNames(nodes) {
-		runtimeEnvironmentName, err := soloRuntimeEnvironmentNameForNode(current, workspaceRoot, environmentName, nodeName)
+		runtimeEnvironmentNames, err := soloRuntimeEnvironmentNameCandidatesForNode(current, workspaceRoot, environmentName, nodeName)
 		if err != nil {
 			return err
 		}
-		diag := runRemoteDiagnostic(ctx, nodes[nodeName], remoteDockerLogsCommand(runtimeEnvironmentName, serviceName, linesLimit))
+		diag := runRemoteDiagnostic(ctx, nodes[nodeName], remoteDockerLogsCommand(runtimeEnvironmentNames, serviceName, linesLimit))
 		entry := map[string]any{
 			"node":                nodeName,
 			"service":             serviceName,
-			"runtime_environment": runtimeEnvironmentName,
+			"runtime_environment": runtimeEnvironmentNames[0],
 			"ok":                  diag.Err == nil && diag.ExitCode == 0,
 			"lines":               splitNonFinalEmptyLines(diag.Stdout),
+		}
+		if len(runtimeEnvironmentNames) > 1 {
+			entry["runtime_environment_candidates"] = runtimeEnvironmentNames
 		}
 		if diag.Err != nil {
 			entry["error"] = diag.Err.Error()
@@ -2755,11 +2758,11 @@ func (a *App) SoloExec(ctx context.Context, opts SoloExecOptions) error {
 		if result.Missing {
 			continue
 		}
-		runtimeEnvironmentName, err := soloRuntimeEnvironmentNameForNode(current, workspaceRoot, environmentName, nodeName)
+		runtimeEnvironmentNames, err := soloRuntimeEnvironmentNameCandidatesForNode(current, workspaceRoot, environmentName, nodeName)
 		if err != nil {
 			return err
 		}
-		container := statusServiceContainer(result.Status, runtimeEnvironmentName, serviceName)
+		runtimeEnvironmentName, container := statusServiceContainerForRuntimeEnvironments(result.Status, runtimeEnvironmentNames, serviceName)
 		if container == "" {
 			continue
 		}
@@ -3057,6 +3060,16 @@ func soloExecFields(target soloExecTarget) map[string]any {
 		payload["container"] = target.Container
 	}
 	return payload
+}
+
+func statusServiceContainerForRuntimeEnvironments(status soloNodeStatus, environmentNames []string, serviceName string) (string, string) {
+	for _, environmentName := range environmentNames {
+		container := statusServiceContainer(status, environmentName, serviceName)
+		if container != "" {
+			return environmentName, container
+		}
+	}
+	return "", ""
 }
 
 func statusServiceContainer(status soloNodeStatus, environmentName, serviceName string) string {
@@ -4831,25 +4844,48 @@ func (a *App) soloCurrentWorkspaceRoot() (string, error) {
 	return discovered.WorkspaceRoot, nil
 }
 
-func soloRuntimeEnvironmentNameForNode(current solo.State, workspaceRoot, logicalEnvironment, _ string) (string, error) {
+func soloRuntimeEnvironmentNameForNode(current solo.State, workspaceRoot, logicalEnvironment, nodeName string) (string, error) {
+	candidates, err := soloRuntimeEnvironmentNameCandidatesForNode(current, workspaceRoot, logicalEnvironment, nodeName)
+	if err != nil {
+		return "", err
+	}
+	return candidates[0], nil
+}
+
+func soloRuntimeEnvironmentNameCandidatesForNode(current solo.State, workspaceRoot, logicalEnvironment, _ string) ([]string, error) {
 	logicalEnvironment = strings.TrimSpace(logicalEnvironment)
 	if logicalEnvironment == "" {
 		logicalEnvironment = config.DefaultEnvironment
 	}
 	currentKey, err := solo.EnvironmentStateKey(workspaceRoot, logicalEnvironment)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	currentSnapshot, ok := current.Snapshots[currentKey]
 	if !ok {
-		return logicalEnvironment, nil
+		return []string{logicalEnvironment}, nil
 	}
 	base := defaultSoloSnapshotEnvironment(currentSnapshot, logicalEnvironment)
-	// Keep CLI lookups aligned with deployment-core's aggregated desired-state
-	// naming. Once a snapshot exists, solo runtime environment names are always
-	// project-scoped/stable, even if a co-hosted peer with the same logical
-	// environment has detached.
-	return uniqueSoloRuntimeEnvironmentName(currentSnapshot, base), nil
+	// Prefer the stable project-scoped name emitted by deployment-core for new
+	// aggregated publications, but keep the logical/base environment as a
+	// compatibility fallback for nodes last deployed before this naming change.
+	return appendUniqueNonEmptyStrings(nil, uniqueSoloRuntimeEnvironmentName(currentSnapshot, base), base, logicalEnvironment), nil
+}
+
+func appendUniqueNonEmptyStrings(values []string, candidates ...string) []string {
+	seen := map[string]bool{}
+	for _, value := range values {
+		seen[value] = true
+	}
+	for _, candidate := range candidates {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" || seen[candidate] {
+			continue
+		}
+		values = append(values, candidate)
+		seen[candidate] = true
+	}
+	return values
 }
 
 func defaultSoloSnapshotEnvironment(snapshot desiredstate.DeploySnapshot, fallback string) string {
@@ -6130,21 +6166,37 @@ func remoteDockerNetworksJSONCommand() string {
 	return withRemoteLineLimit("if docker info >/dev/null 2>&1; then docker network ls --format '{{json .}}'; elif command -v sudo >/dev/null 2>&1 && sudo -n docker info >/dev/null 2>&1; then sudo -n docker network ls --format '{{json .}}'; else echo 'Docker is not reachable' >&2; exit 1; fi", soloDiagnoseDockerItemLimit)
 }
 
-func remoteDockerLogsCommand(environmentName, serviceName string, lines int) string {
-	env := shellQuote(environmentName)
+func remoteDockerLogsCommand(environmentNames []string, serviceName string, lines int) string {
+	environmentNames = appendUniqueNonEmptyStrings(nil, environmentNames...)
+	if len(environmentNames) == 0 {
+		environmentNames = []string{config.DefaultEnvironment}
+	}
+	envs := shellQuote(strings.Join(environmentNames, "\n"))
+	envDescription := shellQuote(strings.Join(environmentNames, ", "))
 	service := shellQuote(serviceName)
 	return fmt.Sprintf(`if docker info >/dev/null 2>&1; then docker_cmd=docker; elif command -v sudo >/dev/null 2>&1 && sudo -n docker info >/dev/null 2>&1; then docker_cmd="sudo -n docker"; else echo 'Docker is not reachable' >&2; exit 1; fi
-ids=$($docker_cmd ps -a -q --filter label=devopsellence.managed=true --filter label=devopsellence.environment=%s --filter label=devopsellence.service=%s 2>&1)
-ps_status=$?
-if [ "$ps_status" -ne 0 ]; then
-  echo "Failed to list workload containers for service %s in environment %s" >&2
-  if [ -n "$ids" ]; then
-    printf '%%s\n' "$ids" >&2
+env_candidates=%s
+service=%s
+ids=""
+selected_env=""
+for env in $env_candidates; do
+  candidate_ids=$($docker_cmd ps -a -q --filter label=devopsellence.managed=true --filter "label=devopsellence.environment=$env" --filter "label=devopsellence.service=$service" 2>&1)
+  ps_status=$?
+  if [ "$ps_status" -ne 0 ]; then
+    echo "Failed to list workload containers for service $service in environment $env" >&2
+    if [ -n "$candidate_ids" ]; then
+      printf '%%s\n' "$candidate_ids" >&2
+    fi
+    exit "$ps_status"
   fi
-  exit "$ps_status"
-fi
-ids=$(printf '%%s\n' "$ids" | sed '/^$/d' | head -n %d)
-if [ -z "$ids" ]; then echo "%s" >&2; echo "No workload containers found for service %s in environment %s" >&2; exit 1; fi
+  candidate_ids=$(printf '%%s\n' "$candidate_ids" | sed '/^$/d' | head -n %d)
+  if [ -n "$candidate_ids" ]; then
+    ids="$candidate_ids"
+    selected_env="$env"
+    break
+  fi
+done
+if [ -z "$ids" ]; then echo "%s" >&2; echo "No workload containers found for service $service in environments %s" >&2; exit 1; fi
 rc=0
 for id in $ids; do
   name=$($docker_cmd inspect --format '{{.Name}}' "$id" 2>/dev/null | sed 's#^/##')
@@ -6160,7 +6212,7 @@ for id in $ids; do
     rc=$logs_status
   fi
 done
-	exit "$rc"`, env, service, service, env, soloWorkloadLogsContainerLimit, soloNoWorkloadContainersSentinel, service, env, lines)
+	exit "$rc"`, envs, service, soloWorkloadLogsContainerLimit, soloNoWorkloadContainersSentinel, envDescription, lines)
 }
 
 func remoteUserCommand(args []string) (string, error) {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -4823,7 +4823,7 @@ func (a *App) soloCurrentWorkspaceRoot() (string, error) {
 	return discovered.WorkspaceRoot, nil
 }
 
-func soloRuntimeEnvironmentNameForNode(current solo.State, workspaceRoot, logicalEnvironment, nodeName string) (string, error) {
+func soloRuntimeEnvironmentNameForNode(current solo.State, workspaceRoot, logicalEnvironment, _ string) (string, error) {
 	logicalEnvironment = strings.TrimSpace(logicalEnvironment)
 	if logicalEnvironment == "" {
 		logicalEnvironment = config.DefaultEnvironment
@@ -4837,22 +4837,10 @@ func soloRuntimeEnvironmentNameForNode(current solo.State, workspaceRoot, logica
 		return logicalEnvironment, nil
 	}
 	base := defaultSoloSnapshotEnvironment(currentSnapshot, logicalEnvironment)
-	duplicates := 0
-	for key, attachment := range current.Attachments {
-		if !stringSliceContains(attachment.NodeNames, nodeName) {
-			continue
-		}
-		snapshot, ok := current.Snapshots[key]
-		if !ok {
-			continue
-		}
-		if defaultSoloSnapshotEnvironment(snapshot, attachment.Environment) == base {
-			duplicates++
-		}
-	}
-	if duplicates <= 1 {
-		return base, nil
-	}
+	// Keep CLI lookups aligned with deployment-core's aggregated desired-state
+	// naming. Once a snapshot exists, solo runtime environment names are always
+	// project-scoped/stable, even if a co-hosted peer with the same logical
+	// environment has detached.
 	return uniqueSoloRuntimeEnvironmentName(currentSnapshot, base), nil
 }
 
@@ -4864,16 +4852,6 @@ func defaultSoloSnapshotEnvironment(snapshot desiredstate.DeploySnapshot, fallba
 		return value
 	}
 	return config.DefaultEnvironment
-}
-
-func stringSliceContains(values []string, target string) bool {
-	target = strings.TrimSpace(target)
-	for _, value := range values {
-		if strings.TrimSpace(value) == target {
-			return true
-		}
-	}
-	return false
 }
 
 func uniqueSoloRuntimeEnvironmentName(snapshot desiredstate.DeploySnapshot, base string) string {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -4535,6 +4535,9 @@ func (a *App) SoloIngressCertInstall(ctx context.Context, opts SoloIngressCertIn
 	if len(nodes) == 0 {
 		return fmt.Errorf("no nodes selected; attach a node or pass --node")
 	}
+	if err := validateSoloManualTLSInstallSafe(current, sortedNodeNames(nodes)); err != nil {
+		return err
+	}
 
 	installed := make([]map[string]any, 0, len(nodes))
 	for _, nodeName := range sortedNodeNames(nodes) {
@@ -4558,6 +4561,54 @@ func (a *App) SoloIngressCertInstall(ctx context.Context, opts SoloIngressCertIn
 			"curl -vk https://<hostname>/",
 		},
 	})
+}
+
+func validateSoloManualTLSInstallSafe(current solo.State, nodeNames []string) error {
+	for _, nodeName := range normalizeSoloNames(nodeNames) {
+		for _, key := range current.AttachmentKeysForNode(nodeName) {
+			snapshot, ok := current.Snapshots[key]
+			if !ok {
+				releaseID := strings.TrimSpace(current.Current[key])
+				if releaseID != "" {
+					if release, releaseOK := current.Releases[releaseID]; releaseOK {
+						snapshot = release.Snapshot
+						ok = true
+					}
+				}
+			}
+			if !ok || snapshot.Ingress == nil || normalizedSoloSnapshotIngressMode(snapshot.Ingress.Mode) != "public" {
+				continue
+			}
+			if normalizedSoloSnapshotTLSMode(snapshot.Ingress.TLS.Mode) != "auto" {
+				continue
+			}
+			project := strings.TrimSpace(snapshot.Metadata.Project)
+			if project == "" {
+				project = strings.TrimSpace(snapshot.WorkspaceRoot)
+			}
+			if project == "" {
+				project = key
+			}
+			return fmt.Errorf("manual TLS cert install would affect auto TLS environment %s on node %s; move manual TLS to a dedicated node or switch all co-hosted public ingress on that node to manual/off first", project, nodeName)
+		}
+	}
+	return nil
+}
+
+func normalizedSoloSnapshotIngressMode(mode string) string {
+	mode = strings.TrimSpace(mode)
+	if mode == "" {
+		return "public"
+	}
+	return mode
+}
+
+func normalizedSoloSnapshotTLSMode(mode string) string {
+	mode = strings.TrimSpace(mode)
+	if mode == "" {
+		return "auto"
+	}
+	return mode
 }
 
 func validateReadableFile(filePath, label string) error {

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -2114,6 +2114,58 @@ func TestSoloIngressCertInstallRejectsAutoTLSCohostOnSelectedNode(t *testing.T) 
 	}
 }
 
+func TestSoloIngressCertInstallAllowsCurrentEnvironmentAutoTLSMigration(t *testing.T) {
+	cwd := rootTestSoloWorkspace(t)
+	uploadsPath := filepath.Join(t.TempDir(), "uploads")
+	scriptPath := filepath.Join(t.TempDir(), "script")
+	t.Setenv("DEVOPSELLENCE_FAKE_SSH_UPLOADS", uploadsPath)
+	t.Setenv("DEVOPSELLENCE_FAKE_SSH_SCRIPT", scriptPath)
+	installFakeSoloCommands(t, nil)
+	certFile := filepath.Join(t.TempDir(), "cert.pem")
+	keyFile := filepath.Join(t.TempDir(), "key.pem")
+	if err := os.WriteFile(certFile, []byte("cert"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyFile, []byte("key"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	current := solo.State{}
+	if err := current.SetNode("node-a", config.Node{Host: "203.0.113.10", User: "root"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := current.AttachNode(cwd, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	currentKey, err := solo.EnvironmentStateKey(cwd, "production")
+	if err != nil {
+		t.Fatal(err)
+	}
+	current.Snapshots[currentKey] = desiredstate.DeploySnapshot{
+		WorkspaceRoot: cwd,
+		WorkspaceKey:  strings.Split(currentKey, "\n")[0],
+		Environment:   "production",
+		Revision:      "auto1234",
+		Metadata:      desiredstate.SnapshotMetadata{Project: "demo"},
+		Ingress:       &desiredstate.IngressJSON{Mode: "public", TLS: desiredstate.IngressTLSJSON{Mode: "auto"}, Hosts: []string{"demo.example.com"}},
+	}
+	if err := solo.NewStateStore(solo.DefaultStatePath()).Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := NewApp(bytes.NewBuffer(nil), &stdout, io.Discard, cwd)
+	if err := app.SoloIngressCertInstall(context.Background(), SoloIngressCertInstallOptions{CertFile: certFile, KeyFile: keyFile}); err != nil {
+		t.Fatalf("SoloIngressCertInstall() error = %v, want current environment auto TLS migration allowed", err)
+	}
+	uploads, err := os.ReadFile(uploadsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Count(string(uploads), "/tmp/devopsellence-ingress-"); got != 2 {
+		t.Fatalf("uploads = %q, want cert and key uploads", uploads)
+	}
+}
+
 func TestSoloIngressCertInstallUploadsManualTLSFilesToAttachedNode(t *testing.T) {
 	cwd := rootTestSoloWorkspace(t)
 	uploadsPath := filepath.Join(t.TempDir(), "uploads")

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -1860,65 +1860,14 @@ func TestSoloWorkloadLogsUsesProjectScopedRuntimeEnvironmentForCoHostedNode(t *t
 	if !strings.Contains(command, runtimeEnvironment) {
 		t.Fatalf("workload logs command = %q, want runtime environment %q", command, runtimeEnvironment)
 	}
-	if !strings.Contains(command, "production") {
-		t.Fatalf("workload logs command = %q, want legacy logical environment fallback", command)
+	if strings.Contains(command, "env_candidates") || strings.Contains(command, "__DEVOPSELLENCE_SELECTED_ENVIRONMENT__") {
+		t.Fatalf("workload logs command = %q, should target one clean-slate runtime environment without compatibility candidates", command)
 	}
 	payload := decodeJSONOutput(t, &stdout)
 	nodes := jsonArrayFromMap(t, payload, "nodes")
 	node := jsonMapFromAny(t, nodes[0])
 	if node["runtime_environment"] != runtimeEnvironment {
 		t.Fatalf("node payload = %#v, want runtime environment %q", node, runtimeEnvironment)
-	}
-}
-
-func TestSoloWorkloadLogsReportsSelectedRuntimeEnvironmentFallback(t *testing.T) {
-	t.Setenv("DEVOPSELLENCE_FAKE_SSH_WORKLOAD_LOGS_SELECTED_ENVIRONMENT", "production")
-	installFakeSoloCommands(t, nil)
-	workspaceRoot := t.TempDir()
-	cfg := config.DefaultProjectConfig("solo", "demo", "production")
-	if _, err := config.Write(workspaceRoot, cfg); err != nil {
-		t.Fatal(err)
-	}
-
-	current := solo.State{}
-	if err := current.SetNode("node-a", config.Node{Host: "203.0.113.10", User: "root"}); err != nil {
-		t.Fatal(err)
-	}
-	if _, _, err := current.AttachNode(workspaceRoot, "production", "node-a"); err != nil {
-		t.Fatal(err)
-	}
-	workspaceKey, err := solo.EnvironmentStateKey(workspaceRoot, "production")
-	if err != nil {
-		t.Fatal(err)
-	}
-	current.Snapshots = map[string]desiredstate.DeploySnapshot{
-		workspaceKey: {WorkspaceRoot: workspaceRoot, WorkspaceKey: strings.Split(workspaceKey, "\n")[0], Environment: "production", Metadata: desiredstate.SnapshotMetadata{Project: "demo"}},
-	}
-	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
-	if err := soloState.Write(current); err != nil {
-		t.Fatal(err)
-	}
-
-	var stdout bytes.Buffer
-	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState, ConfigStore: config.NewStore(), Cwd: workspaceRoot}
-	if err := app.SoloWorkloadLogs(context.Background(), SoloWorkloadLogsOptions{ServiceName: "web", Nodes: []string{"node-a"}, Lines: 20}); err != nil {
-		t.Fatalf("SoloWorkloadLogs() error = %v", err)
-	}
-	payload := decodeJSONOutput(t, &stdout)
-	nodes := jsonArrayFromMap(t, payload, "nodes")
-	node := jsonMapFromAny(t, nodes[0])
-	if node["runtime_environment"] != "production" {
-		t.Fatalf("node payload = %#v, want selected fallback runtime environment", node)
-	}
-	candidates := jsonArrayFromMap(t, node, "runtime_environment_candidates")
-	if len(candidates) < 2 || candidates[0] == "production" {
-		t.Fatalf("runtime_environment_candidates = %#v, want project-scoped primary plus logical fallback", candidates)
-	}
-	lines := jsonArrayFromMap(t, node, "lines")
-	for _, line := range lines {
-		if strings.Contains(fmt.Sprint(line), soloWorkloadLogsSelectedEnvironmentPrefix) {
-			t.Fatalf("lines = %#v, want selected-environment marker stripped", lines)
-		}
 	}
 }
 
@@ -2013,7 +1962,7 @@ func TestSoloExecUsesProjectScopedRuntimeEnvironmentForCoHostedNode(t *testing.T
 	}
 }
 
-func TestSoloExecFallsBackToLogicalRuntimeEnvironmentForLegacyNode(t *testing.T) {
+func TestSoloExecDoesNotFallBackToLogicalRuntimeEnvironment(t *testing.T) {
 	cwd := rootTestSoloWorkspace(t)
 	current := solo.State{}
 	if err := current.SetNode("node-a", config.Node{Host: "203.0.113.10", User: "root"}); err != nil {
@@ -2038,12 +1987,8 @@ func TestSoloExecFallsBackToLogicalRuntimeEnvironmentForLegacyNode(t *testing.T)
 	var stdout bytes.Buffer
 	app := NewApp(bytes.NewBuffer(nil), &stdout, io.Discard, cwd)
 	err = app.SoloExec(context.Background(), SoloExecOptions{ServiceName: "web", Nodes: []string{"node-a"}, Command: []string{"bin/rails", "runner", "puts Rails.env"}})
-	if err != nil {
-		t.Fatalf("SoloExec() error = %v", err)
-	}
-	events := decodeNDJSONOutput(t, &stdout)
-	if len(events) == 0 || events[0]["container"] != "svc-production-web-abc" || events[0]["environment"] != "production" {
-		t.Fatalf("started event = %#v, want legacy logical environment container", events[0])
+	if err == nil || !strings.Contains(err.Error(), `no active container found for service "web" in environment production`) {
+		t.Fatalf("SoloExec() error = %v, want clean-slate runtime environment miss", err)
 	}
 }
 
@@ -2627,18 +2572,20 @@ func TestSoloWorkloadLogsRequiresWorkspaceConfig(t *testing.T) {
 }
 
 func TestRemoteDockerLogsCommandPreservesPerContainerFailure(t *testing.T) {
-	command := remoteDockerLogsCommand([]string{"demo-production-abc123", "production"}, "web", 20)
-	for _, snippet := range []string{`ps_status=$?`, `Failed to list workload containers`, `__DEVOPSELLENCE_NO_WORKLOAD_CONTAINERS__`, `head -n 20`, `rc=0`, `inspect_status=$?`, `logs_status=$?`, `exit "$rc"`, `while IFS= read -r env`, `demo-production-abc123`, `production`} {
+	command := remoteDockerLogsCommand("demo-production-abc123", "web", 20)
+	for _, snippet := range []string{`ps_status=$?`, `Failed to list workload containers`, `__DEVOPSELLENCE_NO_WORKLOAD_CONTAINERS__`, `head -n 20`, `rc=0`, `inspect_status=$?`, `logs_status=$?`, `exit "$rc"`, `demo-production-abc123`} {
 		if !strings.Contains(command, snippet) {
 			t.Fatalf("command = %q, want %q", command, snippet)
 		}
 	}
-	if strings.Contains(command, `for env in $env_candidates`) {
-		t.Fatalf("command = %q, should not iterate env candidates with shell word-splitting", command)
+	for _, forbidden := range []string{`env_candidates`, `while IFS= read -r env`, `__DEVOPSELLENCE_SELECTED_ENVIRONMENT__`} {
+		if strings.Contains(command, forbidden) {
+			t.Fatalf("command = %q, should not contain compatibility candidate machinery %q", command, forbidden)
+		}
 	}
 }
 
-func TestRemoteDockerLogsCommandHandlesEnvironmentCandidateWithWhitespace(t *testing.T) {
+func TestRemoteDockerLogsCommandHandlesRuntimeEnvironmentWithWhitespace(t *testing.T) {
 	binDir := t.TempDir()
 	writeExecutable(t, filepath.Join(binDir, "docker"), `#!/usr/bin/env bash
 set -euo pipefail
@@ -2674,14 +2621,14 @@ esac
 printf 'unexpected docker command: %s\n' "$*" >&2
 exit 1
 `)
-	cmd := exec.Command("sh", "-c", remoteDockerLogsCommand([]string{"prod us", "production"}, "web", 20))
+	cmd := exec.Command("sh", "-c", remoteDockerLogsCommand("prod us", "web", 20))
 	cmd.Env = append(os.Environ(), "PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("remote docker logs command failed: %v\n%s", err, out)
 	}
-	if !strings.Contains(string(out), soloWorkloadLogsSelectedEnvironmentPrefix+"prod us") || !strings.Contains(string(out), "==> svc-prod-us <==") || !strings.Contains(string(out), "log line for spaced env") {
-		t.Fatalf("output = %q, want selected environment marker and logs for whitespace environment candidate", out)
+	if strings.Contains(string(out), "__DEVOPSELLENCE_SELECTED_ENVIRONMENT__") || !strings.Contains(string(out), "==> svc-prod-us <==") || !strings.Contains(string(out), "log line for spaced env") {
+		t.Fatalf("output = %q, want logs for whitespace runtime environment without compatibility marker", out)
 	}
 }
 
@@ -5374,11 +5321,7 @@ if [[ "$command" == *" logs --tail "* ]]; then
   if [[ -n "${DEVOPSELLENCE_FAKE_SSH_WORKLOAD_LOGS_COMMAND:-}" ]]; then
     printf '%s' "$command" >"$DEVOPSELLENCE_FAKE_SSH_WORKLOAD_LOGS_COMMAND"
   fi
-  selected_env_line=""
-  if [[ -n "${DEVOPSELLENCE_FAKE_SSH_WORKLOAD_LOGS_SELECTED_ENVIRONMENT:-}" ]]; then
-    selected_env_line="__DEVOPSELLENCE_SELECTED_ENVIRONMENT__=${DEVOPSELLENCE_FAKE_SSH_WORKLOAD_LOGS_SELECTED_ENVIRONMENT}"$'\n'
-  fi
-  printf '__DEVOPSELLENCE_EXIT_CODE__0\n__DEVOPSELLENCE_STDOUT__\n%s==> svc-production-web <==\napp line one\napp line two\n__DEVOPSELLENCE_STDERR__\n' "$selected_env_line"
+  printf '__DEVOPSELLENCE_EXIT_CODE__0\n__DEVOPSELLENCE_STDOUT__\n==> svc-production-web <==\napp line one\napp line two\n__DEVOPSELLENCE_STDERR__\n'
   exit 0
 fi
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -1857,11 +1857,11 @@ func TestSoloWorkloadLogsUsesProjectScopedRuntimeEnvironmentForCoHostedNode(t *t
 		t.Fatalf("read workload command: %v", err)
 	}
 	command := string(commandBytes)
-	if !strings.Contains(command, "label=devopsellence.environment='"+runtimeEnvironment+"'") {
+	if !strings.Contains(command, runtimeEnvironment) {
 		t.Fatalf("workload logs command = %q, want runtime environment %q", command, runtimeEnvironment)
 	}
-	if strings.Contains(command, "label=devopsellence.environment=production") || strings.Contains(command, "label=devopsellence.environment='production'") {
-		t.Fatalf("workload logs command = %q, should not filter by logical production", command)
+	if !strings.Contains(command, "production") {
+		t.Fatalf("workload logs command = %q, want legacy logical environment fallback", command)
 	}
 	payload := decodeJSONOutput(t, &stdout)
 	nodes := jsonArrayFromMap(t, payload, "nodes")
@@ -1959,6 +1959,40 @@ func TestSoloExecUsesProjectScopedRuntimeEnvironmentForCoHostedNode(t *testing.T
 	events := decodeNDJSONOutput(t, &stdout)
 	if len(events) == 0 || events[0]["container"] != "svc-production-web-abc" || events[0]["environment"] != runtimeEnvironment {
 		t.Fatalf("started event = %#v, want co-hosted runtime env %q container", events[0], runtimeEnvironment)
+	}
+}
+
+func TestSoloExecFallsBackToLogicalRuntimeEnvironmentForLegacyNode(t *testing.T) {
+	cwd := rootTestSoloWorkspace(t)
+	current := solo.State{}
+	if err := current.SetNode("node-a", config.Node{Host: "203.0.113.10", User: "root"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := current.AttachNode(cwd, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	workspaceKey, err := solo.EnvironmentStateKey(cwd, "production")
+	if err != nil {
+		t.Fatal(err)
+	}
+	current.Snapshots = map[string]desiredstate.DeploySnapshot{
+		workspaceKey: {WorkspaceRoot: cwd, WorkspaceKey: strings.Split(workspaceKey, "\n")[0], Environment: "production", Metadata: desiredstate.SnapshotMetadata{Project: "demo"}},
+	}
+	status := `{"revision":"abc","phase":"settled","environments":[{"name":"production","services":[{"name":"web","state":"running","container":"svc-production-web-abc"}]}]}` + "\n"
+	installFakeSoloCommands(t, []fakeSSHResponse{{stdout: status}})
+	if err := solo.NewStateStore(solo.DefaultStatePath()).Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := NewApp(bytes.NewBuffer(nil), &stdout, io.Discard, cwd)
+	err = app.SoloExec(context.Background(), SoloExecOptions{ServiceName: "web", Nodes: []string{"node-a"}, Command: []string{"bin/rails", "runner", "puts Rails.env"}})
+	if err != nil {
+		t.Fatalf("SoloExec() error = %v", err)
+	}
+	events := decodeNDJSONOutput(t, &stdout)
+	if len(events) == 0 || events[0]["container"] != "svc-production-web-abc" || events[0]["environment"] != "production" {
+		t.Fatalf("started event = %#v, want legacy logical environment container", events[0])
 	}
 }
 
@@ -2507,8 +2541,8 @@ func TestSoloWorkloadLogsRequiresWorkspaceConfig(t *testing.T) {
 }
 
 func TestRemoteDockerLogsCommandPreservesPerContainerFailure(t *testing.T) {
-	command := remoteDockerLogsCommand("production", "web", 20)
-	for _, snippet := range []string{`ps_status=$?`, `Failed to list workload containers`, `__DEVOPSELLENCE_NO_WORKLOAD_CONTAINERS__`, `head -n 20`, `rc=0`, `inspect_status=$?`, `logs_status=$?`, `exit "$rc"`} {
+	command := remoteDockerLogsCommand([]string{"demo-production-abc123", "production"}, "web", 20)
+	for _, snippet := range []string{`ps_status=$?`, `Failed to list workload containers`, `__DEVOPSELLENCE_NO_WORKLOAD_CONTAINERS__`, `head -n 20`, `rc=0`, `inspect_status=$?`, `logs_status=$?`, `exit "$rc"`, `demo-production-abc123`, `production`} {
 		if !strings.Contains(command, snippet) {
 			t.Fatalf("command = %q, want %q", command, snippet)
 		}

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -1962,6 +1962,42 @@ func TestSoloExecUsesProjectScopedRuntimeEnvironmentForCoHostedNode(t *testing.T
 	}
 }
 
+func TestSoloRuntimeEnvironmentNameStaysProjectScopedAfterPeerDetach(t *testing.T) {
+	cwd := rootTestSoloWorkspace(t)
+	otherRoot := t.TempDir()
+	current := solo.State{}
+	if err := current.SetNode("node-a", config.Node{Host: "203.0.113.10", User: "root"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := current.AttachNode(cwd, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	workspaceKey, err := solo.EnvironmentStateKey(cwd, "production")
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherKey, err := solo.EnvironmentStateKey(otherRoot, "production")
+	if err != nil {
+		t.Fatal(err)
+	}
+	current.Snapshots = map[string]desiredstate.DeploySnapshot{
+		workspaceKey: {WorkspaceRoot: cwd, WorkspaceKey: strings.Split(workspaceKey, "\n")[0], Environment: "production", Metadata: desiredstate.SnapshotMetadata{Project: "demo"}},
+		// The peer was detached, so its attachment is gone, but historical solo
+		// state may still retain its snapshot. CLI lookups must still match the
+		// project-scoped runtime name that aggregated desired-state publishes for
+		// the surviving project.
+		otherKey: {WorkspaceRoot: otherRoot, WorkspaceKey: strings.Split(otherKey, "\n")[0], Environment: "production", Metadata: desiredstate.SnapshotMetadata{Project: "api"}},
+	}
+
+	runtimeEnvironment, err := soloRuntimeEnvironmentNameForNode(current, cwd, "production", "node-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if runtimeEnvironment == "production" || !strings.HasPrefix(runtimeEnvironment, "demo-production-") {
+		t.Fatalf("runtime environment = %q, want stable project-scoped name after peer detach", runtimeEnvironment)
+	}
+}
+
 func TestRootExecEnvSelectsAttachedEnvironment(t *testing.T) {
 	cwd := rootTestSoloWorkspace(t)
 	cfg, err := config.LoadFromRoot(cwd)

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -2029,6 +2029,55 @@ func TestRootExecEnvFailsWhenSelectedEnvironmentHasNoAttachedNodes(t *testing.T)
 	}
 }
 
+func TestSoloIngressCertInstallRejectsAutoTLSCohostOnSelectedNode(t *testing.T) {
+	cwd := rootTestSoloWorkspace(t)
+	installFakeSoloCommands(t, nil)
+	certFile := filepath.Join(t.TempDir(), "cert.pem")
+	keyFile := filepath.Join(t.TempDir(), "key.pem")
+	if err := os.WriteFile(certFile, []byte("cert"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyFile, []byte("key"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	otherRoot := filepath.Join(t.TempDir(), "other")
+	if err := os.MkdirAll(otherRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	current := solo.State{}
+	if err := current.SetNode("node-a", config.Node{Host: "203.0.113.10", User: "root"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := current.AttachNode(cwd, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := current.AttachNode(otherRoot, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	otherKey, err := solo.EnvironmentStateKey(otherRoot, "production")
+	if err != nil {
+		t.Fatal(err)
+	}
+	current.Snapshots[otherKey] = desiredstate.DeploySnapshot{
+		WorkspaceRoot: otherRoot,
+		WorkspaceKey:  otherRoot,
+		Environment:   "production",
+		Revision:      "auto1234",
+		Metadata:      desiredstate.SnapshotMetadata{Project: "auto-app"},
+		Ingress:       &desiredstate.IngressJSON{Mode: "public", TLS: desiredstate.IngressTLSJSON{Mode: "auto"}, Hosts: []string{"auto.example.com"}},
+	}
+	if err := solo.NewStateStore(solo.DefaultStatePath()).Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := NewApp(bytes.NewBuffer(nil), &stdout, io.Discard, cwd)
+	err = app.SoloIngressCertInstall(context.Background(), SoloIngressCertInstallOptions{CertFile: certFile, KeyFile: keyFile})
+	if err == nil || !strings.Contains(err.Error(), "manual TLS cert install would affect auto TLS") {
+		t.Fatalf("SoloIngressCertInstall() error = %v, want auto TLS cohost guard", err)
+	}
+}
+
 func TestSoloIngressCertInstallUploadsManualTLSFilesToAttachedNode(t *testing.T) {
 	cwd := rootTestSoloWorkspace(t)
 	uploadsPath := filepath.Join(t.TempDir(), "uploads")

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -2542,10 +2542,60 @@ func TestSoloWorkloadLogsRequiresWorkspaceConfig(t *testing.T) {
 
 func TestRemoteDockerLogsCommandPreservesPerContainerFailure(t *testing.T) {
 	command := remoteDockerLogsCommand([]string{"demo-production-abc123", "production"}, "web", 20)
-	for _, snippet := range []string{`ps_status=$?`, `Failed to list workload containers`, `__DEVOPSELLENCE_NO_WORKLOAD_CONTAINERS__`, `head -n 20`, `rc=0`, `inspect_status=$?`, `logs_status=$?`, `exit "$rc"`, `demo-production-abc123`, `production`} {
+	for _, snippet := range []string{`ps_status=$?`, `Failed to list workload containers`, `__DEVOPSELLENCE_NO_WORKLOAD_CONTAINERS__`, `head -n 20`, `rc=0`, `inspect_status=$?`, `logs_status=$?`, `exit "$rc"`, `while IFS= read -r env`, `demo-production-abc123`, `production`} {
 		if !strings.Contains(command, snippet) {
 			t.Fatalf("command = %q, want %q", command, snippet)
 		}
+	}
+	if strings.Contains(command, `for env in $env_candidates`) {
+		t.Fatalf("command = %q, should not iterate env candidates with shell word-splitting", command)
+	}
+}
+
+func TestRemoteDockerLogsCommandHandlesEnvironmentCandidateWithWhitespace(t *testing.T) {
+	binDir := t.TempDir()
+	writeExecutable(t, filepath.Join(binDir, "docker"), `#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-}" in
+  info)
+    exit 0
+    ;;
+  ps)
+    saw_env=0
+    saw_service=0
+    for arg in "$@"; do
+      if [[ "$arg" == "label=devopsellence.environment=prod us" ]]; then
+        saw_env=1
+      fi
+      if [[ "$arg" == "label=devopsellence.service=web" ]]; then
+        saw_service=1
+      fi
+    done
+    if [[ "$saw_env" == "1" && "$saw_service" == "1" ]]; then
+      printf 'container-1\n'
+    fi
+    exit 0
+    ;;
+  inspect)
+    printf '/svc-prod-us\n'
+    exit 0
+    ;;
+  logs)
+    printf 'log line for spaced env\n'
+    exit 0
+    ;;
+esac
+printf 'unexpected docker command: %s\n' "$*" >&2
+exit 1
+`)
+	cmd := exec.Command("sh", "-c", remoteDockerLogsCommand([]string{"prod us", "production"}, "web", 20))
+	cmd.Env = append(os.Environ(), "PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("remote docker logs command failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "==> svc-prod-us <==") || !strings.Contains(string(out), "log line for spaced env") {
+		t.Fatalf("output = %q, want logs for whitespace environment candidate", out)
 	}
 }
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -1871,6 +1871,57 @@ func TestSoloWorkloadLogsUsesProjectScopedRuntimeEnvironmentForCoHostedNode(t *t
 	}
 }
 
+func TestSoloWorkloadLogsReportsSelectedRuntimeEnvironmentFallback(t *testing.T) {
+	t.Setenv("DEVOPSELLENCE_FAKE_SSH_WORKLOAD_LOGS_SELECTED_ENVIRONMENT", "production")
+	installFakeSoloCommands(t, nil)
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	current := solo.State{}
+	if err := current.SetNode("node-a", config.Node{Host: "203.0.113.10", User: "root"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := current.AttachNode(workspaceRoot, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	workspaceKey, err := solo.EnvironmentStateKey(workspaceRoot, "production")
+	if err != nil {
+		t.Fatal(err)
+	}
+	current.Snapshots = map[string]desiredstate.DeploySnapshot{
+		workspaceKey: {WorkspaceRoot: workspaceRoot, WorkspaceKey: strings.Split(workspaceKey, "\n")[0], Environment: "production", Metadata: desiredstate.SnapshotMetadata{Project: "demo"}},
+	}
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState, ConfigStore: config.NewStore(), Cwd: workspaceRoot}
+	if err := app.SoloWorkloadLogs(context.Background(), SoloWorkloadLogsOptions{ServiceName: "web", Nodes: []string{"node-a"}, Lines: 20}); err != nil {
+		t.Fatalf("SoloWorkloadLogs() error = %v", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	nodes := jsonArrayFromMap(t, payload, "nodes")
+	node := jsonMapFromAny(t, nodes[0])
+	if node["runtime_environment"] != "production" {
+		t.Fatalf("node payload = %#v, want selected fallback runtime environment", node)
+	}
+	candidates := jsonArrayFromMap(t, node, "runtime_environment_candidates")
+	if len(candidates) < 2 || candidates[0] == "production" {
+		t.Fatalf("runtime_environment_candidates = %#v, want project-scoped primary plus logical fallback", candidates)
+	}
+	lines := jsonArrayFromMap(t, node, "lines")
+	for _, line := range lines {
+		if strings.Contains(fmt.Sprint(line), soloWorkloadLogsSelectedEnvironmentPrefix) {
+			t.Fatalf("lines = %#v, want selected-environment marker stripped", lines)
+		}
+	}
+}
+
 func TestSoloExecRunsCommandInServiceContainer(t *testing.T) {
 	cwd := rootTestSoloWorkspace(t)
 	installFakeSoloCommands(t, []fakeSSHResponse{{stdout: `{"revision":"abc","phase":"settled","environments":[{"name":"production","services":[{"name":"web","state":"starting","container":"svc-production-web-abc"}]}]}` + "\n"}})
@@ -2259,6 +2310,41 @@ func TestSoloIngressCertInstallUploadsManualTLSFilesToAttachedNode(t *testing.T)
 	}
 }
 
+func TestSoloIngressCertInstallWithExplicitNodeDoesNotRequireWorkspaceConfig(t *testing.T) {
+	cwd := t.TempDir()
+	uploadsPath := filepath.Join(t.TempDir(), "uploads")
+	t.Setenv("DEVOPSELLENCE_FAKE_SSH_UPLOADS", uploadsPath)
+	installFakeSoloCommands(t, nil)
+	certFile := filepath.Join(t.TempDir(), "cert.pem")
+	keyFile := filepath.Join(t.TempDir(), "key.pem")
+	if err := os.WriteFile(certFile, []byte("cert"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyFile, []byte("key"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	current := solo.State{}
+	if err := current.SetNode("node-a", config.Node{Host: "203.0.113.10", User: "root"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := solo.NewStateStore(solo.DefaultStatePath()).Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := NewApp(bytes.NewBuffer(nil), &stdout, io.Discard, cwd)
+	if err := app.SoloIngressCertInstall(context.Background(), SoloIngressCertInstallOptions{CertFile: certFile, KeyFile: keyFile, Nodes: []string{"node-a"}}); err != nil {
+		t.Fatalf("SoloIngressCertInstall() error = %v, want explicit --node to work outside a workspace", err)
+	}
+	uploads, err := os.ReadFile(uploadsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Count(string(uploads), "/tmp/devopsellence-ingress-"); got != 2 {
+		t.Fatalf("uploads = %q, want cert and key uploads", uploads)
+	}
+}
+
 func TestSoloIngressCertInstallFailsWhenAgentRestartFails(t *testing.T) {
 	cwd := rootTestSoloWorkspace(t)
 	t.Setenv("DEVOPSELLENCE_FAKE_SSH_RESTART_FAIL", "1")
@@ -2594,8 +2680,8 @@ exit 1
 	if err != nil {
 		t.Fatalf("remote docker logs command failed: %v\n%s", err, out)
 	}
-	if !strings.Contains(string(out), "==> svc-prod-us <==") || !strings.Contains(string(out), "log line for spaced env") {
-		t.Fatalf("output = %q, want logs for whitespace environment candidate", out)
+	if !strings.Contains(string(out), soloWorkloadLogsSelectedEnvironmentPrefix+"prod us") || !strings.Contains(string(out), "==> svc-prod-us <==") || !strings.Contains(string(out), "log line for spaced env") {
+		t.Fatalf("output = %q, want selected environment marker and logs for whitespace environment candidate", out)
 	}
 }
 
@@ -5288,7 +5374,11 @@ if [[ "$command" == *" logs --tail "* ]]; then
   if [[ -n "${DEVOPSELLENCE_FAKE_SSH_WORKLOAD_LOGS_COMMAND:-}" ]]; then
     printf '%s' "$command" >"$DEVOPSELLENCE_FAKE_SSH_WORKLOAD_LOGS_COMMAND"
   fi
-  printf '__DEVOPSELLENCE_EXIT_CODE__0\n__DEVOPSELLENCE_STDOUT__\n==> svc-production-web <==\napp line one\napp line two\n__DEVOPSELLENCE_STDERR__\n'
+  selected_env_line=""
+  if [[ -n "${DEVOPSELLENCE_FAKE_SSH_WORKLOAD_LOGS_SELECTED_ENVIRONMENT:-}" ]]; then
+    selected_env_line="__DEVOPSELLENCE_SELECTED_ENVIRONMENT__=${DEVOPSELLENCE_FAKE_SSH_WORKLOAD_LOGS_SELECTED_ENVIRONMENT}"$'\n'
+  fi
+  printf '__DEVOPSELLENCE_EXIT_CODE__0\n__DEVOPSELLENCE_STDOUT__\n%s==> svc-production-web <==\napp line one\napp line two\n__DEVOPSELLENCE_STDERR__\n' "$selected_env_line"
   exit 0
 fi
 

--- a/deployment-core/pkg/deploycore/desiredstate/desiredstate.go
+++ b/deployment-core/pkg/deploycore/desiredstate/desiredstate.go
@@ -301,18 +301,14 @@ func buildAggregatedDesiredState(nodeName string, currentNode config.Node, snaps
 }
 
 func aggregatedEnvironmentNames(snapshots []DeploySnapshot) map[string]string {
-	counts := map[string]int{}
 	names := map[string]string{}
-	for _, snapshot := range snapshots {
-		counts[defaultEnvironmentName(snapshot.Environment)]++
-	}
 	for _, snapshot := range snapshots {
 		key := snapshotKey(snapshot)
 		base := defaultEnvironmentName(snapshot.Environment)
-		if counts[base] == 1 {
-			names[key] = base
-			continue
-		}
+		// Solo nodes can host multiple projects with the same logical environment
+		// name. Keep the runtime environment name project-scoped even after peers
+		// attach/detach so republishing one project does not rename and recreate a
+		// healthy co-hosted project's containers.
 		names[key] = uniqueAggregatedEnvironmentName(snapshot, base)
 	}
 	return names

--- a/deployment-core/pkg/deploycore/desiredstate/desiredstate_test.go
+++ b/deployment-core/pkg/deploycore/desiredstate/desiredstate_test.go
@@ -620,3 +620,80 @@ func TestPlanNodePublicationNamespacesDuplicateEnvironmentNames(t *testing.T) {
 		t.Fatalf("ingress targets = %#v, want %#v", gotTargets, gotNames)
 	}
 }
+
+func TestPlanNodePublicationKeepsEnvironmentNameStableWhenCohostedPeerDetaches(t *testing.T) {
+	t.Parallel()
+
+	currentNode := config.Node{Labels: []string{config.DefaultWebRole}}
+	alpha := DeploySnapshot{
+		WorkspaceRoot: "/workspace/a",
+		WorkspaceKey:  "/workspace/a",
+		Environment:   "production",
+		Revision:      "aaa1111",
+		Metadata:      SnapshotMetadata{Project: "alpha"},
+		Services:      []ServiceJSON{{Name: "web", Kind: config.ServiceKindWeb, Image: "alpha:aaa1111"}},
+		Ingress: &IngressJSON{
+			Mode:  "public",
+			TLS:   IngressTLSJSON{Mode: "auto"},
+			Hosts: []string{"a.example.com"},
+			Routes: []IngressRouteJSON{{
+				Match:  IngressMatchJSON{Hostname: "a.example.com"},
+				Target: IngressTargetJSON{Environment: "production", Service: "web", Port: "http"},
+			}},
+		},
+		IngressService:     "web",
+		IngressServiceKind: config.ServiceKindWeb,
+	}
+	bravo := DeploySnapshot{
+		WorkspaceRoot: "/workspace/b",
+		WorkspaceKey:  "/workspace/b",
+		Environment:   "production",
+		Revision:      "bbb2222",
+		Metadata:      SnapshotMetadata{Project: "bravo"},
+		Services:      []ServiceJSON{{Name: "web", Kind: config.ServiceKindWeb, Image: "bravo:bbb2222"}},
+		Ingress: &IngressJSON{
+			Mode:  "public",
+			TLS:   IngressTLSJSON{Mode: "auto"},
+			Hosts: []string{"b.example.com"},
+			Routes: []IngressRouteJSON{{
+				Match:  IngressMatchJSON{Hostname: "b.example.com"},
+				Target: IngressTargetJSON{Environment: "production", Service: "web", Port: "http"},
+			}},
+		},
+		IngressService:     "web",
+		IngressServiceKind: config.ServiceKindWeb,
+	}
+
+	cohosted, err := PlanNodePublication(NodePublicationInput{NodeName: "web-a", CurrentNode: currentNode, Snapshots: []DeploySnapshot{alpha, bravo}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	solo, err := PlanNodePublication(NodePublicationInput{NodeName: "web-a", CurrentNode: currentNode, Snapshots: []DeploySnapshot{alpha}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var cohostedDS DesiredStateJSON
+	if err := json.Unmarshal(cohosted.DesiredStateJSON, &cohostedDS); err != nil {
+		t.Fatal(err)
+	}
+	var soloDS DesiredStateJSON
+	if err := json.Unmarshal(solo.DesiredStateJSON, &soloDS); err != nil {
+		t.Fatal(err)
+	}
+	cohostedName := ""
+	for _, env := range cohostedDS.Environments {
+		if env.Revision == "aaa1111" {
+			cohostedName = env.Name
+		}
+	}
+	if cohostedName == "" {
+		t.Fatalf("alpha environment missing from cohosted desired state: %#v", cohostedDS.Environments)
+	}
+	if len(soloDS.Environments) != 1 {
+		t.Fatalf("single-project desired state environments = %#v", soloDS.Environments)
+	}
+	if soloDS.Environments[0].Name != cohostedName {
+		t.Fatalf("environment name changed after peer detach: solo=%q cohosted=%q", soloDS.Environments[0].Name, cohostedName)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes both issues found in the official `v0.2.0-preview` dogfood rerun:

- Fixes #104 by refusing `ingress cert install` when any selected solo node already hosts an attached public auto-TLS environment. This prevents manual cert/key files from overriding ACME-managed co-hosted routes on restart.
- Fixes #105 by making solo aggregated runtime environment names stable and project-scoped regardless of the current co-host count, so detaching one project does not rename/recreate remaining projects that share the same logical environment name.

## Tests

- `cd deployment-core && mise exec -- go test ./pkg/deploycore/desiredstate -run 'TestPlanNodePublication(KeepsEnvironmentNameStableWhenCohostedPeerDetaches|NamespacesDuplicateEnvironmentNames)' -count=1 -v`
- `cd cli && mise exec -- go test ./internal/workflow -run 'TestSoloIngressCertInstall(RejectsAutoTLSCohostOnSelectedNode|UploadsManualTLSFilesToAttachedNode|FailsWhenAgentRestartFails|FailsWhenCurrentEnvironmentHasNoAttachedNodes)' -count=1 -v`
- `cd deployment-core && mise exec -- go test ./...`
- `cd cli && mise exec -- go test ./internal/workflow -count=1`
- `cd cli && mise exec -- go test ./...`
- `git diff --check`

## Notes

I did not run live destructive dogfood on the shared preview node for this branch before opening the PR; the changes are covered with regression tests and full relevant Go suites. After merge/release, rerun the dogfood-solo detach/manual-TLS probes against official artifacts.
