### PR TITLE
Respect solo environment in ingress set

### DIFF
--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -4540,17 +4540,26 @@ func (a *App) IngressSet(_ context.Context, opts IngressSetOptions) error {
 	if cfg == nil {
 		cfg = soloDefaultProjectConfig(discovered)
 	}
+	selectedEnvironment := a.effectiveEnvironment("", cfg)
+	resolvedCfg := *cfg
+	if selectedEnvironment != soloEnvironmentName(cfg, "") {
+		resolved, err := config.ResolveEnvironmentConfig(*cfg, selectedEnvironment)
+		if err != nil {
+			return err
+		}
+		resolvedCfg = resolved
+	}
 	hosts := normalizeIngressHosts(opts.Hosts)
 	if len(hosts) == 0 {
 		return fmt.Errorf("ingress set requires at least one --host")
 	}
 	serviceName := strings.TrimSpace(opts.Service)
-	if serviceName == "" && cfg.Ingress != nil && len(cfg.Ingress.Rules) > 0 {
-		serviceName = strings.TrimSpace(cfg.Ingress.Rules[0].Target.Service)
+	if serviceName == "" && resolvedCfg.Ingress != nil && len(resolvedCfg.Ingress.Rules) > 0 {
+		serviceName = strings.TrimSpace(resolvedCfg.Ingress.Rules[0].Target.Service)
 	}
 	if serviceName == "" {
 		var ok bool
-		serviceName, ok = cfg.PrimaryWebServiceName()
+		serviceName, ok = resolvedCfg.PrimaryWebServiceName()
 		if !ok {
 			return fmt.Errorf("ingress set requires --service when the primary web service cannot be inferred")
 		}
@@ -4575,7 +4584,7 @@ func (a *App) IngressSet(_ context.Context, opts IngressSetOptions) error {
 	if opts.RedirectHTTPChanged {
 		redirectHTTP = opts.RedirectHTTP
 	}
-	cfg.Ingress = &config.IngressConfig{
+	ingress := config.IngressConfig{
 		Hosts: hosts,
 		Rules: rules,
 		TLS: config.IngressTLSConfig{
@@ -4585,14 +4594,32 @@ func (a *App) IngressSet(_ context.Context, opts IngressSetOptions) error {
 		},
 		RedirectHTTP: configBoolPtr(redirectHTTP),
 	}
-	written, err := a.ConfigStore.Write(discovered.WorkspaceRoot, *cfg)
-	if err != nil {
+	if selectedEnvironment != soloEnvironmentName(cfg, "") {
+		if cfg.Environments == nil {
+			cfg.Environments = map[string]config.EnvironmentOverlay{}
+		}
+		overlay := cfg.Environments[selectedEnvironment]
+		overlay.Ingress = &config.IngressConfigOverlay{
+			Hosts: hosts,
+			Rules: rules,
+			TLS: &config.IngressTLSConfigOverlay{
+				Mode:           configStringPtr(tlsMode),
+				Email:          configOptionalStringPtr(opts.TLSEmail),
+				CADirectoryURL: configOptionalStringPtr(opts.TLSCADirectoryURL),
+			},
+			RedirectHTTP: configBoolPtr(redirectHTTP),
+		}
+		cfg.Environments[selectedEnvironment] = overlay
+	} else {
+		cfg.Ingress = &ingress
+	}
+	if _, err := a.ConfigStore.Write(discovered.WorkspaceRoot, *cfg); err != nil {
 		return err
 	}
 
 	return a.Printer.PrintJSON(map[string]any{
 		"schema_version": outputSchemaVersion,
-		"ingress":        written.Ingress,
+		"ingress":        ingress,
 		"config_path":    a.ConfigStore.PathFor(discovered.WorkspaceRoot),
 	})
 
@@ -5244,6 +5271,18 @@ func soloDefaultProjectConfig(discovered discovery.Result) *config.ProjectConfig
 }
 
 func configBoolPtr(value bool) *bool {
+	return &value
+}
+
+func configStringPtr(value string) *string {
+	return &value
+}
+
+func configOptionalStringPtr(value string) *string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
 	return &value
 }
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -6123,6 +6123,58 @@ func TestIngressSetPreservesExistingServiceWhenFlagOmitted(t *testing.T) {
 	}
 }
 
+func TestIngressSetWritesSelectedEnvironmentOverlay(t *testing.T) {
+	t.Setenv("DEVOPSELLENCE_ENVIRONMENT", "staging")
+
+	dir := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", config.DefaultEnvironment)
+	cfg.Ingress = &config.IngressConfig{
+		Hosts: []string{"prod.example.com"},
+		Rules: []config.IngressRuleConfig{{
+			Match:  config.IngressMatchConfig{Host: "prod.example.com", PathPrefix: "/"},
+			Target: config.IngressTargetConfig{Service: config.DefaultWebServiceName, Port: "http"},
+		}},
+		TLS: config.IngressTLSConfig{Mode: "auto", Email: "prod@example.com"},
+	}
+	cfg.Environments = map[string]config.EnvironmentOverlay{"staging": {}}
+	if _, err := config.Write(dir, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	app := &App{
+		Cwd:         dir,
+		ConfigStore: config.NewStore(),
+		Printer:     output.New(io.Discard, io.Discard),
+	}
+	if err := app.IngressSet(context.Background(), IngressSetOptions{
+		Hosts:               []string{"staging.example.com"},
+		TLSMode:             "auto",
+		TLSEmail:            "staging@example.com",
+		RedirectHTTP:        true,
+		RedirectHTTPChanged: true,
+	}); err != nil {
+		t.Fatalf("IngressSet() error = %v", err)
+	}
+
+	written, err := config.Load(filepath.Join(dir, config.FilePath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Join(written.Ingress.Hosts, ","); got != "prod.example.com" {
+		t.Fatalf("base ingress hosts = %q, want prod.example.com", got)
+	}
+	overlay := written.Environments["staging"].Ingress
+	if overlay == nil {
+		t.Fatal("staging ingress overlay = nil, want populated overlay")
+	}
+	if got := strings.Join(overlay.Hosts, ","); got != "staging.example.com" {
+		t.Fatalf("staging ingress hosts = %q, want staging.example.com", got)
+	}
+	if overlay.TLS == nil || overlay.TLS.Email == nil || *overlay.TLS.Email != "staging@example.com" {
+		t.Fatalf("staging tls overlay = %#v, want staging email", overlay.TLS)
+	}
+}
+
 func TestLineProgressWriterEmitsLines(t *testing.T) {
 	var got []string
 	writer := &lineProgressWriter{progress: func(line string) { got = append(got, line) }}


### PR DESCRIPTION
## Summary
- make `devopsellence ingress set` write an environment overlay when a non-default solo environment is selected
- preserve base/production ingress while configuring staging ingress
- infer the target service from the resolved selected environment
- add regression coverage for selected-environment ingress overlays

## Dogfood evidence
- On official PR #116 artifacts, selected app A `staging`, ran `ingress set --host staging-a-...`, and saw base production ingress overwritten with the staging host while `environments.staging` stayed empty
- This blocks safe multi-env solo operation because configuring staging can silently change production routing config

Evidence: `/tmp/devopsellence-dogfood-solo/20260430T023024799365Z-solo-release-v0-2-0-preview`

## Tests
- `mise run test:cli -- ./internal/workflow`
