### PR TITLE
Tighten solo logs validation

### DIFF
--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -3106,6 +3106,9 @@ func (a *App) SoloWorkloadLogs(ctx context.Context, opts SoloWorkloadLogsOptions
 	if cfg == nil {
 		return fmt.Errorf("no workspace selected; attach a workspace or run this command from a workspace")
 	}
+	if _, ok := cfg.Services[serviceName]; !ok {
+		return ExitError{Code: 2, Err: fmt.Errorf("service %q not found in devopsellence.yml", serviceName)}
+	}
 	current, err := a.readSoloState()
 	if err != nil {
 		return err

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -2321,6 +2321,44 @@ func TestSoloWorkloadLogsReadsDockerLogs(t *testing.T) {
 	}
 }
 
+func TestSoloWorkloadLogsRejectsUnknownService(t *testing.T) {
+	installFakeSoloCommands(t, nil)
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.Node{
+			"node-a": {Host: "203.0.113.10", User: "root"},
+		},
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{
+		Printer:     output.New(&stdout, io.Discard),
+		SoloState:   soloState,
+		ConfigStore: config.NewStore(),
+		Cwd:         workspaceRoot,
+	}
+	err := app.SoloWorkloadLogs(context.Background(), SoloWorkloadLogsOptions{ServiceName: "typo", Nodes: []string{"node-a"}, Lines: 20})
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 2 {
+		t.Fatalf("SoloWorkloadLogs() error = %#v, want ExitError code 2", err)
+	}
+	if !strings.Contains(err.Error(), `service "typo" not found in devopsellence.yml`) {
+		t.Fatalf("error = %v, want unknown service message", err)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want no remote log output", stdout.String())
+	}
+}
+
 func TestSoloWorkloadLogsUsesProjectScopedRuntimeEnvironmentForCoHostedNode(t *testing.T) {
 	commandPath := filepath.Join(t.TempDir(), "workload-command")
 	t.Setenv("DEVOPSELLENCE_FAKE_SSH_WORKLOAD_LOGS_COMMAND", commandPath)

--- a/test/e2e/solo_e2e.rb
+++ b/test/e2e/solo_e2e.rb
@@ -25,6 +25,7 @@
 #   DEVOPSELLENCE_E2E_KEEP=1            - preserve runtime after test
 #   DEVOPSELLENCE_E2E_GO_BIN            - custom Go binary path
 #   DEVOPSELLENCE_E2E_SSH_PORT          - custom SSH port for the node container
+#   DEVOPSELLENCE_E2E_APP_TMPDIR        - parent directory for generated app/runtime files
 
 require "digest"
 require "fileutils"
@@ -154,7 +155,7 @@ class SoloE2E
     @cli_root = resolve_repo_root(%w[cli], "DEVOPSELLENCE_CLI_ROOT")
     @agent_root = resolve_repo_root(%w[agent], "DEVOPSELLENCE_AGENT_ROOT")
     @state_dir = MONOREPO_ROOT.join("test/e2e/tmp/solo", @run_id)
-    @app_root_dir = Pathname(Dir.tmpdir).join("devopsellence-solo-e2e", @run_id)
+    @app_root_dir = app_tmp_root.join(@run_id)
     @agent_state_dir = @app_root_dir.join("node-state").to_s
     @desired_state_path = File.join(@agent_state_dir, "desired-state-override.json")
     @status_path = File.join(@agent_state_dir, "status.json")
@@ -208,6 +209,13 @@ class SoloE2E
   end
 
   private
+
+  def app_tmp_root
+    configured_root = ENV.fetch("DEVOPSELLENCE_E2E_APP_TMPDIR", "").to_s.strip
+    return Pathname(configured_root).expand_path unless configured_root.empty?
+
+    Pathname(Dir.tmpdir).join("devopsellence-solo-e2e-#{Process.uid}")
+  end
 
   def step(name)
     puts "\n==> #{name}"
@@ -785,20 +793,17 @@ PY
     raise "secret #{SECRET_VALUE_NAME} not resolved" unless web_service.dig("env", SECRET_VALUE_NAME) == "secret-solo-123"
     puts "[ok] Desired state verified: secrets resolved, env present"
 
-    # Verify CLI logs command runs (may fail inside test container due to no systemd,
-    # but verify the SSH connection and command dispatch works).
-    begin
-      logs_output = run!(
-        cli_binary.to_s, "node", "logs", "node-1",
-        chdir: @app_dir.to_s,
-        timeout: 30,
-        env: ssh_env
-      )
-      puts "[ok] Logs command succeeded (#{logs_output.lines.length} lines)"
-    rescue StandardError => e
-      # journalctl may not be available in the test container — that's expected.
-      puts "[skip] Logs command failed (expected in test env): #{e.message.lines.first}"
-    end
+    logs_output = run!(
+      cli_binary.to_s, "node", "logs", "node-1",
+      chdir: @app_dir.to_s,
+      timeout: 30,
+      env: ssh_env
+    )
+    logs_result = parse_cli_json(logs_output)
+    log_lines = logs_result.fetch("lines")
+    raise "node logs did not return agent log lines" if log_lines.empty?
+
+    puts "[ok] Logs command returned #{log_lines.length} agent log lines"
   end
 
   def current_revision


### PR DESCRIPTION
## Summary
- make solo workload logs reject unknown services before SSH, matching `exec`
- make solo e2e use a UID-scoped temp app/runtime root so stale root-owned `/tmp` state cannot block the harness
- require solo e2e `node logs` to return nonempty agent log lines instead of skipping diagnostics failures

## Dogfood / evidence
- Run path: `/tmp/devopsellence-dogfood-solo/20260430T154356992833Z-solo-loop-local-cli-a8c7882`
- Base: `master` at `a8c7882d81fff30de33ab97031ec1a52390f38d3`
- Head: `92e480e`
- Local CLI loop only; not an official artifact release-readiness pass

## Tests
- `cd cli && mise run test -- ./internal/workflow -run 'TestSoloWorkloadLogs'`
- `mise run test:cli`
- `mise run e2e-solo`
- `mise run release:cli:local`

## Notes
- Did not touch shared/control-plane code; per loop instruction, not waiting for `e2e-shared`.
- Unrelated untracked local file left untouched: `control-plane/devopsellence.yml`.
