### PR TITLE
Surface solo dry-run DNS plan

### DIFF
--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -452,6 +452,9 @@ func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 		}
 		if urls := soloStatusPublicURLs(cfg, nodes); len(urls) > 0 {
 			payload["configured_public_urls"] = urls
+			if plannedCheck := soloPlannedDNSCheck(cfg, nodes); len(plannedCheck) > 0 {
+				payload["planned_dns_check"] = plannedCheck
+			}
 			if len(soloReadyPublicURLs(cfg, nodes)) == 0 {
 				payload["public_url_status"] = soloPublicURLStatus(cfg)
 				payload["warnings"] = []string{soloPublicURLWarning(cfg)}
@@ -1773,6 +1776,7 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 
 	payload := map[string]any{
 		"schema_version": outputSchemaVersion,
+		"environment":    environmentName,
 		"nodes":          jsonResults,
 	}
 	if len(verifiedPublicURLs) > 0 {
@@ -2049,6 +2053,23 @@ func soloReadyPublicURLs(cfg *config.ProjectConfig, nodes map[string]config.Node
 		return nil
 	}
 	return soloStatusPublicURLs(cfg, nodes)
+}
+
+func soloPlannedDNSCheck(cfg *config.ProjectConfig, nodes map[string]config.Node) map[string]any {
+	if cfg == nil || len(nodes) == 0 {
+		return nil
+	}
+	hosts := concreteIngressHosts(cfg)
+	if len(hosts) == 0 {
+		return nil
+	}
+	return map[string]any{
+		"live_lookup":   false,
+		"hosts":         hosts,
+		"expected_ips":  webNodeIPs(cfg, nodes),
+		"required":      ingressRequiresTLSReadiness(cfg),
+		"check_command": "devopsellence ingress check",
+	}
 }
 
 func soloStatusPublicURLs(cfg *config.ProjectConfig, nodes map[string]config.Node) []string {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -452,7 +452,7 @@ func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 		}
 		if urls := soloStatusPublicURLs(cfg, nodes); len(urls) > 0 {
 			payload["configured_public_urls"] = urls
-			if plannedCheck := soloPlannedDNSCheck(cfg, nodes); len(plannedCheck) > 0 {
+			if plannedCheck := soloPlannedDNSCheck(cfg, nodes, environmentName, opts.SkipDNSCheck); len(plannedCheck) > 0 {
 				payload["planned_dns_check"] = plannedCheck
 			}
 			if len(soloReadyPublicURLs(cfg, nodes)) == 0 {
@@ -2055,7 +2055,7 @@ func soloReadyPublicURLs(cfg *config.ProjectConfig, nodes map[string]config.Node
 	return soloStatusPublicURLs(cfg, nodes)
 }
 
-func soloPlannedDNSCheck(cfg *config.ProjectConfig, nodes map[string]config.Node) map[string]any {
+func soloPlannedDNSCheck(cfg *config.ProjectConfig, nodes map[string]config.Node, environmentName string, skipDNSCheck bool) map[string]any {
 	if cfg == nil || len(nodes) == 0 {
 		return nil
 	}
@@ -2063,13 +2063,21 @@ func soloPlannedDNSCheck(cfg *config.ProjectConfig, nodes map[string]config.Node
 	if len(hosts) == 0 {
 		return nil
 	}
-	return map[string]any{
-		"live_lookup":   false,
-		"hosts":         hosts,
-		"expected_ips":  webNodeIPs(cfg, nodes),
-		"required":      ingressRequiresTLSReadiness(cfg),
-		"check_command": "devopsellence ingress check",
+	payload := map[string]any{
+		"live_lookup":  false,
+		"hosts":        hosts,
+		"expected_ips": webNodeIPs(cfg, nodes),
+		"required":     !skipDNSCheck && ingressRequiresTLSReadiness(cfg),
 	}
+	if skipDNSCheck {
+		payload["skipped"] = true
+		return payload
+	}
+	if environmentName == "" {
+		environmentName = config.DefaultEnvironment
+	}
+	payload["check_command"] = "devopsellence ingress check --env " + shellQuote(environmentName)
+	return payload
 }
 
 func soloStatusPublicURLs(cfg *config.ProjectConfig, nodes map[string]config.Node) []string {

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -1145,6 +1145,9 @@ func TestSoloStatusUsesExplicitEnvironment(t *testing.T) {
 		t.Fatalf("SoloStatus() error = %v", err)
 	}
 	payload := decodeJSONOutput(t, &stdout)
+	if payload["environment"] != "staging" {
+		t.Fatalf("environment = %#v, want staging", payload["environment"])
+	}
 	urls := jsonArrayFromMap(t, payload, "public_urls")
 	if len(urls) != 1 || urls[0] != "http://staging.example.com/" {
 		t.Fatalf("public_urls = %#v, want explicit staging host only", urls)
@@ -4264,6 +4267,18 @@ func TestSoloDeployDryRunUsesExplicitEnvironmentWithoutDNS(t *testing.T) {
 	}
 	if payload["public_url_status"] != "configured_tls_pending" {
 		t.Fatalf("payload = %#v, want TLS pending dry-run without DNS failure", payload)
+	}
+	planned := jsonMapFromAny(t, payload["planned_dns_check"])
+	if planned["live_lookup"] != false || planned["required"] != true || planned["check_command"] != "devopsellence ingress check" {
+		t.Fatalf("planned_dns_check = %#v, want no-network required DNS check", planned)
+	}
+	hosts := jsonArrayFromMap(t, planned, "hosts")
+	if len(hosts) != 1 || hosts[0] != "staging.invalid" {
+		t.Fatalf("planned_dns_check.hosts = %#v, want staging.invalid", hosts)
+	}
+	expected := jsonArrayFromMap(t, planned, "expected_ips")
+	if len(expected) != 1 || expected[0] != "203.0.113.10" {
+		t.Fatalf("planned_dns_check.expected_ips = %#v, want node IP", expected)
 	}
 }
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -4269,8 +4269,8 @@ func TestSoloDeployDryRunUsesExplicitEnvironmentWithoutDNS(t *testing.T) {
 		t.Fatalf("payload = %#v, want TLS pending dry-run without DNS failure", payload)
 	}
 	planned := jsonMapFromAny(t, payload["planned_dns_check"])
-	if planned["live_lookup"] != false || planned["required"] != true || planned["check_command"] != "devopsellence ingress check" {
-		t.Fatalf("planned_dns_check = %#v, want no-network required DNS check", planned)
+	if planned["live_lookup"] != false || planned["required"] != true || planned["check_command"] != "devopsellence ingress check --env 'staging'" {
+		t.Fatalf("planned_dns_check = %#v, want no-network required DNS check for staging", planned)
 	}
 	hosts := jsonArrayFromMap(t, planned, "hosts")
 	if len(hosts) != 1 || hosts[0] != "staging.invalid" {
@@ -4279,6 +4279,20 @@ func TestSoloDeployDryRunUsesExplicitEnvironmentWithoutDNS(t *testing.T) {
 	expected := jsonArrayFromMap(t, planned, "expected_ips")
 	if len(expected) != 1 || expected[0] != "203.0.113.10" {
 		t.Fatalf("planned_dns_check.expected_ips = %#v, want node IP", expected)
+	}
+
+	stdout.Reset()
+	if err := app.SoloDeploy(context.Background(), SoloDeployOptions{DryRun: true, Environment: "staging", SkipDNSCheck: true}); err != nil {
+		t.Fatal(err)
+	}
+	events = decodeNDJSONOutput(t, &stdout)
+	payload = events[len(events)-1]
+	planned = jsonMapFromAny(t, payload["planned_dns_check"])
+	if planned["live_lookup"] != false || planned["required"] != false || planned["skipped"] != true {
+		t.Fatalf("planned_dns_check = %#v, want DNS check marked skipped/not required", planned)
+	}
+	if _, ok := planned["check_command"]; ok {
+		t.Fatalf("planned_dns_check = %#v, want no check command when DNS check is skipped", planned)
 	}
 }
 


### PR DESCRIPTION
## Summary
- include selected environment in solo status output
- include a no-network planned DNS check in deploy dry-run output when concrete ingress hosts are configured
- add regression coverage for both probe findings

## Dogfood evidence
- loop-2 QA found `status --env staging` did not echo env and dry-run had no DNS proof fields
- PR #121 official artifacts verified `ingress set/check --env` and deploy dry-run --env from v0.2.0-preview commit 29318303e800

## Tests
- cd cli && mise exec -- go test ./internal/workflow
- mise run test:cli

## Release loop
After review/checks, re-run component-release.yml v0.2.0-preview from solo-release-readiness-3 and repeat official-artifact probes.