### PR TITLE
Harden solo release readiness

### DIFF
--- a/.github/workflows/component-release.yml
+++ b/.github/workflows/component-release.yml
@@ -227,8 +227,29 @@ jobs:
               "${dist_dir}/SHA256SUMS" > "${upload_dir}/${asset_prefix}-SHA256SUMS"
           }
 
+          verify_release_binary() {
+            local component="$1"
+            local binary="$2"
+            local version="$3"
+            local short_sha="$4"
+            local output
+
+            output="$("$binary" --version)"
+            if [[ "$output" != *"$version"* ]] || [[ "$output" != *"$short_sha"* ]]; then
+              echo "${component} release artifact has unexpected version output: $output" >&2
+              echo "expected version=$version commit=$short_sha" >&2
+              exit 1
+            fi
+          }
+
+          verify_release_artifacts() {
+            verify_release_binary agent "${workspace_dir}/agent/dist/${version}/linux-amd64" "$version" "$short_sha"
+            verify_release_binary cli "${workspace_dir}/cli/dist/${version}/linux-amd64" "$version" "$short_sha"
+          }
+
           publish_component agent
           publish_component cli
+          verify_release_artifacts
           prepare_release_target "$tag_name"
 
           release_assets=(

--- a/cli/internal/workflow/app.go
+++ b/cli/internal/workflow/app.go
@@ -2064,6 +2064,9 @@ func (a *App) ProjectUse(ctx context.Context, opts ProjectUseOptions) error {
 }
 
 func (a *App) EnvironmentList(ctx context.Context, opts EnvironmentListOptions) error {
+	if mode, err := a.ResolveMode(); err == nil && mode == ModeSolo {
+		return a.soloEnvironmentList(opts)
+	}
 	tokens, err := a.ensureAuth(ctx, false)
 	if err != nil {
 		return err

--- a/cli/internal/workflow/root.go
+++ b/cli/internal/workflow/root.go
@@ -556,6 +556,7 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 			"  shared - deploys through the control plane using org/project/environment context",
 		}, "\n"),
 		RunE: runByMode(func(ctx context.Context) error {
+			deploySoloOpts.Environment = deploySharedOpts.Environment
 			return app.SoloDeploy(ctx, deploySoloOpts)
 		}, func(ctx context.Context) error {
 			return app.Deploy(ctx, deploySharedOpts)
@@ -566,7 +567,7 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 	deployCommand.Flags().StringVar(&deploySharedOpts.Organization, "org", os.Getenv("DEVOPSELLENCE_ORGANIZATION"), "Organization name override (shared mode)")
 	deployCommand.Flags().StringVar(&deploySharedOpts.Project, "project", os.Getenv("DEVOPSELLENCE_PROJECT"), "Project name override (shared mode)")
 	deployCommand.Flags().StringVar(&deploySharedOpts.Image, "image", "", "Deploy an existing digest ref instead of building locally (shared mode)")
-	deployCommand.Flags().StringVar(&deploySharedOpts.Environment, "env", os.Getenv("DEVOPSELLENCE_ENVIRONMENT"), "Environment name override (shared mode)")
+	deployCommand.Flags().StringVar(&deploySharedOpts.Environment, "env", os.Getenv("DEVOPSELLENCE_ENVIRONMENT"), "Environment name override (solo/shared)")
 	deployCommand.Flags().BoolVar(&deploySharedOpts.NonInteractive, "non-interactive", false, "Disable interactive prompts if re-initialization is needed (shared mode)")
 	root.AddCommand(deployCommand)
 
@@ -634,6 +635,7 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 		Use:   "status",
 		Short: "Show deploy or runtime status for the selected workspace mode",
 		RunE: runByMode(func(ctx context.Context) error {
+			statusSoloOpts.Environment = statusSharedOpts.Environment
 			return app.SoloStatus(ctx, statusSoloOpts)
 		}, func(ctx context.Context) error {
 			return app.Status(ctx, statusSharedOpts)
@@ -642,7 +644,7 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 	statusCommand.Flags().StringSliceVar(&statusSoloOpts.Nodes, "nodes", nil, "Comma-separated node names (solo mode)")
 	statusCommand.Flags().StringVar(&statusSharedOpts.Organization, "org", "", "Organization name override (shared mode)")
 	statusCommand.Flags().StringVar(&statusSharedOpts.Project, "project", "", "Project name override (shared mode)")
-	statusCommand.Flags().StringVar(&statusSharedOpts.Environment, "env", "", "Environment name override (shared mode)")
+	statusCommand.Flags().StringVar(&statusSharedOpts.Environment, "env", os.Getenv("DEVOPSELLENCE_ENVIRONMENT"), "Environment name override (solo/shared)")
 	root.AddCommand(statusCommand)
 
 	var releaseListOpts SoloReleaseListOptions
@@ -661,6 +663,7 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 		}),
 	}
 	releaseListCommand.Flags().IntVar(&releaseListOpts.Limit, "limit", 20, "Maximum releases to return (0 for full history)")
+	releaseListCommand.Flags().StringVar(&releaseListOpts.Environment, "env", os.Getenv("DEVOPSELLENCE_ENVIRONMENT"), "Environment name override (solo mode)")
 	releaseRollbackCommand := &cobra.Command{
 		Use:   "rollback [revision-or-release-id]",
 		Short: "Republish a previous release",
@@ -677,6 +680,7 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 		},
 	}
 	releaseRollbackCommand.Flags().BoolVar(&releaseRollbackOpts.DryRun, "dry-run", false, "Plan solo rollback without publishing, SSHing, or mutating state")
+	releaseRollbackCommand.Flags().StringVar(&releaseRollbackOpts.Environment, "env", os.Getenv("DEVOPSELLENCE_ENVIRONMENT"), "Environment name override (solo mode)")
 	releaseCommand.AddCommand(releaseListCommand, releaseRollbackCommand)
 	root.AddCommand(releaseCommand)
 
@@ -1080,6 +1084,7 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 		},
 	}
 	logsCommand.Flags().StringSliceVar(&workloadLogsOpts.Nodes, "node", nil, "Solo node name to read logs from (repeatable or comma-separated)")
+	logsCommand.Flags().StringVar(&workloadLogsOpts.Environment, "env", os.Getenv("DEVOPSELLENCE_ENVIRONMENT"), "Environment name override")
 	logsCommand.Flags().IntVar(&workloadLogsOpts.Lines, "lines", soloLogsDefaultLines, fmt.Sprintf("Number of recent log lines to return, 1-%d", soloLogsMaxLines))
 	root.AddCommand(logsCommand)
 

--- a/cli/internal/workflow/root_test.go
+++ b/cli/internal/workflow/root_test.go
@@ -115,6 +115,34 @@ func TestInitModeFlagPersistsWorkspaceModeAndWritesConfig(t *testing.T) {
 	}
 }
 
+func TestRootSoloContextEnvListDoesNotRequireAuth(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	cwd := rootTestWorkspaceWithMode(t, ModeSolo)
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	cfg.Environments = map[string]config.EnvironmentOverlay{"staging": {}}
+	if _, err := config.Write(cwd, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, cwd)
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{"context", "env", "list"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	if payload["mode"] != "solo" {
+		t.Fatalf("payload = %#v, want solo mode", payload)
+	}
+	environments := jsonArrayFromMap(t, payload, "environments")
+	if len(environments) != 2 {
+		t.Fatalf("environments = %#v, want production and staging", environments)
+	}
+}
+
 func TestModeCommandDefaultsToShow(t *testing.T) {
 	var stdout bytes.Buffer
 	cwd := rootTestWorkspaceWithMode(t, ModeSolo)

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -37,19 +37,23 @@ import (
 type SoloDeployOptions struct {
 	SkipDNSCheck bool
 	DryRun       bool
+	Environment  string
 }
 
 type SoloReleaseListOptions struct {
-	Limit int
+	Limit       int
+	Environment string
 }
 
 type SoloReleaseRollbackOptions struct {
-	Selector string
-	DryRun   bool
+	Selector    string
+	DryRun      bool
+	Environment string
 }
 
 type SoloStatusOptions struct {
-	Nodes []string
+	Nodes       []string
+	Environment string
 }
 
 var (
@@ -99,6 +103,7 @@ type SoloLogsOptions struct {
 
 type SoloWorkloadLogsOptions struct {
 	ServiceName string
+	Environment string
 	Nodes       []string
 	Lines       int
 }
@@ -394,7 +399,7 @@ func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 	if err := stream.Event("started", map[string]any{}); err != nil {
 		return err
 	}
-	cfg, workspaceRoot, environmentName, err := a.loadResolvedSoloProjectConfig("")
+	cfg, workspaceRoot, environmentName, err := a.loadResolvedSoloProjectConfig(opts.Environment)
 	if err != nil {
 		return err
 	}
@@ -416,10 +421,6 @@ func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 	if _, err := validateNodeSchedule(cfg, nodes); err != nil {
 		return err
 	}
-	if err := a.checkIngressBeforeDeploy(ctx, cfg, nodes, opts.SkipDNSCheck); err != nil {
-		return err
-	}
-
 	sha, err := a.Git.CurrentSHA(workspaceRoot)
 	if err != nil {
 		return fmt.Errorf("get git SHA: %w", err)
@@ -455,6 +456,10 @@ func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 			}
 		}
 		return stream.Result(payload)
+	}
+
+	if err := a.checkIngressBeforeDeploy(ctx, cfg, nodes, opts.SkipDNSCheck); err != nil {
+		return err
 	}
 
 	buildCtx := filepath.Join(workspaceRoot, cfg.Build.Context)
@@ -565,7 +570,7 @@ func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 		"nodes":                   sortedNodeNames(nodes),
 		"phase":                   "settled",
 	}
-	if urls := a.soloVerifiedPublicURLs(cfg, nodes); len(urls) > 0 {
+	if urls := a.soloVerifiedPublicURLs(workspaceRoot, environmentName, cfg, nodes); len(urls) > 0 {
 		payload["public_urls"] = urls
 		payload["next_steps"] = append([]string{"devopsellence status", "curl " + urls[0]}, soloNodeLogNextSteps(nodes)...)
 	} else if urls := soloStatusPublicURLs(cfg, nodes); len(urls) > 0 {
@@ -863,11 +868,11 @@ func soloNodeStatusAdvancedAfter(status soloNodeStatus, previousStatusTime strin
 	}
 	observed := strings.TrimSpace(status.Time)
 	if observed == "" {
-		return true
+		return false
 	}
 	parsedObserved, err := time.Parse(time.RFC3339Nano, observed)
 	if err != nil {
-		return true
+		return false
 	}
 	parsedPrevious, err := time.Parse(time.RFC3339Nano, previousStatusTime)
 	if err != nil {
@@ -1674,32 +1679,29 @@ func sortedSoloPeerNames(peers map[string]desiredstate.NodePeer) []string {
 }
 
 func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
-	nodes, cfg, err := a.soloStatusSelection(opts)
+	nodes, cfg, workspaceRoot, environmentName, err := a.soloStatusSelection(opts)
 	if err != nil {
 		return err
 	}
 	if len(nodes) == 0 {
 		return fmt.Errorf("no nodes attached to the current environment")
 	}
-	verifiedPublicURLs := a.soloVerifiedPublicURLs(cfg, nodes)
+	verifiedPublicURLs := a.soloVerifiedPublicURLs(workspaceRoot, environmentName, cfg, nodes)
 	localReleaseKnown := len(opts.Nodes) > 0
 	expectedRevisions := map[string]string{}
 	expectedRuntimeEnvironment := ""
 	expectedWorkloadRevision := ""
 	if len(opts.Nodes) == 0 {
 		if current, stateErr := a.readSoloState(); stateErr == nil {
-			_, workspaceRoot, environmentName, configErr := a.loadResolvedSoloProjectConfig("")
-			if configErr == nil {
-				_, currentRelease, hasCurrent, releaseErr := current.CurrentRelease(workspaceRoot, environmentName)
-				if releaseErr != nil {
-					return releaseErr
-				}
-				if hasCurrent {
-					localReleaseKnown = true
-					expectedRevisions = soloExpectedStatusRevisions(current, currentRelease)
-					expectedWorkloadRevision = strings.TrimSpace(currentRelease.Revision)
-					expectedRuntimeEnvironment, _ = soloRuntimeEnvironmentNameForNode(current, workspaceRoot, environmentName, "")
-				}
+			_, currentRelease, hasCurrent, releaseErr := current.CurrentRelease(workspaceRoot, environmentName)
+			if releaseErr != nil {
+				return releaseErr
+			}
+			if hasCurrent {
+				localReleaseKnown = true
+				expectedRevisions = soloExpectedStatusRevisions(current, currentRelease)
+				expectedWorkloadRevision = strings.TrimSpace(currentRelease.Revision)
+				expectedRuntimeEnvironment, _ = soloRuntimeEnvironmentNameForNode(current, workspaceRoot, environmentName, "")
 			}
 		}
 	}
@@ -1850,7 +1852,7 @@ func soloExpectedStatusRevision(expected map[string]string, nodeName string) str
 }
 
 func (a *App) SoloReleaseList(ctx context.Context, opts SoloReleaseListOptions) error {
-	_, workspaceRoot, environmentName, err := a.loadResolvedSoloProjectConfig("")
+	_, workspaceRoot, environmentName, err := a.loadResolvedSoloProjectConfig(opts.Environment)
 	if err != nil {
 		return err
 	}
@@ -1905,7 +1907,7 @@ func (a *App) SoloReleaseRollback(ctx context.Context, opts SoloReleaseRollbackO
 	if err := stream.Event("started", map[string]any{}); err != nil {
 		return err
 	}
-	_, workspaceRoot, environmentName, err := a.loadResolvedSoloProjectConfig("")
+	_, workspaceRoot, environmentName, err := a.loadResolvedSoloProjectConfig(opts.Environment)
 	if err != nil {
 		return err
 	}
@@ -2086,7 +2088,7 @@ func soloPublicURLStatus(cfg *config.ProjectConfig) string {
 
 func soloPublicURLWarning(cfg *config.ProjectConfig) string {
 	if ingressRequiresTLSReadiness(cfg) {
-		return "HTTPS public URLs are configured, but TLS readiness has not been verified yet; use `devopsellence ingress check --wait 2m` before treating them as reachable"
+		return "HTTPS public URLs are configured, but TLS reachability has not been verified yet; use `devopsellence status` and curl the HTTPS endpoint before treating it as reachable"
 	}
 	return "public URLs are configured, but one or more nodes are not settled; check node status before testing reachability"
 }
@@ -2758,7 +2760,7 @@ func (a *App) SoloWorkloadLogs(ctx context.Context, opts SoloWorkloadLogsOptions
 	if linesLimit < 1 || linesLimit > soloLogsMaxLines {
 		return ExitError{Code: 2, Err: fmt.Errorf("--lines must be between 1 and %d", soloLogsMaxLines)}
 	}
-	nodes, cfg, err := a.soloStatusSelection(SoloStatusOptions{Nodes: opts.Nodes})
+	nodes, cfg, workspaceRoot, environmentName, err := a.soloStatusSelection(SoloStatusOptions{Nodes: opts.Nodes, Environment: opts.Environment})
 	if err != nil {
 		return err
 	}
@@ -2767,11 +2769,6 @@ func (a *App) SoloWorkloadLogs(ctx context.Context, opts SoloWorkloadLogsOptions
 	}
 	if cfg == nil {
 		return fmt.Errorf("no workspace selected; attach a workspace or run this command from a workspace")
-	}
-	environmentName := a.effectiveEnvironment("", cfg)
-	workspaceRoot, err := a.soloCurrentWorkspaceRoot()
-	if err != nil {
-		return err
 	}
 	current, err := a.readSoloState()
 	if err != nil {
@@ -5148,6 +5145,44 @@ func (a *App) soloEnvironmentCreate(opts EnvironmentCreateOptions) error {
 	})
 }
 
+func (a *App) soloEnvironmentList(opts EnvironmentListOptions) error {
+	if strings.TrimSpace(opts.Organization) != "" || strings.TrimSpace(opts.Project) != "" {
+		return ExitError{Code: 2, Err: errors.New("--org and --project are only supported in shared mode")}
+	}
+	cfg, _, err := a.loadSoloProjectConfig()
+	if err != nil {
+		return err
+	}
+	current := a.effectiveEnvironment("", cfg)
+
+	defaultEnvironment := soloEnvironmentName(cfg, "")
+	names := []string{defaultEnvironment}
+	seen := map[string]bool{defaultEnvironment: true}
+	for name := range cfg.Environments {
+		if strings.TrimSpace(name) != "" && !seen[name] {
+			names = append(names, name)
+			seen[name] = true
+		}
+	}
+	sort.Strings(names)
+	environments := make([]map[string]any, 0, len(names))
+	for _, name := range names {
+		environments = append(environments, map[string]any{
+			"name":    name,
+			"default": name == defaultEnvironment,
+			"current": name == current,
+		})
+	}
+	return a.Printer.PrintJSON(map[string]any{
+		"schema_version": outputSchemaVersion,
+		"ok":             true,
+		"mode":           string(ModeSolo),
+		"project":        cfg.Project,
+		"current":        current,
+		"environments":   environments,
+	})
+}
+
 func (a *App) soloEnvironmentUse(opts EnvironmentUseOptions) error {
 	environmentName := strings.TrimSpace(opts.Name)
 	cfg, _, err := a.loadSoloProjectConfig()
@@ -5173,44 +5208,48 @@ func (a *App) soloEnvironmentUse(opts EnvironmentUseOptions) error {
 }
 
 func (a *App) soloStatusNodes(opts SoloStatusOptions) (map[string]config.Node, error) {
-	nodes, _, err := a.soloStatusSelection(opts)
+	nodes, _, _, _, err := a.soloStatusSelection(opts)
 	return nodes, err
 }
 
-func (a *App) soloStatusSelection(opts SoloStatusOptions) (map[string]config.Node, *config.ProjectConfig, error) {
+func (a *App) soloStatusSelection(opts SoloStatusOptions) (map[string]config.Node, *config.ProjectConfig, string, string, error) {
 	current, err := a.readSoloState()
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, "", "", err
 	}
 	if len(opts.Nodes) > 0 {
 		nodes, err := a.resolveNodes(current, opts.Nodes)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, "", "", err
 		}
+		workspaceRoot := ""
+		environmentName := ""
 		_, cfg, cfgErr := a.optionalWorkspaceConfig()
 		if cfgErr != nil {
 			cfg = nil
-		} else if resolved, _, _, resolveErr := a.loadResolvedSoloProjectConfig(""); resolveErr == nil {
+		} else if resolved, resolvedWorkspaceRoot, resolvedEnvironmentName, resolveErr := a.loadResolvedSoloProjectConfig(opts.Environment); resolveErr == nil {
 			cfg = resolved
+			workspaceRoot = resolvedWorkspaceRoot
+			environmentName = resolvedEnvironmentName
 		}
-		return nodes, cfg, nil
+		return nodes, cfg, workspaceRoot, environmentName, nil
 	}
-	cfg, workspaceRoot, environmentName, err := a.loadResolvedSoloProjectConfig("")
+	cfg, workspaceRoot, environmentName, err := a.loadResolvedSoloProjectConfig(opts.Environment)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, "", "", err
 	}
 	nodeNames, err := current.AttachedNodeNames(workspaceRoot, environmentName)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, "", "", err
 	}
 	if len(nodeNames) == 0 {
-		return map[string]config.Node{}, cfg, nil
+		return map[string]config.Node{}, cfg, workspaceRoot, environmentName, nil
 	}
 	nodes, err := a.resolveNodes(current, nodeNames)
-	return nodes, cfg, err
+	return nodes, cfg, workspaceRoot, environmentName, err
 }
 
-func (a *App) soloVerifiedPublicURLs(cfg *config.ProjectConfig, nodes map[string]config.Node) []string {
+func (a *App) soloVerifiedPublicURLs(workspaceRoot, environmentName string, cfg *config.ProjectConfig, nodes map[string]config.Node) []string {
 	if !ingressRequiresTLSReadiness(cfg) {
 		return soloReadyPublicURLs(cfg, nodes)
 	}
@@ -5218,14 +5257,13 @@ func (a *App) soloVerifiedPublicURLs(cfg *config.ProjectConfig, nodes map[string
 	if err != nil {
 		return nil
 	}
-	_, workspaceRoot, environmentName, err := a.loadResolvedSoloProjectConfig("")
-	if err != nil {
-		return nil
-	}
 	return soloVerifiedIngressPublicURLs(current, workspaceRoot, environmentName, cfg, nodes)
 }
 
 func soloVerifiedIngressPublicURLs(current solo.State, workspaceRoot, environmentName string, cfg *config.ProjectConfig, nodes map[string]config.Node) []string {
+	if ingressRequiresTLSReadiness(cfg) {
+		return nil
+	}
 	key, err := solo.EnvironmentStateKey(workspaceRoot, environmentName)
 	if err != nil {
 		return nil

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -1101,7 +1101,57 @@ func TestSoloStatusUsesResolvedEnvironmentOverlay(t *testing.T) {
 	}
 }
 
-func TestSoloStatusUsesVerifiedTLSPublicURLsAfterIngressCheckRecord(t *testing.T) {
+func TestSoloStatusUsesExplicitEnvironment(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	cfg.Ingress = &config.IngressConfig{
+		Hosts: []string{"prod.example.com"},
+		Rules: []config.IngressRuleConfig{{
+			Match:  config.IngressMatchConfig{Host: "prod.example.com", PathPrefix: "/"},
+			Target: config.IngressTargetConfig{Service: config.DefaultWebServiceName, Port: "http"},
+		}},
+		TLS: config.IngressTLSConfig{Mode: "off"},
+	}
+	cfg.Environments = map[string]config.EnvironmentOverlay{
+		"staging": {Ingress: &config.IngressConfigOverlay{
+			Hosts: []string{"staging.example.com"},
+			Rules: []config.IngressRuleConfig{{
+				Match:  config.IngressMatchConfig{Host: "staging.example.com", PathPrefix: "/"},
+				Target: config.IngressTargetConfig{Service: config.DefaultWebServiceName, Port: "http"},
+			}},
+		}},
+	}
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	installFakeSoloCommands(t, []fakeSSHResponse{{stdout: `{"revision":"rev","phase":"settled","summary":{"environments":1,"services":1}}` + "\n"}})
+
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{Nodes: map[string]config.Node{"node-a": {Host: "203.0.113.10", User: "root", Labels: []string{config.DefaultWebRole}}}}
+	if _, _, err := current.AttachNode(workspaceRoot, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := current.AttachNode(workspaceRoot, "staging", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	seedSoloCurrentRelease(t, &current, workspaceRoot, "staging", "rev")
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState, ConfigStore: config.NewStore(), Cwd: workspaceRoot}
+	if err := app.SoloStatus(context.Background(), SoloStatusOptions{Environment: "staging"}); err != nil {
+		t.Fatalf("SoloStatus() error = %v", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	urls := jsonArrayFromMap(t, payload, "public_urls")
+	if len(urls) != 1 || urls[0] != "http://staging.example.com/" {
+		t.Fatalf("public_urls = %#v, want explicit staging host only", urls)
+	}
+}
+
+func TestSoloStatusDoesNotTreatDNSOnlyTLSCheckAsVerifiedPublicURL(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")
 	cfg.Ingress = &config.IngressConfig{
@@ -1144,15 +1194,15 @@ func TestSoloStatusUsesVerifiedTLSPublicURLsAfterIngressCheckRecord(t *testing.T
 		t.Fatalf("SoloStatus() error = %v", err)
 	}
 	payload := decodeJSONOutput(t, &stdout)
-	urls := jsonArrayFromMap(t, payload, "public_urls")
+	if _, ok := payload["public_urls"]; ok {
+		t.Fatalf("payload = %#v, DNS-only TLS check must not emit verified public_urls", payload)
+	}
+	urls := jsonArrayFromMap(t, payload, "configured_public_urls")
 	if len(urls) != 1 || urls[0] != "https://app.example.com/" {
-		t.Fatalf("public_urls = %#v, want verified HTTPS URL", urls)
+		t.Fatalf("configured_public_urls = %#v, want configured HTTPS URL", urls)
 	}
-	if _, ok := payload["public_url_status"]; ok {
-		t.Fatalf("payload = %#v, did not expect tls pending status after verified ingress check", payload)
-	}
-	if _, ok := payload["warnings"]; ok {
-		t.Fatalf("payload = %#v, did not expect TLS warning after verified ingress check", payload)
+	if payload["public_url_status"] != "configured_tls_pending" {
+		t.Fatalf("public_url_status = %#v, want configured_tls_pending", payload["public_url_status"])
 	}
 }
 
@@ -2216,6 +2266,58 @@ func TestSoloWorkloadLogsUsesProjectScopedRuntimeEnvironmentForCoHostedNode(t *t
 	node := jsonMapFromAny(t, nodes[0])
 	if node["runtime_environment"] != runtimeEnvironment {
 		t.Fatalf("node payload = %#v, want runtime environment %q", node, runtimeEnvironment)
+	}
+}
+
+func TestSoloWorkloadLogsUsesExplicitEnvironment(t *testing.T) {
+	commandPath := filepath.Join(t.TempDir(), "workload-command")
+	t.Setenv("DEVOPSELLENCE_FAKE_SSH_WORKLOAD_LOGS_COMMAND", commandPath)
+	installFakeSoloCommands(t, nil)
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	cfg.Environments = map[string]config.EnvironmentOverlay{"staging": {}}
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	current := solo.State{}
+	if err := current.SetNode("node-a", config.Node{Host: "203.0.113.10", User: "root"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := current.AttachNode(workspaceRoot, "staging", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	key, err := solo.EnvironmentStateKey(workspaceRoot, "staging")
+	if err != nil {
+		t.Fatal(err)
+	}
+	current.Snapshots = map[string]desiredstate.DeploySnapshot{
+		key: {WorkspaceRoot: workspaceRoot, WorkspaceKey: strings.Split(key, "\n")[0], Environment: "staging", Metadata: desiredstate.SnapshotMetadata{Project: "demo"}},
+	}
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState, ConfigStore: config.NewStore(), Cwd: workspaceRoot}
+	if err := app.SoloWorkloadLogs(context.Background(), SoloWorkloadLogsOptions{ServiceName: "web", Environment: "staging", Lines: 20}); err != nil {
+		t.Fatalf("SoloWorkloadLogs() error = %v", err)
+	}
+	runtimeEnvironment, err := soloRuntimeEnvironmentNameForNode(current, workspaceRoot, "staging", "node-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	commandBytes, err := os.ReadFile(commandPath)
+	if err != nil {
+		t.Fatalf("read workload command: %v", err)
+	}
+	if !strings.Contains(string(commandBytes), runtimeEnvironment) {
+		t.Fatalf("workload logs command = %q, want explicit staging runtime environment %q", commandBytes, runtimeEnvironment)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	if payload["environment"] != "staging" {
+		t.Fatalf("payload = %#v, want staging environment", payload)
 	}
 }
 
@@ -4056,6 +4158,57 @@ func TestSoloDeployDryRunUsesResolvedEnvironmentOverlay(t *testing.T) {
 	}
 }
 
+func TestSoloDeployDryRunUsesExplicitEnvironmentWithoutDNS(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	cfg.Ingress = &config.IngressConfig{
+		Hosts: []string{"prod.invalid"},
+		Rules: []config.IngressRuleConfig{{
+			Match:  config.IngressMatchConfig{Host: "prod.invalid", PathPrefix: "/"},
+			Target: config.IngressTargetConfig{Service: config.DefaultWebServiceName, Port: "http"},
+		}},
+		TLS: config.IngressTLSConfig{Mode: "auto"},
+	}
+	cfg.Environments = map[string]config.EnvironmentOverlay{
+		"staging": {
+			Ingress: &config.IngressConfigOverlay{
+				Hosts: []string{"staging.invalid"},
+				Rules: []config.IngressRuleConfig{{
+					Match:  config.IngressMatchConfig{Host: "staging.invalid", PathPrefix: "/"},
+					Target: config.IngressTargetConfig{Service: config.DefaultWebServiceName, Port: "http"},
+				}},
+			},
+		},
+	}
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	commitTestRepo(t, workspaceRoot)
+
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{Nodes: map[string]config.Node{"node-a": {Host: "203.0.113.10", User: "root", Port: 22, Labels: []string{config.DefaultWebRole}}}}
+	if _, _, err := current.AttachNode(workspaceRoot, "staging", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState, ConfigStore: config.NewStore(), Git: git.Client{}, Cwd: workspaceRoot}
+	if err := app.SoloDeploy(context.Background(), SoloDeployOptions{DryRun: true, Environment: "staging"}); err != nil {
+		t.Fatal(err)
+	}
+	events := decodeNDJSONOutput(t, &stdout)
+	payload := events[len(events)-1]
+	if payload["environment"] != "staging" {
+		t.Fatalf("payload = %#v, want explicit staging environment", payload)
+	}
+	if payload["public_url_status"] != "configured_tls_pending" {
+		t.Fatalf("payload = %#v, want TLS pending dry-run without DNS failure", payload)
+	}
+}
+
 func TestSoloDeployRepublishFailureDoesNotRecordCurrentRelease(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	if err := os.WriteFile(filepath.Join(workspaceRoot, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
@@ -4403,7 +4556,26 @@ func TestSoloDeployWaitsForSettledStatusBeforeSuccess(t *testing.T) {
 	}
 }
 
-func TestSoloDeployUsesVerifiedIngressPublicURLs(t *testing.T) {
+func TestSoloNodeStatusAdvancedAfterRequiresFreshParseableObservedTime(t *testing.T) {
+	baseline := "2026-04-28T12:00:00Z"
+	for _, status := range []soloNodeStatus{
+		{Time: ""},
+		{Time: "not-a-time"},
+		{Time: "2026-04-28T12:00:00Z"},
+	} {
+		if soloNodeStatusAdvancedAfter(status, baseline) {
+			t.Fatalf("status time %q advanced after baseline %q; want false", status.Time, baseline)
+		}
+	}
+	if !soloNodeStatusAdvancedAfter(soloNodeStatus{Time: "2026-04-28T12:00:01Z"}, baseline) {
+		t.Fatal("newer status time did not advance after baseline")
+	}
+	if !soloNodeStatusAdvancedAfter(soloNodeStatus{Time: ""}, "") {
+		t.Fatal("missing baseline should accept status time")
+	}
+}
+
+func TestSoloDeployDoesNotTreatDNSOnlyTLSCheckAsVerifiedPublicURL(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	if err := os.WriteFile(filepath.Join(workspaceRoot, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
 		t.Fatal(err)
@@ -4468,15 +4640,15 @@ func TestSoloDeployUsesVerifiedIngressPublicURLs(t *testing.T) {
 
 	events := decodeNDJSONOutput(t, &stdout)
 	payload := events[len(events)-1]
-	urls := jsonArrayFromMap(t, payload, "public_urls")
+	if _, ok := payload["public_urls"]; ok {
+		t.Fatalf("payload = %#v, DNS-only TLS check must not emit verified public_urls", payload)
+	}
+	urls := jsonArrayFromMap(t, payload, "configured_public_urls")
 	if len(urls) != 1 || urls[0] != "https://app.example.com/" {
-		t.Fatalf("public_urls = %#v, want verified HTTPS URL", urls)
+		t.Fatalf("configured_public_urls = %#v, want configured HTTPS URL", urls)
 	}
-	if _, ok := payload["public_url_status"]; ok {
-		t.Fatalf("payload = %#v, did not expect TLS pending status", payload)
-	}
-	if _, ok := payload["warnings"]; ok {
-		t.Fatalf("payload = %#v, did not expect TLS warning", payload)
+	if payload["public_url_status"] != "configured_tls_pending" {
+		t.Fatalf("public_url_status = %#v, want configured_tls_pending", payload["public_url_status"])
 	}
 }
 
@@ -4558,6 +4730,33 @@ func TestSoloReleaseListUsesCurrentSoloEnvironment(t *testing.T) {
 	}
 	if environmentID, ok := payload["environment_id"].(string); !ok || !strings.Contains(environmentID, "#staging") {
 		t.Fatalf("environment_id = %#v, want staging identifier", payload["environment_id"])
+	}
+	if payload["current_release_id"] != "rel-2" {
+		t.Fatalf("current_release_id = %#v, want staging current release rel-2", payload["current_release_id"])
+	}
+}
+
+func TestSoloReleaseListUsesExplicitEnvironment(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	cfg.Environments = map[string]config.EnvironmentOverlay{"staging": {}}
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := soloReleaseWorkflowStateForEnvironment(workspaceRoot, "staging")
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState, ConfigStore: config.NewStore(), Cwd: workspaceRoot}
+	if err := app.SoloReleaseList(context.Background(), SoloReleaseListOptions{Limit: 1, Environment: "staging"}); err != nil {
+		t.Fatal(err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	if payload["environment"] != "staging" {
+		t.Fatalf("environment = %#v, want staging", payload["environment"])
 	}
 	if payload["current_release_id"] != "rel-2" {
 		t.Fatalf("current_release_id = %#v, want staging current release rel-2", payload["current_release_id"])
@@ -4675,6 +4874,31 @@ func TestSoloReleaseRollbackDryRunUsesCurrentSoloEnvironment(t *testing.T) {
 	payload := events[len(events)-1]
 	if payload["environment"] != "staging" || payload["release_id"] != "rel-1" || payload["rolled_back_from"] != "rel-2" {
 		t.Fatalf("payload = %#v, want staging rollback from rel-2 to rel-1", payload)
+	}
+}
+
+func TestSoloReleaseRollbackDryRunUsesExplicitEnvironment(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	cfg.Environments = map[string]config.EnvironmentOverlay{"staging": {}}
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := soloReleaseWorkflowStateForEnvironment(workspaceRoot, "staging")
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState, ConfigStore: config.NewStore(), Cwd: workspaceRoot}
+	if err := app.SoloReleaseRollback(context.Background(), SoloReleaseRollbackOptions{Selector: "aaa1111", DryRun: true, Environment: "staging"}); err != nil {
+		t.Fatal(err)
+	}
+	events := decodeNDJSONOutput(t, &stdout)
+	payload := events[len(events)-1]
+	if payload["environment"] != "staging" || payload["release_id"] != "rel-1" || payload["rolled_back_from"] != "rel-2" {
+		t.Fatalf("payload = %#v, want explicit staging rollback from rel-2 to rel-1", payload)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add explicit solo --env support for deploy/status/logs/release list/rollback
- keep deploy dry-run free of live DNS preflight and make rollout freshness require parseable newer status times
- stop treating DNS-only TLS checks as verified HTTPS public_urls
- add solo context env list without auth
- add release artifact version/commit smoke before publishing

## Dogfood evidence
- released v0.2.0-preview from master: https://github.com/devopsellence/devopsellence/actions/runs/25160766200
- run report: /tmp/devopsellence-dogfood-solo/20260430T103524133771Z-solo-release-v0-2-0-preview/report.md
- official CLI/agent artifacts currently verify as v0.2.0-preview bacfdbfa1092

## Tests
- cd cli && mise exec -- go test ./internal/workflow
- mise run test:cli

## Follow-up loop
After merge/update, re-run component-release.yml with v0.2.0-preview from this branch and repeat official-artifact dogfood with a disposable node.