### PR TITLE
Normalize CLI install directory paths

### DIFF
--- a/cli/scripts/release-local.sh
+++ b/cli/scripts/release-local.sh
@@ -31,6 +31,10 @@ esac
 if [[ -z "$INSTALL_DIR" ]]; then
   INSTALL_DIR="$HOME/.local/bin"
 fi
+case "$INSTALL_DIR" in
+  /*) ;;
+  *) INSTALL_DIR="$(pwd -P)/$INSTALL_DIR" ;;
+esac
 
 BUILD_DIR="$CLI_DIR/dist/local-head"
 mkdir -p "$BUILD_DIR"

--- a/control-plane/app/controllers/cli_installs_controller.rb
+++ b/control-plane/app/controllers/cli_installs_controller.rb
@@ -112,6 +112,10 @@ class CliInstallsController < ActionController::Base
       if [[ -z "$INSTALL_DIR" ]]; then
         INSTALL_DIR="$HOME/.local/bin"
       fi
+      case "$INSTALL_DIR" in
+        /*) ;;
+        *) INSTALL_DIR="$(pwd -P)/$INSTALL_DIR" ;;
+      esac
 
       DOWNLOAD_URL="$BASE_URL/cli/download?os=$OS&arch=$ARCH&version=$CLI_VERSION"
       CHECKSUM_URL="$CLI_CHECKSUM_URL?version=$CLI_VERSION"

--- a/control-plane/test/integration/installs_test.rb
+++ b/control-plane/test/integration/installs_test.rb
@@ -175,6 +175,23 @@ class InstallsTest < ActionDispatch::IntegrationTest
     assert_equal "prerelease build\n", installed_cli
   end
 
+  test "cli install script normalizes relative install dir before path advice" do
+    get "/lfg.sh", params: { version: "master-0053792f6aec" }
+
+    assert_response :success
+
+    stdout, stderr, status, installed_cli = run_cli_install_script(
+      response.body,
+      version: "master-0053792f6aec",
+      install_dir: "bin"
+    )
+
+    assert_predicate status, :success?, -> { "stdout:\n#{stdout}\nstderr:\n#{stderr}" }
+    assert_includes stdout, "/bin/devopsellence"
+    refute_includes stdout, "installed to bin/devopsellence"
+    assert_equal "prerelease build\n", installed_cli
+  end
+
   test "cli install script derives checksum url after parsing base url overrides" do
     get "/lfg.sh"
 
@@ -422,8 +439,17 @@ class InstallsTest < ActionDispatch::IntegrationTest
       env["DEVOPSELLENCE_CLI_INSTALL_DIR"] = effective_install_dir if effective_install_dir
       env["DEVOPSELLENCE_INSTALL_AGENT_SKILL"] = "1" if install_agent_skill
 
-      stdout, stderr, status = Open3.capture3(env, script_path)
-      expected_install_dir = effective_install_dir || File.join(tmpdir, ".local", "bin")
+      working_dir = File.join(tmpdir, "work")
+      FileUtils.mkdir_p(working_dir)
+      stdout, stderr, status = Open3.capture3(env, script_path, chdir: working_dir)
+      expected_install_dir =
+        if effective_install_dir.nil?
+          File.join(tmpdir, ".local", "bin")
+        elsif effective_install_dir.start_with?("/")
+          effective_install_dir
+        else
+          File.expand_path(effective_install_dir, working_dir)
+        end
       installed_cli = File.exist?(File.join(expected_install_dir, "devopsellence")) ? File.read(File.join(expected_install_dir, "devopsellence")) : nil
       skill_args = File.exist?(skill_args_path) ? File.readlines(skill_args_path, chomp: true) : nil
       [ stdout, stderr, status, installed_cli, skill_args ]


### PR DESCRIPTION
## Summary
- normalize relative CLI install directories to absolute paths in the public installer
- apply the same behavior to the local release installer
- add an installer regression test for relative `DEVOPSELLENCE_CLI_INSTALL_DIR`

## Tests
- `cd control-plane && mise run test -- test/integration/installs_test.rb`