### PR TITLE
Tighten solo env-scoped diagnostics

### DIFF
--- a/cli/internal/workflow/root.go
+++ b/cli/internal/workflow/root.go
@@ -592,6 +592,7 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 	}
 	ingressSetCommand.Flags().StringSliceVar(&ingressSetOpts.Hosts, "host", nil, "Hostname, repeatable or comma-separated")
 	ingressSetCommand.Flags().StringVar(&ingressSetOpts.Service, "service", "", "Ingress service name")
+	ingressSetCommand.Flags().StringVar(&ingressSetOpts.Environment, "env", os.Getenv("DEVOPSELLENCE_ENVIRONMENT"), "Environment name override")
 	ingressSetCommand.Flags().StringVar(&ingressSetOpts.TLSMode, "tls-mode", "auto", "TLS mode: auto, manual, or off")
 	ingressSetCommand.Flags().StringVar(&ingressSetOpts.TLSEmail, "tls-email", "", "ACME account email")
 	ingressSetCommand.Flags().StringVar(&ingressSetOpts.TLSCADirectoryURL, "acme-ca", "", "ACME directory URL override")
@@ -606,6 +607,7 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 		}),
 	}
 	ingressCheckCommand.Flags().DurationVar(&ingressCheckOpts.Wait, "wait", 0, "Poll until DNS is ready or this timeout elapses")
+	ingressCheckCommand.Flags().StringVar(&ingressCheckOpts.Environment, "env", os.Getenv("DEVOPSELLENCE_ENVIRONMENT"), "Environment name override")
 	ingressCertCommand := &cobra.Command{
 		Use:   "cert",
 		Short: "Manage manual ingress TLS certificates",

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -202,6 +202,7 @@ type SoloInitOptions struct{}
 type IngressSetOptions struct {
 	Hosts               []string
 	Service             string
+	Environment         string
 	TLSMode             string
 	TLSEmail            string
 	TLSCADirectoryURL   string
@@ -210,7 +211,8 @@ type IngressSetOptions struct {
 }
 
 type IngressCheckOptions struct {
-	Wait time.Duration
+	Wait        time.Duration
+	Environment string
 }
 
 type soloNodeStatus struct {
@@ -1691,8 +1693,9 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 	expectedRevisions := map[string]string{}
 	expectedRuntimeEnvironment := ""
 	expectedWorkloadRevision := ""
-	if len(opts.Nodes) == 0 {
-		if current, stateErr := a.readSoloState(); stateErr == nil {
+	if workspaceRoot != "" && environmentName != "" {
+		current, stateErr := a.readSoloState()
+		if stateErr == nil {
 			_, currentRelease, hasCurrent, releaseErr := current.CurrentRelease(workspaceRoot, environmentName)
 			if releaseErr != nil {
 				return releaseErr
@@ -1704,6 +1707,8 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 				expectedRuntimeEnvironment, _ = soloRuntimeEnvironmentNameForNode(current, workspaceRoot, environmentName, "")
 			}
 		}
+	} else if len(opts.Nodes) > 0 {
+		localReleaseKnown = true
 	}
 
 	var jsonResults []map[string]any
@@ -4576,7 +4581,7 @@ func (a *App) IngressSet(_ context.Context, opts IngressSetOptions) error {
 	if cfg == nil {
 		cfg = soloDefaultProjectConfig(discovered)
 	}
-	selectedEnvironment := a.effectiveEnvironment("", cfg)
+	selectedEnvironment := a.effectiveEnvironment(opts.Environment, cfg)
 	resolvedCfg := *cfg
 	if selectedEnvironment != soloEnvironmentName(cfg, "") {
 		resolved, err := config.ResolveEnvironmentConfig(*cfg, selectedEnvironment)
@@ -4860,7 +4865,7 @@ func uploadSoloFile(ctx context.Context, node config.Node, localPath, remotePath
 }
 
 func (a *App) IngressCheck(ctx context.Context, opts IngressCheckOptions) error {
-	cfg, workspaceRoot, environmentName, err := a.loadResolvedSoloProjectConfig("")
+	cfg, workspaceRoot, environmentName, err := a.loadResolvedSoloProjectConfig(opts.Environment)
 	if err != nil {
 		return err
 	}

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -1151,6 +1151,64 @@ func TestSoloStatusUsesExplicitEnvironment(t *testing.T) {
 	}
 }
 
+func TestSoloStatusWithExplicitNodesUsesExplicitEnvironmentRelease(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	cfg.Ingress = &config.IngressConfig{
+		Hosts: []string{"prod.example.com"},
+		Rules: []config.IngressRuleConfig{{
+			Match:  config.IngressMatchConfig{Host: "prod.example.com", PathPrefix: "/"},
+			Target: config.IngressTargetConfig{Service: config.DefaultWebServiceName, Port: "http"},
+		}},
+		TLS: config.IngressTLSConfig{Mode: "off"},
+	}
+	cfg.Environments = map[string]config.EnvironmentOverlay{
+		"staging": {Ingress: &config.IngressConfigOverlay{
+			Hosts: []string{"staging.example.com"},
+			Rules: []config.IngressRuleConfig{{
+				Match:  config.IngressMatchConfig{Host: "staging.example.com", PathPrefix: "/"},
+				Target: config.IngressTargetConfig{Service: config.DefaultWebServiceName, Port: "http"},
+			}},
+		}},
+	}
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	installFakeSoloCommands(t, []fakeSSHResponse{{stdout: `{"revision":"prod-rev","phase":"settled","summary":{"environments":1,"services":1}}` + "\n"}})
+
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{Nodes: map[string]config.Node{"node-a": {Host: "203.0.113.10", User: "root", Labels: []string{config.DefaultWebRole}}}}
+	if _, _, err := current.AttachNode(workspaceRoot, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := current.AttachNode(workspaceRoot, "staging", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	seedSoloCurrentRelease(t, &current, workspaceRoot, "staging", "staging-rev")
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState, ConfigStore: config.NewStore(), Cwd: workspaceRoot}
+	if err := app.SoloStatus(context.Background(), SoloStatusOptions{Nodes: []string{"node-a"}, Environment: "staging"}); err != nil {
+		t.Fatalf("SoloStatus() error = %v", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	if _, ok := payload["public_urls"]; ok {
+		t.Fatalf("payload = %#v, explicit node stale status must not emit verified public_urls", payload)
+	}
+	urls := jsonArrayFromMap(t, payload, "configured_public_urls")
+	if len(urls) != 1 || urls[0] != "http://staging.example.com/" {
+		t.Fatalf("configured_public_urls = %#v, want staging URL only", urls)
+	}
+	nodes := jsonArrayFromMap(t, payload, "nodes")
+	node := jsonMapFromAny(t, nodes[0])
+	if node["status"] != nil || !strings.Contains(stringValueAny(node["message"]), "does not match current local deployment") {
+		t.Fatalf("node payload = %#v, want stale status message", node)
+	}
+}
+
 func TestSoloStatusDoesNotTreatDNSOnlyTLSCheckAsVerifiedPublicURL(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")
@@ -6515,6 +6573,91 @@ func TestIngressSetWritesSelectedEnvironmentOverlay(t *testing.T) {
 	}
 	if overlay.TLS == nil || overlay.TLS.Email == nil || *overlay.TLS.Email != "staging@example.com" {
 		t.Fatalf("staging tls overlay = %#v, want staging email", overlay.TLS)
+	}
+}
+
+func TestIngressSetWritesExplicitEnvironmentOverlay(t *testing.T) {
+	dir := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", config.DefaultEnvironment)
+	cfg.Ingress = &config.IngressConfig{
+		Hosts: []string{"prod.example.com"},
+		Rules: []config.IngressRuleConfig{{
+			Match:  config.IngressMatchConfig{Host: "prod.example.com", PathPrefix: "/"},
+			Target: config.IngressTargetConfig{Service: config.DefaultWebServiceName, Port: "http"},
+		}},
+		TLS: config.IngressTLSConfig{Mode: "auto"},
+	}
+	cfg.Environments = map[string]config.EnvironmentOverlay{"staging": {}}
+	if _, err := config.Write(dir, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	app := &App{Cwd: dir, ConfigStore: config.NewStore(), Printer: output.New(io.Discard, io.Discard)}
+	if err := app.IngressSet(context.Background(), IngressSetOptions{
+		Hosts:       []string{"staging.example.com"},
+		Environment: "staging",
+		TLSMode:     "auto",
+	}); err != nil {
+		t.Fatalf("IngressSet() error = %v", err)
+	}
+
+	written, err := config.Load(filepath.Join(dir, config.FilePath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Join(written.Ingress.Hosts, ","); got != "prod.example.com" {
+		t.Fatalf("base ingress hosts = %q, want prod.example.com", got)
+	}
+	overlay := written.Environments["staging"].Ingress
+	if overlay == nil || strings.Join(overlay.Hosts, ",") != "staging.example.com" {
+		t.Fatalf("staging ingress overlay = %#v, want explicit staging host", overlay)
+	}
+}
+
+func TestIngressCheckUsesExplicitEnvironment(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	cfg.Environments = map[string]config.EnvironmentOverlay{
+		"staging": {Ingress: &config.IngressConfigOverlay{
+			Hosts: []string{"127.0.0.1"},
+			Rules: []config.IngressRuleConfig{{
+				Match:  config.IngressMatchConfig{Host: "127.0.0.1", PathPrefix: "/"},
+				Target: config.IngressTargetConfig{Service: config.DefaultWebServiceName, Port: "http"},
+			}},
+			TLS: &config.IngressTLSConfigOverlay{Mode: configStringPtr("off")},
+		}},
+	}
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{Nodes: map[string]config.Node{"node-a": {Host: "127.0.0.1", User: "root", Labels: []string{config.DefaultWebRole}}}}
+	if _, _, err := current.AttachNode(workspaceRoot, "staging", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState, ConfigStore: config.NewStore(), Cwd: workspaceRoot}
+	if err := app.IngressCheck(context.Background(), IngressCheckOptions{Environment: "staging"}); err != nil {
+		t.Fatalf("IngressCheck() error = %v", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	if payload["ok"] != true {
+		t.Fatalf("payload = %#v, want successful explicit staging DNS check", payload)
+	}
+	loaded, err := soloState.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+	key, err := solo.EnvironmentStateKey(workspaceRoot, "staging")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if record, ok := loaded.IngressChecks[key]; !ok || !record.OK {
+		t.Fatalf("ingress checks = %#v, want staging success record", loaded.IngressChecks)
 	}
 }
 


### PR DESCRIPTION
## Summary
- make `status --nodes --env` validate selected nodes against the current release for that env instead of trusting any settled node status
- add explicit `--env` support to `ingress set` and `ingress check`
- add regression coverage for env-scoped explicit node status and ingress set/check

## Dogfood evidence
- loop-2 PR #120 official artifacts verified as v0.2.0-preview cde0a16b2ba0
- fresh source QA found `status --nodes --env` false-readiness gap
- fresh runtime QA found `ingress check --env` missing
- loop-2 run path: /tmp/devopsellence-dogfood-solo/20260430T104850133253Z-solo-release-v0-2-0-preview-pr120

## Tests
- cd cli && mise exec -- go test ./internal/workflow
- mise run test:cli

## Release loop
After this stacked PR is ready, re-run component-release.yml v0.2.0-preview from solo-release-readiness-2 and repeat official-artifact probes.