### PR TITLE
Warn on duplicate solo node hosts

### DIFF
--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -976,6 +976,41 @@ func soloNodeListAttachments(attachments []solo.AttachmentRecord, currentWorkspa
 	return items
 }
 
+func soloNodeListDuplicateHostWarnings(current solo.State, listedNodeNames []string) []string {
+	listed := make(map[string]bool, len(listedNodeNames))
+	for _, name := range listedNodeNames {
+		listed[name] = true
+	}
+	hosts := make(map[string][]string)
+	for name, node := range current.Nodes {
+		host := strings.TrimSpace(strings.ToLower(node.Host))
+		if host == "" {
+			continue
+		}
+		hosts[host] = append(hosts[host], name)
+	}
+	warnings := []string{}
+	for host, names := range hosts {
+		if len(names) < 2 {
+			continue
+		}
+		listedInGroup := false
+		for _, name := range names {
+			if listed[name] {
+				listedInGroup = true
+				break
+			}
+		}
+		if !listedInGroup {
+			continue
+		}
+		sort.Strings(names)
+		warnings = append(warnings, fmt.Sprintf("multiple solo node records share host %s: %s; verify stale state or provider IP reuse before deploy/remove", host, strings.Join(names, ", ")))
+	}
+	sort.Strings(warnings)
+	return warnings
+}
+
 type soloRepublishErrorEntry struct {
 	node      string
 	operation string
@@ -2531,12 +2566,16 @@ func (a *App) SoloNodeList(_ context.Context, opts SoloNodeListOptions) error {
 		})
 	}
 
-	return a.Printer.PrintJSON(map[string]any{
+	payload := map[string]any{
 		"schema_version": outputSchemaVersion,
 		"scope":          scope,
 		"nodes":          nodes,
 		"node_items":     items,
-	})
+	}
+	if warnings := soloNodeListDuplicateHostWarnings(current, nodeNames); len(warnings) > 0 {
+		payload["warnings"] = warnings
+	}
+	return a.Printer.PrintJSON(payload)
 
 }
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -2010,6 +2010,48 @@ func TestSoloNodeListDefaultsToCurrentEnvironmentAndRedactsPrivateFields(t *test
 	t.Fatalf("node_items = %#v, want node-a", items)
 }
 
+func TestSoloNodeListWarnsWhenListedNodeSharesHost(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.Node{
+			"current-prod": {Host: "203.0.113.10", User: "root", ProviderServerID: "server-new"},
+			"stale-prod":   {Host: "203.0.113.10", User: "root", ProviderServerID: "server-old"},
+			"other-prod":   {Host: "203.0.113.11", User: "root"},
+		},
+	}
+	if _, _, err := current.AttachNode(workspaceRoot, "production", "current-prod"); err != nil {
+		t.Fatal(err)
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState, Cwd: workspaceRoot}
+	if err := app.SoloNodeList(context.Background(), SoloNodeListOptions{}); err != nil {
+		t.Fatalf("SoloNodeList() error = %v", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	warnings := jsonArrayFromMap(t, payload, "warnings")
+	if len(warnings) != 1 {
+		t.Fatalf("warnings = %#v, want one duplicate-host warning", warnings)
+	}
+	warning := stringValueAny(warnings[0])
+	for _, want := range []string{"203.0.113.10", "current-prod", "stale-prod", "stale state", "provider IP reuse"} {
+		if !strings.Contains(warning, want) {
+			t.Fatalf("warning = %q, want %q", warning, want)
+		}
+	}
+	if strings.Contains(warning, "server-new") || strings.Contains(warning, "server-old") {
+		t.Fatalf("warning = %q, leaked provider server id", warning)
+	}
+}
+
 func TestSoloNodeListRequiresConfigForDefaultScope(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))


### PR DESCRIPTION
## Summary
- add a solo `node list` warning when listed node records share the same host/IP
- keep private provider server IDs redacted while still surfacing stale-state/provider-IP-reuse risk
- cover the warning with a focused workflow regression test

## Dogfood evidence
During the `v0.2.0-preview` solo dogfood loop from official artifacts at `9852c89cddb0`, a disposable manual TLS node reused an IP that was still present in older local solo state under another node name. `devopsellence node list --all` exposed both records but gave no warning, which is easy for an operator agent to miss before deploy/remove.

Run artifact: `/tmp/devopsellence-dogfood-solo/20260430T100309497849Z-solo-release-v0-2-0-preview-after-pr118`

## Validation
- `cd cli && go test ./internal/workflow -run 'TestSoloNodeList'`
- `mise run test:cli`
