### PR TITLE
Align solo dry-run DNS preflight metadata

### DIFF
--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -2068,7 +2068,7 @@ func soloPlannedDNSCheck(cfg *config.ProjectConfig, nodes map[string]config.Node
 		"live_lookup":  false,
 		"hosts":        hosts,
 		"expected_ips": webNodeIPs(cfg, nodes),
-		"required":     !skipDNSCheck && ingressRequiresTLSReadiness(cfg),
+		"required":     !skipDNSCheck && ingressRequiresDNSPreflight(cfg),
 		"skipped":      false,
 	}
 	if skipDNSCheck {
@@ -2113,6 +2113,13 @@ func ingressRequiresTLSReadiness(cfg *config.ProjectConfig) bool {
 	}
 	tlsMode := strings.TrimSpace(cfg.Ingress.TLS.Mode)
 	return strings.EqualFold(tlsMode, "auto") || strings.EqualFold(tlsMode, "manual")
+}
+
+func ingressRequiresDNSPreflight(cfg *config.ProjectConfig) bool {
+	if cfg == nil || cfg.Ingress == nil {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(cfg.Ingress.TLS.Mode), "auto")
 }
 
 func soloPublicURLStatus(cfg *config.ProjectConfig) string {
@@ -5467,7 +5474,7 @@ func (e ingressDNSReadinessError) ErrorFields() map[string]any {
 const soloStatusMissingSentinel = "__DEVOPSELLENCE_STATUS_MISSING__"
 
 func (a *App) checkIngressBeforeDeploy(ctx context.Context, cfg *config.ProjectConfig, nodes map[string]config.Node, skip bool) error {
-	if skip || cfg == nil || cfg.Ingress == nil || !strings.EqualFold(strings.TrimSpace(cfg.Ingress.TLS.Mode), "auto") {
+	if skip || !ingressRequiresDNSPreflight(cfg) {
 		return nil
 	}
 	report, err := ingressDNSReport(ctx, cfg, nodes)

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -4353,6 +4353,47 @@ func TestSoloDeployDryRunUsesExplicitEnvironmentWithoutDNS(t *testing.T) {
 	}
 }
 
+func TestSoloDeployDryRunDoesNotRequireDNSPreflightForManualTLS(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	cfg.Ingress = &config.IngressConfig{
+		Hosts: []string{"prod.invalid"},
+		Rules: []config.IngressRuleConfig{{
+			Match:  config.IngressMatchConfig{Host: "prod.invalid", PathPrefix: "/"},
+			Target: config.IngressTargetConfig{Service: config.DefaultWebServiceName, Port: "http"},
+		}},
+		TLS: config.IngressTLSConfig{Mode: "manual"},
+	}
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	commitTestRepo(t, workspaceRoot)
+
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{Nodes: map[string]config.Node{"node-a": {Host: "203.0.113.10", User: "root", Port: 22, Labels: []string{config.DefaultWebRole}}}}
+	if _, _, err := current.AttachNode(workspaceRoot, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState, ConfigStore: config.NewStore(), Git: git.Client{}, Cwd: workspaceRoot}
+	if err := app.SoloDeploy(context.Background(), SoloDeployOptions{DryRun: true}); err != nil {
+		t.Fatal(err)
+	}
+	events := decodeNDJSONOutput(t, &stdout)
+	payload := events[len(events)-1]
+	if payload["public_url_status"] != "configured_tls_pending" {
+		t.Fatalf("payload = %#v, want TLS pending dry-run", payload)
+	}
+	planned := jsonMapFromAny(t, payload["planned_dns_check"])
+	if planned["live_lookup"] != false || planned["required"] != false || planned["skipped"] != false || planned["check_command"] != "devopsellence ingress check --env 'production'" {
+		t.Fatalf("planned_dns_check = %#v, want optional manual-TLS DNS check", planned)
+	}
+}
+
 func TestSoloDeployRepublishFailureDoesNotRecordCurrentRelease(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	if err := os.WriteFile(filepath.Join(workspaceRoot, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {


### PR DESCRIPTION
## Summary
- align solo dry-run planned_dns_check.required with the actual deploy DNS preflight rule
- keep manual TLS public URL status pending without claiming deploy will require DNS preflight
- add a manual TLS dry-run regression test

## Tests
- mise exec -- go test ./internal/workflow (from cli)
- mise run test:cli