### PR TITLE
fix(cli): reconcile solo ingress check readiness in status

### DIFF
--- a/cli/internal/solo/state.go
+++ b/cli/internal/solo/state.go
@@ -31,6 +31,7 @@ type State struct {
 	Current       map[string]string                      `json:"current_releases,omitempty"`
 	Deployments   map[string]corerelease.Deployment      `json:"deployments,omitempty"`
 	Secrets       map[string]SecretRecord                `json:"secrets,omitempty"`
+	IngressChecks map[string]IngressCheckRecord          `json:"ingress_checks,omitempty"`
 }
 
 type AttachmentRecord struct {
@@ -50,6 +51,16 @@ type SecretRecord struct {
 	Value         string `json:"value"`
 	Reference     string `json:"reference,omitempty"`
 	UpdatedAt     string `json:"updated_at,omitempty"`
+}
+
+type IngressCheckRecord struct {
+	WorkspaceRoot string   `json:"workspace_root,omitempty"`
+	WorkspaceKey  string   `json:"workspace_key,omitempty"`
+	Environment   string   `json:"environment,omitempty"`
+	OK            bool     `json:"ok"`
+	PublicURLs    []string `json:"public_urls,omitempty"`
+	ExpectedIPs   []string `json:"expected_ips,omitempty"`
+	CheckedAt     string   `json:"checked_at,omitempty"`
 }
 
 func DefaultStatePath() string {
@@ -337,6 +348,7 @@ func newState() State {
 		Current:       map[string]string{},
 		Deployments:   map[string]corerelease.Deployment{},
 		Secrets:       map[string]SecretRecord{},
+		IngressChecks: map[string]IngressCheckRecord{},
 	}
 }
 
@@ -364,6 +376,9 @@ func (s *State) ensureDefaults() {
 	}
 	if s.Secrets == nil {
 		s.Secrets = map[string]SecretRecord{}
+	}
+	if s.IngressChecks == nil {
+		s.IngressChecks = map[string]IngressCheckRecord{}
 	}
 }
 
@@ -557,6 +572,21 @@ func normalizeState(current State) (State, error) {
 	}
 	current.Secrets = normalizedSecrets
 
+	ingressKeys := make([]string, 0, len(current.IngressChecks))
+	for key := range current.IngressChecks {
+		ingressKeys = append(ingressKeys, key)
+	}
+	sort.Strings(ingressKeys)
+	normalizedIngressChecks := make(map[string]IngressCheckRecord, len(current.IngressChecks))
+	for _, key := range ingressKeys {
+		normalizedKey, record, err := normalizeIngressCheckRecord(key, current.IngressChecks[key])
+		if err != nil {
+			return State{}, fmt.Errorf("normalize ingress check %q: %w", key, err)
+		}
+		normalizedIngressChecks[normalizedKey] = record
+	}
+	current.IngressChecks = normalizedIngressChecks
+
 	return current, nil
 }
 
@@ -614,6 +644,21 @@ func normalizeSecretRecord(key string, secret SecretRecord) (string, SecretRecor
 	}
 	secret.Reference = reference
 	return secretKey(secret.WorkspaceKey, secret.Environment, secret.ServiceName, secret.Name), secret, nil
+}
+
+func normalizeIngressCheckRecord(key string, record IngressCheckRecord) (string, IngressCheckRecord, error) {
+	workspaceRoot, workspaceKey, err := normalizeWorkspaceIdentity(key, record.WorkspaceRoot, record.WorkspaceKey)
+	if err != nil {
+		return "", IngressCheckRecord{}, err
+	}
+	_, keyEnvironment := splitEnvironmentStateKey(key)
+	record.WorkspaceRoot = workspaceRoot
+	record.WorkspaceKey = workspaceKey
+	record.Environment = defaultEnvironmentName(firstNonEmpty(record.Environment, keyEnvironment))
+	record.PublicURLs = normalizeStringSet(record.PublicURLs)
+	record.ExpectedIPs = normalizeStringSet(record.ExpectedIPs)
+	record.CheckedAt = strings.TrimSpace(record.CheckedAt)
+	return record.WorkspaceKey + "\n" + record.Environment, record, nil
 }
 
 func normalizeWorkspaceIdentity(key, workspaceRoot, workspaceKey string) (string, string, error) {
@@ -932,6 +977,21 @@ func normalizeNodeNames(names []string) []string {
 		}
 		seen[name] = true
 		normalized = append(normalized, name)
+	}
+	sort.Strings(normalized)
+	return normalized
+}
+
+func normalizeStringSet(values []string) []string {
+	seen := map[string]bool{}
+	normalized := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" || seen[value] {
+			continue
+		}
+		seen[value] = true
+		normalized = append(normalized, value)
 	}
 	sort.Strings(normalized)
 	return normalized

--- a/cli/internal/solo/state_test.go
+++ b/cli/internal/solo/state_test.go
@@ -84,6 +84,30 @@ func TestStateStoreRoundTrip(t *testing.T) {
 	}
 }
 
+func TestStateStorePersistsIngressCheckRecords(t *testing.T) {
+	t.Parallel()
+
+	store := NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := newState()
+	current.IngressChecks["/workspace/demo\nproduction"] = IngressCheckRecord{
+		OK:          true,
+		PublicURLs:  []string{"https://app.example.com/"},
+		ExpectedIPs: []string{"203.0.113.10"},
+		CheckedAt:   "2026-04-29T23:30:00Z",
+	}
+	if err := store.Write(current); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := store.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+	record := loaded.IngressChecks["/workspace/demo\nproduction"]
+	if !record.OK || !reflect.DeepEqual(record.PublicURLs, []string{"https://app.example.com/"}) || !reflect.DeepEqual(record.ExpectedIPs, []string{"203.0.113.10"}) {
+		t.Fatalf("ingress check record = %#v", record)
+	}
+}
+
 func TestStateStoreWriteUsesAtomicPrivateFile(t *testing.T) {
 	t.Parallel()
 

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -3423,7 +3423,7 @@ func (a *App) SoloNodeLabelSet(ctx context.Context, opts SoloNodeLabelSetOptions
 	if err := a.writeSoloState(current); err != nil {
 		return err
 	}
-	if _, err := a.republishNodes(ctx, current, soloAffectedNodesForNode(current, opts.Node)); err != nil {
+	if _, err := a.republishNodes(ctx, current, soloAffectedNodesForNodeWithReleaseState(current, opts.Node)); err != nil {
 		return err
 	}
 
@@ -3483,7 +3483,7 @@ func (a *App) SoloNodeLabelRemove(ctx context.Context, opts SoloNodeLabelRemoveO
 	if err := a.writeSoloState(current); err != nil {
 		return err
 	}
-	if _, err := a.republishNodes(ctx, current, soloAffectedNodesForNode(current, opts.Node)); err != nil {
+	if _, err := a.republishNodes(ctx, current, soloAffectedNodesForNodeWithReleaseState(current, opts.Node)); err != nil {
 		return err
 	}
 	return a.Printer.PrintJSON(map[string]any{"schema_version": outputSchemaVersion, "node": opts.Node, "labels": current.Nodes[opts.Node].Labels, "removed": labels})
@@ -5100,6 +5100,18 @@ func soloAffectedNodesForNode(current solo.State, nodeName string) []string {
 	affected := []string{nodeName}
 	for _, key := range current.AttachmentKeysForNode(nodeName) {
 		attachment := current.Attachments[key]
+		affected = append(affected, attachment.NodeNames...)
+	}
+	return normalizeSoloNames(affected)
+}
+
+func soloAffectedNodesForNodeWithReleaseState(current solo.State, nodeName string) []string {
+	affected := []string{}
+	for _, key := range current.AttachmentKeysForNode(nodeName) {
+		attachment := current.Attachments[key]
+		if !soloAttachmentHasReleaseState(current, attachment) {
+			continue
+		}
 		affected = append(affected, attachment.NodeNames...)
 	}
 	return normalizeSoloNames(affected)

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -922,7 +922,7 @@ func (a *App) currentSoloAttachment(current solo.State) (*config.ProjectConfig, 
 	if cfg == nil {
 		return nil, discovered.WorkspaceRoot, "", nil, false, nil
 	}
-	environmentName := soloEnvironmentName(cfg, "")
+	environmentName := a.effectiveEnvironment("", cfg)
 	nodeNames, err := current.AttachedNodeNames(discovered.WorkspaceRoot, environmentName)
 	if err != nil {
 		return nil, "", "", nil, true, err
@@ -2449,7 +2449,7 @@ func (a *App) SoloNodeAttach(ctx context.Context, opts SoloNodeAttachOptions) er
 	if err != nil {
 		return err
 	}
-	environmentName := soloEnvironmentName(cfg, opts.Environment)
+	environmentName := a.effectiveEnvironment(opts.Environment, cfg)
 	attachment, changed, err := a.attachNode(&current, workspaceRoot, environmentName, opts.Node)
 	if err != nil {
 		return err
@@ -2488,7 +2488,7 @@ func (a *App) SoloNodeDetach(ctx context.Context, opts SoloNodeDetachOptions) er
 	if err != nil {
 		return err
 	}
-	environmentName := soloEnvironmentName(cfg, opts.Environment)
+	environmentName := a.effectiveEnvironment(opts.Environment, cfg)
 	nodeNamesBefore, err := current.AttachedNodeNames(workspaceRoot, environmentName)
 	if err != nil {
 		return err
@@ -2629,7 +2629,7 @@ func (a *App) SoloWorkloadLogs(ctx context.Context, opts SoloWorkloadLogsOptions
 	if cfg == nil {
 		return fmt.Errorf("no workspace selected; attach a workspace or run this command from a workspace")
 	}
-	environmentName := soloEnvironmentName(cfg, "")
+	environmentName := a.effectiveEnvironment("", cfg)
 	workspaceRoot, err := a.soloCurrentWorkspaceRoot()
 	if err != nil {
 		return err
@@ -3668,14 +3668,15 @@ func (a *App) SoloDoctor(ctx context.Context) error {
 		if len(current.Nodes) == 0 {
 			return "", errors.New("No nodes registered in solo state. Run `devopsellence node create <name>`.")
 		}
-		nodeNames, err := current.AttachedNodeNames(discovered.WorkspaceRoot, soloEnvironmentName(cfg, ""))
+		environmentName := a.effectiveEnvironment("", cfg)
+		nodeNames, err := current.AttachedNodeNames(discovered.WorkspaceRoot, environmentName)
 		if err != nil {
 			return "", err
 		}
 		if len(nodeNames) == 0 {
 			return "", errors.New("No nodes attached to the current environment. Run `devopsellence node attach <name>`.")
 		}
-		return fmt.Sprintf("%d node(s) attached to %s", len(nodeNames), soloEnvironmentName(cfg, "")), nil
+		return fmt.Sprintf("%d node(s) attached to %s", len(nodeNames), environmentName), nil
 	})
 
 	ok := true
@@ -3692,7 +3693,8 @@ func (a *App) SoloDoctor(ctx context.Context) error {
 		"checks":         checks,
 	}
 	if ok && cfg != nil {
-		nodeNames, err := current.AttachedNodeNames(discovered.WorkspaceRoot, soloEnvironmentName(cfg, ""))
+		environmentName := a.effectiveEnvironment("", cfg)
+		nodeNames, err := current.AttachedNodeNames(discovered.WorkspaceRoot, environmentName)
 		if err != nil {
 			return err
 		}
@@ -3796,7 +3798,7 @@ func (a *App) SoloNodeCreate(ctx context.Context, opts SoloNodeCreateOptions) er
 	attached := false
 	var attachment solo.AttachmentRecord
 	if opts.Attach {
-		environmentName := soloEnvironmentName(cfg, "")
+		environmentName := a.effectiveEnvironment("", cfg)
 		var attachErr error
 		attachment, _, attachErr = a.attachNode(&current, workspaceRoot, environmentName, nodeName)
 		if attachErr != nil {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1647,6 +1647,7 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 	if len(nodes) == 0 {
 		return fmt.Errorf("no nodes attached to the current environment")
 	}
+	verifiedPublicURLs := a.soloVerifiedPublicURLs(cfg, nodes)
 
 	var jsonResults []map[string]any
 	readErrors := 0
@@ -1693,11 +1694,11 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 		"schema_version": outputSchemaVersion,
 		"nodes":          jsonResults,
 	}
-	if urls := soloReadyPublicURLs(cfg, nodes); len(urls) > 0 {
+	if len(verifiedPublicURLs) > 0 {
 		if allSettled {
-			payload["public_urls"] = urls
+			payload["public_urls"] = verifiedPublicURLs
 		} else {
-			payload["configured_public_urls"] = urls
+			payload["configured_public_urls"] = verifiedPublicURLs
 			payload["warnings"] = []string{"public URLs are configured, but one or more nodes are not settled; check node status before testing reachability"}
 		}
 	} else if urls := soloStatusPublicURLs(cfg, nodes); len(urls) > 0 {
@@ -4720,6 +4721,14 @@ func (a *App) IngressCheck(ctx context.Context, opts IngressCheckOptions) error 
 			return err
 		}
 		if report.OK || !ingressDNSReportRetryable(report) || opts.Wait <= 0 || time.Now().After(deadline) {
+			if report.OK {
+				if err := recordSuccessfulSoloIngressCheck(&current, workspaceRoot, environmentName, report); err != nil {
+					return err
+				}
+				if err := a.writeSoloState(current); err != nil {
+					return err
+				}
+			}
 
 			if err := a.Printer.PrintJSON(report); err != nil {
 				return err
@@ -4736,6 +4745,28 @@ func (a *App) IngressCheck(ctx context.Context, opts IngressCheckOptions) error 
 		case <-time.After(5 * time.Second):
 		}
 	}
+}
+
+func recordSuccessfulSoloIngressCheck(current *solo.State, workspaceRoot, environmentName string, report ingressDNSReportResult) error {
+	if current == nil {
+		return errors.New("solo state is required")
+	}
+	key, err := solo.EnvironmentStateKey(workspaceRoot, environmentName)
+	if err != nil {
+		return err
+	}
+	if current.IngressChecks == nil {
+		current.IngressChecks = map[string]solo.IngressCheckRecord{}
+	}
+	current.IngressChecks[key] = solo.IngressCheckRecord{
+		OK:            true,
+		PublicURLs:    append([]string(nil), report.PublicURLs...),
+		ExpectedIPs:   append([]string(nil), report.ExpectedIPs...),
+		CheckedAt:     time.Now().UTC().Format(time.RFC3339),
+		WorkspaceRoot: workspaceRoot,
+		Environment:   environmentName,
+	}
+	return nil
 }
 
 func (a *App) installSoloAgent(ctx context.Context, nodeName string, node config.Node, opts SoloAgentInstallOptions) error {
@@ -4815,6 +4846,12 @@ func cloneSoloState(current solo.State) solo.State {
 		cloned.Secrets = make(map[string]solo.SecretRecord, len(current.Secrets))
 		for key, value := range current.Secrets {
 			cloned.Secrets[key] = value
+		}
+	}
+	if current.IngressChecks != nil {
+		cloned.IngressChecks = make(map[string]solo.IngressCheckRecord, len(current.IngressChecks))
+		for key, value := range current.IngressChecks {
+			cloned.IngressChecks[key] = value
 		}
 	}
 	return cloned
@@ -4997,6 +5034,57 @@ func (a *App) soloStatusSelection(opts SoloStatusOptions) (map[string]config.Nod
 	}
 	nodes, err := a.resolveNodes(current, nodeNames)
 	return nodes, cfg, err
+}
+
+func (a *App) soloVerifiedPublicURLs(cfg *config.ProjectConfig, nodes map[string]config.Node) []string {
+	if !ingressRequiresTLSReadiness(cfg) {
+		return soloReadyPublicURLs(cfg, nodes)
+	}
+	current, err := a.readSoloState()
+	if err != nil {
+		return nil
+	}
+	_, workspaceRoot, environmentName, err := a.loadResolvedSoloProjectConfig("")
+	if err != nil {
+		return nil
+	}
+	return soloVerifiedIngressPublicURLs(current, workspaceRoot, environmentName, cfg, nodes)
+}
+
+func soloVerifiedIngressPublicURLs(current solo.State, workspaceRoot, environmentName string, cfg *config.ProjectConfig, nodes map[string]config.Node) []string {
+	key, err := solo.EnvironmentStateKey(workspaceRoot, environmentName)
+	if err != nil {
+		return nil
+	}
+	record, ok := current.IngressChecks[key]
+	if !ok || !record.OK {
+		return nil
+	}
+	urls := soloStatusPublicURLs(cfg, nodes)
+	if len(urls) == 0 || !sameStringSet(record.PublicURLs, urls) {
+		return nil
+	}
+	expectedIPs := webNodeIPs(cfg, nodes)
+	if len(expectedIPs) > 0 && !sameStringSet(record.ExpectedIPs, expectedIPs) {
+		return nil
+	}
+	return urls
+}
+
+func sameStringSet(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	leftCopy := append([]string(nil), left...)
+	rightCopy := append([]string(nil), right...)
+	sort.Strings(leftCopy)
+	sort.Strings(rightCopy)
+	for i := range leftCopy {
+		if leftCopy[i] != rightCopy[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func (a *App) attachNode(current *solo.State, workspaceRoot, environmentName, nodeName string) (solo.AttachmentRecord, bool, error) {

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -991,6 +991,60 @@ func TestSoloStatusUsesResolvedEnvironmentOverlay(t *testing.T) {
 	}
 }
 
+func TestSoloStatusUsesVerifiedTLSPublicURLsAfterIngressCheckRecord(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	cfg.Ingress = &config.IngressConfig{
+		Hosts: []string{"app.example.com"},
+		Rules: []config.IngressRuleConfig{{
+			Match:  config.IngressMatchConfig{Host: "app.example.com", PathPrefix: "/"},
+			Target: config.IngressTargetConfig{Service: config.DefaultWebServiceName, Port: "http"},
+		}},
+		TLS: config.IngressTLSConfig{Mode: "auto"},
+	}
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	installFakeSoloCommands(t, []fakeSSHResponse{{stdout: `{"revision":"rev","phase":"settled","summary":{"environments":1,"services":1}}` + "\n"}})
+
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{Nodes: map[string]config.Node{"node-a": {Host: "203.0.113.10", User: "root", Labels: []string{config.DefaultWebRole}}}}
+	if _, _, err := current.AttachNode(workspaceRoot, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	key, err := solo.EnvironmentStateKey(workspaceRoot, "production")
+	if err != nil {
+		t.Fatal(err)
+	}
+	current.IngressChecks = map[string]solo.IngressCheckRecord{
+		key: {
+			OK:          true,
+			PublicURLs:  []string{"https://app.example.com/"},
+			ExpectedIPs: []string{"203.0.113.10"},
+		},
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState, ConfigStore: config.NewStore(), Cwd: workspaceRoot}
+	if err := app.SoloStatus(context.Background(), SoloStatusOptions{}); err != nil {
+		t.Fatalf("SoloStatus() error = %v", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	urls := jsonArrayFromMap(t, payload, "public_urls")
+	if len(urls) != 1 || urls[0] != "https://app.example.com/" {
+		t.Fatalf("public_urls = %#v, want verified HTTPS URL", urls)
+	}
+	if _, ok := payload["public_url_status"]; ok {
+		t.Fatalf("payload = %#v, did not expect tls pending status after verified ingress check", payload)
+	}
+	if _, ok := payload["warnings"]; ok {
+		t.Fatalf("payload = %#v, did not expect TLS warning after verified ingress check", payload)
+	}
+}
+
 func TestSoloStatusUsesConfiguredPublicURLsWhenNodeIsNotSettled(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")
@@ -1091,6 +1145,59 @@ func TestIngressDNSReportIncludesPublicURLsAndReadyNextSteps(t *testing.T) {
 	}
 	if len(report.NextSteps) != 2 || report.NextSteps[0] != "devopsellence status" || report.NextSteps[1] != "curl https://127.0.0.1/" {
 		t.Fatalf("next_steps = %#v, want status and curl", report.NextSteps)
+	}
+}
+
+func TestIngressCheckPersistsSuccessfulReadinessRecord(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	cfg.Ingress = &config.IngressConfig{
+		Hosts: []string{"127.0.0.1"},
+		Rules: []config.IngressRuleConfig{{
+			Match:  config.IngressMatchConfig{Host: "127.0.0.1", PathPrefix: "/"},
+			Target: config.IngressTargetConfig{Service: config.DefaultWebServiceName, Port: "http"},
+		}},
+		TLS: config.IngressTLSConfig{Mode: "auto"},
+	}
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.Node{
+			"node-a": {Host: "127.0.0.1", User: "root", Labels: []string{config.DefaultWebRole}},
+		},
+		Attachments: map[string]solo.AttachmentRecord{},
+		Snapshots:   map[string]desiredstate.DeploySnapshot{},
+	}
+	if _, _, err := current.AttachNode(workspaceRoot, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState, ConfigStore: config.NewStore(), Cwd: workspaceRoot}
+	if err := app.IngressCheck(context.Background(), IngressCheckOptions{}); err != nil {
+		t.Fatalf("IngressCheck() error = %v", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	if payload["ok"] != true {
+		t.Fatalf("payload ok = %v, want true", payload["ok"])
+	}
+	loaded, err := soloState.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+	key, err := solo.EnvironmentStateKey(workspaceRoot, "production")
+	if err != nil {
+		t.Fatal(err)
+	}
+	record := loaded.IngressChecks[key]
+	if !record.OK || !reflect.DeepEqual(record.PublicURLs, []string{"https://127.0.0.1/"}) || !reflect.DeepEqual(record.ExpectedIPs, []string{"127.0.0.1"}) || strings.TrimSpace(record.CheckedAt) == "" {
+		t.Fatalf("ingress check record = %#v", record)
 	}
 }
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -737,6 +737,56 @@ func TestSoloNodeCreateRegistersExistingSSHNode(t *testing.T) {
 	}
 }
 
+func TestSoloNodeAttachUsesSavedCurrentEnvironment(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	cfg.Environments = map[string]config.EnvironmentOverlay{"staging": {}}
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	if err := soloState.Write(solo.State{Nodes: map[string]config.Node{"node-a": {Host: "203.0.113.10", User: "root", Labels: []string{config.DefaultWebRole}}}}); err != nil {
+		t.Fatal(err)
+	}
+	workspaceState := state.New(filepath.Join(t.TempDir(), "workspace-state.json"))
+	var stdout bytes.Buffer
+	app := &App{
+		Printer:        output.New(&stdout, io.Discard),
+		SoloState:      soloState,
+		WorkspaceState: workspaceState,
+		ConfigStore:    config.NewStore(),
+		Cwd:            workspaceRoot,
+	}
+	if err := app.SetEnvironment("staging"); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.SoloNodeAttach(context.Background(), SoloNodeAttachOptions{Node: "node-a"}); err != nil {
+		t.Fatal(err)
+	}
+	current, err := soloState.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stagingNodes, err := current.AttachedNodeNames(workspaceRoot, "staging")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(stagingNodes, []string{"node-a"}) {
+		t.Fatalf("staging attachments = %#v, want node-a", stagingNodes)
+	}
+	productionNodes, err := current.AttachedNodeNames(workspaceRoot, "production")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(productionNodes) != 0 {
+		t.Fatalf("production attachments = %#v, want none", productionNodes)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	if payload["environment"] != "staging" {
+		t.Fatalf("payload environment = %#v, want staging", payload["environment"])
+	}
+}
+
 func TestSoloNodeCreateValidatesExistingSSHBeforeWritingState(t *testing.T) {
 	binDir := t.TempDir()
 	writeExecutable(t, filepath.Join(binDir, "ssh"), "#!/usr/bin/env bash\necho 'Permission denied (publickey).' >&2\nexit 255\n")

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -938,6 +938,41 @@ func TestSoloAffectedNodesForNodeIncludesCoHostedNodes(t *testing.T) {
 	}
 }
 
+func TestSoloAffectedNodesForNodeWithReleaseStateSkipsStatelessAttachments(t *testing.T) {
+	current := solo.State{
+		Nodes: map[string]config.Node{
+			"node-a": {},
+			"node-b": {},
+			"node-c": {},
+		},
+		Attachments: map[string]solo.AttachmentRecord{
+			"/workspace/a\nproduction": {
+				WorkspaceKey: "/workspace/a",
+				Environment:  "production",
+				NodeNames:    []string{"node-a", "node-b"},
+			},
+			"/workspace/b\nproduction": {
+				WorkspaceKey: "/workspace/b",
+				Environment:  "production",
+				NodeNames:    []string{"node-a", "node-c"},
+			},
+		},
+		Snapshots: map[string]desiredstate.DeploySnapshot{
+			"/workspace/b\nproduction": {WorkspaceKey: "/workspace/b", Environment: "production"},
+		},
+	}
+
+	got := soloAffectedNodesForNodeWithReleaseState(current, "node-a")
+	want := []string{"node-a", "node-c"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("affected nodes with release state = %#v, want %#v", got, want)
+	}
+	delete(current.Snapshots, "/workspace/b\nproduction")
+	if got := soloAffectedNodesForNodeWithReleaseState(current, "node-a"); len(got) != 0 {
+		t.Fatalf("affected nodes with no release state = %#v, want none", got)
+	}
+}
+
 func TestSoloStatusIncludesPublicURLs(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -2367,6 +2367,7 @@ func TestSoloIngressCertInstallUploadsManualTLSFilesToAttachedNode(t *testing.T)
 
 func TestSoloIngressCertInstallWithExplicitNodeDoesNotRequireWorkspaceConfig(t *testing.T) {
 	cwd := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	uploadsPath := filepath.Join(t.TempDir(), "uploads")
 	t.Setenv("DEVOPSELLENCE_FAKE_SSH_UPLOADS", uploadsPath)
 	installFakeSoloCommands(t, nil)


### PR DESCRIPTION
## Summary
- Persist successful solo `ingress check` results in local solo state per workspace/environment.
- Teach `devopsellence status` to clear `configured_tls_pending` and expose `public_urls` only when the saved check still matches the current configured URLs and selected web-node IPs.
- Add regression coverage for state persistence, ingress-check recording, and status reconciliation.

## Dogfood finding mapping
- ✅ Addressed: `public_url_status=configured_tls_pending` remained after `ingress check` returned `ok:true` and direct HTTPS curls succeeded.
- 🔎 Not reproduced in code triage: solo state placeholder/reset instability. I did not find production code writing the observed `node-a`/`203.0.113.10` placeholder state; the rerun will watch this explicitly and preserve before/after state evidence.
- ✅ Dogfood procedure adjustment for rerun: endpoint probes will be project-aware so the API sample is checked via `/up` + `/` revision instead of incorrectly requiring app-only `/env-check`.

Original evidence: `/tmp/devopsellence-dogfood-solo/20260429T230452Z-release-v0-2-0-preview/REPORT.md`.

## Test Plan
- `cd cli && mise x -- go test ./internal/solo ./internal/workflow -run 'TestStateStorePersistsIngressCheckRecords|TestSoloStatusUsesVerifiedTLSPublicURLsAfterIngressCheckRecord|TestIngressCheckPersistsSuccessfulReadinessRecord'`
- `cd cli && mise x -- go test ./internal/solo ./internal/workflow`
- `cd cli && mise x -- go test ./...`
- built local PR CLI at `/tmp/devopsellence-dogfood-solo/pr-20260429T233751Z-solo-status-fix/bin/devopsellence`

## Follow-up validation
After opening this PR I will run focused solo dogfood with the PR CLI against `hcloud-1` and iterate if it finds new gaps.
