### PR TITLE
fix(cli): address solo dogfood findings

### DIFF
--- a/cli/internal/workflow/root.go
+++ b/cli/internal/workflow/root.go
@@ -15,6 +15,22 @@ import (
 	"github.com/spf13/cobra"
 )
 
+func versionPayload() map[string]any {
+	versionNumber := strings.TrimSpace(version.Version)
+	payload := map[string]any{
+		"schema_version": outputSchemaVersion,
+		"version":        version.String(),
+		"version_number": versionNumber,
+		"commit":         strings.TrimSpace(version.Commit),
+		"built_at":       strings.TrimSpace(version.Date),
+	}
+	if versionNumber != "" && versionNumber != "dev" {
+		payload["release_url"] = "https://github.com/devopsellence/devopsellence/releases/tag/" + versionNumber
+		payload["checksums_url"] = "https://github.com/devopsellence/devopsellence/releases/download/" + versionNumber + "/cli-SHA256SUMS"
+	}
+	return payload
+}
+
 func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command {
 	app := NewApp(in, out, err, cwd)
 
@@ -95,10 +111,7 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 		SilenceUsage:  true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if rootVersion {
-				return app.Printer.PrintJSON(map[string]any{
-					"schema_version": outputSchemaVersion,
-					"version":        version.String(),
-				})
+				return app.Printer.PrintJSON(versionPayload())
 			}
 			return cmd.Help()
 		},
@@ -108,10 +121,7 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 		Use:   "version",
 		Short: "Print the CLI version",
 		RunE: func(_ *cobra.Command, _ []string) error {
-			return app.Printer.PrintJSON(map[string]any{
-				"schema_version": outputSchemaVersion,
-				"version":        version.String(),
-			})
+			return app.Printer.PrintJSON(versionPayload())
 		},
 	})
 

--- a/cli/internal/workflow/root_test.go
+++ b/cli/internal/workflow/root_test.go
@@ -9,16 +9,14 @@ import (
 	"testing"
 
 	"github.com/devopsellence/cli/internal/solo"
+	cliversion "github.com/devopsellence/cli/internal/version"
 	"github.com/devopsellence/devopsellence/deployment-core/pkg/deploycore/config"
 )
 
 func TestRootVersionCommand(t *testing.T) {
-	t.Parallel()
-
 	for _, args := range [][]string{{"version"}, {"--version"}} {
 		args := args
 		t.Run(strings.Join(args, " "), func(t *testing.T) {
-			t.Parallel()
 
 			var stdout bytes.Buffer
 			cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, t.TempDir())
@@ -37,6 +35,38 @@ func TestRootVersionCommand(t *testing.T) {
 				t.Fatalf("version = %v, want non-empty string", payload["version"])
 			}
 		})
+	}
+}
+
+func TestRootVersionCommandIncludesReleaseProvenanceFields(t *testing.T) {
+	oldVersion, oldCommit, oldDate := cliversion.Version, cliversion.Commit, cliversion.Date
+	t.Cleanup(func() {
+		cliversion.Version = oldVersion
+		cliversion.Commit = oldCommit
+		cliversion.Date = oldDate
+	})
+	cliversion.Version = "v0.2.0-preview"
+	cliversion.Commit = "edbbd8e9688c"
+	cliversion.Date = "2026-04-29T19:38:29Z"
+
+	var stdout bytes.Buffer
+	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, t.TempDir())
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{"version"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	if payload["version_number"] != "v0.2.0-preview" || payload["commit"] != "edbbd8e9688c" || payload["built_at"] != "2026-04-29T19:38:29Z" {
+		t.Fatalf("payload = %#v, want split version provenance fields", payload)
+	}
+	if payload["release_url"] != "https://github.com/devopsellence/devopsellence/releases/tag/v0.2.0-preview" {
+		t.Fatalf("release_url = %#v, want GitHub release tag URL", payload["release_url"])
+	}
+	if payload["checksums_url"] != "https://github.com/devopsellence/devopsellence/releases/download/v0.2.0-preview/cli-SHA256SUMS" {
+		t.Fatalf("checksums_url = %#v, want CLI checksums asset URL", payload["checksums_url"])
 	}
 }
 
@@ -131,6 +161,9 @@ func TestRootSoloSecretSetHonorsEnvironmentAndService(t *testing.T) {
 		t.Fatalf("Execute() error = %v", err)
 	}
 	setPayload := decodeJSONOutput(t, &stdout)
+	if setPayload["schema_version"] != float64(outputSchemaVersion) {
+		t.Fatalf("schema_version = %#v, want %d", setPayload["schema_version"], outputSchemaVersion)
+	}
 	if setPayload["secret_ref"] != "devopsellence://plaintext/DATABASE_URL" {
 		t.Fatalf("secret_ref = %#v, want plaintext config ref", setPayload["secret_ref"])
 	}
@@ -209,6 +242,44 @@ func TestRootSoloSecretSetHonorsEnvironmentAndService(t *testing.T) {
 				t.Fatalf("secret %s %s = %#v, want %#v", name, key, item[key], expected)
 			}
 		}
+	}
+}
+
+func TestRootSoloSecretSetFromStdinUpdatesConfigAndResolvedConfig(t *testing.T) {
+	var stdout bytes.Buffer
+	cwd := rootTestSoloWorkspace(t)
+	cmd := NewRootCommand(strings.NewReader("super-secret\n"), &stdout, &stdout, cwd)
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{"secret", "set", "DOGFOOD_SECRET", "--service", "web", "--stdin"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	setPayload := decodeJSONOutput(t, &stdout)
+	if setPayload["schema_version"] != float64(outputSchemaVersion) || setPayload["config_updated"] != true {
+		t.Fatalf("secret set payload = %#v, want schema_version and config_updated=true", setPayload)
+	}
+
+	cfg, err := config.LoadFromRoot(cwd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	refs := cfg.Services["web"].SecretRefs
+	if len(refs) != 1 || refs[0].Name != "DOGFOOD_SECRET" || refs[0].Secret != "devopsellence://plaintext/DOGFOOD_SECRET" {
+		t.Fatalf("secret refs = %#v, want DOGFOOD_SECRET plaintext ref", refs)
+	}
+
+	stdout.Reset()
+	cmd = NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, cwd)
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{"config", "resolve"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("config resolve error = %v", err)
+	}
+	if !strings.Contains(stdout.String(), "DOGFOOD_SECRET") || !strings.Contains(stdout.String(), "devopsellence://plaintext/DOGFOOD_SECRET") {
+		t.Fatalf("resolved config = %s, want DOGFOOD_SECRET secret ref", stdout.String())
 	}
 }
 

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1646,7 +1646,7 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 	}
 	verifiedPublicURLs := a.soloVerifiedPublicURLs(cfg, nodes)
 	localReleaseKnown := len(opts.Nodes) > 0
-	expectedRevision := ""
+	expectedRevisions := map[string]string{}
 	if len(opts.Nodes) == 0 {
 		if current, stateErr := a.readSoloState(); stateErr == nil {
 			_, workspaceRoot, environmentName, configErr := a.loadResolvedSoloProjectConfig("")
@@ -1657,7 +1657,7 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 				}
 				if hasCurrent {
 					localReleaseKnown = true
-					expectedRevision = strings.TrimSpace(currentRelease.Revision)
+					expectedRevisions = soloExpectedStatusRevisions(current, currentRelease)
 				}
 			}
 		}
@@ -1703,12 +1703,13 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 			})
 			continue
 		}
+		expectedRevision := soloExpectedStatusRevision(expectedRevisions, name)
 		if expectedRevision != "" && strings.TrimSpace(result.Status.Revision) != expectedRevision {
 			allSettled = false
 			jsonResults = append(jsonResults, map[string]any{
 				"node":    name,
 				"status":  nil,
-				"message": fmt.Sprintf("remote agent status revision %q does not match current local release %q; run `devopsellence deploy`", strings.TrimSpace(result.Status.Revision), expectedRevision),
+				"message": fmt.Sprintf("remote agent status revision %q does not match current local deployment %q; run `devopsellence deploy`", strings.TrimSpace(result.Status.Revision), expectedRevision),
 			})
 			continue
 		}
@@ -1745,6 +1746,44 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 		return ExitError{Code: 1, Err: RenderedError{Err: fmt.Errorf("status failed for %d node(s)", readErrors)}}
 	}
 	return nil
+}
+
+func soloExpectedStatusRevisions(current solo.State, release corerelease.Release) map[string]string {
+	expected := map[string]string{}
+	latestSequence := -1
+	var latest corerelease.Deployment
+	for _, deployment := range current.Deployments {
+		if deployment.EnvironmentID != release.EnvironmentID || deployment.ReleaseID != release.ID || deployment.PublicationResult == nil {
+			continue
+		}
+		if deployment.Sequence > latestSequence {
+			latestSequence = deployment.Sequence
+			latest = deployment
+		}
+	}
+	if latestSequence >= 0 {
+		for _, result := range latest.PublicationResult.NodeResults {
+			nodeName := strings.TrimSpace(result.NodeName)
+			if nodeName == "" {
+				nodeName = strings.TrimSpace(result.NodeID)
+			}
+			revision := strings.TrimSpace(result.Revision)
+			if nodeName != "" && revision != "" {
+				expected[nodeName] = revision
+			}
+		}
+	}
+	if len(expected) == 0 {
+		expected[""] = strings.TrimSpace(release.Revision)
+	}
+	return expected
+}
+
+func soloExpectedStatusRevision(expected map[string]string, nodeName string) string {
+	if revision := strings.TrimSpace(expected[nodeName]); revision != "" {
+		return revision
+	}
+	return strings.TrimSpace(expected[""])
 }
 
 func (a *App) SoloReleaseList(ctx context.Context, opts SoloReleaseListOptions) error {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -492,9 +492,6 @@ func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 	if err != nil {
 		return err
 	}
-	if _, err := current.SaveRelease(release); err != nil {
-		return err
-	}
 	deployment, err := corerelease.NewDeployment(corerelease.DeploymentCreateInput{
 		ID:            soloDeploymentID(corerelease.DeploymentKindDeploy, shortSHA, now),
 		EnvironmentID: release.EnvironmentID,
@@ -507,25 +504,25 @@ func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 	if err != nil {
 		return err
 	}
-	if err := current.SaveDeployment(deployment); err != nil {
-		return err
-	}
 	deployment.Status = corerelease.DeploymentStatusRunning
 	deployment.StatusMessage = "publishing desired state"
-	if err := current.SaveDeployment(deployment); err != nil {
-		return err
-	}
-	// Persist desired local state first so follow-up republish operations can
-	// recover cleanly from partial remote updates.
-	if err := a.writeSoloState(current); err != nil {
+
+	publishState := cloneSoloState(current)
+	if _, err := publishState.SaveRelease(release); err != nil {
 		return err
 	}
 	statusBaselines := a.soloNodeStatusTimes(ctx, nodes)
-	desiredStateRevisions, err := a.republishNodes(ctx, current, attachedNodeNames)
+	desiredStateRevisions, err := a.republishNodes(ctx, publishState, attachedNodeNames)
 	if err != nil {
-		if persistErr := a.persistSoloDeploymentFailure(current, deployment, desiredStateRevisions, err); persistErr != nil {
-			return errors.Join(err, fmt.Errorf("persist deployment failure: %w", persistErr))
-		}
+		return err
+	}
+	if _, err := current.SaveRelease(release); err != nil {
+		return err
+	}
+	if err := current.SaveDeployment(deployment); err != nil {
+		return err
+	}
+	if err := a.writeSoloState(current); err != nil {
 		return err
 	}
 	if err := a.waitForSoloRollout(ctx, nodes, desiredStateRevisions, statusBaselines); err != nil {
@@ -1648,6 +1645,23 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 		return fmt.Errorf("no nodes attached to the current environment")
 	}
 	verifiedPublicURLs := a.soloVerifiedPublicURLs(cfg, nodes)
+	localReleaseKnown := len(opts.Nodes) > 0
+	expectedRevision := ""
+	if len(opts.Nodes) == 0 {
+		if current, stateErr := a.readSoloState(); stateErr == nil {
+			_, workspaceRoot, environmentName, configErr := a.loadResolvedSoloProjectConfig("")
+			if configErr == nil {
+				_, currentRelease, hasCurrent, releaseErr := current.CurrentRelease(workspaceRoot, environmentName)
+				if releaseErr != nil {
+					return releaseErr
+				}
+				if hasCurrent {
+					localReleaseKnown = true
+					expectedRevision = strings.TrimSpace(currentRelease.Revision)
+				}
+			}
+		}
+	}
 
 	var jsonResults []map[string]any
 	readErrors := 0
@@ -1680,6 +1694,24 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 			continue
 		}
 
+		if !localReleaseKnown {
+			allSettled = false
+			jsonResults = append(jsonResults, map[string]any{
+				"node":    name,
+				"status":  nil,
+				"message": "remote agent has status, but this workspace has no current local release yet; run `devopsellence deploy`",
+			})
+			continue
+		}
+		if expectedRevision != "" && strings.TrimSpace(result.Status.Revision) != expectedRevision {
+			allSettled = false
+			jsonResults = append(jsonResults, map[string]any{
+				"node":    name,
+				"status":  nil,
+				"message": fmt.Sprintf("remote agent status revision %q does not match current local release %q; run `devopsellence deploy`", strings.TrimSpace(result.Status.Revision), expectedRevision),
+			})
+			continue
+		}
 		if strings.TrimSpace(result.Status.Phase) != "settled" {
 			allSettled = false
 		}
@@ -2063,6 +2095,7 @@ func (a *App) SoloSecretsSet(_ context.Context, opts SoloSecretsSetOptions) erro
 	}
 
 	payload := map[string]any{
+		"schema_version": outputSchemaVersion,
 		"key":            record.Name,
 		"service_name":   record.ServiceName,
 		"environment":    record.Environment,

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -36,6 +36,30 @@ func (errorWriter) Write([]byte) (int, error) {
 
 const testSoloExecExitMarker = soloExecExitMarkerPrefix + "0123456789abcdef0123456789abcdef__"
 
+func seedSoloCurrentRelease(t *testing.T, current *solo.State, workspaceRoot, environment, revision string) {
+	t.Helper()
+	release, err := corerelease.NewRelease(corerelease.ReleaseCreateInput{
+		ID:            "rel_test_" + strings.ReplaceAll(revision, "-", "_"),
+		EnvironmentID: workspaceRoot + "\n" + environment,
+		Revision:      revision,
+		Snapshot: desiredstate.DeploySnapshot{
+			WorkspaceRoot: workspaceRoot,
+			WorkspaceKey:  workspaceRoot,
+			Environment:   environment,
+			Revision:      revision,
+			Image:         "demo:" + revision,
+		},
+		Image:     corerelease.ImageRef{Reference: "demo:" + revision},
+		CreatedAt: time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := current.SaveRelease(release); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestSoloImageTagSlugifiesProjectName(t *testing.T) {
 	got := soloImageTag("ShopApp", "abc1234")
 	if got != "shop-app:abc1234" {
@@ -1060,6 +1084,7 @@ func TestSoloStatusUsesResolvedEnvironmentOverlay(t *testing.T) {
 	if _, _, err := current.AttachNode(workspaceRoot, "staging", "node-a"); err != nil {
 		t.Fatal(err)
 	}
+	seedSoloCurrentRelease(t, &current, workspaceRoot, "staging", "rev")
 	if err := soloState.Write(current); err != nil {
 		t.Fatal(err)
 	}
@@ -1097,6 +1122,7 @@ func TestSoloStatusUsesVerifiedTLSPublicURLsAfterIngressCheckRecord(t *testing.T
 	if _, _, err := current.AttachNode(workspaceRoot, "production", "node-a"); err != nil {
 		t.Fatal(err)
 	}
+	seedSoloCurrentRelease(t, &current, workspaceRoot, "production", "rev")
 	key, err := solo.EnvironmentStateKey(workspaceRoot, "production")
 	if err != nil {
 		t.Fatal(err)
@@ -3900,6 +3926,99 @@ func TestSoloDeployDryRunUsesResolvedEnvironmentOverlay(t *testing.T) {
 	urls := jsonArrayFromMap(t, payload, "configured_public_urls")
 	if len(urls) != 1 || urls[0] != "http://staging.example.com/" {
 		t.Fatalf("configured_public_urls = %#v, want staging host only", urls)
+	}
+}
+
+func TestSoloDeployRepublishFailureDoesNotRecordCurrentRelease(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(workspaceRoot, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	commitTestRepo(t, workspaceRoot)
+
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.Node{
+			"node-a": {Host: "203.0.113.10", User: "root", Port: 22, AgentStateDir: "/var/lib/devopsellence", Labels: []string{config.DefaultWebRole}},
+		},
+		Attachments: map[string]solo.AttachmentRecord{},
+	}
+	if _, _, err := current.AttachNode(workspaceRoot, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := current.SetSecret(workspaceRoot, "production", "web", "DOGFOOD_SECRET", solo.SecretMaterial{Value: "super-secret"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+	installFakeSoloCommands(t, nil)
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState, ConfigStore: config.NewStore(), Git: git.Client{}, Cwd: workspaceRoot}
+	err := app.SoloDeploy(context.Background(), SoloDeployOptions{})
+	if err == nil || !strings.Contains(err.Error(), "stored release snapshot") {
+		t.Fatalf("SoloDeploy() error = %v, want stored release snapshot failure", err)
+	}
+	updated, readErr := soloState.Read()
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	key := workspaceRoot + "\nproduction"
+	if updated.Current[key] != "" || len(updated.Releases) != 0 || len(updated.Deployments) != 0 {
+		t.Fatalf("state current=%#v releases=%#v deployments=%#v, want no release/deployment recorded before publish succeeds", updated.Current, updated.Releases, updated.Deployments)
+	}
+}
+
+func TestSoloStatusBeforeLocalDeployTreatsRemoteStatusAsStale(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	cfg.Ingress = &config.IngressConfig{
+		Hosts: []string{"*"},
+		Rules: []config.IngressRuleConfig{{
+			Match:  config.IngressMatchConfig{Host: "*", PathPrefix: "/"},
+			Target: config.IngressTargetConfig{Service: config.DefaultWebServiceName, Port: "http"},
+		}},
+		TLS: config.IngressTLSConfig{Mode: "off"},
+	}
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.Node{
+			"node-a": {Host: "203.0.113.10", User: "root", Port: 22, AgentStateDir: "/var/lib/devopsellence", Labels: []string{config.DefaultWebRole}},
+		},
+		Attachments: map[string]solo.AttachmentRecord{},
+	}
+	if _, _, err := current.AttachNode(workspaceRoot, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+	installFakeSoloCommands(t, []fakeSSHResponse{{stdout: `{"revision":"foreign-revision","phase":"settled"}` + "\n"}})
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState, ConfigStore: config.NewStore(), Cwd: workspaceRoot}
+	if err := app.SoloStatus(context.Background(), SoloStatusOptions{}); err != nil {
+		t.Fatalf("SoloStatus() error = %v", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	if payload["public_urls"] != nil {
+		t.Fatalf("payload = %#v, want stale remote status to withhold public_urls", payload)
+	}
+	nodes := jsonArrayFromMap(t, payload, "nodes")
+	if len(nodes) != 1 {
+		t.Fatalf("nodes = %#v, want one node", nodes)
+	}
+	node := jsonMapFromAny(t, nodes[0])
+	if node["status"] != nil || !strings.Contains(stringValueAny(node["message"]), "devopsellence deploy") {
+		t.Fatalf("node status = %#v, want no local deploy message", node)
 	}
 }
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -4022,6 +4022,84 @@ func TestSoloStatusBeforeLocalDeployTreatsRemoteStatusAsStale(t *testing.T) {
 	}
 }
 
+func TestSoloStatusComparesRemoteStatusToPublishedDesiredStateRevision(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	cfg.Ingress = &config.IngressConfig{
+		Hosts: []string{"*"},
+		Rules: []config.IngressRuleConfig{{
+			Match:  config.IngressMatchConfig{Host: "*", PathPrefix: "/"},
+			Target: config.IngressTargetConfig{Service: config.DefaultWebServiceName, Port: "http"},
+		}},
+		TLS: config.IngressTLSConfig{Mode: "off"},
+	}
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.Node{
+			"node-a": {Host: "203.0.113.10", User: "root", Port: 22, AgentStateDir: "/var/lib/devopsellence", Labels: []string{config.DefaultWebRole}},
+		},
+		Attachments: map[string]solo.AttachmentRecord{},
+	}
+	if _, _, err := current.AttachNode(workspaceRoot, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	seedSoloCurrentRelease(t, &current, workspaceRoot, "production", "shortsha")
+	environmentID, release, ok, err := current.CurrentRelease(workspaceRoot, "production")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("current release missing")
+	}
+	deployment, err := corerelease.NewDeployment(corerelease.DeploymentCreateInput{
+		ID:            "dep_test",
+		EnvironmentID: environmentID,
+		ReleaseID:     release.ID,
+		Kind:          corerelease.DeploymentKindDeploy,
+		Sequence:      1,
+		TargetNodeIDs: []string{"node-a"},
+		CreatedAt:     time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	deployment.Status = corerelease.DeploymentStatusFailed
+	deployment.PublicationResult = &corerelease.DeploymentPublicationResult{
+		Status: corerelease.PublicationStatusWritten,
+		NodeResults: []corerelease.DesiredStatePublication{{
+			NodeName: "node-a",
+			Revision: "desired-state-hash",
+			Status:   corerelease.PublicationStatusWritten,
+		}},
+	}
+	if err := current.SaveDeployment(deployment); err != nil {
+		t.Fatal(err)
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+	installFakeSoloCommands(t, []fakeSSHResponse{{stdout: `{"revision":"desired-state-hash","phase":"settled"}` + "\n"}})
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState, ConfigStore: config.NewStore(), Cwd: workspaceRoot}
+	if err := app.SoloStatus(context.Background(), SoloStatusOptions{}); err != nil {
+		t.Fatalf("SoloStatus() error = %v", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	nodes := jsonArrayFromMap(t, payload, "nodes")
+	if len(nodes) != 1 {
+		t.Fatalf("nodes = %#v, want one node", nodes)
+	}
+	node := jsonMapFromAny(t, nodes[0])
+	status := jsonMapFromAny(t, node["status"])
+	if status["revision"] != "desired-state-hash" {
+		t.Fatalf("node = %#v, want published desired-state revision accepted", node)
+	}
+}
+
 func TestSoloDeployWaitsForSettledStatusBeforeSuccess(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	if err := os.WriteFile(filepath.Join(workspaceRoot, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {


### PR DESCRIPTION
## Summary

Fixes the five solo CLI dogfood follow-up issues from the local dogfood run:

- adds structured version/release provenance output for `devopsellence --version` and `devopsellence version`
- includes `schema_version` in `secret set` success output and verifies `secret set --stdin` mutates `services.<name>.secret_refs`
- prevents solo deploy from recording local current release/deployment state before desired-state publication succeeds
- treats default `devopsellence status` as stale/not settled when this workspace has no current local release, even if the remote agent has status
- adds stale revision detection when remote status reports a different revision than the current local release

## Dogfood evidence

Original report:

`/home/ubuntu/devopsellence-dogfood/solo-cli-20260430T004811Z/report.md`

Follow-up reports/evidence:

- `/home/ubuntu/devopsellence-dogfood/solo-cli-20260430T004811Z/fix-summary.md`
- `/home/ubuntu/devopsellence-dogfood/solo-cli-20260430T004811Z/final-dogfood-followup-report.md`
- `/home/ubuntu/devopsellence-dogfood/solo-cli-20260430T004811Z/fix-verification/02-secret-set.json`
- `/home/ubuntu/devopsellence-dogfood/solo-cli-20260430T004811Z/fix-verification/03-config-resolve.json`

The local plaintext solo state created during secret verification was removed after validation; the retained evidence does not include the plaintext dogfood secret value.

## Test plan

- [x] `git diff --check`
- [x] `mise run test:cli -- ./internal/workflow -run 'TestRootVersionCommand|TestRootSoloSecretSet|TestSoloDeployRepublishFailureDoesNotRecordCurrentRelease|TestSoloStatusBeforeLocalDeployTreatsRemoteStatusAsStale'`
- [x] `mise run test:cli`
- [x] `mise run build:cli`
- [x] `cli/bin/devopsellence --version`
- [x] `cli/bin/devopsellence version`
- [x] verified `/home/ubuntu/devopsellence-dogfood/solo-cli-20260430T004811Z/fix-verification/state` is absent after cleanup

## Caveats

This follow-up verifies the command contracts and state-safety behavior locally. It does not rerun the full original localhost SSH deploy matrix and does not validate DNS/TLS/ACME, provider provisioning, reboot recovery, or official release artifact identity.
