### PR TITLE
Preserve current release on rollback rollout failure

### DIFF
--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -541,11 +541,13 @@ func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 		resultErr := err
 		var rolloutErr *soloRolloutError
 		if errors.As(err, &rolloutErr) {
+			rolloutErr.Environment = environmentName
 			rolloutErr.Healthchecks = soloDeployHealthcheckDetails(cfg)
 			resultErr = ExitError{Code: 1, Err: rolloutErr}
 		}
 		var timeoutErr *soloRolloutTimeoutError
 		if errors.As(err, &timeoutErr) {
+			timeoutErr.Environment = environmentName
 			timeoutErr.Healthchecks = soloDeployHealthcheckDetails(cfg)
 			resultErr = ExitError{Code: 1, Err: timeoutErr}
 		}
@@ -690,6 +692,7 @@ func readNodeStatus(ctx context.Context, node config.Node) (soloNodeStatusResult
 
 type soloRolloutError struct {
 	Node               string
+	Environment        string
 	Message            string
 	Healthchecks       []map[string]any
 	HealthcheckFailure bool
@@ -708,7 +711,10 @@ func (e *soloRolloutError) ErrorFields() map[string]any {
 	}
 	fields := map[string]any{
 		"node":       e.Node,
-		"next_steps": soloRolloutNextSteps([]string{e.Node}, e.Healthchecks, e.HealthcheckFailure),
+		"next_steps": soloRolloutNextSteps(e.Environment, []string{e.Node}, e.Healthchecks, e.HealthcheckFailure),
+	}
+	if strings.TrimSpace(e.Environment) != "" {
+		fields["environment"] = e.Environment
 	}
 	if len(e.Healthchecks) > 0 {
 		fields["healthchecks"] = e.Healthchecks
@@ -719,6 +725,7 @@ func (e *soloRolloutError) ErrorFields() map[string]any {
 type soloRolloutTimeoutError struct {
 	Summary            string
 	Nodes              []string
+	Environment        string
 	Healthchecks       []map[string]any
 	HealthcheckFailure bool
 }
@@ -734,7 +741,10 @@ func (e *soloRolloutTimeoutError) ErrorFields() map[string]any {
 	if e == nil {
 		return map[string]any{}
 	}
-	fields := map[string]any{"next_steps": soloRolloutNextSteps(e.Nodes, e.Healthchecks, e.HealthcheckFailure)}
+	fields := map[string]any{"next_steps": soloRolloutNextSteps(e.Environment, e.Nodes, e.Healthchecks, e.HealthcheckFailure)}
+	if strings.TrimSpace(e.Environment) != "" {
+		fields["environment"] = e.Environment
+	}
 	if len(e.Healthchecks) > 0 {
 		fields["healthchecks"] = e.Healthchecks
 	}
@@ -760,16 +770,39 @@ func soloDeployHealthcheckDetails(cfg *config.ProjectConfig) []map[string]any {
 	return details
 }
 
-func soloRolloutNextSteps(nodes []string, healthchecks []map[string]any, healthcheckFailure bool) []string {
-	steps := []string{"devopsellence status"}
+func soloSnapshotHealthcheckDetails(snapshot desiredstate.DeploySnapshot) []map[string]any {
+	details := []map[string]any{}
+	for _, service := range snapshot.Services {
+		if service.Healthcheck == nil {
+			continue
+		}
+		details = append(details, map[string]any{
+			"service_name": service.Name,
+			"path":         service.Healthcheck.Path,
+			"port":         service.Healthcheck.Port,
+		})
+	}
+	return details
+}
+
+func soloRolloutNextSteps(environment string, nodes []string, healthchecks []map[string]any, healthcheckFailure bool) []string {
+	envFlag := soloEnvFlag(environment)
+	steps := []string{"devopsellence status" + envFlag}
 	if healthcheckFailure {
 		steps = append(steps, soloHealthcheckNextSteps(healthchecks)...)
 	}
 	for _, node := range nodes {
-		steps = append(steps, "devopsellence logs --node "+shellQuote(node)+" --lines 100")
+		steps = append(steps, "devopsellence logs"+envFlag+" --node "+shellQuote(node)+" --lines 100")
 		steps = append(steps, "devopsellence node logs "+shellQuote(node)+" --lines 100")
 	}
 	return steps
+}
+
+func soloEnvFlag(environment string) string {
+	if strings.TrimSpace(environment) == "" {
+		return ""
+	}
+	return " --env " + shellQuote(environment)
 }
 
 func soloHealthcheckNextSteps(healthchecks []map[string]any) []string {
@@ -2041,19 +2074,26 @@ func (a *App) SoloReleaseRollback(ctx context.Context, opts SoloReleaseRollbackO
 		}
 		return err
 	}
-	if _, err := current.SaveRelease(selected); err != nil {
-		return err
-	}
-	if err := current.SaveDeployment(deployment); err != nil {
-		return err
-	}
-	if err := a.writeSoloState(current); err != nil {
-		return err
-	}
 	if err := a.waitForSoloRollout(ctx, nodes, desiredStateRevisions, statusBaselines); err != nil {
-		if persistErr := a.persistSoloDeploymentRolloutFailure(current, deployment, desiredStateRevisions, err); persistErr != nil {
-			return errors.Join(err, fmt.Errorf("persist deployment failure: %w", persistErr))
+		resultErr := err
+		var rolloutErr *soloRolloutError
+		if errors.As(err, &rolloutErr) {
+			rolloutErr.Environment = environmentName
+			rolloutErr.Healthchecks = soloSnapshotHealthcheckDetails(selected.Snapshot)
+			resultErr = ExitError{Code: 1, Err: rolloutErr}
 		}
+		var timeoutErr *soloRolloutTimeoutError
+		if errors.As(err, &timeoutErr) {
+			timeoutErr.Environment = environmentName
+			timeoutErr.Healthchecks = soloSnapshotHealthcheckDetails(selected.Snapshot)
+			resultErr = ExitError{Code: 1, Err: timeoutErr}
+		}
+		if persistErr := a.persistSoloDeploymentRolloutFailure(current, deployment, desiredStateRevisions, resultErr); persistErr != nil {
+			return errors.Join(resultErr, fmt.Errorf("persist deployment failure: %w", persistErr))
+		}
+		return resultErr
+	}
+	if _, err := current.SaveRelease(selected); err != nil {
 		return err
 	}
 	deployment.Status = corerelease.DeploymentStatusSettled

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -5187,7 +5187,7 @@ func TestSoloReleaseRollbackRepublishFailureDoesNotSwitchCurrentRelease(t *testi
 	}
 }
 
-func TestSoloReleaseRollbackPersistsSelectedReleaseOnRolloutFailure(t *testing.T) {
+func TestSoloReleaseRollbackRolloutFailurePreservesCurrentRelease(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")
 	if _, err := config.Write(workspaceRoot, cfg); err != nil {
@@ -5195,10 +5195,14 @@ func TestSoloReleaseRollbackPersistsSelectedReleaseOnRolloutFailure(t *testing.T
 	}
 	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
 	current := soloReleaseWorkflowState(workspaceRoot)
+	oldRelease := current.Releases["rel-1"]
+	oldRelease.Snapshot.Services[0].Healthcheck = &desiredstate.HealthcheckJSON{Path: "/up", Port: 3000}
+	current.Releases["rel-1"] = oldRelease
 	if err := soloState.Write(current); err != nil {
 		t.Fatal(err)
 	}
 	installFakeSoloCommands(t, []fakeSSHResponse{
+		{stdout: soloStatusMissingSentinel + "\n"},
 		{stdout: `{"revision":"__REVISION__","phase":"error","error":"healthcheck failed"}` + "\n"},
 	})
 
@@ -5220,8 +5224,11 @@ func TestSoloReleaseRollbackPersistsSelectedReleaseOnRolloutFailure(t *testing.T
 		t.Fatal(readErr)
 	}
 	key := workspaceRoot + "\nproduction"
-	if updatedState.Current[key] != "rel-1" {
-		t.Fatalf("current release = %q, want selected rollback release rel-1", updatedState.Current[key])
+	if updatedState.Current[key] != "rel-2" {
+		t.Fatalf("current release = %q, want rel-2 preserved after rollback rollout failure", updatedState.Current[key])
+	}
+	if updatedState.Snapshots[key].Revision != "bbb2222" {
+		t.Fatalf("snapshot revision = %q, want current snapshot preserved", updatedState.Snapshots[key].Revision)
 	}
 	var deployment corerelease.Deployment
 	for _, candidate := range updatedState.Deployments {
@@ -5229,6 +5236,22 @@ func TestSoloReleaseRollbackPersistsSelectedReleaseOnRolloutFailure(t *testing.T
 	}
 	if deployment.Status != corerelease.DeploymentStatusFailed || !strings.Contains(deployment.StatusMessage, "rollout failed") {
 		t.Fatalf("deployment = %#v, want failed rollout deployment", deployment)
+	}
+	var rolloutErr *soloRolloutError
+	if !errors.As(err, &rolloutErr) {
+		t.Fatalf("error = %T %v, want soloRolloutError", err, err)
+	}
+	fields := rolloutErr.ErrorFields()
+	if fields["environment"] != "production" {
+		t.Fatalf("fields = %#v, want production environment", fields)
+	}
+	healthchecks := fields["healthchecks"].([]map[string]any)
+	if len(healthchecks) != 1 || healthchecks[0]["path"] != "/up" || healthchecks[0]["port"] != 3000 {
+		t.Fatalf("healthchecks = %#v, want selected release snapshot healthcheck", healthchecks)
+	}
+	steps := fields["next_steps"].([]string)
+	if len(steps) != 4 || steps[0] != "devopsellence status --env 'production'" || steps[2] != "devopsellence logs --env 'production' --node 'node-a' --lines 100" || !strings.Contains(steps[1], "returns HTTP 2xx") {
+		t.Fatalf("next_steps = %#v, want env-scoped healthcheck remediation", steps)
 	}
 }
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -5255,6 +5255,55 @@ func TestSoloReleaseRollbackRolloutFailurePreservesCurrentRelease(t *testing.T) 
 	}
 }
 
+func TestSoloReleaseRollbackTimeoutPreservesCurrentRelease(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := soloReleaseWorkflowState(workspaceRoot)
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+	responses := []fakeSSHResponse{{stdout: soloStatusMissingSentinel + "\n"}}
+	for range 50 {
+		responses = append(responses, fakeSSHResponse{stdout: `{"revision":"__REVISION__","phase":"reconciling"}` + "\n"})
+	}
+	installFakeSoloCommands(t, responses)
+
+	var stdout bytes.Buffer
+	app := &App{
+		Printer:            output.New(&stdout, io.Discard),
+		SoloState:          soloState,
+		ConfigStore:        config.NewStore(),
+		Cwd:                workspaceRoot,
+		DeployPollInterval: 5 * time.Millisecond,
+		DeployTimeout:      20 * time.Millisecond,
+	}
+	err := app.SoloReleaseRollback(context.Background(), SoloReleaseRollbackOptions{Selector: "aaa1111"})
+	if err == nil {
+		t.Fatal("expected rollout timeout")
+	}
+	var timeoutErr *soloRolloutTimeoutError
+	if !errors.As(err, &timeoutErr) {
+		t.Fatalf("error = %T %v, want soloRolloutTimeoutError", err, err)
+	}
+	fields := timeoutErr.ErrorFields()
+	steps := fields["next_steps"].([]string)
+	if fields["environment"] != "production" || len(steps) != 3 || steps[0] != "devopsellence status --env 'production'" || steps[1] != "devopsellence logs --env 'production' --node 'node-a' --lines 100" {
+		t.Fatalf("fields = %#v, want env-scoped timeout guidance", fields)
+	}
+	updatedState, readErr := soloState.Read()
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	key := workspaceRoot + "\nproduction"
+	if updatedState.Current[key] != "rel-2" || updatedState.Snapshots[key].Revision != "bbb2222" {
+		t.Fatalf("current=%q snapshot=%q, want rel-2/bbb2222 preserved", updatedState.Current[key], updatedState.Snapshots[key].Revision)
+	}
+}
+
 func TestSoloRollbackTargetNodeNamesRejectsEmptyIntersection(t *testing.T) {
 	_, err := soloRollbackTargetNodeNames([]string{"node-b"}, corerelease.Release{
 		Revision:      "aaa1111",
@@ -5395,7 +5444,7 @@ func TestSoloDeployRolloutFailureIncludesHealthcheckContext(t *testing.T) {
 		t.Fatalf("healthchecks = %#v, want web healthcheck context", healthchecks)
 	}
 	steps := fields["next_steps"].([]string)
-	if len(steps) != 4 || !strings.Contains(steps[1], "returns HTTP 2xx on healthcheck path '/up' port 3000") {
+	if len(steps) != 4 || steps[0] != "devopsellence status --env 'production'" || steps[2] != "devopsellence logs --env 'production' --node 'node-a' --lines 100" || !strings.Contains(steps[1], "returns HTTP 2xx on healthcheck path '/up' port 3000") {
 		t.Fatalf("next_steps = %#v, want healthcheck remediation before logs", steps)
 	}
 	loaded, err := soloState.Read()


### PR DESCRIPTION
## Summary
- keep the previous current release/snapshot until rollback rollout settles
- persist failed rollback deployments without marking the failed target current
- add environment-scoped rollout failure next steps and rollback snapshot healthcheck guidance

## Tests
- cd cli && mise exec -- go test ./internal/workflow -run 'TestSoloReleaseRollback(UsesSelectedReleaseTargets|RepublishFailureDoesNotSwitchCurrentRelease|RolloutFailurePreservesCurrentRelease)|TestSoloDeployRolloutFailureIncludesHealthcheckContext|TestWaitForSoloRollout(FailsOnExpectedRevisionErrorPhase|TimesOutWhenExpectedRevisionNeverSettles)' -count=1
- mise run test:cli