### PR TITLE
Honor env when creating attached solo nodes

### DIFF
--- a/cli/internal/workflow/root.go
+++ b/cli/internal/workflow/root.go
@@ -802,6 +802,7 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 	var nodeRegisterOpts NodeBootstrapOptions
 	var nodeCreateOpts SoloNodeCreateOptions
 	var nodeCreateBootstrapOpts NodeBootstrapOptions
+	var nodeCreateEnvironment string
 	var nodeListSharedOpts NodeListOptions
 	var nodeListSoloOpts SoloNodeListOptions
 	var nodeAttachSoloOpts SoloNodeAttachOptions
@@ -850,6 +851,8 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			nodeCreateOpts.Name = args[0]
+			nodeCreateOpts.Environment = nodeCreateEnvironment
+			nodeCreateBootstrapOpts.Environment = nodeCreateEnvironment
 			return runByMode(func(ctx context.Context) error {
 				return app.SoloNodeCreate(ctx, nodeCreateOpts)
 			}, func(ctx context.Context) error {
@@ -874,7 +877,7 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 	nodeCreateCommand.Flags().BoolVar(&nodeCreateOpts.Attach, "attach", false, "Attach the created solo node to the current environment (solo mode)")
 	nodeCreateCommand.Flags().StringVar(&nodeCreateBootstrapOpts.Organization, "org", "", "Shared-mode organization name override")
 	nodeCreateCommand.Flags().StringVar(&nodeCreateBootstrapOpts.Project, "project", "", "Shared-mode project name override")
-	nodeCreateCommand.Flags().StringVar(&nodeCreateBootstrapOpts.Environment, "env", "", "Shared-mode environment name override")
+	nodeCreateCommand.Flags().StringVar(&nodeCreateEnvironment, "env", "", "Environment name override (solo/shared)")
 	nodeCreateCommand.Flags().BoolVar(&nodeCreateBootstrapOpts.Unassigned, "unassigned", false, "Shared mode: register without auto-attaching to the current environment")
 	nodeListCommand := &cobra.Command{
 		Use:   "list",

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -166,6 +166,7 @@ type SoloSupportBundleOptions struct {
 
 type SoloNodeCreateOptions struct {
 	Name         string
+	Environment  string
 	Provider     string
 	Host         string
 	User         string
@@ -4273,7 +4274,7 @@ func (a *App) SoloNodeCreate(ctx context.Context, opts SoloNodeCreateOptions) er
 	attached := false
 	var attachment solo.AttachmentRecord
 	if opts.Attach {
-		environmentName := a.effectiveEnvironment("", cfg)
+		environmentName := a.effectiveEnvironment(opts.Environment, cfg)
 		var attachErr error
 		attachment, _, attachErr = a.attachNode(&current, workspaceRoot, environmentName, nodeName)
 		if attachErr != nil {

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -854,6 +854,7 @@ func TestSoloNodeCreateValidatesExistingSSHBeforeWritingState(t *testing.T) {
 func TestSoloNodeCreateProviderReportsMetadataAndProgress(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	cfg.Environments = map[string]config.EnvironmentOverlay{"staging": {}}
 	if _, err := config.Write(workspaceRoot, cfg); err != nil {
 		t.Fatal(err)
 	}
@@ -883,7 +884,7 @@ func TestSoloNodeCreateProviderReportsMetadataAndProgress(t *testing.T) {
 		},
 	}
 
-	err := app.SoloNodeCreate(context.Background(), SoloNodeCreateOptions{Name: "prod-1", Provider: "hetzner", Region: "ash", Size: "cpx11", Image: "  "})
+	err := app.SoloNodeCreate(context.Background(), SoloNodeCreateOptions{Name: "prod-1", Provider: "hetzner", Region: "ash", Size: "cpx11", Image: "  ", Attach: true, Environment: "staging"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -894,6 +895,24 @@ func TestSoloNodeCreateProviderReportsMetadataAndProgress(t *testing.T) {
 	}
 	if payload["provider"] != providerHetzner || payload["provider_server_id"] != "srv-1" || payload["provider_region"] != "ash" || payload["provider_size"] != "cpx11" || payload["provider_image"] != providers.DefaultHetznerImage {
 		t.Fatalf("payload = %#v, want provider metadata", payload)
+	}
+	if payload["attached"] != true || payload["environment"] != "staging" {
+		t.Fatalf("payload = %#v, want attached staging node", payload)
+	}
+	loaded, err := soloState.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stagingNodes, err := loaded.AttachedNodeNames(workspaceRoot, "staging")
+	if err != nil {
+		t.Fatal(err)
+	}
+	productionNodes, err := loaded.AttachedNodeNames(workspaceRoot, "production")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stagingNodes) != 1 || stagingNodes[0] != "prod-1" || len(productionNodes) != 0 {
+		t.Fatalf("attachments staging=%#v production=%#v, want prod-1 only in staging", stagingNodes, productionNodes)
 	}
 	if fakeProvider.createInput.Image != providers.DefaultHetznerImage {
 		t.Fatalf("CreateServer image = %q, want normalized default image", fakeProvider.createInput.Image)


### PR DESCRIPTION
## Summary
- add an explicit solo environment option for `node create`
- wire `node create --env` through both solo and shared option structs
- ensure provider-created solo nodes with `--attach --env staging` attach only the requested environment

## Stack
- Stacked on #132 (`codex/solo-loop-20260430`)

## Tests
- `cd cli && mise run test -- ./internal/workflow -run 'TestSoloNodeCreateProviderReportsMetadataAndProgress'`
- `mise run test:cli`
- `mise run release:cli:local`

## Notes
- CLI-only solo fix; no shared/control-plane behavior touched beyond preserving the shared flag wiring.
