### PR TITLE
fix(cli): harden solo ingress readiness records

### DIFF
--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -4724,10 +4724,7 @@ func (a *App) IngressCheck(ctx context.Context, opts IngressCheckOptions) error 
 		}
 		if report.OK || !ingressDNSReportRetryable(report) || opts.Wait <= 0 || time.Now().After(deadline) {
 			if report.OK {
-				if err := recordSuccessfulSoloIngressCheck(&current, workspaceRoot, environmentName, report); err != nil {
-					return err
-				}
-				if err := a.writeSoloState(current); err != nil {
+				if err := recordSuccessfulSoloIngressCheckToStore(a.SoloState, workspaceRoot, environmentName, report); err != nil {
 					return err
 				}
 			}
@@ -4747,6 +4744,15 @@ func (a *App) IngressCheck(ctx context.Context, opts IngressCheckOptions) error 
 		case <-time.After(5 * time.Second):
 		}
 	}
+}
+
+func recordSuccessfulSoloIngressCheckToStore(store *solo.StateStore, workspaceRoot, environmentName string, report ingressDNSReportResult) error {
+	if store == nil {
+		return errors.New("solo state store is required")
+	}
+	return store.Update(func(current *solo.State) error {
+		return recordSuccessfulSoloIngressCheck(current, workspaceRoot, environmentName, report)
+	})
 }
 
 func recordSuccessfulSoloIngressCheck(current *solo.State, workspaceRoot, environmentName string, report ingressDNSReportResult) error {
@@ -5067,7 +5073,7 @@ func soloVerifiedIngressPublicURLs(current solo.State, workspaceRoot, environmen
 		return nil
 	}
 	expectedIPs := webNodeIPs(cfg, nodes)
-	if len(expectedIPs) > 0 && !sameStringSet(record.ExpectedIPs, expectedIPs) {
+	if len(expectedIPs) == 0 || !sameStringSet(record.ExpectedIPs, expectedIPs) {
 		return nil
 	}
 	return urls

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -1130,6 +1130,36 @@ func TestSoloStatusUsesVerifiedTLSPublicURLsAfterIngressCheckRecord(t *testing.T
 	}
 }
 
+func TestSoloVerifiedIngressPublicURLsRejectsRecordWhenSelectedNodesHaveNoWebIPs(t *testing.T) {
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	cfg.Ingress = &config.IngressConfig{
+		Hosts: []string{"app.example.com"},
+		Rules: []config.IngressRuleConfig{{
+			Match:  config.IngressMatchConfig{Host: "app.example.com", PathPrefix: "/"},
+			Target: config.IngressTargetConfig{Service: config.DefaultWebServiceName, Port: "http"},
+		}},
+		TLS: config.IngressTLSConfig{Mode: "auto"},
+	}
+	key, err := solo.EnvironmentStateKey("/workspace/demo", "production")
+	if err != nil {
+		t.Fatal(err)
+	}
+	current := solo.State{IngressChecks: map[string]solo.IngressCheckRecord{
+		key: {
+			OK:          true,
+			PublicURLs:  []string{"https://app.example.com/"},
+			ExpectedIPs: []string{"203.0.113.10"},
+		},
+	}}
+	nodes := map[string]config.Node{
+		"worker-a": {Host: "203.0.113.11", User: "root", Labels: []string{"worker"}},
+	}
+
+	if got := soloVerifiedIngressPublicURLs(current, "/workspace/demo", "production", &cfg, nodes); len(got) != 0 {
+		t.Fatalf("verified public URLs = %#v, want none when selected nodes have no web-node IPs", got)
+	}
+}
+
 func TestSoloStatusUsesConfiguredPublicURLsWhenNodeIsNotSettled(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")
@@ -1282,6 +1312,61 @@ func TestIngressCheckPersistsSuccessfulReadinessRecord(t *testing.T) {
 	}
 	record := loaded.IngressChecks[key]
 	if !record.OK || !reflect.DeepEqual(record.PublicURLs, []string{"https://127.0.0.1/"}) || !reflect.DeepEqual(record.ExpectedIPs, []string{"127.0.0.1"}) || strings.TrimSpace(record.CheckedAt) == "" {
+		t.Fatalf("ingress check record = %#v", record)
+	}
+}
+
+func TestRecordSuccessfulSoloIngressCheckToStorePreservesFreshState(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.Node{
+			"node-a": {Host: "127.0.0.1", User: "root", Labels: []string{config.DefaultWebRole}},
+		},
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+	fresh, err := soloState.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+	fresh.Secrets = map[string]solo.SecretRecord{
+		"api-key": {WorkspaceRoot: workspaceRoot, Environment: "production", ServiceName: config.DefaultWebServiceName, Name: "API_KEY", Value: "devopsellence://plaintext/redacted"},
+	}
+	if err := soloState.Write(fresh); err != nil {
+		t.Fatal(err)
+	}
+
+	report := ingressDNSReportResult{
+		OK:          true,
+		PublicURLs:  []string{"https://127.0.0.1/"},
+		ExpectedIPs: []string{"127.0.0.1"},
+	}
+	if err := recordSuccessfulSoloIngressCheckToStore(soloState, workspaceRoot, "production", report); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := soloState.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+	secretFound := false
+	for _, secret := range loaded.Secrets {
+		if secret.Name == "API_KEY" && secret.Value == "devopsellence://plaintext/redacted" {
+			secretFound = true
+			break
+		}
+	}
+	if !secretFound {
+		t.Fatalf("secrets = %#v, want unrelated fresh secret preserved", loaded.Secrets)
+	}
+	key, err := solo.EnvironmentStateKey(workspaceRoot, "production")
+	if err != nil {
+		t.Fatal(err)
+	}
+	record := loaded.IngressChecks[key]
+	if !record.OK || !reflect.DeepEqual(record.PublicURLs, []string{"https://127.0.0.1/"}) || !reflect.DeepEqual(record.ExpectedIPs, []string{"127.0.0.1"}) {
 		t.Fatalf("ingress check record = %#v", record)
 	}
 }


### PR DESCRIPTION
## Summary
- Tightens solo TLS readiness reconciliation so persisted ingress-check records are only accepted when the currently selected web-node IP set is non-empty and exactly matches the recorded IPs.
- Persists successful `ingress check` records via a fresh `StateStore.Update` instead of rewriting the stale state object read before the wait loop.
- Adds focused regressions for worker-only/no-web selections and preserving unrelated fresh solo state while recording ingress readiness.

## Original review findings
- Fixed: `status --node <worker>` / relabeled or detached web-node selections can no longer promote stale HTTPS `public_urls` from a prior successful ingress check.
- Fixed: `ingress check --wait` success now re-reads state at write time, avoiding clobbering unrelated state changes made during the wait.

## Rebase note
- Rebased onto latest `master` after #107 was merged; PR base is now `master`.

## Test Plan
- [x] `mise x -- go test ./internal/workflow -run 'TestSoloVerifiedIngressPublicURLsRejectsRecordWhenSelectedNodesHaveNoWebIPs|TestRecordSuccessfulSoloIngressCheckToStorePreservesFreshState|TestSoloStatusUsesVerifiedTLSPublicURLsAfterIngressCheckRecord|TestIngressCheckPersistsSuccessfulReadinessRecord' -count=1`
- [x] `mise x -- go test ./internal/solo ./internal/workflow -count=1`
- [x] `mise x -- go test ./... -count=1` from `cli/`
- [x] `git diff --check`
