### PR TITLE
Fix solo status for cohosted environments

### DIFF
--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -218,6 +218,8 @@ type soloNodeStatus struct {
 
 type soloNodeStatusEnvironment struct {
 	Name     string                  `json:"name"`
+	Revision string                  `json:"revision,omitempty"`
+	Phase    string                  `json:"phase,omitempty"`
 	Services []soloNodeStatusService `json:"services"`
 }
 
@@ -1647,6 +1649,8 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 	verifiedPublicURLs := a.soloVerifiedPublicURLs(cfg, nodes)
 	localReleaseKnown := len(opts.Nodes) > 0
 	expectedRevisions := map[string]string{}
+	expectedRuntimeEnvironment := ""
+	expectedWorkloadRevision := ""
 	if len(opts.Nodes) == 0 {
 		if current, stateErr := a.readSoloState(); stateErr == nil {
 			_, workspaceRoot, environmentName, configErr := a.loadResolvedSoloProjectConfig("")
@@ -1658,6 +1662,8 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 				if hasCurrent {
 					localReleaseKnown = true
 					expectedRevisions = soloExpectedStatusRevisions(current, currentRelease)
+					expectedWorkloadRevision = strings.TrimSpace(currentRelease.Revision)
+					expectedRuntimeEnvironment, _ = soloRuntimeEnvironmentNameForNode(current, workspaceRoot, environmentName, "")
 				}
 			}
 		}
@@ -1704,7 +1710,7 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 			continue
 		}
 		expectedRevision := soloExpectedStatusRevision(expectedRevisions, name)
-		if expectedRevision != "" && strings.TrimSpace(result.Status.Revision) != expectedRevision {
+		if expectedRevision != "" && !soloNodeStatusMatchesExpectedRelease(result.Status, expectedRevision, expectedRuntimeEnvironment, expectedWorkloadRevision) {
 			allSettled = false
 			jsonResults = append(jsonResults, map[string]any{
 				"node":    name,
@@ -1777,6 +1783,28 @@ func soloExpectedStatusRevisions(current solo.State, release corerelease.Release
 		expected[""] = strings.TrimSpace(release.Revision)
 	}
 	return expected
+}
+
+func soloNodeStatusMatchesExpectedRelease(status soloNodeStatus, expectedDesiredStateRevision, expectedRuntimeEnvironment, expectedWorkloadRevision string) bool {
+	if strings.TrimSpace(status.Revision) == strings.TrimSpace(expectedDesiredStateRevision) {
+		return true
+	}
+	expectedRuntimeEnvironment = strings.TrimSpace(expectedRuntimeEnvironment)
+	expectedWorkloadRevision = strings.TrimSpace(expectedWorkloadRevision)
+	if expectedRuntimeEnvironment == "" || expectedWorkloadRevision == "" {
+		return false
+	}
+	for _, environment := range status.Environments {
+		if strings.TrimSpace(environment.Name) != expectedRuntimeEnvironment {
+			continue
+		}
+		if strings.TrimSpace(environment.Revision) != expectedWorkloadRevision {
+			return false
+		}
+		phase := strings.TrimSpace(environment.Phase)
+		return phase == "" || phase == "settled"
+	}
+	return false
 }
 
 func soloExpectedStatusRevision(expected map[string]string, nodeName string) string {

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -4185,6 +4185,91 @@ func TestSoloStatusComparesRemoteStatusToPublishedDesiredStateRevision(t *testin
 	}
 }
 
+func TestSoloStatusAcceptsNewerCohostedDesiredStateWhenCurrentEnvironmentSettled(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	cfg.Ingress = &config.IngressConfig{
+		Hosts: []string{"app.example.com"},
+		Rules: []config.IngressRuleConfig{{
+			Match:  config.IngressMatchConfig{Host: "app.example.com", PathPrefix: "/"},
+			Target: config.IngressTargetConfig{Service: config.DefaultWebServiceName, Port: "http"},
+		}},
+		TLS: config.IngressTLSConfig{Mode: "off"},
+	}
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.Node{
+			"node-a": {Host: "203.0.113.10", User: "root", Port: 22, AgentStateDir: "/var/lib/devopsellence", Labels: []string{config.DefaultWebRole}},
+		},
+		Attachments: map[string]solo.AttachmentRecord{},
+	}
+	if _, _, err := current.AttachNode(workspaceRoot, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	seedSoloCurrentRelease(t, &current, workspaceRoot, "production", "shortsha")
+	environmentID, release, ok, err := current.CurrentRelease(workspaceRoot, "production")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("current release missing")
+	}
+	deployment, err := corerelease.NewDeployment(corerelease.DeploymentCreateInput{
+		ID:            "dep_test",
+		EnvironmentID: environmentID,
+		ReleaseID:     release.ID,
+		Kind:          corerelease.DeploymentKindDeploy,
+		Sequence:      1,
+		TargetNodeIDs: []string{"node-a"},
+		CreatedAt:     time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	deployment.Status = corerelease.DeploymentStatusSettled
+	deployment.PublicationResult = &corerelease.DeploymentPublicationResult{
+		Status: corerelease.PublicationStatusWritten,
+		NodeResults: []corerelease.DesiredStatePublication{{
+			NodeName: "node-a",
+			Revision: "current-workspace-desired-state",
+			Status:   corerelease.PublicationStatusWritten,
+		}},
+	}
+	if err := current.SaveDeployment(deployment); err != nil {
+		t.Fatal(err)
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+	runtimeEnvironment, err := soloRuntimeEnvironmentNameForNode(current, workspaceRoot, "production", "node-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	statusJSON := fmt.Sprintf(`{"revision":"newer-cohosted-desired-state","phase":"settled","environments":[{"name":%q,"revision":"shortsha","phase":"settled","services":[{"name":"web","state":"running"}]}]}`, runtimeEnvironment)
+	installFakeSoloCommands(t, []fakeSSHResponse{{stdout: statusJSON + "\n"}})
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState, ConfigStore: config.NewStore(), Cwd: workspaceRoot}
+	if err := app.SoloStatus(context.Background(), SoloStatusOptions{}); err != nil {
+		t.Fatalf("SoloStatus() error = %v", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	nodes := jsonArrayFromMap(t, payload, "nodes")
+	if len(nodes) != 1 {
+		t.Fatalf("nodes = %#v, want one node", nodes)
+	}
+	node := jsonMapFromAny(t, nodes[0])
+	if node["status"] == nil || node["message"] != nil {
+		t.Fatalf("node = %#v, want cohosted status accepted", node)
+	}
+	if urls := jsonArrayFromMap(t, payload, "public_urls"); len(urls) != 1 || urls[0] != "http://app.example.com/" {
+		t.Fatalf("public_urls = %#v, want public URL when scoped environment is settled", urls)
+	}
+}
+
 func TestSoloDeployWaitsForSettledStatusBeforeSuccess(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	if err := os.WriteFile(filepath.Join(workspaceRoot, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {


### PR DESCRIPTION
## Summary
- accept co-hosted solo node status when the selected workspace environment is settled inside a newer merged desired-state revision
- parse environment revision/phase from node status
- add regression coverage for co-hosted desired-state status validation

## Dogfood evidence
- Released and installed official `v0.2.0-preview` from `640eb780c2ca` built `2026-04-30T02:31:03Z`
- Provisioned Hetzner solo node `solo-df-04300234`, verified node agent reports the same official version
- Deployed app A and app B to the same node with auto TLS and distinct `sslip.io` hostnames
- Found app A `devopsellence status` reported a stale desired-state revision after app B deployed, while both HTTPS endpoints and containers were healthy
- Verified patched local CLI reports app A status as settled with the public URL while app B remains co-hosted

Evidence: `/tmp/devopsellence-dogfood-solo/20260430T023024799365Z-solo-release-v0-2-0-preview`

## Tests
- `mise run test:cli -- ./internal/workflow`
