### PR TITLE
Ratchet solo release diagnostics

### DIFF
--- a/.github/workflows/component-release.yml
+++ b/.github/workflows/component-release.yml
@@ -252,12 +252,12 @@ jobs:
               echo "${component} release artifact is missing or empty: $binary" >&2
               exit 1
             fi
-            if ! grep -a -q -- "$version" "$binary"; then
+            if ! grep -a -F -q -- "$version" "$binary"; then
               echo "${component} release artifact is missing version metadata: $binary" >&2
               echo "expected version=$version" >&2
               exit 1
             fi
-            if ! grep -a -q -- "$short_sha" "$binary"; then
+            if ! grep -a -F -q -- "$short_sha" "$binary"; then
               echo "${component} release artifact is missing commit metadata: $binary" >&2
               echo "expected commit=$short_sha" >&2
               exit 1

--- a/.github/workflows/component-release.yml
+++ b/.github/workflows/component-release.yml
@@ -242,9 +242,41 @@ jobs:
             fi
           }
 
+          verify_release_artifact_metadata() {
+            local component="$1"
+            local binary="$2"
+            local version="$3"
+            local short_sha="$4"
+
+            if [[ ! -s "$binary" ]]; then
+              echo "${component} release artifact is missing or empty: $binary" >&2
+              exit 1
+            fi
+            if ! grep -a -q -- "$version" "$binary"; then
+              echo "${component} release artifact is missing version metadata: $binary" >&2
+              echo "expected version=$version" >&2
+              exit 1
+            fi
+            if ! grep -a -q -- "$short_sha" "$binary"; then
+              echo "${component} release artifact is missing commit metadata: $binary" >&2
+              echo "expected commit=$short_sha" >&2
+              exit 1
+            fi
+          }
+
           verify_release_artifacts() {
-            verify_release_binary agent "${workspace_dir}/agent/dist/${version}/linux-amd64" "$version" "$short_sha"
-            verify_release_binary cli "${workspace_dir}/cli/dist/${version}/linux-amd64" "$version" "$short_sha"
+            local component target binary
+
+            for component in agent cli; do
+              (cd "${workspace_dir}/${component}/dist/${version}" && sha256sum -c SHA256SUMS)
+              for target in linux-amd64 linux-arm64 darwin-amd64 darwin-arm64; do
+                binary="${workspace_dir}/${component}/dist/${version}/${target}"
+                verify_release_artifact_metadata "$component" "$binary" "$version" "$short_sha"
+                if [[ "$target" == "linux-amd64" ]]; then
+                  verify_release_binary "$component" "$binary" "$version" "$short_sha"
+                fi
+              done
+            done
           }
 
           publish_component agent

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1692,7 +1692,8 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 		return fmt.Errorf("no nodes attached to the current environment")
 	}
 	verifiedPublicURLs := a.soloVerifiedPublicURLs(workspaceRoot, environmentName, cfg, nodes)
-	localReleaseKnown := len(opts.Nodes) > 0
+	releaseRequired := workspaceRoot != "" && environmentName != "" && (len(opts.Nodes) == 0 || strings.TrimSpace(opts.Environment) != "")
+	localReleaseKnown := len(opts.Nodes) > 0 && !releaseRequired
 	expectedRevisions := map[string]string{}
 	expectedRuntimeEnvironment := ""
 	expectedWorkloadRevision := ""
@@ -2068,6 +2069,7 @@ func soloPlannedDNSCheck(cfg *config.ProjectConfig, nodes map[string]config.Node
 		"hosts":        hosts,
 		"expected_ips": webNodeIPs(cfg, nodes),
 		"required":     !skipDNSCheck && ingressRequiresTLSReadiness(cfg),
+		"skipped":      false,
 	}
 	if skipDNSCheck {
 		payload["skipped"] = true
@@ -4689,6 +4691,7 @@ func (a *App) IngressSet(_ context.Context, opts IngressSetOptions) error {
 
 	return a.Printer.PrintJSON(map[string]any{
 		"schema_version": outputSchemaVersion,
+		"environment":    selectedEnvironment,
 		"ingress":        ingress,
 		"config_path":    a.ConfigStore.PathFor(discovered.WorkspaceRoot),
 	})
@@ -4920,6 +4923,7 @@ func (a *App) IngressCheck(ctx context.Context, opts IngressCheckOptions) error 
 			return err
 		}
 		if report.OK || !ingressDNSReportRetryable(report) || opts.Wait <= 0 || time.Now().After(deadline) {
+			report.Environment = environmentName
 			if report.OK {
 				if err := recordSuccessfulSoloIngressCheckToStore(a.SoloState, workspaceRoot, environmentName, report); err != nil {
 					return err
@@ -5400,6 +5404,9 @@ func configOptionalStringPtr(value string) *string {
 type ingressDNSReportResult struct {
 	SchemaVersion int                    `json:"schema_version"`
 	OK            bool                   `json:"ok"`
+	Environment   string                 `json:"environment,omitempty"`
+	CheckScope    string                 `json:"check_scope"`
+	TLSVerified   bool                   `json:"tls_verified"`
 	PublicURLs    []string               `json:"public_urls,omitempty"`
 	ExpectedIPs   []string               `json:"expected_ips"`
 	Hosts         []ingressDNSHostResult `json:"hosts"`
@@ -5500,6 +5507,8 @@ func ingressDNSReport(ctx context.Context, cfg *config.ProjectConfig, selected m
 	report := ingressDNSReportResult{
 		SchemaVersion: outputSchemaVersion,
 		OK:            true,
+		CheckScope:    "dns",
+		TLSVerified:   false,
 		PublicURLs:    ingressConfiguredPublicURLs(cfg),
 		ExpectedIPs:   expected,
 		Hosts:         make([]ingressDNSHostResult, 0, len(hosts)),

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -1212,6 +1212,63 @@ func TestSoloStatusWithExplicitNodesUsesExplicitEnvironmentRelease(t *testing.T)
 	}
 }
 
+func TestSoloStatusWithExplicitNodesAndEnvBeforeLocalDeployTreatsRemoteStatusAsStale(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	cfg.Ingress = &config.IngressConfig{
+		Hosts: []string{"prod.example.com"},
+		Rules: []config.IngressRuleConfig{{
+			Match:  config.IngressMatchConfig{Host: "prod.example.com", PathPrefix: "/"},
+			Target: config.IngressTargetConfig{Service: config.DefaultWebServiceName, Port: "http"},
+		}},
+		TLS: config.IngressTLSConfig{Mode: "off"},
+	}
+	cfg.Environments = map[string]config.EnvironmentOverlay{
+		"staging": {Ingress: &config.IngressConfigOverlay{
+			Hosts: []string{"staging.example.com"},
+			Rules: []config.IngressRuleConfig{{
+				Match:  config.IngressMatchConfig{Host: "staging.example.com", PathPrefix: "/"},
+				Target: config.IngressTargetConfig{Service: config.DefaultWebServiceName, Port: "http"},
+			}},
+		}},
+	}
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	installFakeSoloCommands(t, []fakeSSHResponse{{stdout: `{"revision":"foreign-rev","phase":"settled","summary":{"environments":1,"services":1}}` + "\n"}})
+
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{Nodes: map[string]config.Node{"node-a": {Host: "203.0.113.10", User: "root", Labels: []string{config.DefaultWebRole}}}}
+	if _, _, err := current.AttachNode(workspaceRoot, "staging", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState, ConfigStore: config.NewStore(), Cwd: workspaceRoot}
+	if err := app.SoloStatus(context.Background(), SoloStatusOptions{Nodes: []string{"node-a"}, Environment: "staging"}); err != nil {
+		t.Fatalf("SoloStatus() error = %v", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	if payload["environment"] != "staging" {
+		t.Fatalf("environment = %#v, want staging", payload["environment"])
+	}
+	if _, ok := payload["public_urls"]; ok {
+		t.Fatalf("payload = %#v, explicit node without local release must not emit verified public_urls", payload)
+	}
+	urls := jsonArrayFromMap(t, payload, "configured_public_urls")
+	if len(urls) != 1 || urls[0] != "http://staging.example.com/" {
+		t.Fatalf("configured_public_urls = %#v, want staging URL only", urls)
+	}
+	nodes := jsonArrayFromMap(t, payload, "nodes")
+	node := jsonMapFromAny(t, nodes[0])
+	if node["status"] != nil || !strings.Contains(stringValueAny(node["message"]), "no current local release") {
+		t.Fatalf("node payload = %#v, want stale status message", node)
+	}
+}
+
 func TestSoloStatusDoesNotTreatDNSOnlyTLSCheckAsVerifiedPublicURL(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")
@@ -4269,8 +4326,8 @@ func TestSoloDeployDryRunUsesExplicitEnvironmentWithoutDNS(t *testing.T) {
 		t.Fatalf("payload = %#v, want TLS pending dry-run without DNS failure", payload)
 	}
 	planned := jsonMapFromAny(t, payload["planned_dns_check"])
-	if planned["live_lookup"] != false || planned["required"] != true || planned["check_command"] != "devopsellence ingress check --env 'staging'" {
-		t.Fatalf("planned_dns_check = %#v, want no-network required DNS check for staging", planned)
+	if planned["live_lookup"] != false || planned["required"] != true || planned["skipped"] != false || planned["check_command"] != "devopsellence ingress check --env 'staging'" {
+		t.Fatalf("planned_dns_check = %#v, want no-network required DNS check", planned)
 	}
 	hosts := jsonArrayFromMap(t, planned, "hosts")
 	if len(hosts) != 1 || hosts[0] != "staging.invalid" {
@@ -6621,7 +6678,8 @@ func TestIngressSetWritesExplicitEnvironmentOverlay(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	app := &App{Cwd: dir, ConfigStore: config.NewStore(), Printer: output.New(io.Discard, io.Discard)}
+	var stdout bytes.Buffer
+	app := &App{Cwd: dir, ConfigStore: config.NewStore(), Printer: output.New(&stdout, io.Discard)}
 	if err := app.IngressSet(context.Background(), IngressSetOptions{
 		Hosts:       []string{"staging.example.com"},
 		Environment: "staging",
@@ -6640,6 +6698,10 @@ func TestIngressSetWritesExplicitEnvironmentOverlay(t *testing.T) {
 	overlay := written.Environments["staging"].Ingress
 	if overlay == nil || strings.Join(overlay.Hosts, ",") != "staging.example.com" {
 		t.Fatalf("staging ingress overlay = %#v, want explicit staging host", overlay)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	if payload["environment"] != "staging" {
+		t.Fatalf("payload = %#v, want explicit staging environment", payload)
 	}
 }
 
@@ -6676,6 +6738,9 @@ func TestIngressCheckUsesExplicitEnvironment(t *testing.T) {
 	payload := decodeJSONOutput(t, &stdout)
 	if payload["ok"] != true {
 		t.Fatalf("payload = %#v, want successful explicit staging DNS check", payload)
+	}
+	if payload["environment"] != "staging" || payload["check_scope"] != "dns" || payload["tls_verified"] != false {
+		t.Fatalf("payload = %#v, want self-auditing staging DNS-only check", payload)
 	}
 	loaded, err := soloState.Read()
 	if err != nil {


### PR DESCRIPTION
## Summary
- require a current local release for explicit `status --nodes --env` before trusting remote settled status
- make dry-run DNS plans reflect `--skip-dns-check` and include the selected environment in the suggested check command
- add environment/check metadata to ingress outputs and verify all release artifact metadata/checksums before publish

## Tests
- `cd cli && mise exec -- go test ./internal/workflow`
- `mise run test:cli`