### PR TITLE
Guide solo healthcheck rollout failures

### DIFF
--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -706,12 +706,8 @@ func (e *soloRolloutError) ErrorFields() map[string]any {
 		return map[string]any{}
 	}
 	fields := map[string]any{
-		"node": e.Node,
-		"next_steps": []string{
-			"devopsellence status",
-			"devopsellence logs --node " + shellQuote(e.Node) + " --lines 100",
-			"devopsellence node logs " + shellQuote(e.Node) + " --lines 100",
-		},
+		"node":       e.Node,
+		"next_steps": soloRolloutNextSteps([]string{e.Node}, e.Healthchecks),
 	}
 	if len(e.Healthchecks) > 0 {
 		fields["healthchecks"] = e.Healthchecks
@@ -736,12 +732,7 @@ func (e *soloRolloutTimeoutError) ErrorFields() map[string]any {
 	if e == nil {
 		return map[string]any{}
 	}
-	steps := []string{"devopsellence status"}
-	for _, node := range e.Nodes {
-		steps = append(steps, "devopsellence logs --node "+shellQuote(node)+" --lines 100")
-		steps = append(steps, "devopsellence node logs "+shellQuote(node)+" --lines 100")
-	}
-	fields := map[string]any{"next_steps": steps}
+	fields := map[string]any{"next_steps": soloRolloutNextSteps(e.Nodes, e.Healthchecks)}
 	if len(e.Healthchecks) > 0 {
 		fields["healthchecks"] = e.Healthchecks
 	}
@@ -765,6 +756,35 @@ func soloDeployHealthcheckDetails(cfg *config.ProjectConfig) []map[string]any {
 		})
 	}
 	return details
+}
+
+func soloRolloutNextSteps(nodes []string, healthchecks []map[string]any) []string {
+	steps := []string{"devopsellence status"}
+	steps = append(steps, soloHealthcheckNextSteps(healthchecks)...)
+	for _, node := range nodes {
+		steps = append(steps, "devopsellence logs --node "+shellQuote(node)+" --lines 100")
+		steps = append(steps, "devopsellence node logs "+shellQuote(node)+" --lines 100")
+	}
+	return steps
+}
+
+func soloHealthcheckNextSteps(healthchecks []map[string]any) []string {
+	if len(healthchecks) == 0 {
+		return nil
+	}
+	if len(healthchecks) > 1 {
+		return []string{"ensure each configured healthcheck returns HTTP 2xx, or edit services.<name>.healthcheck in devopsellence.yml"}
+	}
+	serviceName, _ := healthchecks[0]["service_name"].(string)
+	pathValue, _ := healthchecks[0]["path"].(string)
+	portValue := healthchecks[0]["port"]
+	if strings.TrimSpace(serviceName) == "" {
+		serviceName = config.DefaultWebServiceName
+	}
+	if strings.TrimSpace(pathValue) == "" {
+		pathValue = config.DefaultHealthcheckPath
+	}
+	return []string{fmt.Sprintf("ensure service %s returns HTTP 2xx on healthcheck path %s port %v, or edit services.%s.healthcheck in devopsellence.yml", shellQuote(serviceName), shellQuote(pathValue), portValue, serviceName)}
 }
 
 func (a *App) waitForSoloRollout(ctx context.Context, nodes map[string]config.Node, expectedRevisions map[string]string, previousStatusTimes ...map[string]string) error {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -689,9 +689,10 @@ func readNodeStatus(ctx context.Context, node config.Node) (soloNodeStatusResult
 }
 
 type soloRolloutError struct {
-	Node         string
-	Message      string
-	Healthchecks []map[string]any
+	Node               string
+	Message            string
+	Healthchecks       []map[string]any
+	HealthcheckFailure bool
 }
 
 func (e *soloRolloutError) Error() string {
@@ -707,7 +708,7 @@ func (e *soloRolloutError) ErrorFields() map[string]any {
 	}
 	fields := map[string]any{
 		"node":       e.Node,
-		"next_steps": soloRolloutNextSteps([]string{e.Node}, e.Healthchecks),
+		"next_steps": soloRolloutNextSteps([]string{e.Node}, e.Healthchecks, e.HealthcheckFailure),
 	}
 	if len(e.Healthchecks) > 0 {
 		fields["healthchecks"] = e.Healthchecks
@@ -716,9 +717,10 @@ func (e *soloRolloutError) ErrorFields() map[string]any {
 }
 
 type soloRolloutTimeoutError struct {
-	Summary      string
-	Nodes        []string
-	Healthchecks []map[string]any
+	Summary            string
+	Nodes              []string
+	Healthchecks       []map[string]any
+	HealthcheckFailure bool
 }
 
 func (e *soloRolloutTimeoutError) Error() string {
@@ -732,7 +734,7 @@ func (e *soloRolloutTimeoutError) ErrorFields() map[string]any {
 	if e == nil {
 		return map[string]any{}
 	}
-	fields := map[string]any{"next_steps": soloRolloutNextSteps(e.Nodes, e.Healthchecks)}
+	fields := map[string]any{"next_steps": soloRolloutNextSteps(e.Nodes, e.Healthchecks, e.HealthcheckFailure)}
 	if len(e.Healthchecks) > 0 {
 		fields["healthchecks"] = e.Healthchecks
 	}
@@ -758,9 +760,11 @@ func soloDeployHealthcheckDetails(cfg *config.ProjectConfig) []map[string]any {
 	return details
 }
 
-func soloRolloutNextSteps(nodes []string, healthchecks []map[string]any) []string {
+func soloRolloutNextSteps(nodes []string, healthchecks []map[string]any, healthcheckFailure bool) []string {
 	steps := []string{"devopsellence status"}
-	steps = append(steps, soloHealthcheckNextSteps(healthchecks)...)
+	if healthcheckFailure {
+		steps = append(steps, soloHealthcheckNextSteps(healthchecks)...)
+	}
 	for _, node := range nodes {
 		steps = append(steps, "devopsellence logs --node "+shellQuote(node)+" --lines 100")
 		steps = append(steps, "devopsellence node logs "+shellQuote(node)+" --lines 100")
@@ -785,6 +789,11 @@ func soloHealthcheckNextSteps(healthchecks []map[string]any) []string {
 		pathValue = config.DefaultHealthcheckPath
 	}
 	return []string{fmt.Sprintf("ensure service %s returns HTTP 2xx on healthcheck path %s port %v, or edit services.%s.healthcheck in devopsellence.yml", shellQuote(serviceName), shellQuote(pathValue), portValue, serviceName)}
+}
+
+func soloRolloutMessageLooksLikeHealthcheck(message string) bool {
+	normalized := strings.ToLower(message)
+	return strings.Contains(normalized, "healthcheck") || strings.Contains(normalized, "health check") || strings.Contains(normalized, "http probe")
 }
 
 func (a *App) waitForSoloRollout(ctx context.Context, nodes map[string]config.Node, expectedRevisions map[string]string, previousStatusTimes ...map[string]string) error {
@@ -842,7 +851,7 @@ func (a *App) waitForSoloRollout(ctx context.Context, nodes map[string]config.No
 					settledCount++
 				case "error":
 					message := firstNonEmpty(strings.TrimSpace(result.Status.Error), "node reported phase=error")
-					return ExitError{Code: 1, Err: &soloRolloutError{Node: name, Message: message}}
+					return ExitError{Code: 1, Err: &soloRolloutError{Node: name, Message: message, HealthcheckFailure: soloRolloutMessageLooksLikeHealthcheck(message)}}
 				default:
 					reconcilingCount++
 					details = append(details, fmt.Sprintf("%s=%s", name, firstNonEmpty(strings.TrimSpace(result.Status.Phase), "reconciling")))

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -5397,6 +5397,66 @@ func TestSoloDeployRolloutFailureIncludesHealthcheckContext(t *testing.T) {
 	}
 }
 
+func TestSoloDeployRolloutFailureDoesNotPrescribeHealthcheckForImagePull(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(workspaceRoot, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	commitTestRepo(t, workspaceRoot)
+
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.Node{
+			"node-a": {Host: "203.0.113.10", User: "root", Port: 22, AgentStateDir: "/var/lib/devopsellence", Labels: []string{config.DefaultWebRole}},
+		},
+		Attachments: map[string]solo.AttachmentRecord{},
+		Snapshots:   map[string]desiredstate.DeploySnapshot{},
+	}
+	if _, _, err := current.AttachNode(workspaceRoot, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+	installFakeSoloCommands(t, []fakeSSHResponse{
+		{stdout: soloStatusMissingSentinel + "\n"},
+		{stdout: `{"revision":"__REVISION__","phase":"error","error":"image pull failed"}` + "\n"},
+	})
+
+	var stdout bytes.Buffer
+	app := &App{
+		Printer:            output.New(&stdout, io.Discard),
+		SoloState:          soloState,
+		ConfigStore:        config.NewStore(),
+		Git:                git.Client{},
+		Cwd:                workspaceRoot,
+		DeployPollInterval: 5 * time.Millisecond,
+		DeployTimeout:      time.Second,
+	}
+
+	err := app.SoloDeploy(context.Background(), SoloDeployOptions{})
+	if err == nil {
+		t.Fatal("expected deploy failure")
+	}
+	var rolloutErr *soloRolloutError
+	if !errors.As(err, &rolloutErr) {
+		t.Fatalf("error = %T %v, want soloRolloutError", err, err)
+	}
+	fields := rolloutErr.ErrorFields()
+	if _, ok := fields["healthchecks"]; !ok {
+		t.Fatalf("fields = %#v, want healthcheck context", fields)
+	}
+	steps := fields["next_steps"].([]string)
+	if len(steps) != 3 || strings.Contains(strings.Join(steps, "\n"), "returns HTTP 2xx") {
+		t.Fatalf("next_steps = %#v, want log diagnostics without healthcheck remediation", steps)
+	}
+}
+
 func TestWaitForSoloRolloutIgnoresMissingAndStaleStatusUntilExpectedRevisionSettles(t *testing.T) {
 	statusCountPath := installFakeSoloCommands(t, []fakeSSHResponse{
 		{stdout: soloStatusMissingSentinel + "\n"},

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -5371,6 +5371,10 @@ func TestSoloDeployRolloutFailureIncludesHealthcheckContext(t *testing.T) {
 	if len(healthchecks) != 1 || healthchecks[0]["service_name"] != config.DefaultWebServiceName || healthchecks[0]["path"] != config.DefaultHealthcheckPath {
 		t.Fatalf("healthchecks = %#v, want web healthcheck context", healthchecks)
 	}
+	steps := fields["next_steps"].([]string)
+	if len(steps) != 4 || !strings.Contains(steps[1], "returns HTTP 2xx on healthcheck path '/up' port 3000") {
+		t.Fatalf("next_steps = %#v, want healthcheck remediation before logs", steps)
+	}
 	loaded, err := soloState.Read()
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Summary
- include healthcheck remediation in solo rollout failure next steps
- keep status/log commands, but put the likely app/config fix before log digging when healthcheck context is known
- cover the rollout failure payload with a regression assertion

## Tests
- mise exec -- go test ./internal/workflow -run 'TestSoloDeployRolloutFailureIncludesHealthcheckContext|TestWaitForSoloRollout(FailsWhenNodeReportsError|TimesOutWhenExpectedRevisionNeverSettles)' -count=1
- mise run test:cli