### PR TITLE
Harden solo runtime health and detach state

### DIFF
--- a/agent/internal/reconcile/reconcile.go
+++ b/agent/internal/reconcile/reconcile.go
@@ -116,6 +116,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, desired *desiredstatepb.Desi
 		existingByService[containerServiceKey(c)] = append(existingByService[containerServiceKey(c)], c)
 	}
 
+	var reconcileErr error
 	for serviceKey, c := range desiredByService {
 		serviceResult, err := r.reconcileService(ctx, desired.GetIngress(), desired.GetNodePeers(), c, existingByService[serviceKey], workloadNetworks)
 		result.Created += serviceResult.Created
@@ -123,8 +124,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, desired *desiredstatepb.Desi
 		result.Removed += serviceResult.Removed
 		result.Unchanged += serviceResult.Unchanged
 		if err != nil {
-			return result, err
+			reconcileErr = errors.Join(reconcileErr, err)
+			continue
 		}
+	}
+	if reconcileErr != nil {
+		return result, reconcileErr
 	}
 	for _, c := range existing {
 		if _, ok := desiredByService[containerServiceKey(c)]; ok {

--- a/agent/internal/reconcile/reconcile_test.go
+++ b/agent/internal/reconcile/reconcile_test.go
@@ -730,6 +730,65 @@ func TestReconcileWebUnhealthyDoesNotUpdateEDS(t *testing.T) {
 	}
 }
 
+func TestReconcileContinuesHealthyCohostedServiceWhenPeerServiceFails(t *testing.T) {
+	eng := newFakeEngine()
+	eng.images["httpbin"] = true
+
+	healthy := webService(80, "/up")
+	healthyHash, err := desiredstate.HashService(healthy)
+	if err != nil {
+		t.Fatalf("hash healthy service: %v", err)
+	}
+	healthyNetwork, err := desiredstate.EnvironmentNetworkName("devopsellence", "app-b-production")
+	if err != nil {
+		t.Fatalf("healthy network: %v", err)
+	}
+	healthyHash = runtimeContainerHash(healthyHash, nil, healthyNetwork)
+	healthyName, err := desiredstate.ServiceContainerName("app-b-production", "web", "rev-b", healthyHash)
+	if err != nil {
+		t.Fatalf("healthy container name: %v", err)
+	}
+	eng.containers[healthyName] = engine.ContainerState{
+		Name:        healthyName,
+		Image:       "httpbin",
+		Running:     true,
+		Hash:        healthyHash,
+		Environment: "app-b-production",
+		Service:     "web",
+		ServiceKind: "web",
+	}
+
+	unhealthy := webService(80, "/up")
+	unhealthy.Image = "missing"
+	state := &desiredstatepb.DesiredState{
+		SchemaVersion: 2,
+		Revision:      "node-plan-1",
+		Environments: []*desiredstatepb.Environment{
+			{Name: "app-a-production", Revision: "rev-a", Services: []*desiredstatepb.Service{unhealthy}},
+			{Name: "app-b-production", Revision: "rev-b", Services: []*desiredstatepb.Service{healthy}},
+		},
+	}
+
+	envoyManager := &fakeEnvoyManager{engine: eng}
+	rec := New(eng, Options{Network: "devopsellence", StopTimeout: 2 * time.Second, WebPort: 80, Envoy: envoyManager})
+	result, err := rec.Reconcile(context.Background(), state)
+	if err == nil {
+		t.Fatal("expected failing peer service error")
+	}
+	if !strings.Contains(err.Error(), "image not found locally: missing") {
+		t.Fatalf("error = %v, want missing image error", err)
+	}
+	if result.Unchanged != 1 {
+		t.Fatalf("result = %+v, want healthy cohosted service reconciled", result)
+	}
+	if envoyManager.lastCluster != "env-app-b-production-web-http" {
+		t.Fatalf("last cluster = %q, want app-b EDS update despite app-a failure", envoyManager.lastCluster)
+	}
+	if len(eng.removed) != 0 {
+		t.Fatalf("removed = %#v, want no cleanup after partial reconcile failure", eng.removed)
+	}
+}
+
 func TestReconcileWebUpdateCutsOverBeforeRemovingOldContainer(t *testing.T) {
 	eng := newFakeEngine()
 	eng.images["httpbin"] = true

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -2015,12 +2015,31 @@ func soloStaleStatusRevisions(current solo.State, release corerelease.Release, e
 }
 
 func soloCohostedStatusRevisions(current solo.State, release corerelease.Release) map[string]map[string]bool {
+	type latestPublication struct {
+		sequence int
+		revision string
+	}
+	currentReleaseIDs := map[string]string{}
+	for environmentID, releaseID := range current.Current {
+		environmentID = strings.TrimSpace(environmentID)
+		releaseID = strings.TrimSpace(releaseID)
+		if environmentID != "" && releaseID != "" {
+			currentReleaseIDs[environmentID] = releaseID
+		}
+	}
+	latest := map[string]latestPublication{}
 	cohosted := map[string]map[string]bool{}
 	for _, deployment := range current.Deployments {
-		if deployment.EnvironmentID == release.EnvironmentID || deployment.PublicationResult == nil {
+		if deployment.EnvironmentID == release.EnvironmentID || deployment.Status != corerelease.DeploymentStatusSettled || deployment.PublicationResult == nil {
+			continue
+		}
+		if currentReleaseIDs[deployment.EnvironmentID] != strings.TrimSpace(deployment.ReleaseID) {
 			continue
 		}
 		for _, result := range deployment.PublicationResult.NodeResults {
+			if result.Status != corerelease.PublicationStatusWritten {
+				continue
+			}
 			nodeName := strings.TrimSpace(result.NodeName)
 			if nodeName == "" {
 				nodeName = strings.TrimSpace(result.NodeID)
@@ -2029,11 +2048,22 @@ func soloCohostedStatusRevisions(current solo.State, release corerelease.Release
 			if nodeName == "" || revision == "" {
 				continue
 			}
-			if cohosted[nodeName] == nil {
-				cohosted[nodeName] = map[string]bool{}
+			key := deployment.EnvironmentID + "\x00" + nodeName
+			if existing, ok := latest[key]; ok && existing.sequence > deployment.Sequence {
+				continue
 			}
-			cohosted[nodeName][revision] = true
+			latest[key] = latestPublication{sequence: deployment.Sequence, revision: revision}
 		}
+	}
+	for key, publication := range latest {
+		_, nodeName, ok := strings.Cut(key, "\x00")
+		if !ok || nodeName == "" || publication.revision == "" {
+			continue
+		}
+		if cohosted[nodeName] == nil {
+			cohosted[nodeName] = map[string]bool{}
+		}
+		cohosted[nodeName][publication.revision] = true
 	}
 	return cohosted
 }

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1829,6 +1829,8 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 	releaseRequired := workspaceRoot != "" && environmentName != "" && (len(opts.Nodes) == 0 || strings.TrimSpace(opts.Environment) != "")
 	localReleaseKnown := len(opts.Nodes) > 0 && !releaseRequired
 	expectedRevisions := map[string]string{}
+	cohostedRevisions := map[string]map[string]bool{}
+	staleRevisions := map[string]map[string]bool{}
 	expectedRuntimeEnvironment := ""
 	expectedWorkloadRevision := ""
 	if workspaceRoot != "" && environmentName != "" {
@@ -1841,6 +1843,8 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 			if hasCurrent {
 				localReleaseKnown = true
 				expectedRevisions = soloExpectedStatusRevisions(current, currentRelease)
+				cohostedRevisions = soloCohostedStatusRevisions(current, currentRelease)
+				staleRevisions = soloStaleStatusRevisions(current, currentRelease, expectedRevisions)
 				expectedWorkloadRevision = strings.TrimSpace(currentRelease.Revision)
 				expectedRuntimeEnvironment, _ = soloRuntimeEnvironmentNameForNode(current, workspaceRoot, environmentName, "")
 			}
@@ -1851,6 +1855,7 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 
 	var jsonResults []map[string]any
 	readErrors := 0
+	statusErrors := 0
 	allSettled := true
 
 	for name, node := range nodes {
@@ -1890,12 +1895,18 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 			continue
 		}
 		expectedRevision := soloExpectedStatusRevision(expectedRevisions, name)
-		if expectedRevision != "" && !soloNodeStatusMatchesExpectedRelease(result.Status, expectedRevision, expectedRuntimeEnvironment, expectedWorkloadRevision) {
+		if expectedRevision != "" && !soloNodeStatusMatchesExpectedRelease(result.Status, expectedRevision, expectedRuntimeEnvironment, expectedWorkloadRevision, cohostedRevisions[name], staleRevisions[name]) {
 			allSettled = false
+			message := fmt.Sprintf("remote agent status revision %q does not match current local deployment %q; run `devopsellence deploy`", strings.TrimSpace(result.Status.Revision), expectedRevision)
+			runtime := soloRuntimeEnvironmentStatus(result.Status, expectedRuntimeEnvironment, expectedWorkloadRevision)
+			if runtime.State == "error" {
+				statusErrors++
+				message = runtime.Message
+			}
 			jsonResults = append(jsonResults, map[string]any{
 				"node":    name,
 				"status":  nil,
-				"message": fmt.Sprintf("remote agent status revision %q does not match current local deployment %q; run `devopsellence deploy`", strings.TrimSpace(result.Status.Revision), expectedRevision),
+				"message": message,
 			})
 			continue
 		}
@@ -1932,6 +1943,9 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 	if readErrors > 0 {
 		return ExitError{Code: 1, Err: RenderedError{Err: fmt.Errorf("status failed for %d node(s)", readErrors)}}
 	}
+	if statusErrors > 0 {
+		return ExitError{Code: 1, Err: RenderedError{Err: fmt.Errorf("status reported unhealthy runtime environment on %d node(s)", statusErrors)}}
+	}
 	return nil
 }
 
@@ -1966,10 +1980,68 @@ func soloExpectedStatusRevisions(current solo.State, release corerelease.Release
 	return expected
 }
 
-func soloNodeStatusMatchesExpectedRelease(status soloNodeStatus, expectedDesiredStateRevision, expectedRuntimeEnvironment, expectedWorkloadRevision string) bool {
+func soloStaleStatusRevisions(current solo.State, release corerelease.Release, expected map[string]string) map[string]map[string]bool {
+	stale := map[string]map[string]bool{}
+	for _, deployment := range current.Deployments {
+		if deployment.EnvironmentID != release.EnvironmentID || deployment.PublicationResult == nil {
+			continue
+		}
+		for _, result := range deployment.PublicationResult.NodeResults {
+			nodeName := strings.TrimSpace(result.NodeName)
+			if nodeName == "" {
+				nodeName = strings.TrimSpace(result.NodeID)
+			}
+			revision := strings.TrimSpace(result.Revision)
+			if nodeName == "" || revision == "" || revision == soloExpectedStatusRevision(expected, nodeName) {
+				continue
+			}
+			if stale[nodeName] == nil {
+				stale[nodeName] = map[string]bool{}
+			}
+			stale[nodeName][revision] = true
+		}
+	}
+	return stale
+}
+
+func soloCohostedStatusRevisions(current solo.State, release corerelease.Release) map[string]map[string]bool {
+	cohosted := map[string]map[string]bool{}
+	for _, deployment := range current.Deployments {
+		if deployment.EnvironmentID == release.EnvironmentID || deployment.PublicationResult == nil {
+			continue
+		}
+		for _, result := range deployment.PublicationResult.NodeResults {
+			nodeName := strings.TrimSpace(result.NodeName)
+			if nodeName == "" {
+				nodeName = strings.TrimSpace(result.NodeID)
+			}
+			revision := strings.TrimSpace(result.Revision)
+			if nodeName == "" || revision == "" {
+				continue
+			}
+			if cohosted[nodeName] == nil {
+				cohosted[nodeName] = map[string]bool{}
+			}
+			cohosted[nodeName][revision] = true
+		}
+	}
+	return cohosted
+}
+
+func soloNodeStatusMatchesExpectedRelease(status soloNodeStatus, expectedDesiredStateRevision, expectedRuntimeEnvironment, expectedWorkloadRevision string, cohostedDesiredStateRevisions, staleDesiredStateRevisions map[string]bool) bool {
 	runtime := soloRuntimeEnvironmentStatus(status, expectedRuntimeEnvironment, expectedWorkloadRevision)
 	if runtime.State != "" {
-		return runtime.State == "settled"
+		if runtime.State != "settled" {
+			return false
+		}
+		statusRevision := strings.TrimSpace(status.Revision)
+		if statusRevision == strings.TrimSpace(expectedDesiredStateRevision) {
+			return true
+		}
+		if staleDesiredStateRevisions[statusRevision] {
+			return false
+		}
+		return cohostedDesiredStateRevisions[statusRevision]
 	}
 	if strings.TrimSpace(status.Revision) == strings.TrimSpace(expectedDesiredStateRevision) {
 		return true

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -232,6 +232,7 @@ type soloNodeStatusEnvironment struct {
 
 type soloNodeStatusService struct {
 	Name      string `json:"name"`
+	Phase     string `json:"phase,omitempty"`
 	State     string `json:"state"`
 	Container string `json:"container"`
 }
@@ -537,7 +538,11 @@ func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 	if err := a.writeSoloState(current); err != nil {
 		return err
 	}
-	if err := a.waitForSoloRollout(ctx, nodes, desiredStateRevisions, statusBaselines); err != nil {
+	expectedRuntimeEnvironment, err := soloRuntimeEnvironmentNameForNode(current, workspaceRoot, environmentName, "")
+	if err != nil {
+		return err
+	}
+	if err := a.waitForSoloRolloutForRuntime(ctx, nodes, desiredStateRevisions, expectedRuntimeEnvironment, release.Revision, statusBaselines); err != nil {
 		resultErr := err
 		var rolloutErr *soloRolloutError
 		if errors.As(err, &rolloutErr) {
@@ -830,6 +835,10 @@ func soloRolloutMessageLooksLikeHealthcheck(message string) bool {
 }
 
 func (a *App) waitForSoloRollout(ctx context.Context, nodes map[string]config.Node, expectedRevisions map[string]string, previousStatusTimes ...map[string]string) error {
+	return a.waitForSoloRolloutForRuntime(ctx, nodes, expectedRevisions, "", "", previousStatusTimes...)
+}
+
+func (a *App) waitForSoloRolloutForRuntime(ctx context.Context, nodes map[string]config.Node, expectedRevisions map[string]string, expectedRuntimeEnvironment, expectedWorkloadRevision string, previousStatusTimes ...map[string]string) error {
 	timeout := a.DeployTimeout
 	if timeout <= 0 {
 		timeout = defaultDeployProgressTimeout
@@ -879,6 +888,22 @@ func (a *App) waitForSoloRollout(ctx context.Context, nodes map[string]config.No
 				pendingCount++
 				details = append(details, fmt.Sprintf("%s=status_time:%s", name, firstNonEmpty(strings.TrimSpace(result.Status.Time), "none")))
 			default:
+				runtime := soloRuntimeEnvironmentStatus(result.Status, expectedRuntimeEnvironment, expectedWorkloadRevision)
+				switch runtime.State {
+				case "pending":
+					pendingCount++
+					details = append(details, name+"="+runtime.Detail)
+					continue
+				case "reconciling":
+					reconcilingCount++
+					details = append(details, name+"="+runtime.Detail)
+					continue
+				case "error":
+					return ExitError{Code: 1, Err: &soloRolloutError{Node: name, Message: runtime.Message, HealthcheckFailure: runtime.HealthcheckFailure}}
+				case "settled":
+					settledCount++
+					continue
+				}
 				switch strings.TrimSpace(result.Status.Phase) {
 				case "settled":
 					settledCount++
@@ -912,6 +937,53 @@ func (a *App) waitForSoloRollout(ctx context.Context, nodes map[string]config.No
 		case <-timer.C:
 		}
 	}
+}
+
+type soloRuntimeStatusResult struct {
+	State              string
+	Detail             string
+	Message            string
+	HealthcheckFailure bool
+}
+
+func soloRuntimeEnvironmentStatus(status soloNodeStatus, expectedRuntimeEnvironment, expectedWorkloadRevision string) soloRuntimeStatusResult {
+	expectedRuntimeEnvironment = strings.TrimSpace(expectedRuntimeEnvironment)
+	expectedWorkloadRevision = strings.TrimSpace(expectedWorkloadRevision)
+	if expectedRuntimeEnvironment == "" || expectedWorkloadRevision == "" || len(status.Environments) == 0 {
+		return soloRuntimeStatusResult{}
+	}
+	for _, environment := range status.Environments {
+		if strings.TrimSpace(environment.Name) != expectedRuntimeEnvironment {
+			continue
+		}
+		if revision := strings.TrimSpace(environment.Revision); revision != expectedWorkloadRevision {
+			return soloRuntimeStatusResult{State: "pending", Detail: fmt.Sprintf("runtime_env_revision:%s", firstNonEmpty(revision, "none"))}
+		}
+		if strings.TrimSpace(environment.Phase) == "error" {
+			return soloRuntimeStatusResult{State: "error", Message: fmt.Sprintf("runtime environment %s reported phase=error", expectedRuntimeEnvironment)}
+		}
+		for _, service := range environment.Services {
+			serviceName := firstNonEmpty(strings.TrimSpace(service.Name), config.DefaultWebServiceName)
+			servicePhase := strings.TrimSpace(service.Phase)
+			serviceState := strings.ToLower(strings.TrimSpace(service.State))
+			if servicePhase == "error" {
+				return soloRuntimeStatusResult{State: "error", Message: fmt.Sprintf("service %s reported phase=error", serviceName), HealthcheckFailure: serviceState == "unhealthy"}
+			}
+			switch serviceState {
+			case "unhealthy", "stopped", "exited", "dead":
+				return soloRuntimeStatusResult{State: "error", Message: fmt.Sprintf("service %s reported state=%s", serviceName, serviceState), HealthcheckFailure: serviceState == "unhealthy"}
+			}
+			if servicePhase != "" && servicePhase != "settled" {
+				return soloRuntimeStatusResult{State: "reconciling", Detail: fmt.Sprintf("service:%s:%s", serviceName, servicePhase)}
+			}
+		}
+		phase := strings.TrimSpace(environment.Phase)
+		if phase == "" || phase == "settled" {
+			return soloRuntimeStatusResult{State: "settled"}
+		}
+		return soloRuntimeStatusResult{State: "reconciling", Detail: fmt.Sprintf("runtime_env:%s", phase)}
+	}
+	return soloRuntimeStatusResult{State: "pending", Detail: "runtime_env:missing"}
 }
 
 func (a *App) soloNodeStatusTimes(ctx context.Context, nodes map[string]config.Node) map[string]string {
@@ -1895,23 +1967,12 @@ func soloExpectedStatusRevisions(current solo.State, release corerelease.Release
 }
 
 func soloNodeStatusMatchesExpectedRelease(status soloNodeStatus, expectedDesiredStateRevision, expectedRuntimeEnvironment, expectedWorkloadRevision string) bool {
+	runtime := soloRuntimeEnvironmentStatus(status, expectedRuntimeEnvironment, expectedWorkloadRevision)
+	if runtime.State != "" {
+		return runtime.State == "settled"
+	}
 	if strings.TrimSpace(status.Revision) == strings.TrimSpace(expectedDesiredStateRevision) {
 		return true
-	}
-	expectedRuntimeEnvironment = strings.TrimSpace(expectedRuntimeEnvironment)
-	expectedWorkloadRevision = strings.TrimSpace(expectedWorkloadRevision)
-	if expectedRuntimeEnvironment == "" || expectedWorkloadRevision == "" {
-		return false
-	}
-	for _, environment := range status.Environments {
-		if strings.TrimSpace(environment.Name) != expectedRuntimeEnvironment {
-			continue
-		}
-		if strings.TrimSpace(environment.Revision) != expectedWorkloadRevision {
-			return false
-		}
-		phase := strings.TrimSpace(environment.Phase)
-		return phase == "" || phase == "settled"
 	}
 	return false
 }
@@ -2034,7 +2095,7 @@ func (a *App) SoloReleaseRollback(ctx context.Context, opts SoloReleaseRollbackO
 				"publish":     false,
 				"state_write": false,
 			},
-			"next_steps": []string{"devopsellence release rollback " + selected.ID},
+			"next_steps": []string{"devopsellence release rollback" + soloEnvFlag(environmentName) + " " + selected.ID},
 		})
 	}
 	now := time.Now().UTC()
@@ -2074,7 +2135,11 @@ func (a *App) SoloReleaseRollback(ctx context.Context, opts SoloReleaseRollbackO
 		}
 		return err
 	}
-	if err := a.waitForSoloRollout(ctx, nodes, desiredStateRevisions, statusBaselines); err != nil {
+	expectedRuntimeEnvironment, err := soloRuntimeEnvironmentNameForNode(publishState, workspaceRoot, environmentName, "")
+	if err != nil {
+		return err
+	}
+	if err := a.waitForSoloRolloutForRuntime(ctx, nodes, desiredStateRevisions, expectedRuntimeEnvironment, selected.Revision, statusBaselines); err != nil {
 		resultErr := err
 		var rolloutErr *soloRolloutError
 		if errors.As(err, &rolloutErr) {
@@ -2749,7 +2814,8 @@ func (a *App) SoloNodeDetach(ctx context.Context, opts SoloNodeDetachOptions) er
 	if len(nodeNamesBefore) == 0 {
 		return fmt.Errorf("environment %s has no attached nodes", environmentName)
 	}
-	if _, changed, err := current.DetachNode(workspaceRoot, environmentName, opts.Node); err != nil {
+	next := cloneSoloState(current)
+	if _, changed, err := next.DetachNode(workspaceRoot, environmentName, opts.Node); err != nil {
 		return err
 	} else if !changed {
 		return fmt.Errorf("node %q is not attached to %s", opts.Node, environmentName)
@@ -2761,18 +2827,18 @@ func (a *App) SoloNodeDetach(ctx context.Context, opts SoloNodeDetachOptions) er
 		}
 	}
 	remainingNodeNames = normalizeSoloNames(remainingNodeNames)
-	if err := a.writeSoloState(current); err != nil {
-		return err
-	}
-	if _, err := a.republishNodes(ctx, current, remainingNodeNames); err != nil {
+	if _, err := a.republishNodes(ctx, next, remainingNodeNames); err != nil {
 		return err
 	}
 	warnings := []string{}
-	if _, err := a.republishNodes(ctx, current, []string{opts.Node}); err != nil {
-		if current.NodeHasAttachments(opts.Node) || !soloRepublishMissingAgentError(err) {
+	if _, err := a.republishNodes(ctx, next, []string{opts.Node}); err != nil {
+		if next.NodeHasAttachments(opts.Node) || !soloRepublishMissingAgentError(err) {
 			return err
 		}
 		warnings = append(warnings, "remote desired state was not cleared because the agent is already uninstalled on the node")
+	}
+	if err := a.writeSoloState(next); err != nil {
+		return err
 	}
 
 	payload := map[string]any{

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1902,6 +1902,9 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 			if runtime.State == "error" {
 				statusErrors++
 				message = runtime.Message
+			} else if strings.TrimSpace(result.Status.Phase) == "error" {
+				statusErrors++
+				message = firstNonEmpty(strings.TrimSpace(result.Status.Error), "node reported phase=error")
 			}
 			jsonResults = append(jsonResults, map[string]any{
 				"node":    name,
@@ -1910,7 +1913,14 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 			})
 			continue
 		}
-		if strings.TrimSpace(result.Status.Phase) != "settled" {
+		switch strings.TrimSpace(result.Status.Phase) {
+		case "settled":
+		case "error":
+			allSettled = false
+			if expectedRevision != "" {
+				statusErrors++
+			}
+		default:
 			allSettled = false
 		}
 		jsonResults = append(jsonResults, map[string]any{

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -4620,6 +4620,83 @@ func TestSoloStatusComparesRemoteStatusToPublishedDesiredStateRevision(t *testin
 	}
 }
 
+func TestSoloStatusFailsWhenCurrentDeploymentStatusIsError(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	cfg.Ingress = &config.IngressConfig{
+		Hosts: []string{"*"},
+		Rules: []config.IngressRuleConfig{{
+			Match:  config.IngressMatchConfig{Host: "*", PathPrefix: "/"},
+			Target: config.IngressTargetConfig{Service: config.DefaultWebServiceName, Port: "http"},
+		}},
+		TLS: config.IngressTLSConfig{Mode: "off"},
+	}
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.Node{
+			"node-a": {Host: "203.0.113.10", User: "root", Port: 22, AgentStateDir: "/var/lib/devopsellence", Labels: []string{config.DefaultWebRole}},
+		},
+		Attachments: map[string]solo.AttachmentRecord{},
+	}
+	if _, _, err := current.AttachNode(workspaceRoot, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	seedSoloCurrentRelease(t, &current, workspaceRoot, "production", "shortsha")
+	environmentID, release, ok, err := current.CurrentRelease(workspaceRoot, "production")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("current release missing")
+	}
+	deployment, err := corerelease.NewDeployment(corerelease.DeploymentCreateInput{
+		ID:            "dep_test",
+		EnvironmentID: environmentID,
+		ReleaseID:     release.ID,
+		Kind:          corerelease.DeploymentKindDeploy,
+		Sequence:      1,
+		TargetNodeIDs: []string{"node-a"},
+		CreatedAt:     time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	deployment.Status = corerelease.DeploymentStatusFailed
+	deployment.PublicationResult = &corerelease.DeploymentPublicationResult{
+		Status: corerelease.PublicationStatusWritten,
+		NodeResults: []corerelease.DesiredStatePublication{{
+			NodeName: "node-a",
+			Revision: "desired-state-hash",
+			Status:   corerelease.PublicationStatusWritten,
+		}},
+	}
+	if err := current.SaveDeployment(deployment); err != nil {
+		t.Fatal(err)
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+	installFakeSoloCommands(t, []fakeSSHResponse{{stdout: `{"revision":"desired-state-hash","phase":"error","error":"healthcheck failed"}` + "\n"}})
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState, ConfigStore: config.NewStore(), Cwd: workspaceRoot}
+	err = app.SoloStatus(context.Background(), SoloStatusOptions{})
+	if err == nil {
+		t.Fatal("expected status failure")
+	}
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("error = %T %v, want ExitError", err, err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	if _, ok := payload["public_urls"]; ok {
+		t.Fatalf("payload = %#v, did not expect public_urls for errored current deployment", payload)
+	}
+}
+
 func TestSoloStatusAcceptsNewerCohostedDesiredStateWhenCurrentEnvironmentSettled(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -3591,6 +3591,61 @@ exit 1
 	}
 }
 
+func TestSoloNodeDetachPreservesLocalAttachmentWhenRemoteCleanupFails(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.Node{
+			"prod-1": {Host: "203.0.113.10", User: "root", Labels: []string{config.DefaultWebRole}},
+		},
+		Attachments: map[string]solo.AttachmentRecord{},
+		Snapshots:   map[string]desiredstate.DeploySnapshot{},
+	}
+	if _, _, err := current.AttachNode(workspaceRoot, "production", "prod-1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	binDir := t.TempDir()
+	writeExecutable(t, filepath.Join(binDir, "ssh"), `#!/usr/bin/env bash
+set -euo pipefail
+command="${!#}"
+if [[ "$command" == *"desired-state set-override"* ]]; then
+  echo 'remote write failed' >&2
+  exit 1
+fi
+echo "unexpected ssh command: $command" >&2
+exit 1
+`)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	var stdout bytes.Buffer
+	app := &App{
+		Printer:     output.New(&stdout, io.Discard),
+		SoloState:   soloState,
+		ConfigStore: config.NewStore(),
+		Cwd:         workspaceRoot,
+	}
+
+	if err := app.SoloNodeDetach(context.Background(), SoloNodeDetachOptions{Node: "prod-1"}); err == nil {
+		t.Fatal("expected detach failure")
+	}
+	loaded, err := soloState.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !loaded.NodeHasAttachments("prod-1") {
+		t.Fatalf("prod-1 attachment was removed after failed detach: %#v", loaded.Attachments)
+	}
+}
+
 func TestNodeRemoveForManualNodeForgetsLocalState(t *testing.T) {
 	t.Parallel()
 
@@ -4650,6 +4705,91 @@ func TestSoloStatusAcceptsNewerCohostedDesiredStateWhenCurrentEnvironmentSettled
 	}
 }
 
+func TestSoloStatusRejectsUnhealthyRuntimeEnvironmentDespiteTopLevelSettled(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	cfg.Ingress = &config.IngressConfig{
+		Hosts: []string{"app.example.com"},
+		Rules: []config.IngressRuleConfig{{
+			Match:  config.IngressMatchConfig{Host: "app.example.com", PathPrefix: "/"},
+			Target: config.IngressTargetConfig{Service: config.DefaultWebServiceName, Port: "http"},
+		}},
+		TLS: config.IngressTLSConfig{Mode: "off"},
+	}
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.Node{
+			"node-a": {Host: "203.0.113.10", User: "root", Port: 22, AgentStateDir: "/var/lib/devopsellence", Labels: []string{config.DefaultWebRole}},
+		},
+		Attachments: map[string]solo.AttachmentRecord{},
+	}
+	if _, _, err := current.AttachNode(workspaceRoot, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	seedSoloCurrentRelease(t, &current, workspaceRoot, "production", "shortsha")
+	environmentID, release, ok, err := current.CurrentRelease(workspaceRoot, "production")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("current release missing")
+	}
+	deployment, err := corerelease.NewDeployment(corerelease.DeploymentCreateInput{
+		ID:            "dep_test",
+		EnvironmentID: environmentID,
+		ReleaseID:     release.ID,
+		Kind:          corerelease.DeploymentKindDeploy,
+		Sequence:      1,
+		TargetNodeIDs: []string{"node-a"},
+		CreatedAt:     time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	deployment.Status = corerelease.DeploymentStatusSettled
+	deployment.PublicationResult = &corerelease.DeploymentPublicationResult{
+		Status: corerelease.PublicationStatusWritten,
+		NodeResults: []corerelease.DesiredStatePublication{{
+			NodeName: "node-a",
+			Revision: "current-workspace-desired-state",
+			Status:   corerelease.PublicationStatusWritten,
+		}},
+	}
+	if err := current.SaveDeployment(deployment); err != nil {
+		t.Fatal(err)
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+	runtimeEnvironment, err := soloRuntimeEnvironmentNameForNode(current, workspaceRoot, "production", "node-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	statusJSON := fmt.Sprintf(`{"revision":"current-workspace-desired-state","phase":"settled","environments":[{"name":%q,"revision":"shortsha","phase":"settled","services":[{"name":"web","phase":"settled","state":"unhealthy"}]}]}`, runtimeEnvironment)
+	installFakeSoloCommands(t, []fakeSSHResponse{{stdout: statusJSON + "\n"}})
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState, ConfigStore: config.NewStore(), Cwd: workspaceRoot}
+	if err := app.SoloStatus(context.Background(), SoloStatusOptions{}); err != nil {
+		t.Fatalf("SoloStatus() error = %v", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	if _, ok := payload["public_urls"]; ok {
+		t.Fatalf("payload = %#v, did not expect public_urls while runtime environment is unhealthy", payload)
+	}
+	if urls := jsonArrayFromMap(t, payload, "configured_public_urls"); len(urls) != 1 || urls[0] != "http://app.example.com/" {
+		t.Fatalf("configured_public_urls = %#v, want configured URL", urls)
+	}
+	nodes := jsonArrayFromMap(t, payload, "nodes")
+	node := jsonMapFromAny(t, nodes[0])
+	if node["status"] != nil || node["message"] == nil {
+		t.Fatalf("node = %#v, want unhealthy status withheld", node)
+	}
+}
+
 func TestSoloDeployWaitsForSettledStatusBeforeSuccess(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	if err := os.WriteFile(filepath.Join(workspaceRoot, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
@@ -5084,6 +5224,10 @@ func TestSoloReleaseRollbackDryRunUsesExplicitEnvironment(t *testing.T) {
 	payload := events[len(events)-1]
 	if payload["environment"] != "staging" || payload["release_id"] != "rel-1" || payload["rolled_back_from"] != "rel-2" {
 		t.Fatalf("payload = %#v, want explicit staging rollback from rel-2 to rel-1", payload)
+	}
+	steps := jsonArrayFromMap(t, payload, "next_steps")
+	if len(steps) != 1 || steps[0] != "devopsellence release rollback --env 'staging' rel-1" {
+		t.Fatalf("next_steps = %#v, want env-scoped rollback command", steps)
 	}
 }
 
@@ -5614,6 +5758,34 @@ func TestWaitForSoloRolloutFailsOnExpectedRevisionErrorPhase(t *testing.T) {
 	steps := fields["next_steps"].([]string)
 	if len(steps) != 3 || steps[1] != "devopsellence logs --node 'node-a' --lines 100" || steps[2] != "devopsellence node logs 'node-a' --lines 100" {
 		t.Fatalf("next_steps = %#v, want status, workload logs, and node logs commands", steps)
+	}
+}
+
+func TestWaitForSoloRolloutFailsOnUnhealthyRuntimeEnvironmentDespiteTopLevelSettled(t *testing.T) {
+	installFakeSoloCommands(t, []fakeSSHResponse{
+		{stdout: `{"revision":"expected-revision","phase":"settled","environments":[{"name":"production","revision":"workload-revision","phase":"settled","services":[{"name":"web","phase":"settled","state":"unhealthy"}]}]}` + "\n"},
+	})
+
+	app := &App{
+		Printer:            output.New(io.Discard, io.Discard),
+		DeployPollInterval: 5 * time.Millisecond,
+		DeployTimeout:      100 * time.Millisecond,
+	}
+
+	err := app.waitForSoloRolloutForRuntime(context.Background(), map[string]config.Node{
+		"node-a": {Host: "203.0.113.10", User: "root", Port: 22, AgentStateDir: "/var/lib/devopsellence"},
+	}, map[string]string{
+		"node-a": "expected-revision",
+	}, "production", "workload-revision")
+	if err == nil {
+		t.Fatal("expected rollout failure")
+	}
+	var rolloutErr *soloRolloutError
+	if !errors.As(err, &rolloutErr) {
+		t.Fatalf("error = %T %v, want soloRolloutError", err, err)
+	}
+	if !rolloutErr.HealthcheckFailure || !strings.Contains(rolloutErr.Message, "state=unhealthy") {
+		t.Fatalf("rollout error = %#v, want healthcheck-like unhealthy service failure", rolloutErr)
 	}
 }
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -4676,6 +4676,54 @@ func TestSoloStatusAcceptsNewerCohostedDesiredStateWhenCurrentEnvironmentSettled
 	if err := current.SaveDeployment(deployment); err != nil {
 		t.Fatal(err)
 	}
+	cohostedEnvironmentID, err := solo.EnvironmentStateKey(workspaceRoot, "staging")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cohostedRelease, err := corerelease.NewRelease(corerelease.ReleaseCreateInput{
+		ID:            "rel_cohosted",
+		EnvironmentID: cohostedEnvironmentID,
+		Revision:      "cohostedsha",
+		Snapshot: desiredstate.DeploySnapshot{
+			WorkspaceRoot: workspaceRoot,
+			WorkspaceKey:  workspaceRoot,
+			Environment:   "staging",
+			Revision:      "cohostedsha",
+			Image:         "demo:cohostedsha",
+		},
+		Image:     corerelease.ImageRef{Reference: "demo:cohostedsha"},
+		CreatedAt: time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := current.SaveRelease(cohostedRelease); err != nil {
+		t.Fatal(err)
+	}
+	cohostedDeployment, err := corerelease.NewDeployment(corerelease.DeploymentCreateInput{
+		ID:            "dep_cohosted",
+		EnvironmentID: cohostedEnvironmentID,
+		ReleaseID:     "rel_cohosted",
+		Kind:          corerelease.DeploymentKindDeploy,
+		Sequence:      1,
+		TargetNodeIDs: []string{"node-a"},
+		CreatedAt:     time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cohostedDeployment.Status = corerelease.DeploymentStatusSettled
+	cohostedDeployment.PublicationResult = &corerelease.DeploymentPublicationResult{
+		Status: corerelease.PublicationStatusWritten,
+		NodeResults: []corerelease.DesiredStatePublication{{
+			NodeName: "node-a",
+			Revision: "newer-cohosted-desired-state",
+			Status:   corerelease.PublicationStatusWritten,
+		}},
+	}
+	if err := current.SaveDeployment(cohostedDeployment); err != nil {
+		t.Fatal(err)
+	}
 	if err := soloState.Write(current); err != nil {
 		t.Fatal(err)
 	}
@@ -4773,8 +4821,13 @@ func TestSoloStatusRejectsUnhealthyRuntimeEnvironmentDespiteTopLevelSettled(t *t
 
 	var stdout bytes.Buffer
 	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState, ConfigStore: config.NewStore(), Cwd: workspaceRoot}
-	if err := app.SoloStatus(context.Background(), SoloStatusOptions{}); err != nil {
-		t.Fatalf("SoloStatus() error = %v", err)
+	err = app.SoloStatus(context.Background(), SoloStatusOptions{})
+	if err == nil {
+		t.Fatal("expected unhealthy runtime environment status failure")
+	}
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("error = %T %v, want ExitError", err, err)
 	}
 	payload := decodeJSONOutput(t, &stdout)
 	if _, ok := payload["public_urls"]; ok {
@@ -4787,6 +4840,90 @@ func TestSoloStatusRejectsUnhealthyRuntimeEnvironmentDespiteTopLevelSettled(t *t
 	node := jsonMapFromAny(t, nodes[0])
 	if node["status"] != nil || node["message"] == nil {
 		t.Fatalf("node = %#v, want unhealthy status withheld", node)
+	}
+}
+
+func TestSoloStatusRejectsKnownStaleDesiredStateDespiteSettledRuntimeEnvironment(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	cfg.Ingress = &config.IngressConfig{
+		Hosts: []string{"app.example.com"},
+		Rules: []config.IngressRuleConfig{{
+			Match:  config.IngressMatchConfig{Host: "app.example.com", PathPrefix: "/"},
+			Target: config.IngressTargetConfig{Service: config.DefaultWebServiceName, Port: "http"},
+		}},
+		TLS: config.IngressTLSConfig{Mode: "off"},
+	}
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.Node{
+			"node-a": {Host: "203.0.113.10", User: "root", Port: 22, AgentStateDir: "/var/lib/devopsellence", Labels: []string{config.DefaultWebRole}},
+		},
+		Attachments: map[string]solo.AttachmentRecord{},
+	}
+	if _, _, err := current.AttachNode(workspaceRoot, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	seedSoloCurrentRelease(t, &current, workspaceRoot, "production", "shortsha")
+	environmentID, release, ok, err := current.CurrentRelease(workspaceRoot, "production")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("current release missing")
+	}
+	for sequence, revision := range []string{"old-desired-state", "current-desired-state"} {
+		deployment, err := corerelease.NewDeployment(corerelease.DeploymentCreateInput{
+			ID:            fmt.Sprintf("dep_%d", sequence+1),
+			EnvironmentID: environmentID,
+			ReleaseID:     release.ID,
+			Kind:          corerelease.DeploymentKindDeploy,
+			Sequence:      sequence + 1,
+			TargetNodeIDs: []string{"node-a"},
+			CreatedAt:     time.Now().UTC(),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		deployment.Status = corerelease.DeploymentStatusSettled
+		deployment.PublicationResult = &corerelease.DeploymentPublicationResult{
+			Status: corerelease.PublicationStatusWritten,
+			NodeResults: []corerelease.DesiredStatePublication{{
+				NodeName: "node-a",
+				Revision: revision,
+				Status:   corerelease.PublicationStatusWritten,
+			}},
+		}
+		if err := current.SaveDeployment(deployment); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+	runtimeEnvironment, err := soloRuntimeEnvironmentNameForNode(current, workspaceRoot, "production", "node-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	statusJSON := fmt.Sprintf(`{"revision":"old-desired-state","phase":"settled","environments":[{"name":%q,"revision":"shortsha","phase":"settled","services":[{"name":"web","phase":"settled","state":"running"}]}]}`, runtimeEnvironment)
+	installFakeSoloCommands(t, []fakeSSHResponse{{stdout: statusJSON + "\n"}})
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState, ConfigStore: config.NewStore(), Cwd: workspaceRoot}
+	if err := app.SoloStatus(context.Background(), SoloStatusOptions{}); err != nil {
+		t.Fatalf("SoloStatus() error = %v", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	if _, ok := payload["public_urls"]; ok {
+		t.Fatalf("payload = %#v, did not expect public_urls for known stale desired state", payload)
+	}
+	nodes := jsonArrayFromMap(t, payload, "nodes")
+	node := jsonMapFromAny(t, nodes[0])
+	if node["status"] != nil || node["message"] == nil {
+		t.Fatalf("node = %#v, want stale desired-state status withheld", node)
 	}
 }
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -4777,12 +4777,36 @@ func TestSoloStatusAcceptsNewerCohostedDesiredStateWhenCurrentEnvironmentSettled
 	if _, err := current.SaveRelease(cohostedRelease); err != nil {
 		t.Fatal(err)
 	}
+	oldCohostedDeployment, err := corerelease.NewDeployment(corerelease.DeploymentCreateInput{
+		ID:            "dep_old_cohosted",
+		EnvironmentID: cohostedEnvironmentID,
+		ReleaseID:     "rel_cohosted",
+		Kind:          corerelease.DeploymentKindDeploy,
+		Sequence:      1,
+		TargetNodeIDs: []string{"node-a"},
+		CreatedAt:     time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldCohostedDeployment.Status = corerelease.DeploymentStatusSettled
+	oldCohostedDeployment.PublicationResult = &corerelease.DeploymentPublicationResult{
+		Status: corerelease.PublicationStatusWritten,
+		NodeResults: []corerelease.DesiredStatePublication{{
+			NodeName: "node-a",
+			Revision: "old-cohosted-desired-state",
+			Status:   corerelease.PublicationStatusWritten,
+		}},
+	}
+	if err := current.SaveDeployment(oldCohostedDeployment); err != nil {
+		t.Fatal(err)
+	}
 	cohostedDeployment, err := corerelease.NewDeployment(corerelease.DeploymentCreateInput{
 		ID:            "dep_cohosted",
 		EnvironmentID: cohostedEnvironmentID,
 		ReleaseID:     "rel_cohosted",
 		Kind:          corerelease.DeploymentKindDeploy,
-		Sequence:      1,
+		Sequence:      2,
 		TargetNodeIDs: []string{"node-a"},
 		CreatedAt:     time.Now().UTC(),
 	})
@@ -4827,6 +4851,180 @@ func TestSoloStatusAcceptsNewerCohostedDesiredStateWhenCurrentEnvironmentSettled
 	}
 	if urls := jsonArrayFromMap(t, payload, "public_urls"); len(urls) != 1 || urls[0] != "http://app.example.com/" {
 		t.Fatalf("public_urls = %#v, want public URL when scoped environment is settled", urls)
+	}
+}
+
+func TestSoloStatusRejectsStaleCohostedDesiredStateDespiteSettledRuntimeEnvironment(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	cfg.Ingress = &config.IngressConfig{
+		Hosts: []string{"app.example.com"},
+		Rules: []config.IngressRuleConfig{{
+			Match:  config.IngressMatchConfig{Host: "app.example.com", PathPrefix: "/"},
+			Target: config.IngressTargetConfig{Service: config.DefaultWebServiceName, Port: "http"},
+		}},
+		TLS: config.IngressTLSConfig{Mode: "off"},
+	}
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.Node{
+			"node-a": {Host: "203.0.113.10", User: "root", Port: 22, AgentStateDir: "/var/lib/devopsellence", Labels: []string{config.DefaultWebRole}},
+		},
+		Attachments: map[string]solo.AttachmentRecord{},
+	}
+	if _, _, err := current.AttachNode(workspaceRoot, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	seedSoloCurrentRelease(t, &current, workspaceRoot, "production", "shortsha")
+	environmentID, release, ok, err := current.CurrentRelease(workspaceRoot, "production")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("current release missing")
+	}
+	deployment, err := corerelease.NewDeployment(corerelease.DeploymentCreateInput{
+		ID:            "dep_test",
+		EnvironmentID: environmentID,
+		ReleaseID:     release.ID,
+		Kind:          corerelease.DeploymentKindDeploy,
+		Sequence:      1,
+		TargetNodeIDs: []string{"node-a"},
+		CreatedAt:     time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	deployment.Status = corerelease.DeploymentStatusSettled
+	deployment.PublicationResult = &corerelease.DeploymentPublicationResult{
+		Status: corerelease.PublicationStatusWritten,
+		NodeResults: []corerelease.DesiredStatePublication{{
+			NodeName: "node-a",
+			Revision: "current-workspace-desired-state",
+			Status:   corerelease.PublicationStatusWritten,
+		}},
+	}
+	if err := current.SaveDeployment(deployment); err != nil {
+		t.Fatal(err)
+	}
+	cohostedEnvironmentID, err := solo.EnvironmentStateKey(workspaceRoot, "staging")
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldCohostedRelease, err := corerelease.NewRelease(corerelease.ReleaseCreateInput{
+		ID:            "rel_old_cohosted",
+		EnvironmentID: cohostedEnvironmentID,
+		Revision:      "oldcohostedsha",
+		Snapshot: desiredstate.DeploySnapshot{
+			WorkspaceRoot: workspaceRoot,
+			WorkspaceKey:  workspaceRoot,
+			Environment:   "staging",
+			Revision:      "oldcohostedsha",
+			Image:         "demo:oldcohostedsha",
+		},
+		Image:     corerelease.ImageRef{Reference: "demo:oldcohostedsha"},
+		CreatedAt: time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := current.SaveRelease(oldCohostedRelease); err != nil {
+		t.Fatal(err)
+	}
+	cohostedRelease, err := corerelease.NewRelease(corerelease.ReleaseCreateInput{
+		ID:            "rel_cohosted",
+		EnvironmentID: cohostedEnvironmentID,
+		Revision:      "cohostedsha",
+		Snapshot: desiredstate.DeploySnapshot{
+			WorkspaceRoot: workspaceRoot,
+			WorkspaceKey:  workspaceRoot,
+			Environment:   "staging",
+			Revision:      "cohostedsha",
+			Image:         "demo:cohostedsha",
+		},
+		Image:     corerelease.ImageRef{Reference: "demo:cohostedsha"},
+		CreatedAt: time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := current.SaveRelease(cohostedRelease); err != nil {
+		t.Fatal(err)
+	}
+	oldCohostedDeployment, err := corerelease.NewDeployment(corerelease.DeploymentCreateInput{
+		ID:            "dep_old_cohosted",
+		EnvironmentID: cohostedEnvironmentID,
+		ReleaseID:     "rel_old_cohosted",
+		Kind:          corerelease.DeploymentKindDeploy,
+		Sequence:      3,
+		TargetNodeIDs: []string{"node-a"},
+		CreatedAt:     time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldCohostedDeployment.Status = corerelease.DeploymentStatusSettled
+	oldCohostedDeployment.PublicationResult = &corerelease.DeploymentPublicationResult{
+		Status: corerelease.PublicationStatusWritten,
+		NodeResults: []corerelease.DesiredStatePublication{{
+			NodeName: "node-a",
+			Revision: "old-cohosted-desired-state",
+			Status:   corerelease.PublicationStatusWritten,
+		}},
+	}
+	if err := current.SaveDeployment(oldCohostedDeployment); err != nil {
+		t.Fatal(err)
+	}
+	cohostedDeployment, err := corerelease.NewDeployment(corerelease.DeploymentCreateInput{
+		ID:            "dep_cohosted",
+		EnvironmentID: cohostedEnvironmentID,
+		ReleaseID:     "rel_cohosted",
+		Kind:          corerelease.DeploymentKindDeploy,
+		Sequence:      2,
+		TargetNodeIDs: []string{"node-a"},
+		CreatedAt:     time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cohostedDeployment.Status = corerelease.DeploymentStatusSettled
+	cohostedDeployment.PublicationResult = &corerelease.DeploymentPublicationResult{
+		Status: corerelease.PublicationStatusWritten,
+		NodeResults: []corerelease.DesiredStatePublication{{
+			NodeName: "node-a",
+			Revision: "newer-cohosted-desired-state",
+			Status:   corerelease.PublicationStatusWritten,
+		}},
+	}
+	if err := current.SaveDeployment(cohostedDeployment); err != nil {
+		t.Fatal(err)
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+	runtimeEnvironment, err := soloRuntimeEnvironmentNameForNode(current, workspaceRoot, "production", "node-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	statusJSON := fmt.Sprintf(`{"revision":"old-cohosted-desired-state","phase":"settled","environments":[{"name":%q,"revision":"shortsha","phase":"settled","services":[{"name":"web","state":"running"}]}]}`, runtimeEnvironment)
+	installFakeSoloCommands(t, []fakeSSHResponse{{stdout: statusJSON + "\n"}})
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState, ConfigStore: config.NewStore(), Cwd: workspaceRoot}
+	if err := app.SoloStatus(context.Background(), SoloStatusOptions{}); err != nil {
+		t.Fatalf("SoloStatus() error = %v", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	if _, ok := payload["public_urls"]; ok {
+		t.Fatalf("payload = %#v, did not expect public URL for stale cohosted desired-state revision", payload)
+	}
+	nodes := jsonArrayFromMap(t, payload, "nodes")
+	node := jsonMapFromAny(t, nodes[0])
+	if node["status"] != nil || node["message"] == nil {
+		t.Fatalf("node = %#v, want stale cohosted status withheld", node)
 	}
 }
 

--- a/test/e2e/solo_e2e.rb
+++ b/test/e2e/solo_e2e.rb
@@ -755,13 +755,13 @@ PY
     puts "[ok] Web container running: #{web_containers.join(', ')}"
 
     # Verify via CLI status command.
-    cli_status_output = run!(
+    cli_status_result = run_command(
       cli_binary.to_s, "status",
       chdir: @app_dir.to_s,
       timeout: 60,
       env: ssh_env
     )
-    cli_status = parse_cli_json(cli_status_output)
+    cli_status = parse_cli_json(cli_status_result.fetch(:output))
     node_status = (cli_status["nodes"] || []).find { |entry| entry["node"] == "node-1" }
     raise "CLI status missing node-1" unless node_status
     cli_revision = node_status.dig("status", "revision")
@@ -769,6 +769,9 @@ PY
     raise "CLI status revision mismatch: #{cli_revision}" unless cli_revision == revision
     unless ["settled", "error"].include?(cli_phase)
       raise "CLI status phase unexpected: #{cli_phase.inspect}"
+    end
+    unless cli_status_result.fetch(:status).success? || (cli_phase == "error" && known_probe_error?(node_status.dig("status", "error").to_s))
+      raise "CLI status failed unexpectedly (#{cli_status_result.fetch(:status).exitstatus}): #{excerpt(cli_status_result.fetch(:output), 20)}"
     end
     puts "[ok] CLI status confirms revision #{cli_revision} phase=#{cli_phase}"
 


### PR DESCRIPTION
## Summary
- fail solo rollout/status when the selected runtime environment reports unhealthy/error services even if node top-level phase is settled
- preserve local node attachment state when remote detach cleanup fails
- include --env in rollback dry-run next-step commands

## Tests
- mise exec -- go test ./internal/workflow -run 'TestSoloNodeDetach|TestSoloStatusRejectsUnhealthyRuntimeEnvironmentDespiteTopLevelSettled|TestSoloStatusAcceptsNewerCohostedDesiredStateWhenCurrentEnvironmentSettled|TestSoloReleaseRollbackDryRunUsesExplicitEnvironment|TestWaitForSoloRollout' -count=1
- mise run test:cli