### PR TITLE
[codex] Improve solo CLI operator guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ services:
 Then store the token as a project secret and deploy normally:
 
 ```bash
-devopsellence secret set CLOUDFLARE_TUNNEL_TOKEN --service cloudflared
+printf '%s' "$CLOUDFLARE_TUNNEL_TOKEN" | devopsellence secret set CLOUDFLARE_TUNNEL_TOKEN --service cloudflared --stdin
 devopsellence deploy
 ```
 

--- a/cli/internal/workflow/json_test.go
+++ b/cli/internal/workflow/json_test.go
@@ -25,6 +25,15 @@ func jsonArrayFromMap(t *testing.T, payload map[string]any, key string) []any {
 	return items
 }
 
+func jsonArrayContains(items []any, want string) bool {
+	for _, item := range items {
+		if item == want {
+			return true
+		}
+	}
+	return false
+}
+
 func jsonMapFromAny(t *testing.T, value any) map[string]any {
 	t.Helper()
 	item, ok := value.(map[string]any)

--- a/cli/internal/workflow/root.go
+++ b/cli/internal/workflow/root.go
@@ -667,9 +667,15 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 	releaseListCommand.Flags().IntVar(&releaseListOpts.Limit, "limit", 20, "Maximum releases to return (0 for full history)")
 	releaseListCommand.Flags().StringVar(&releaseListOpts.Environment, "env", os.Getenv("DEVOPSELLENCE_ENVIRONMENT"), "Environment name override (solo mode)")
 	releaseRollbackCommand := &cobra.Command{
-		Use:   "rollback [revision-or-release-id]",
+		Use:   "rollback [release-id|revision-prefix]",
 		Short: "Republish a previous release",
-		Args:  cobra.MaximumNArgs(1),
+		Long:  "Republish a previous solo release. The optional selector must be a release id or workload revision shown by `devopsellence release list`; git rev syntax such as HEAD~1 is not supported.",
+		Example: strings.Join([]string{
+			"  devopsellence release list --limit 5",
+			"  devopsellence release rollback rel_abc123_01K00000000000000000000000",
+			"  devopsellence release rollback abc1234",
+		}, "\n"),
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 {
 				releaseRollbackOpts.Selector = strings.TrimSpace(args[0])
@@ -749,11 +755,11 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 	secretSetCommand.Flags().StringVar(&secretServiceName, "service", "", "Service name (required)")
 	secretSetCommand.Flags().StringVar(&secretStore, "store", "", "Solo secret store: plaintext or 1password")
 	secretSetCommand.Flags().StringVar(&secretReference, "op-ref", "", "1Password secret reference for solo mode")
-	secretSetCommand.Flags().StringVar(&secretValue, "value", "", "Secret value")
+	secretSetCommand.Flags().StringVar(&secretValue, "value", "", "Secret value (prefer --stdin to avoid shell history)")
 	secretSetCommand.Flags().BoolVar(&secretValueStdin, "stdin", false, "Read secret value from stdin")
 	secretSetCommand.Example = strings.Join([]string{
-		"  devopsellence secret set SECRET_KEY_BASE --service web --value super-secret",
 		"  printf '%s' \"$VALUE\" | devopsellence secret set SECRET_KEY_BASE --service web --stdin",
+		"  devopsellence secret set SECRET_KEY_BASE --service web --value \"$VALUE\"",
 		"  devopsellence secret set DATABASE_URL --service web --env production --store 1password --op-ref op://app-prod/db/password",
 	}, "\n")
 	secretListCommand := &cobra.Command{
@@ -1051,6 +1057,9 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 		Short: "Run a command on a solo node over SSH",
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if cmd.ArgsLenAtDash() == 0 {
+				return ExitError{Code: 2, Err: errors.New("missing node before --: devopsellence node exec <node> -- <command>")}
+			}
 			nodeExecOpts.Node = args[0]
 			if len(args) < 2 {
 				return ExitError{Code: 2, Err: errors.New("missing command after --")}
@@ -1098,6 +1107,9 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 		Short: "Run a command in a workload service container",
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if cmd.ArgsLenAtDash() == 0 {
+				return ExitError{Code: 2, Err: errors.New("missing service before --: devopsellence exec <service> -- <command>")}
+			}
 			workloadExecOpts.ServiceName = args[0]
 			if len(args) < 2 {
 				return ExitError{Code: 2, Err: errors.New("missing command after --")}

--- a/cli/internal/workflow/root.go
+++ b/cli/internal/workflow/root.go
@@ -1140,7 +1140,11 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 	agentInstallCommand := &cobra.Command{
 		Use:   "install <name>",
 		Short: "Install the agent on a solo node",
-		Args:  cobra.ExactArgs(1),
+		Long: strings.Join([]string{
+			"Install the agent on a solo node over SSH.",
+			"This command writes newline-delimited JSON progress events followed by a final result event to stdout.",
+		}, "\n"),
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			agentInstallOpts.Node = args[0]
 			return runSoloOnly("agent install", func(ctx context.Context) error {

--- a/cli/internal/workflow/root_test.go
+++ b/cli/internal/workflow/root_test.go
@@ -606,6 +606,26 @@ func TestExecReturnsMissingCommandAfterSeparator(t *testing.T) {
 	}
 }
 
+func TestExecReturnsMissingServiceBeforeSeparator(t *testing.T) {
+	var stdout bytes.Buffer
+	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, rootTestSoloWorkspace(t))
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{"exec", "--", "printenv", "API_TOKEN"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() error = nil, want missing service")
+	}
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 2 {
+		t.Fatalf("error = %T %v, want ExitError code 2", err, err)
+	}
+	if !strings.Contains(err.Error(), "missing service before --") || !strings.Contains(err.Error(), "devopsellence exec <service> -- <command>") {
+		t.Fatalf("error = %v, want missing service syntax hint", err)
+	}
+}
+
 func TestNodeExecReturnsMissingCommandAfterSeparator(t *testing.T) {
 	var stdout bytes.Buffer
 	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, rootTestSoloWorkspace(t))
@@ -623,6 +643,67 @@ func TestNodeExecReturnsMissingCommandAfterSeparator(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "missing command after --") {
 		t.Fatalf("error = %v, want missing command after --", err)
+	}
+}
+
+func TestNodeExecReturnsMissingNodeBeforeSeparator(t *testing.T) {
+	var stdout bytes.Buffer
+	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, rootTestSoloWorkspace(t))
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{"node", "exec", "--", "uptime"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() error = nil, want missing node")
+	}
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 2 {
+		t.Fatalf("error = %T %v, want ExitError code 2", err, err)
+	}
+	if !strings.Contains(err.Error(), "missing node before --") || !strings.Contains(err.Error(), "devopsellence node exec <node> -- <command>") {
+		t.Fatalf("error = %v, want missing node syntax hint", err)
+	}
+}
+
+func TestSecretSetHelpPrefersStdinForValues(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, t.TempDir())
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{"secret", "set", "--help"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	output := stdout.String()
+	if !strings.Contains(output, "--stdin") || !strings.Contains(output, "prefer --stdin") {
+		t.Fatalf("help output = %q, want stdin guidance", output)
+	}
+	if strings.Contains(output, "--value super-secret") {
+		t.Fatalf("help output = %q, leaked unsafe literal example", output)
+	}
+}
+
+func TestReleaseRollbackHelpClarifiesSelectorSource(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, t.TempDir())
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{"release", "rollback", "--help"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	output := stdout.String()
+	for _, want := range []string{"release list", "release id", "workload revision", "HEAD~1 is not supported"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("help output = %q, want %q", output, want)
+		}
 	}
 }
 

--- a/cli/internal/workflow/root_test.go
+++ b/cli/internal/workflow/root_test.go
@@ -687,6 +687,24 @@ func TestSecretSetHelpPrefersStdinForValues(t *testing.T) {
 	}
 }
 
+func TestAgentInstallHelpDocumentsNDJSONProgress(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, t.TempDir())
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{"agent", "install", "--help"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	output := stdout.String()
+	if !strings.Contains(output, "newline-delimited JSON progress events") || !strings.Contains(output, "final result event") {
+		t.Fatalf("help output = %q, want NDJSON progress contract", output)
+	}
+}
+
 func TestReleaseRollbackHelpClarifiesSelectorSource(t *testing.T) {
 	t.Parallel()
 

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1877,7 +1877,6 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 	releaseRequired := workspaceRoot != "" && environmentName != "" && (len(opts.Nodes) == 0 || strings.TrimSpace(opts.Environment) != "")
 	localReleaseKnown := len(opts.Nodes) > 0 && !releaseRequired
 	expectedRevisions := map[string]string{}
-	expectedStatusCreatedAts := map[string]string{}
 	cohostedRevisions := map[string]map[string]bool{}
 	staleRevisions := map[string]map[string]bool{}
 	expectedRuntimeEnvironment := ""
@@ -1892,7 +1891,6 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 			if hasCurrent {
 				localReleaseKnown = true
 				expectedRevisions = soloExpectedStatusRevisions(current, currentRelease)
-				expectedStatusCreatedAts = soloExpectedStatusCreatedAts(current, currentRelease)
 				cohostedRevisions = soloCohostedStatusRevisions(current, currentRelease)
 				staleRevisions = soloStaleStatusRevisions(current, currentRelease, expectedRevisions)
 				expectedWorkloadRevision = strings.TrimSpace(currentRelease.Revision)
@@ -1952,17 +1950,6 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 			continue
 		}
 		expectedRevision := soloExpectedStatusRevision(expectedRevisions, name)
-		expectedStatusCreatedAt := soloExpectedStatusCreatedAt(expectedStatusCreatedAts, name)
-		if expectedRevision != "" && !soloStatusFreshForDeployment(result.Status, expectedStatusCreatedAt) {
-			allSettled = false
-			statusMismatches++
-			jsonResults = append(jsonResults, map[string]any{
-				"node":    name,
-				"status":  nil,
-				"message": fmt.Sprintf("remote agent status time %q predates current local deployment created_at %q; wait for rollout, rerun `devopsellence status%s`, and redeploy only if the remote status never advances", strings.TrimSpace(result.Status.Time), expectedStatusCreatedAt, soloEnvFlag(environmentName)),
-			})
-			continue
-		}
 		if expectedRevision != "" && !soloNodeStatusMatchesExpectedRelease(result.Status, expectedRevision, expectedRuntimeEnvironment, expectedWorkloadRevision, cohostedRevisions[name], staleRevisions[name]) {
 			allSettled = false
 			runtime := soloRuntimeEnvironmentStatus(result.Status, expectedRuntimeEnvironment, expectedWorkloadRevision)
@@ -2054,61 +2041,6 @@ func soloStatusMismatchMessage(status soloNodeStatus, expectedDesiredStateRevisi
 		}
 	}
 	return fmt.Sprintf("remote agent status revision %q does not match current local deployment %q; run `devopsellence deploy`", statusRevision, expectedDesiredStateRevision)
-}
-
-func soloExpectedStatusCreatedAts(current solo.State, release corerelease.Release) map[string]string {
-	expected := map[string]string{}
-	latestSequence := -1
-	var latest corerelease.Deployment
-	for _, deployment := range current.Deployments {
-		if deployment.EnvironmentID != release.EnvironmentID || deployment.ReleaseID != release.ID || deployment.PublicationResult == nil {
-			continue
-		}
-		if deployment.Sequence > latestSequence {
-			latestSequence = deployment.Sequence
-			latest = deployment
-		}
-	}
-	if latestSequence < 0 || strings.TrimSpace(latest.CreatedAt) == "" {
-		return expected
-	}
-	for _, result := range latest.PublicationResult.NodeResults {
-		nodeName := strings.TrimSpace(result.NodeName)
-		if nodeName == "" {
-			nodeName = strings.TrimSpace(result.NodeID)
-		}
-		if nodeName != "" {
-			expected[nodeName] = latest.CreatedAt
-		}
-	}
-	if len(expected) == 0 {
-		expected[""] = latest.CreatedAt
-	}
-	return expected
-}
-
-func soloExpectedStatusCreatedAt(expected map[string]string, nodeName string) string {
-	if createdAt := strings.TrimSpace(expected[nodeName]); createdAt != "" {
-		return createdAt
-	}
-	return strings.TrimSpace(expected[""])
-}
-
-func soloStatusFreshForDeployment(status soloNodeStatus, deploymentCreatedAt string) bool {
-	observed := strings.TrimSpace(status.Time)
-	deploymentCreatedAt = strings.TrimSpace(deploymentCreatedAt)
-	if observed == "" || deploymentCreatedAt == "" {
-		return true
-	}
-	observedTime, err := time.Parse(time.RFC3339Nano, observed)
-	if err != nil {
-		return false
-	}
-	createdTime, err := time.Parse(time.RFC3339Nano, deploymentCreatedAt)
-	if err != nil {
-		return true
-	}
-	return !observedTime.Before(createdTime)
 }
 
 func soloExpectedStatusRevisions(current solo.State, release corerelease.Release) map[string]string {
@@ -4444,13 +4376,23 @@ func (a *App) SoloNodeCreate(ctx context.Context, opts SoloNodeCreateOptions) er
 	if attached {
 		if soloAttachmentHasReleaseState(current, attachment) {
 			if _, err := a.republishNodes(ctx, current, attachment.NodeNames); err != nil {
-				rollbackState := cloneSoloState(current)
-				_, _, _ = rollbackState.DetachNode(workspaceRoot, attachment.Environment, nodeName)
+				remoteRollbackState := cloneSoloState(current)
+				_, _, _ = remoteRollbackState.DetachNode(workspaceRoot, attachment.Environment, nodeName)
+				_, rollbackRepublishErr := a.republishNodes(ctx, remoteRollbackState, attachment.NodeNames)
+
+				localRollbackState := cloneSoloState(remoteRollbackState)
 				if hasHost {
-					rollbackState.RemoveNode(nodeName)
+					localRollbackState.RemoveNode(nodeName)
 				}
-				if rollbackErr := a.writeSoloState(rollbackState); rollbackErr != nil {
-					return errors.Join(err, fmt.Errorf("rollback failed node create state: %w", rollbackErr))
+				if rollbackErr := a.writeSoloState(localRollbackState); rollbackErr != nil {
+					rollbackErrs := []error{err, fmt.Errorf("rollback failed node create state: %w", rollbackErr)}
+					if rollbackRepublishErr != nil {
+						rollbackErrs = append(rollbackErrs, fmt.Errorf("rollback failed remote desired state: %w", rollbackRepublishErr))
+					}
+					return errors.Join(rollbackErrs...)
+				}
+				if rollbackRepublishErr != nil {
+					return errors.Join(err, fmt.Errorf("rollback failed remote desired state: %w", rollbackRepublishErr))
 				}
 				return err
 			}

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -450,7 +450,7 @@ func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 				"publish":     false,
 				"state_write": false,
 			},
-			"next_steps": []string{"devopsellence deploy"},
+			"next_steps": []string{"devopsellence deploy" + soloEnvFlag(environmentName)},
 		}
 		if urls := soloStatusPublicURLs(cfg, nodes); len(urls) > 0 {
 			payload["configured_public_urls"] = urls
@@ -459,13 +459,13 @@ func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 			}
 			if len(soloReadyPublicURLs(cfg, nodes)) == 0 {
 				payload["public_url_status"] = soloPublicURLStatus(cfg)
-				payload["warnings"] = []string{soloPublicURLWarning(cfg)}
+				payload["warnings"] = []string{soloPublicURLWarning(cfg, environmentName)}
 			}
 		}
 		return stream.Result(payload)
 	}
 
-	if err := a.checkIngressBeforeDeploy(ctx, cfg, nodes, opts.SkipDNSCheck); err != nil {
+	if err := a.checkIngressBeforeDeploy(ctx, cfg, nodes, opts.SkipDNSCheck, environmentName); err != nil {
 		return err
 	}
 
@@ -585,14 +585,14 @@ func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 	}
 	if urls := a.soloVerifiedPublicURLs(workspaceRoot, environmentName, cfg, nodes); len(urls) > 0 {
 		payload["public_urls"] = urls
-		payload["next_steps"] = append([]string{"devopsellence status", "curl " + urls[0]}, soloNodeLogNextSteps(nodes)...)
+		payload["next_steps"] = append([]string{"devopsellence status" + soloEnvFlag(environmentName), "curl " + urls[0]}, soloNodeLogNextSteps(environmentName, nodes)...)
 	} else if urls := soloStatusPublicURLs(cfg, nodes); len(urls) > 0 {
 		payload["configured_public_urls"] = urls
 		payload["public_url_status"] = soloPublicURLStatus(cfg)
-		payload["warnings"] = []string{soloPublicURLWarning(cfg)}
-		payload["next_steps"] = append([]string{"devopsellence status"}, soloNodeLogNextSteps(nodes)...)
+		payload["warnings"] = []string{soloPublicURLWarning(cfg, environmentName)}
+		payload["next_steps"] = append([]string{"devopsellence status" + soloEnvFlag(environmentName)}, soloNodeLogNextSteps(environmentName, nodes)...)
 	} else {
-		payload["next_steps"] = append([]string{"devopsellence status"}, soloNodeLogNextSteps(nodes)...)
+		payload["next_steps"] = append([]string{"devopsellence status" + soloEnvFlag(environmentName)}, soloNodeLogNextSteps(environmentName, nodes)...)
 	}
 	return stream.Result(payload)
 
@@ -1739,10 +1739,11 @@ func (a *App) soloProgress(operation string, fields map[string]any) func(string)
 	}
 }
 
-func soloNodeLogNextSteps(nodes map[string]config.Node) []string {
+func soloNodeLogNextSteps(environment string, nodes map[string]config.Node) []string {
+	envFlag := soloEnvFlag(environment)
 	steps := []string{}
 	for _, nodeName := range sortedNodeNames(nodes) {
-		steps = append(steps, "devopsellence logs --node "+shellQuote(nodeName)+" --lines 100")
+		steps = append(steps, "devopsellence logs"+envFlag+" --node "+shellQuote(nodeName)+" --lines 100")
 		steps = append(steps, "devopsellence node logs "+shellQuote(nodeName)+" --lines 100")
 	}
 	return steps
@@ -1876,6 +1877,7 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 	releaseRequired := workspaceRoot != "" && environmentName != "" && (len(opts.Nodes) == 0 || strings.TrimSpace(opts.Environment) != "")
 	localReleaseKnown := len(opts.Nodes) > 0 && !releaseRequired
 	expectedRevisions := map[string]string{}
+	expectedStatusCreatedAts := map[string]string{}
 	cohostedRevisions := map[string]map[string]bool{}
 	staleRevisions := map[string]map[string]bool{}
 	expectedRuntimeEnvironment := ""
@@ -1890,6 +1892,7 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 			if hasCurrent {
 				localReleaseKnown = true
 				expectedRevisions = soloExpectedStatusRevisions(current, currentRelease)
+				expectedStatusCreatedAts = soloExpectedStatusCreatedAts(current, currentRelease)
 				cohostedRevisions = soloCohostedStatusRevisions(current, currentRelease)
 				staleRevisions = soloStaleStatusRevisions(current, currentRelease, expectedRevisions)
 				expectedWorkloadRevision = strings.TrimSpace(currentRelease.Revision)
@@ -1903,6 +1906,8 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 	var jsonResults []map[string]any
 	readErrors := 0
 	statusErrors := 0
+	statusMismatches := 0
+	missingStatuses := 0
 	allSettled := true
 
 	for name, node := range nodes {
@@ -1922,6 +1927,10 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 		if result.Missing {
 			allSettled = false
 			message := "no deploy status yet; run `devopsellence deploy`"
+			if localReleaseKnown {
+				missingStatuses++
+				message = "remote agent has no status for the current local deployment yet; wait for rollout, rerun `devopsellence status" + soloEnvFlag(environmentName) + "`, and redeploy only if the remote status never appears"
+			}
 
 			jsonResults = append(jsonResults, map[string]any{
 				"node":    name,
@@ -1934,6 +1943,7 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 
 		if !localReleaseKnown {
 			allSettled = false
+			statusMismatches++
 			jsonResults = append(jsonResults, map[string]any{
 				"node":    name,
 				"status":  nil,
@@ -1942,16 +1952,29 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 			continue
 		}
 		expectedRevision := soloExpectedStatusRevision(expectedRevisions, name)
+		expectedStatusCreatedAt := soloExpectedStatusCreatedAt(expectedStatusCreatedAts, name)
+		if expectedRevision != "" && !soloStatusFreshForDeployment(result.Status, expectedStatusCreatedAt) {
+			allSettled = false
+			statusMismatches++
+			jsonResults = append(jsonResults, map[string]any{
+				"node":    name,
+				"status":  nil,
+				"message": fmt.Sprintf("remote agent status time %q predates current local deployment created_at %q; wait for rollout, rerun `devopsellence status%s`, and redeploy only if the remote status never advances", strings.TrimSpace(result.Status.Time), expectedStatusCreatedAt, soloEnvFlag(environmentName)),
+			})
+			continue
+		}
 		if expectedRevision != "" && !soloNodeStatusMatchesExpectedRelease(result.Status, expectedRevision, expectedRuntimeEnvironment, expectedWorkloadRevision, cohostedRevisions[name], staleRevisions[name]) {
 			allSettled = false
-			message := fmt.Sprintf("remote agent status revision %q does not match current local deployment %q; run `devopsellence deploy`", strings.TrimSpace(result.Status.Revision), expectedRevision)
 			runtime := soloRuntimeEnvironmentStatus(result.Status, expectedRuntimeEnvironment, expectedWorkloadRevision)
+			message := soloStatusMismatchMessage(result.Status, expectedRevision, runtime, expectedRuntimeEnvironment, expectedWorkloadRevision, environmentName)
 			if runtime.State == "error" {
 				statusErrors++
 				message = runtime.Message
 			} else if strings.TrimSpace(result.Status.Phase) == "error" {
 				statusErrors++
 				message = firstNonEmpty(strings.TrimSpace(result.Status.Error), "node reported phase=error")
+			} else {
+				statusMismatches++
 			}
 			jsonResults = append(jsonResults, map[string]any{
 				"node":    name,
@@ -1987,12 +2010,12 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 			payload["public_urls"] = verifiedPublicURLs
 		} else {
 			payload["configured_public_urls"] = verifiedPublicURLs
-			payload["warnings"] = []string{"public URLs are configured, but one or more nodes are not settled; check node status before testing reachability"}
+			payload["warnings"] = []string{"public URLs are configured, but one or more nodes are not settled; check `devopsellence status" + soloEnvFlag(environmentName) + "` before testing reachability"}
 		}
 	} else if urls := soloStatusPublicURLs(cfg, nodes); len(urls) > 0 {
 		payload["configured_public_urls"] = urls
 		payload["public_url_status"] = soloPublicURLStatus(cfg)
-		payload["warnings"] = []string{soloPublicURLWarning(cfg)}
+		payload["warnings"] = []string{soloPublicURLWarning(cfg, environmentName)}
 	}
 	if err := a.Printer.PrintJSON(payload); err != nil {
 		return err
@@ -2003,7 +2026,89 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 	if statusErrors > 0 {
 		return ExitError{Code: 1, Err: RenderedError{Err: fmt.Errorf("status reported unhealthy runtime environment on %d node(s)", statusErrors)}}
 	}
+	if statusMismatches > 0 {
+		return ExitError{Code: 1, Err: RenderedError{Err: fmt.Errorf("status did not match the current local deployment on %d node(s)", statusMismatches)}}
+	}
+	if missingStatuses > 0 {
+		return ExitError{Code: 1, Err: RenderedError{Err: fmt.Errorf("status missing for current local deployment on %d node(s)", missingStatuses)}}
+	}
 	return nil
+}
+
+func soloStatusMismatchMessage(status soloNodeStatus, expectedDesiredStateRevision string, runtime soloRuntimeStatusResult, expectedRuntimeEnvironment, expectedWorkloadRevision, logicalEnvironment string) string {
+	statusRevision := strings.TrimSpace(status.Revision)
+	if statusRevision == strings.TrimSpace(expectedDesiredStateRevision) && runtime.State != "" && runtime.State != "settled" {
+		statusCommand := "devopsellence status" + soloEnvFlag(logicalEnvironment)
+		runtimeEnvironment := firstNonEmpty(expectedRuntimeEnvironment, "expected runtime environment")
+		switch runtime.State {
+		case "pending":
+			if revision, ok := strings.CutPrefix(runtime.Detail, "runtime_env_revision:"); ok {
+				return fmt.Sprintf("remote runtime environment %q revision %q does not match current workload revision %q; wait for rollout, rerun `%s`, and redeploy only if the remote runtime never advances", runtimeEnvironment, revision, expectedWorkloadRevision, statusCommand)
+			}
+			if runtime.Detail == "runtime_env:missing" {
+				return fmt.Sprintf("remote runtime environment %q is missing from status; wait for rollout, rerun `%s`, and redeploy only if the remote runtime never appears", runtimeEnvironment, statusCommand)
+			}
+		case "reconciling":
+			detail := firstNonEmpty(runtime.Detail, "reconciling")
+			return fmt.Sprintf("remote runtime environment %q is still reconciling (%s); wait for rollout and rerun `%s`", runtimeEnvironment, detail, statusCommand)
+		}
+	}
+	return fmt.Sprintf("remote agent status revision %q does not match current local deployment %q; run `devopsellence deploy`", statusRevision, expectedDesiredStateRevision)
+}
+
+func soloExpectedStatusCreatedAts(current solo.State, release corerelease.Release) map[string]string {
+	expected := map[string]string{}
+	latestSequence := -1
+	var latest corerelease.Deployment
+	for _, deployment := range current.Deployments {
+		if deployment.EnvironmentID != release.EnvironmentID || deployment.ReleaseID != release.ID || deployment.PublicationResult == nil {
+			continue
+		}
+		if deployment.Sequence > latestSequence {
+			latestSequence = deployment.Sequence
+			latest = deployment
+		}
+	}
+	if latestSequence < 0 || strings.TrimSpace(latest.CreatedAt) == "" {
+		return expected
+	}
+	for _, result := range latest.PublicationResult.NodeResults {
+		nodeName := strings.TrimSpace(result.NodeName)
+		if nodeName == "" {
+			nodeName = strings.TrimSpace(result.NodeID)
+		}
+		if nodeName != "" {
+			expected[nodeName] = latest.CreatedAt
+		}
+	}
+	if len(expected) == 0 {
+		expected[""] = latest.CreatedAt
+	}
+	return expected
+}
+
+func soloExpectedStatusCreatedAt(expected map[string]string, nodeName string) string {
+	if createdAt := strings.TrimSpace(expected[nodeName]); createdAt != "" {
+		return createdAt
+	}
+	return strings.TrimSpace(expected[""])
+}
+
+func soloStatusFreshForDeployment(status soloNodeStatus, deploymentCreatedAt string) bool {
+	observed := strings.TrimSpace(status.Time)
+	deploymentCreatedAt = strings.TrimSpace(deploymentCreatedAt)
+	if observed == "" || deploymentCreatedAt == "" {
+		return true
+	}
+	observedTime, err := time.Parse(time.RFC3339Nano, observed)
+	if err != nil {
+		return false
+	}
+	createdTime, err := time.Parse(time.RFC3339Nano, deploymentCreatedAt)
+	if err != nil {
+		return true
+	}
+	return !observedTime.Before(createdTime)
 }
 
 func soloExpectedStatusRevisions(current solo.State, release corerelease.Release) map[string]string {
@@ -2144,6 +2249,9 @@ func soloExpectedStatusRevision(expected map[string]string, nodeName string) str
 }
 
 func (a *App) SoloReleaseList(ctx context.Context, opts SoloReleaseListOptions) error {
+	if opts.Limit < 0 {
+		return ExitError{Code: 2, Err: fmt.Errorf("--limit must be 0 or greater")}
+	}
 	_, workspaceRoot, environmentName, err := a.loadResolvedSoloProjectConfig(opts.Environment)
 	if err != nil {
 		return err
@@ -2227,7 +2335,11 @@ func (a *App) SoloReleaseRollback(ctx context.Context, opts SoloReleaseRollbackO
 	}
 	selected, err := corerelease.SelectRollbackRelease(releases, currentRelease.ID, opts.Selector)
 	if err != nil {
-		return err
+		message := fmt.Errorf("%w; run `devopsellence release list%s --limit 5` and pass a release id or revision shown there", err, soloEnvFlag(environmentName))
+		if strings.TrimSpace(opts.Selector) != "" {
+			return ExitError{Code: 2, Err: message}
+		}
+		return message
 	}
 	rollbackTargetNodeNames, err := soloRollbackTargetNodeNames(attachedNodeNames, selected)
 	if err != nil {
@@ -2422,11 +2534,12 @@ func soloPublicURLStatus(cfg *config.ProjectConfig) string {
 	return "configured_pending"
 }
 
-func soloPublicURLWarning(cfg *config.ProjectConfig) string {
+func soloPublicURLWarning(cfg *config.ProjectConfig, environment ...string) string {
+	statusCommand := "devopsellence status" + soloEnvFlag(firstNonEmpty(environment...))
 	if ingressRequiresTLSReadiness(cfg) {
-		return "HTTPS public URLs are configured, but TLS reachability has not been verified yet; use `devopsellence status` and curl the HTTPS endpoint before treating it as reachable"
+		return "HTTPS public URLs are configured, but TLS reachability has not been verified yet; use `" + statusCommand + "` and curl the HTTPS endpoint before treating it as reachable"
 	}
-	return "public URLs are configured, but one or more nodes are not settled; check node status before testing reachability"
+	return "public URLs are configured, but one or more nodes are not settled; check `" + statusCommand + "` before testing reachability"
 }
 
 func ingressURLScheme(cfg *config.ProjectConfig) string {
@@ -3090,9 +3203,6 @@ func (a *App) SoloLogs(ctx context.Context, opts SoloLogsOptions) error {
 
 func (a *App) SoloWorkloadLogs(ctx context.Context, opts SoloWorkloadLogsOptions) error {
 	serviceName := strings.TrimSpace(opts.ServiceName)
-	if serviceName == "" {
-		serviceName = "web"
-	}
 	linesLimit := opts.Lines
 	if linesLimit < 1 || linesLimit > soloLogsMaxLines {
 		return ExitError{Code: 2, Err: fmt.Errorf("--lines must be between 1 and %d", soloLogsMaxLines)}
@@ -3106,6 +3216,9 @@ func (a *App) SoloWorkloadLogs(ctx context.Context, opts SoloWorkloadLogsOptions
 	}
 	if cfg == nil {
 		return fmt.Errorf("no workspace selected; attach a workspace or run this command from a workspace")
+	}
+	if serviceName == "" {
+		serviceName = primaryWebServiceName(*cfg)
 	}
 	if _, ok := cfg.Services[serviceName]; !ok {
 		return ExitError{Code: 2, Err: fmt.Errorf("service %q not found in devopsellence.yml", serviceName)}
@@ -3618,12 +3731,43 @@ func (a *App) SoloNodeDiagnose(ctx context.Context, opts SoloNodeDiagnoseOptions
 			payload["status"] = string(statusResult.Raw)
 		}
 	}
-	payload["next_steps"] = []string{
-		"devopsellence status",
-		"devopsellence logs --node " + shellQuote(opts.Node) + " --lines 100",
-		"devopsellence node logs " + shellQuote(opts.Node) + " --lines 100",
-	}
+	payload["next_steps"] = a.soloNodeDiagnoseNextSteps(current, opts.Node)
 	return a.printSoloDiagnoseResult(payload, diagnoseOK)
+}
+
+func (a *App) soloNodeDiagnoseNextSteps(current solo.State, nodeName string) []string {
+	environments := []string{}
+	if discovered, err := discovery.Discover(a.Cwd); err == nil {
+		for _, attachment := range current.AttachmentsForNode(nodeName) {
+			if strings.TrimSpace(attachment.WorkspaceKey) == discovered.WorkspaceRoot {
+				environments = append(environments, attachment.Environment)
+			}
+		}
+	}
+	if len(environments) == 0 {
+		for _, attachment := range current.AttachmentsForNode(nodeName) {
+			environments = append(environments, attachment.Environment)
+		}
+	}
+	environments = normalizeSoloNames(environments)
+
+	steps := []string{}
+	if len(environments) == 0 {
+		steps = append(steps,
+			"devopsellence status",
+			"devopsellence logs --node "+shellQuote(nodeName)+" --lines 100",
+		)
+	} else {
+		for _, environment := range environments {
+			envFlag := soloEnvFlag(environment)
+			steps = append(steps,
+				"devopsellence status"+envFlag,
+				"devopsellence logs"+envFlag+" --node "+shellQuote(nodeName)+" --lines 100",
+			)
+		}
+	}
+	steps = append(steps, "devopsellence node logs "+shellQuote(nodeName)+" --lines 100")
+	return steps
 }
 
 func diagnosticSectionsOK(sections ...map[string]any) bool {
@@ -4300,6 +4444,14 @@ func (a *App) SoloNodeCreate(ctx context.Context, opts SoloNodeCreateOptions) er
 	if attached {
 		if soloAttachmentHasReleaseState(current, attachment) {
 			if _, err := a.republishNodes(ctx, current, attachment.NodeNames); err != nil {
+				rollbackState := cloneSoloState(current)
+				_, _, _ = rollbackState.DetachNode(workspaceRoot, attachment.Environment, nodeName)
+				if hasHost {
+					rollbackState.RemoveNode(nodeName)
+				}
+				if rollbackErr := a.writeSoloState(rollbackState); rollbackErr != nil {
+					return errors.Join(err, fmt.Errorf("rollback failed node create state: %w", rollbackErr))
+				}
 				return err
 			}
 		}
@@ -4608,18 +4760,11 @@ func (a *App) SoloSupportBundle(_ context.Context, opts SoloSupportBundleOptions
 			"root": discovered.WorkspaceRoot,
 			"slug": discovered.ProjectSlug,
 		},
-		"environment":    environmentName,
-		"config":         redactProjectConfigForSupport(cfg),
-		"solo_state":     redactSoloStateForSupport(current),
-		"attached_nodes": attachedNodes,
-		"recommended_commands": []string{
-			"devopsellence doctor",
-			"devopsellence status",
-			"devopsellence release list",
-			"devopsellence node list --all",
-			"devopsellence node diagnose <node>",
-			"devopsellence node logs <node> --lines 200",
-		},
+		"environment":          environmentName,
+		"config":               redactProjectConfigForSupport(cfg),
+		"solo_state":           redactSoloStateForSupport(current),
+		"attached_nodes":       attachedNodes,
+		"recommended_commands": soloSupportBundleRecommendedCommands(environmentName),
 	}
 	outputPath := strings.TrimSpace(opts.Output)
 	if outputPath == "" {
@@ -4645,6 +4790,19 @@ func (a *App) SoloSupportBundle(_ context.Context, opts SoloSupportBundleOptions
 			"Run devopsellence node diagnose <node> for live remote runtime details.",
 		},
 	})
+}
+
+func soloSupportBundleRecommendedCommands(environment string) []string {
+	envFlag := soloEnvFlag(environment)
+	return []string{
+		"devopsellence doctor",
+		"devopsellence status" + envFlag,
+		"devopsellence release list" + envFlag,
+		"devopsellence logs" + envFlag + " --lines 100",
+		"devopsellence node list --all",
+		"devopsellence node diagnose <node>",
+		"devopsellence node logs <node> --lines 200",
+	}
 }
 
 func redactSoloStateForSupport(current solo.State) solo.State {
@@ -5222,7 +5380,7 @@ func (a *App) IngressCheck(ctx context.Context, opts IngressCheckOptions) error 
 	}
 	deadline := time.Now().Add(opts.Wait)
 	for {
-		report, err := ingressDNSReport(ctx, cfg, nodes)
+		report, err := ingressDNSReport(ctx, cfg, nodes, environmentName)
 		if err != nil {
 			return err
 		}
@@ -5770,11 +5928,11 @@ func (e ingressDNSReadinessError) ErrorFields() map[string]any {
 
 const soloStatusMissingSentinel = "__DEVOPSELLENCE_STATUS_MISSING__"
 
-func (a *App) checkIngressBeforeDeploy(ctx context.Context, cfg *config.ProjectConfig, nodes map[string]config.Node, skip bool) error {
+func (a *App) checkIngressBeforeDeploy(ctx context.Context, cfg *config.ProjectConfig, nodes map[string]config.Node, skip bool, environment ...string) error {
 	if skip || !ingressRequiresDNSPreflight(cfg) {
 		return nil
 	}
-	report, err := ingressDNSReport(ctx, cfg, nodes)
+	report, err := ingressDNSReport(ctx, cfg, nodes, firstNonEmpty(environment...))
 	if err != nil {
 		return err
 	}
@@ -5802,15 +5960,18 @@ func ingressDNSReportError(report ingressDNSReportResult) error {
 	return fmt.Errorf("ingress DNS is not ready")
 }
 
-func ingressDNSReport(ctx context.Context, cfg *config.ProjectConfig, selected map[string]config.Node) (ingressDNSReportResult, error) {
+func ingressDNSReport(ctx context.Context, cfg *config.ProjectConfig, selected map[string]config.Node, environment ...string) (ingressDNSReportResult, error) {
 	hosts := concreteIngressHosts(cfg)
 	expected := webNodeIPs(cfg, selected)
 	if len(expected) == 0 {
 		return ingressDNSReportResult{}, fmt.Errorf("no web nodes configured")
 	}
+	environmentName := firstNonEmpty(environment...)
+	envFlag := soloEnvFlag(environmentName)
 	report := ingressDNSReportResult{
 		SchemaVersion: outputSchemaVersion,
 		OK:            true,
+		Environment:   strings.TrimSpace(environmentName),
 		CheckScope:    "dns",
 		TLSVerified:   false,
 		PublicURLs:    ingressConfiguredPublicURLs(cfg),
@@ -5819,8 +5980,8 @@ func ingressDNSReport(ctx context.Context, cfg *config.ProjectConfig, selected m
 	}
 	if len(hosts) == 0 {
 		report.OK = false
-		report.Hints = temporaryDNSHints(cfg, expected)
-		report.NextSteps = []string{"devopsellence status", "devopsellence ingress set --host <hostname> --service <service>", "devopsellence ingress check --wait 5m"}
+		report.Hints = temporaryDNSHints(cfg, expected, environmentName)
+		report.NextSteps = []string{"devopsellence status" + envFlag, "devopsellence ingress set" + envFlag + " --host <hostname> --service <service>", "devopsellence ingress check" + envFlag + " --wait 5m"}
 		return report, nil
 	}
 	for _, host := range hosts {
@@ -5839,9 +6000,9 @@ func ingressDNSReport(ctx context.Context, cfg *config.ProjectConfig, selected m
 	}
 	if len(report.PublicURLs) > 0 {
 		if report.OK {
-			report.NextSteps = []string{"devopsellence status", "curl " + report.PublicURLs[0]}
+			report.NextSteps = []string{"devopsellence status" + envFlag, "curl " + report.PublicURLs[0]}
 		} else {
-			report.NextSteps = []string{"devopsellence status", "update DNS records to point at expected_ips", "devopsellence ingress check --wait 5m"}
+			report.NextSteps = []string{"devopsellence status" + envFlag, "update DNS records to point at expected_ips", "devopsellence ingress check" + envFlag + " --wait 5m"}
 		}
 	}
 	return report, nil
@@ -5869,10 +6030,11 @@ func webNodeIPs(cfg *config.ProjectConfig, selected map[string]config.Node) []st
 	return ips
 }
 
-func temporaryDNSHints(cfg *config.ProjectConfig, expectedIPs []string) []ingressHint {
+func temporaryDNSHints(cfg *config.ProjectConfig, expectedIPs []string, environment ...string) []ingressHint {
 	if len(expectedIPs) != 1 {
 		return nil
 	}
+	environmentName := firstNonEmpty(environment...)
 	hints := []ingressHint{}
 	for _, ip := range expectedIPs {
 		if !isTemporaryDNSIPv4(ip) {
@@ -5887,7 +6049,7 @@ func temporaryDNSHints(cfg *config.ProjectConfig, expectedIPs []string) []ingres
 				Kind:     "use_temporary_dns_hostname",
 				Provider: "sslip.io",
 				Hostname: hostname,
-				Command:  temporaryDNSCommand(cfg, hostname),
+				Command:  temporaryDNSCommand(cfg, hostname, environmentName),
 				Risks: []string{
 					"third_party_dns_dependency",
 					"breaks_if_public_ip_changes",
@@ -5903,8 +6065,8 @@ func temporaryDNSHostname(_ *config.ProjectConfig, ip string) string {
 	return strings.TrimSpace(ip) + ".sslip.io"
 }
 
-func temporaryDNSCommand(cfg *config.ProjectConfig, hostname string) string {
-	return "devopsellence ingress set --host " + shellQuote(hostname) + " --tls-mode " + shellQuote(temporaryDNSTLSMode(cfg))
+func temporaryDNSCommand(cfg *config.ProjectConfig, hostname string, environment ...string) string {
+	return "devopsellence ingress set" + soloEnvFlag(firstNonEmpty(environment...)) + " --host " + shellQuote(hostname) + " --tls-mode " + shellQuote(temporaryDNSTLSMode(cfg))
 }
 
 func temporaryDNSTLSMode(cfg *config.ProjectConfig) string {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -375,12 +375,12 @@ func expandSoloSSHKeyPath(path string) (string, error) {
 		return "", nil
 	}
 	if path == "~" {
-		return "", fmt.Errorf("ssh key path %q must reference a private key file, not the home directory", path)
+		return "", ExitError{Code: 2, Err: fmt.Errorf("ssh key path %q must reference a private key file, not the home directory", path)}
 	}
 	if strings.HasPrefix(path, "~/") {
 		home, err := os.UserHomeDir()
 		if err != nil {
-			return "", fmt.Errorf("expand ssh key path: %w", err)
+			return "", ExitError{Code: 2, Err: fmt.Errorf("expand ssh key path: %w", err)}
 		}
 		path = filepath.Join(home, strings.TrimPrefix(path, "~/"))
 	}
@@ -388,12 +388,12 @@ func expandSoloSSHKeyPath(path string) (string, error) {
 	info, err := os.Stat(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return "", fmt.Errorf("ssh key path %q does not exist", path)
+			return "", ExitError{Code: 2, Err: fmt.Errorf("ssh key path %q does not exist", path)}
 		}
-		return "", fmt.Errorf("stat ssh key path %q: %w", path, err)
+		return "", ExitError{Code: 2, Err: fmt.Errorf("stat ssh key path %q: %w", path, err)}
 	}
 	if info.IsDir() {
-		return "", fmt.Errorf("ssh key path %q must be a file, not a directory", path)
+		return "", ExitError{Code: 2, Err: fmt.Errorf("ssh key path %q must be a file, not a directory", path)}
 	}
 	return path, nil
 }
@@ -4591,7 +4591,7 @@ func sshInteractiveError(prefix string, err error, stdout string, stderr string)
 
 func (a *App) SoloNodeRemove(ctx context.Context, opts SoloNodeRemoveOptions) error {
 	if !opts.Yes {
-		return fmt.Errorf("node remove requires --yes")
+		return ExitError{Code: 2, Err: errors.New("node remove requires --yes; rerun with --yes to confirm local/provider cleanup")}
 	}
 	current, err := a.readSoloState()
 	if err != nil {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1877,7 +1877,6 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 	releaseRequired := workspaceRoot != "" && environmentName != "" && (len(opts.Nodes) == 0 || strings.TrimSpace(opts.Environment) != "")
 	localReleaseKnown := len(opts.Nodes) > 0 && !releaseRequired
 	expectedRevisions := map[string]string{}
-	expectedStatusCreatedAts := map[string]string{}
 	cohostedRevisions := map[string]map[string]bool{}
 	staleRevisions := map[string]map[string]bool{}
 	expectedRuntimeEnvironment := ""
@@ -1892,7 +1891,6 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 			if hasCurrent {
 				localReleaseKnown = true
 				expectedRevisions = soloExpectedStatusRevisions(current, currentRelease)
-				expectedStatusCreatedAts = soloExpectedStatusCreatedAts(current, currentRelease)
 				cohostedRevisions = soloCohostedStatusRevisions(current, currentRelease)
 				staleRevisions = soloStaleStatusRevisions(current, currentRelease, expectedRevisions)
 				expectedWorkloadRevision = strings.TrimSpace(currentRelease.Revision)
@@ -1952,17 +1950,6 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 			continue
 		}
 		expectedRevision := soloExpectedStatusRevision(expectedRevisions, name)
-		expectedStatusCreatedAt := soloExpectedStatusCreatedAt(expectedStatusCreatedAts, name)
-		if expectedRevision != "" && !soloStatusFreshForDeployment(result.Status, expectedStatusCreatedAt) {
-			allSettled = false
-			statusMismatches++
-			jsonResults = append(jsonResults, map[string]any{
-				"node":    name,
-				"status":  nil,
-				"message": fmt.Sprintf("remote agent status time %q predates current local deployment created_at %q; wait for rollout, rerun `devopsellence status%s`, and redeploy only if the remote status never advances", strings.TrimSpace(result.Status.Time), expectedStatusCreatedAt, soloEnvFlag(environmentName)),
-			})
-			continue
-		}
 		if expectedRevision != "" && !soloNodeStatusMatchesExpectedRelease(result.Status, expectedRevision, expectedRuntimeEnvironment, expectedWorkloadRevision, cohostedRevisions[name], staleRevisions[name]) {
 			allSettled = false
 			runtime := soloRuntimeEnvironmentStatus(result.Status, expectedRuntimeEnvironment, expectedWorkloadRevision)
@@ -2054,61 +2041,6 @@ func soloStatusMismatchMessage(status soloNodeStatus, expectedDesiredStateRevisi
 		}
 	}
 	return fmt.Sprintf("remote agent status revision %q does not match current local deployment %q; run `devopsellence deploy`", statusRevision, expectedDesiredStateRevision)
-}
-
-func soloExpectedStatusCreatedAts(current solo.State, release corerelease.Release) map[string]string {
-	expected := map[string]string{}
-	latestSequence := -1
-	var latest corerelease.Deployment
-	for _, deployment := range current.Deployments {
-		if deployment.EnvironmentID != release.EnvironmentID || deployment.ReleaseID != release.ID || deployment.PublicationResult == nil {
-			continue
-		}
-		if deployment.Sequence > latestSequence {
-			latestSequence = deployment.Sequence
-			latest = deployment
-		}
-	}
-	if latestSequence < 0 || strings.TrimSpace(latest.CreatedAt) == "" {
-		return expected
-	}
-	for _, result := range latest.PublicationResult.NodeResults {
-		nodeName := strings.TrimSpace(result.NodeName)
-		if nodeName == "" {
-			nodeName = strings.TrimSpace(result.NodeID)
-		}
-		if nodeName != "" {
-			expected[nodeName] = latest.CreatedAt
-		}
-	}
-	if len(expected) == 0 {
-		expected[""] = latest.CreatedAt
-	}
-	return expected
-}
-
-func soloExpectedStatusCreatedAt(expected map[string]string, nodeName string) string {
-	if createdAt := strings.TrimSpace(expected[nodeName]); createdAt != "" {
-		return createdAt
-	}
-	return strings.TrimSpace(expected[""])
-}
-
-func soloStatusFreshForDeployment(status soloNodeStatus, deploymentCreatedAt string) bool {
-	observed := strings.TrimSpace(status.Time)
-	deploymentCreatedAt = strings.TrimSpace(deploymentCreatedAt)
-	if observed == "" || deploymentCreatedAt == "" {
-		return true
-	}
-	observedTime, err := time.Parse(time.RFC3339Nano, observed)
-	if err != nil {
-		return false
-	}
-	createdTime, err := time.Parse(time.RFC3339Nano, deploymentCreatedAt)
-	if err != nil {
-		return true
-	}
-	return !observedTime.Before(createdTime)
 }
 
 func soloExpectedStatusRevisions(current solo.State, release corerelease.Release) map[string]string {
@@ -4415,6 +4347,7 @@ func (a *App) SoloNodeCreate(ctx context.Context, opts SoloNodeCreateOptions) er
 	if err := current.SetNode(nodeName, node); err != nil {
 		return err
 	}
+	remoteRollbackState := cloneSoloState(current)
 	attached := false
 	var attachment solo.AttachmentRecord
 	if opts.Attach {
@@ -4444,15 +4377,20 @@ func (a *App) SoloNodeCreate(ctx context.Context, opts SoloNodeCreateOptions) er
 	if attached {
 		if soloAttachmentHasReleaseState(current, attachment) {
 			if _, err := a.republishNodes(ctx, current, attachment.NodeNames); err != nil {
+				rollbackTargets := append([]string(nil), attachment.NodeNames...)
+				var rollbackErr error
+				if _, republishErr := a.republishNodes(ctx, remoteRollbackState, rollbackTargets); republishErr != nil {
+					rollbackErr = fmt.Errorf("rollback failed republishing previous desired state: %w", republishErr)
+				}
 				rollbackState := cloneSoloState(current)
 				_, _, _ = rollbackState.DetachNode(workspaceRoot, attachment.Environment, nodeName)
 				if hasHost {
 					rollbackState.RemoveNode(nodeName)
 				}
-				if rollbackErr := a.writeSoloState(rollbackState); rollbackErr != nil {
-					return errors.Join(err, fmt.Errorf("rollback failed node create state: %w", rollbackErr))
+				if writeErr := a.writeSoloState(rollbackState); writeErr != nil {
+					rollbackErr = errors.Join(rollbackErr, fmt.Errorf("rollback failed node create state: %w", writeErr))
 				}
-				return err
+				return errors.Join(err, rollbackErr)
 			}
 		}
 	}

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -851,6 +851,77 @@ func TestSoloNodeCreateValidatesExistingSSHBeforeWritingState(t *testing.T) {
 	}
 }
 
+func TestSoloNodeCreateAttachRollsBackExistingSSHStateWhenRepublishFails(t *testing.T) {
+	binDir := t.TempDir()
+	writeExecutable(t, filepath.Join(binDir, "ssh"), `#!/usr/bin/env bash
+set -euo pipefail
+command="${!#}"
+if [[ "$command" == "true" ]]; then
+  exit 0
+fi
+if [[ "$command" == *"docker image inspect"* ]]; then
+  printf 'present\n'
+  exit 0
+fi
+if [[ "$command" == *"docker info"* ]]; then
+  exit 0
+fi
+if [[ "$command" == *"desired-state set-override"* ]]; then
+  echo 'remote write failed' >&2
+  exit 1
+fi
+echo "unexpected ssh command: $command" >&2
+exit 1
+`)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	key, err := solo.EnvironmentStateKey(workspaceRoot, "production")
+	if err != nil {
+		t.Fatal(err)
+	}
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	if err := soloState.Write(solo.State{
+		Snapshots: map[string]desiredstate.DeploySnapshot{
+			key: {
+				WorkspaceRoot: workspaceRoot,
+				WorkspaceKey:  workspaceRoot,
+				Environment:   "production",
+				Revision:      "abc1234",
+				Image:         "demo:abc1234",
+				Services:      []desiredstate.ServiceJSON{{Name: "web", Kind: config.ServiceKindWeb, Image: "demo:abc1234"}},
+			},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	app := &App{
+		Printer:     output.New(io.Discard, io.Discard),
+		SoloState:   soloState,
+		ConfigStore: config.NewStore(),
+		Cwd:         workspaceRoot,
+	}
+
+	err = app.SoloNodeCreate(context.Background(), SoloNodeCreateOptions{Name: "prod-1", Host: "203.0.113.10", User: "root", Port: 22, Attach: true})
+	if err == nil || !strings.Contains(err.Error(), "remote write failed") {
+		t.Fatalf("SoloNodeCreate() error = %v, want remote write failure", err)
+	}
+	loaded, err := soloState.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := loaded.Nodes["prod-1"]; ok {
+		t.Fatalf("node was kept after failed existing-SSH create/attach: %#v", loaded.Nodes)
+	}
+	if loaded.NodeHasAttachments("prod-1") {
+		t.Fatalf("attachment was kept after failed existing-SSH create/attach: %#v", loaded.Attachments)
+	}
+}
+
 func TestSoloNodeCreateProviderReportsMetadataAndProgress(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")
@@ -1213,8 +1284,13 @@ func TestSoloStatusWithExplicitNodesUsesExplicitEnvironmentRelease(t *testing.T)
 
 	var stdout bytes.Buffer
 	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState, ConfigStore: config.NewStore(), Cwd: workspaceRoot}
-	if err := app.SoloStatus(context.Background(), SoloStatusOptions{Nodes: []string{"node-a"}, Environment: "staging"}); err != nil {
-		t.Fatalf("SoloStatus() error = %v", err)
+	err := app.SoloStatus(context.Background(), SoloStatusOptions{Nodes: []string{"node-a"}, Environment: "staging"})
+	if err == nil {
+		t.Fatal("expected stale status failure")
+	}
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 1 {
+		t.Fatalf("error = %#v, want ExitError code 1", err)
 	}
 	payload := decodeJSONOutput(t, &stdout)
 	if _, ok := payload["public_urls"]; ok {
@@ -1267,8 +1343,13 @@ func TestSoloStatusWithExplicitNodesAndEnvBeforeLocalDeployTreatsRemoteStatusAsS
 
 	var stdout bytes.Buffer
 	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState, ConfigStore: config.NewStore(), Cwd: workspaceRoot}
-	if err := app.SoloStatus(context.Background(), SoloStatusOptions{Nodes: []string{"node-a"}, Environment: "staging"}); err != nil {
-		t.Fatalf("SoloStatus() error = %v", err)
+	err := app.SoloStatus(context.Background(), SoloStatusOptions{Nodes: []string{"node-a"}, Environment: "staging"})
+	if err == nil {
+		t.Fatal("expected foreign status failure")
+	}
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 1 {
+		t.Fatalf("error = %#v, want ExitError code 1", err)
 	}
 	payload := decodeJSONOutput(t, &stdout)
 	if payload["environment"] != "staging" {
@@ -2340,6 +2421,54 @@ func TestSoloWorkloadLogsReadsDockerLogs(t *testing.T) {
 	}
 }
 
+func TestSoloWorkloadLogsDefaultsToPrimaryWebService(t *testing.T) {
+	commandPath := filepath.Join(t.TempDir(), "workload-command")
+	t.Setenv("DEVOPSELLENCE_FAKE_SSH_WORKLOAD_LOGS_COMMAND", commandPath)
+	installFakeSoloCommands(t, nil)
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	cfg.Services["frontend"] = cfg.Services[config.DefaultWebServiceName]
+	delete(cfg.Services, config.DefaultWebServiceName)
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.Node{
+			"node-a": {Host: "203.0.113.10", User: "root"},
+		},
+	}
+	if _, _, err := current.AttachNode(workspaceRoot, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{
+		Printer:     output.New(&stdout, io.Discard),
+		SoloState:   soloState,
+		ConfigStore: config.NewStore(),
+		Cwd:         workspaceRoot,
+	}
+	if err := app.SoloWorkloadLogs(context.Background(), SoloWorkloadLogsOptions{Lines: 20}); err != nil {
+		t.Fatalf("SoloWorkloadLogs() error = %v", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	if payload["service"] != "frontend" {
+		t.Fatalf("payload = %#v, want frontend service", payload)
+	}
+	commandBytes, err := os.ReadFile(commandPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(commandBytes), "frontend") {
+		t.Fatalf("workload logs command = %q, want frontend service", commandBytes)
+	}
+}
+
 func TestSoloWorkloadLogsRejectsUnknownService(t *testing.T) {
 	installFakeSoloCommands(t, nil)
 	workspaceRoot := t.TempDir()
@@ -3331,6 +3460,40 @@ func TestSoloNodeDiagnoseCollectsRuntimeSnapshot(t *testing.T) {
 	}
 }
 
+func TestSoloNodeDiagnoseNextStepsUseCurrentWorkspaceEnvironment(t *testing.T) {
+	installFakeSoloCommands(t, []fakeSSHResponse{{stdout: `{"revision":"abc","phase":"settled"}` + "\n"}})
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	cfg.Environments = map[string]config.EnvironmentOverlay{"staging": {}}
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.Node{
+			"node-a": {Host: "203.0.113.10", User: "root", Labels: []string{config.DefaultWebRole}},
+		},
+	}
+	if _, _, err := current.AttachNode(workspaceRoot, "staging", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState, Cwd: workspaceRoot}
+	if err := app.SoloNodeDiagnose(context.Background(), SoloNodeDiagnoseOptions{Node: "node-a"}); err != nil {
+		t.Fatalf("SoloNodeDiagnose() error = %v", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	steps := jsonArrayFromMap(t, payload, "next_steps")
+	if len(steps) != 3 || steps[0] != "devopsellence status --env 'staging'" || steps[1] != "devopsellence logs --env 'staging' --node 'node-a' --lines 100" || steps[2] != "devopsellence node logs 'node-a' --lines 100" {
+		t.Fatalf("next_steps = %#v, want staging-scoped diagnose follow-ups", steps)
+	}
+}
+
 func TestSoloNodeDiagnoseReturnsFailureWhenSSHCheckFails(t *testing.T) {
 	binDir := t.TempDir()
 	writeExecutable(t, filepath.Join(binDir, "ssh"), `#!/usr/bin/env bash
@@ -3700,6 +3863,95 @@ exit 1
 	}
 	if !loaded.NodeHasAttachments("prod-1") {
 		t.Fatalf("prod-1 attachment was removed after failed detach: %#v", loaded.Attachments)
+	}
+}
+
+func TestSoloNodeDetachRepublishesRemainingCohostedDesiredState(t *testing.T) {
+	workspaceA := t.TempDir()
+	workspaceB := t.TempDir()
+	if _, err := config.Write(workspaceA, config.DefaultProjectConfig("solo", "app-a", "production")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := config.Write(workspaceB, config.DefaultProjectConfig("solo", "app-b", "production")); err != nil {
+		t.Fatal(err)
+	}
+
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes:       map[string]config.Node{"node-a": {Host: "203.0.113.10", User: "root", Labels: []string{config.DefaultWebRole}}},
+		Attachments: map[string]solo.AttachmentRecord{},
+		Snapshots:   map[string]desiredstate.DeploySnapshot{},
+	}
+	if _, _, err := current.AttachNode(workspaceA, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := current.AttachNode(workspaceB, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	keyA, err := solo.EnvironmentStateKey(workspaceA, "production")
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyB, err := solo.EnvironmentStateKey(workspaceB, "production")
+	if err != nil {
+		t.Fatal(err)
+	}
+	current.Snapshots[keyA] = desiredstate.DeploySnapshot{
+		WorkspaceRoot: workspaceA,
+		WorkspaceKey:  workspaceA,
+		Environment:   "production",
+		Revision:      "aaa1111",
+		Image:         "app-a:aaa1111",
+		Services:      []desiredstate.ServiceJSON{{Name: "web", Kind: config.ServiceKindWeb, Image: "app-a:aaa1111"}},
+	}
+	current.Snapshots[keyB] = desiredstate.DeploySnapshot{
+		WorkspaceRoot: workspaceB,
+		WorkspaceKey:  workspaceB,
+		Environment:   "production",
+		Revision:      "bbb2222",
+		Image:         "app-b:bbb2222",
+		Services:      []desiredstate.ServiceJSON{{Name: "web", Kind: config.ServiceKindWeb, Image: "app-b:bbb2222"}},
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+	installFakeSoloCommands(t, nil)
+
+	var stdout bytes.Buffer
+	app := &App{
+		Printer:     output.New(&stdout, io.Discard),
+		SoloState:   soloState,
+		ConfigStore: config.NewStore(),
+		Cwd:         workspaceA,
+	}
+	if err := app.SoloNodeDetach(context.Background(), SoloNodeDetachOptions{Node: "node-a"}); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(os.Getenv("DEVOPSELLENCE_FAKE_SSH_REVISION_FILE"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "aaa1111") {
+		t.Fatalf("published desired state still contains detached revision: %s", data)
+	}
+	var published desiredstate.DesiredStateJSON
+	if err := json.Unmarshal(data, &published); err != nil {
+		t.Fatal(err)
+	}
+	if len(published.Environments) != 1 || published.Environments[0].Revision != "bbb2222" {
+		t.Fatalf("published environments = %#v, want remaining cohosted revision only", published.Environments)
+	}
+
+	loaded, err := soloState.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if nodes, err := loaded.AttachedNodeNames(workspaceA, "production"); err != nil || len(nodes) != 0 {
+		t.Fatalf("workspace A attached nodes = %#v err=%v, want detached", nodes, err)
+	}
+	if nodes, err := loaded.AttachedNodeNames(workspaceB, "production"); err != nil || !reflect.DeepEqual(nodes, []string{"node-a"}) {
+		t.Fatalf("workspace B attached nodes = %#v err=%v, want node-a preserved", nodes, err)
 	}
 }
 
@@ -4114,6 +4366,16 @@ func TestSoloSupportBundleUsesActiveEnvironmentForAttachedNodes(t *testing.T) {
 	if !ok || len(attached) != 1 || attached[0] != "node-staging" {
 		t.Fatalf("attached_nodes = %#v, want staging node only", bundle["attached_nodes"])
 	}
+	commands := jsonArrayFromMap(t, bundle, "recommended_commands")
+	if !jsonArrayContains(commands, "devopsellence status --env 'staging'") {
+		t.Fatalf("recommended_commands = %#v, want env-qualified status", commands)
+	}
+	if !jsonArrayContains(commands, "devopsellence release list --env 'staging'") {
+		t.Fatalf("recommended_commands = %#v, want env-qualified release list", commands)
+	}
+	if !jsonArrayContains(commands, "devopsellence logs --env 'staging' --lines 100") {
+		t.Fatalf("recommended_commands = %#v, want env-qualified workload logs", commands)
+	}
 }
 
 func TestSoloSecretsCommandsUseCurrentSoloEnvironment(t *testing.T) {
@@ -4437,9 +4699,17 @@ func TestSoloDeployDryRunUsesExplicitEnvironmentWithoutDNS(t *testing.T) {
 	if payload["public_url_status"] != "configured_tls_pending" {
 		t.Fatalf("payload = %#v, want TLS pending dry-run without DNS failure", payload)
 	}
+	warnings := jsonArrayFromMap(t, payload, "warnings")
+	if len(warnings) != 1 || !strings.Contains(stringValueAny(warnings[0]), "devopsellence status --env 'staging'") {
+		t.Fatalf("warnings = %#v, want env-qualified status guidance", warnings)
+	}
 	planned := jsonMapFromAny(t, payload["planned_dns_check"])
 	if planned["live_lookup"] != false || planned["required"] != true || planned["skipped"] != false || planned["check_command"] != "devopsellence ingress check --env 'staging'" {
 		t.Fatalf("planned_dns_check = %#v, want no-network required DNS check", planned)
+	}
+	nextSteps := jsonArrayFromMap(t, payload, "next_steps")
+	if len(nextSteps) != 1 || nextSteps[0] != "devopsellence deploy --env 'staging'" {
+		t.Fatalf("next_steps = %#v, want env-scoped deploy command", nextSteps)
 	}
 	hosts := jsonArrayFromMap(t, planned, "hosts")
 	if len(hosts) != 1 || hosts[0] != "staging.invalid" {
@@ -4582,8 +4852,13 @@ func TestSoloStatusBeforeLocalDeployTreatsRemoteStatusAsStale(t *testing.T) {
 
 	var stdout bytes.Buffer
 	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState, ConfigStore: config.NewStore(), Cwd: workspaceRoot}
-	if err := app.SoloStatus(context.Background(), SoloStatusOptions{}); err != nil {
-		t.Fatalf("SoloStatus() error = %v", err)
+	err := app.SoloStatus(context.Background(), SoloStatusOptions{})
+	if err == nil {
+		t.Fatal("expected foreign status failure")
+	}
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 1 {
+		t.Fatalf("error = %#v, want ExitError code 1", err)
 	}
 	payload := decodeJSONOutput(t, &stdout)
 	if payload["public_urls"] != nil {
@@ -4674,6 +4949,199 @@ func TestSoloStatusComparesRemoteStatusToPublishedDesiredStateRevision(t *testin
 	status := jsonMapFromAny(t, node["status"])
 	if status["revision"] != "desired-state-hash" {
 		t.Fatalf("node = %#v, want published desired-state revision accepted", node)
+	}
+}
+
+func TestSoloStatusRejectsExpectedRevisionWhenStatusTimePredatesDeployment(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes:       map[string]config.Node{"node-a": {Host: "203.0.113.10", User: "root", Port: 22, AgentStateDir: "/var/lib/devopsellence", Labels: []string{config.DefaultWebRole}}},
+		Attachments: map[string]solo.AttachmentRecord{},
+	}
+	if _, _, err := current.AttachNode(workspaceRoot, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	seedSoloCurrentRelease(t, &current, workspaceRoot, "production", "shortsha")
+	environmentID, release, ok, err := current.CurrentRelease(workspaceRoot, "production")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("current release missing")
+	}
+	deployment, err := corerelease.NewDeployment(corerelease.DeploymentCreateInput{
+		ID:            "dep_test",
+		EnvironmentID: environmentID,
+		ReleaseID:     release.ID,
+		Kind:          corerelease.DeploymentKindDeploy,
+		Sequence:      1,
+		TargetNodeIDs: []string{"node-a"},
+		CreatedAt:     time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	deployment.Status = corerelease.DeploymentStatusSettled
+	deployment.PublicationResult = &corerelease.DeploymentPublicationResult{
+		Status: corerelease.PublicationStatusWritten,
+		NodeResults: []corerelease.DesiredStatePublication{{
+			NodeName: "node-a",
+			Revision: "current-desired-state",
+			Status:   corerelease.PublicationStatusWritten,
+		}},
+	}
+	if err := current.SaveDeployment(deployment); err != nil {
+		t.Fatal(err)
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+	installFakeSoloCommands(t, []fakeSSHResponse{{stdout: `{"time":"2000-01-01T00:00:00Z","revision":"current-desired-state","phase":"settled"}` + "\n"}})
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState, ConfigStore: config.NewStore(), Cwd: workspaceRoot}
+	err = app.SoloStatus(context.Background(), SoloStatusOptions{})
+	if err == nil {
+		t.Fatal("expected stale status-time failure")
+	}
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 1 {
+		t.Fatalf("error = %#v, want ExitError code 1", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	nodes := jsonArrayFromMap(t, payload, "nodes")
+	node := jsonMapFromAny(t, nodes[0])
+	message := stringValueAny(node["message"])
+	if node["status"] != nil || !strings.Contains(message, "predates current local deployment") || !strings.Contains(message, "2000-01-01T00:00:00Z") || !strings.Contains(message, "2026-04-30T12:00:00Z") {
+		t.Fatalf("node = %#v, want stale status-time message", node)
+	}
+	if strings.Contains(message, "does not match current local deployment") {
+		t.Fatalf("message = %q, want freshness diagnostic instead of revision mismatch", message)
+	}
+}
+
+func TestSoloStatusExplainsRuntimeRevisionMismatchWhenDesiredStateRevisionMatches(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes:       map[string]config.Node{"node-a": {Host: "203.0.113.10", User: "root", Port: 22, AgentStateDir: "/var/lib/devopsellence", Labels: []string{config.DefaultWebRole}}},
+		Attachments: map[string]solo.AttachmentRecord{},
+	}
+	if _, _, err := current.AttachNode(workspaceRoot, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	seedSoloCurrentRelease(t, &current, workspaceRoot, "production", "shortsha")
+	environmentID, release, ok, err := current.CurrentRelease(workspaceRoot, "production")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("current release missing")
+	}
+	deployment, err := corerelease.NewDeployment(corerelease.DeploymentCreateInput{
+		ID:            "dep_test",
+		EnvironmentID: environmentID,
+		ReleaseID:     release.ID,
+		Kind:          corerelease.DeploymentKindDeploy,
+		Sequence:      1,
+		TargetNodeIDs: []string{"node-a"},
+		CreatedAt:     time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	deployment.Status = corerelease.DeploymentStatusSettled
+	deployment.PublicationResult = &corerelease.DeploymentPublicationResult{
+		Status: corerelease.PublicationStatusWritten,
+		NodeResults: []corerelease.DesiredStatePublication{{
+			NodeName: "node-a",
+			Revision: "current-desired-state",
+			Status:   corerelease.PublicationStatusWritten,
+		}},
+	}
+	if err := current.SaveDeployment(deployment); err != nil {
+		t.Fatal(err)
+	}
+	runtimeEnvironment, err := soloRuntimeEnvironmentNameForNode(current, workspaceRoot, "production", "node-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+	statusJSON := fmt.Sprintf(`{"time":"2026-04-30T12:05:00Z","revision":"current-desired-state","phase":"settled","environments":[{"name":%q,"revision":"oldsha","phase":"settled","services":[{"name":"web","state":"running"}]}]}`+"\n", runtimeEnvironment)
+	installFakeSoloCommands(t, []fakeSSHResponse{{stdout: statusJSON}})
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState, ConfigStore: config.NewStore(), Cwd: workspaceRoot}
+	err = app.SoloStatus(context.Background(), SoloStatusOptions{})
+	if err == nil {
+		t.Fatal("expected runtime revision mismatch")
+	}
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 1 {
+		t.Fatalf("error = %#v, want ExitError code 1", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	nodes := jsonArrayFromMap(t, payload, "nodes")
+	node := jsonMapFromAny(t, nodes[0])
+	message := stringValueAny(node["message"])
+	if !strings.Contains(message, "remote runtime environment") || !strings.Contains(message, "oldsha") || !strings.Contains(message, "shortsha") || !strings.Contains(message, "devopsellence status --env 'production'") {
+		t.Fatalf("message = %q, want runtime revision mismatch guidance", message)
+	}
+	if strings.Contains(message, `status revision "current-desired-state" does not match`) {
+		t.Fatalf("message = %q, should not describe equal desired-state revisions as mismatched", message)
+	}
+}
+
+func TestSoloStatusFailsWhenCurrentDeploymentStatusIsMissing(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes:       map[string]config.Node{"node-a": {Host: "203.0.113.10", User: "root", Port: 22, AgentStateDir: "/var/lib/devopsellence", Labels: []string{config.DefaultWebRole}}},
+		Attachments: map[string]solo.AttachmentRecord{},
+	}
+	if _, _, err := current.AttachNode(workspaceRoot, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	seedSoloCurrentRelease(t, &current, workspaceRoot, "production", "shortsha")
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+	installFakeSoloCommands(t, []fakeSSHResponse{{stdout: soloStatusMissingSentinel + "\n"}})
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState, ConfigStore: config.NewStore(), Cwd: workspaceRoot}
+	err := app.SoloStatus(context.Background(), SoloStatusOptions{})
+	if err == nil {
+		t.Fatal("expected missing current status failure")
+	}
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 1 {
+		t.Fatalf("error = %#v, want ExitError code 1", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	nodes := jsonArrayFromMap(t, payload, "nodes")
+	node := jsonMapFromAny(t, nodes[0])
+	message := stringValueAny(node["message"])
+	if node["status"] != nil || !strings.Contains(message, "no status for the current local deployment") || !strings.Contains(message, "devopsellence status --env 'production'") {
+		t.Fatalf("node = %#v, want missing current status message", node)
+	}
+	if strings.Contains(message, "run `devopsellence deploy`") {
+		t.Fatalf("message = %q, want wait/status guidance before redeploy", message)
 	}
 }
 
@@ -5071,8 +5539,13 @@ func TestSoloStatusRejectsStaleCohostedDesiredStateDespiteSettledRuntimeEnvironm
 
 	var stdout bytes.Buffer
 	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState, ConfigStore: config.NewStore(), Cwd: workspaceRoot}
-	if err := app.SoloStatus(context.Background(), SoloStatusOptions{}); err != nil {
-		t.Fatalf("SoloStatus() error = %v", err)
+	err = app.SoloStatus(context.Background(), SoloStatusOptions{})
+	if err == nil {
+		t.Fatal("expected stale cohosted status failure")
+	}
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 1 {
+		t.Fatalf("error = %#v, want ExitError code 1", err)
 	}
 	payload := decodeJSONOutput(t, &stdout)
 	if _, ok := payload["public_urls"]; ok {
@@ -5245,8 +5718,13 @@ func TestSoloStatusRejectsKnownStaleDesiredStateDespiteSettledRuntimeEnvironment
 
 	var stdout bytes.Buffer
 	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState, ConfigStore: config.NewStore(), Cwd: workspaceRoot}
-	if err := app.SoloStatus(context.Background(), SoloStatusOptions{}); err != nil {
-		t.Fatalf("SoloStatus() error = %v", err)
+	err = app.SoloStatus(context.Background(), SoloStatusOptions{})
+	if err == nil {
+		t.Fatal("expected stale desired-state status failure")
+	}
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 1 {
+		t.Fatalf("error = %#v, want ExitError code 1", err)
 	}
 	payload := decodeJSONOutput(t, &stdout)
 	if _, ok := payload["public_urls"]; ok {
@@ -5345,7 +5823,7 @@ func TestSoloDeployWaitsForSettledStatusBeforeSuccess(t *testing.T) {
 		t.Fatalf("public_urls = %#v, want node URL", urls)
 	}
 	nextSteps := jsonArrayFromMap(t, payload, "next_steps")
-	if len(nextSteps) != 4 || nextSteps[0] != "devopsellence status" || nextSteps[1] != "curl http://203.0.113.10/" || nextSteps[2] != "devopsellence logs --node 'node-a' --lines 100" || nextSteps[3] != "devopsellence node logs 'node-a' --lines 100" {
+	if len(nextSteps) != 4 || nextSteps[0] != "devopsellence status --env 'production'" || nextSteps[1] != "curl http://203.0.113.10/" || nextSteps[2] != "devopsellence logs --env 'production' --node 'node-a' --lines 100" || nextSteps[3] != "devopsellence node logs 'node-a' --lines 100" {
 		t.Fatalf("next_steps = %#v, want status, curl, and logs commands", nextSteps)
 	}
 }
@@ -5444,6 +5922,10 @@ func TestSoloDeployDoesNotTreatDNSOnlyTLSCheckAsVerifiedPublicURL(t *testing.T) 
 	if payload["public_url_status"] != "configured_tls_pending" {
 		t.Fatalf("public_url_status = %#v, want configured_tls_pending", payload["public_url_status"])
 	}
+	warnings := jsonArrayFromMap(t, payload, "warnings")
+	if len(warnings) != 1 || !strings.Contains(stringValueAny(warnings[0]), "devopsellence status --env 'production'") {
+		t.Fatalf("warnings = %#v, want env-qualified status guidance", warnings)
+	}
 }
 
 func TestSoloReleaseListReturnsCurrentReleaseHistory(t *testing.T) {
@@ -5496,6 +5978,31 @@ func TestSoloReleaseListReturnsCurrentReleaseHistory(t *testing.T) {
 	releases = jsonArrayFromMap(t, payload, "releases")
 	if len(releases) != 2 {
 		t.Fatalf("releases = %#v, want unlimited result", releases)
+	}
+}
+
+func TestSoloReleaseListRejectsNegativeLimit(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	app := &App{
+		Printer:     output.New(io.Discard, io.Discard),
+		SoloState:   solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json")),
+		ConfigStore: config.NewStore(),
+		Cwd:         workspaceRoot,
+	}
+	err := app.SoloReleaseList(context.Background(), SoloReleaseListOptions{Limit: -1})
+	if err == nil {
+		t.Fatal("SoloReleaseList() error = nil, want negative limit validation")
+	}
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 2 {
+		t.Fatalf("error = %#v, want ExitError code 2", err)
+	}
+	if !strings.Contains(err.Error(), "--limit must be 0 or greater") {
+		t.Fatalf("error = %v, want limit guidance", err)
 	}
 }
 
@@ -5631,6 +6138,65 @@ func TestSoloReleaseRollbackDryRunPlansWithoutSideEffects(t *testing.T) {
 	}
 	if payload["deployment_id"] != nil || payload["desired_state_revisions"] != nil {
 		t.Fatalf("payload = %#v, dry-run must not create deployment/publication revisions", payload)
+	}
+}
+
+func TestSoloReleaseRollbackUnknownSelectorSuggestsReleaseList(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := soloReleaseWorkflowState(workspaceRoot)
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	app := &App{Printer: output.New(io.Discard, io.Discard), SoloState: soloState, ConfigStore: config.NewStore(), Cwd: workspaceRoot}
+	err := app.SoloReleaseRollback(context.Background(), SoloReleaseRollbackOptions{Selector: "HEAD~1"})
+	if err == nil {
+		t.Fatal("SoloReleaseRollback() error = nil, want selector guidance")
+	}
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 2 {
+		t.Fatalf("error = %#v, want ExitError code 2", err)
+	}
+	if !strings.Contains(err.Error(), `release "HEAD~1" not found`) || !strings.Contains(err.Error(), "devopsellence release list --env 'production' --limit 5") || !strings.Contains(err.Error(), "release id or revision") {
+		t.Fatalf("error = %v, want release-list selector guidance", err)
+	}
+}
+
+func TestSoloReleaseRollbackWithoutPreviousReleaseIsStateError(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes:       map[string]config.Node{"node-a": {Host: "203.0.113.10", User: "root", Labels: []string{config.DefaultWebRole}}},
+		Attachments: map[string]solo.AttachmentRecord{},
+	}
+	if _, _, err := current.AttachNode(workspaceRoot, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	seedSoloCurrentRelease(t, &current, workspaceRoot, "production", "aaa1111")
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	app := &App{Printer: output.New(io.Discard, io.Discard), SoloState: soloState, ConfigStore: config.NewStore(), Cwd: workspaceRoot}
+	err := app.SoloReleaseRollback(context.Background(), SoloReleaseRollbackOptions{})
+	if err == nil {
+		t.Fatal("SoloReleaseRollback() error = nil, want no previous release")
+	}
+	var exitErr ExitError
+	if errors.As(err, &exitErr) && exitErr.Code == 2 {
+		t.Fatalf("error = %#v, default rollback state failure should not be syntax code 2", err)
+	}
+	if !strings.Contains(err.Error(), "no previous release found") || !strings.Contains(err.Error(), "devopsellence release list --env 'production' --limit 5") {
+		t.Fatalf("error = %v, want no-previous release-list guidance", err)
 	}
 }
 
@@ -7668,6 +8234,10 @@ func TestIngressCheckUsesExplicitEnvironment(t *testing.T) {
 	}
 	if payload["environment"] != "staging" || payload["check_scope"] != "dns" || payload["tls_verified"] != false {
 		t.Fatalf("payload = %#v, want self-auditing staging DNS-only check", payload)
+	}
+	nextSteps := jsonArrayFromMap(t, payload, "next_steps")
+	if len(nextSteps) != 2 || nextSteps[0] != "devopsellence status --env 'staging'" || nextSteps[1] != "curl http://127.0.0.1/" {
+		t.Fatalf("next_steps = %#v, want env-qualified status and curl", nextSteps)
 	}
 	loaded, err := soloState.Read()
 	if err != nil {

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -853,6 +853,8 @@ func TestSoloNodeCreateValidatesExistingSSHBeforeWritingState(t *testing.T) {
 
 func TestSoloNodeCreateAttachRollsBackExistingSSHStateWhenRepublishFails(t *testing.T) {
 	binDir := t.TempDir()
+	sshLogDir := t.TempDir()
+	t.Setenv("DEVOPSELLENCE_TEST_SSH_LOG_DIR", sshLogDir)
 	writeExecutable(t, filepath.Join(binDir, "ssh"), `#!/usr/bin/env bash
 set -euo pipefail
 command="${!#}"
@@ -867,8 +869,20 @@ if [[ "$command" == *"docker info"* ]]; then
   exit 0
 fi
 if [[ "$command" == *"desired-state set-override"* ]]; then
-  echo 'remote write failed' >&2
-  exit 1
+  log_dir="${DEVOPSELLENCE_TEST_SSH_LOG_DIR:?}"
+  count_file="$log_dir/desired-state-count"
+  count=0
+  if [[ -f "$count_file" ]]; then
+    count=$(cat "$count_file")
+  fi
+  count=$((count + 1))
+  printf '%s' "$count" > "$count_file"
+  cat > "$log_dir/desired-state-$count.json"
+  if [[ "$count" == "1" ]]; then
+    echo 'remote write failed' >&2
+    exit 1
+  fi
+  exit 0
 fi
 echo "unexpected ssh command: $command" >&2
 exit 1
@@ -919,6 +933,20 @@ exit 1
 	}
 	if loaded.NodeHasAttachments("prod-1") {
 		t.Fatalf("attachment was kept after failed existing-SSH create/attach: %#v", loaded.Attachments)
+	}
+	countBytes, err := os.ReadFile(filepath.Join(sshLogDir, "desired-state-count"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(string(countBytes)) != "2" {
+		t.Fatalf("desired-state writes = %q, want original attempt plus rollback republish", strings.TrimSpace(string(countBytes)))
+	}
+	rollbackDesiredState, err := os.ReadFile(filepath.Join(sshLogDir, "desired-state-2.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(rollbackDesiredState, []byte("prod-1")) || bytes.Contains(rollbackDesiredState, []byte("abc1234")) {
+		t.Fatalf("rollback desired state = %s, want pre-attach state without new node release", rollbackDesiredState)
 	}
 }
 
@@ -4952,7 +4980,7 @@ func TestSoloStatusComparesRemoteStatusToPublishedDesiredStateRevision(t *testin
 	}
 }
 
-func TestSoloStatusRejectsExpectedRevisionWhenStatusTimePredatesDeployment(t *testing.T) {
+func TestSoloStatusAcceptsExpectedRevisionWhenStatusTimePredatesLocalDeploymentClock(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")
 	if _, err := config.Write(workspaceRoot, cfg); err != nil {
@@ -5006,22 +5034,15 @@ func TestSoloStatusRejectsExpectedRevisionWhenStatusTimePredatesDeployment(t *te
 	var stdout bytes.Buffer
 	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState, ConfigStore: config.NewStore(), Cwd: workspaceRoot}
 	err = app.SoloStatus(context.Background(), SoloStatusOptions{})
-	if err == nil {
-		t.Fatal("expected stale status-time failure")
-	}
-	var exitErr ExitError
-	if !errors.As(err, &exitErr) || exitErr.Code != 1 {
-		t.Fatalf("error = %#v, want ExitError code 1", err)
+	if err != nil {
+		t.Fatalf("SoloStatus() error = %v, want same desired-state revision accepted despite remote/local clock skew", err)
 	}
 	payload := decodeJSONOutput(t, &stdout)
 	nodes := jsonArrayFromMap(t, payload, "nodes")
 	node := jsonMapFromAny(t, nodes[0])
-	message := stringValueAny(node["message"])
-	if node["status"] != nil || !strings.Contains(message, "predates current local deployment") || !strings.Contains(message, "2000-01-01T00:00:00Z") || !strings.Contains(message, "2026-04-30T12:00:00Z") {
-		t.Fatalf("node = %#v, want stale status-time message", node)
-	}
-	if strings.Contains(message, "does not match current local deployment") {
-		t.Fatalf("message = %q, want freshness diagnostic instead of revision mismatch", message)
+	status := jsonMapFromAny(t, node["status"])
+	if status["revision"] != "current-desired-state" {
+		t.Fatalf("node = %#v, want status accepted from revision evidence", node)
 	}
 }
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -853,6 +853,10 @@ func TestSoloNodeCreateValidatesExistingSSHBeforeWritingState(t *testing.T) {
 
 func TestSoloNodeCreateAttachRollsBackExistingSSHStateWhenRepublishFails(t *testing.T) {
 	binDir := t.TempDir()
+	writeLog := filepath.Join(t.TempDir(), "desired-state-writes.log")
+	writeCount := filepath.Join(t.TempDir(), "desired-state-write-count")
+	t.Setenv("DEVOPSELLENCE_ROLLBACK_WRITE_LOG", writeLog)
+	t.Setenv("DEVOPSELLENCE_ROLLBACK_WRITE_COUNT", writeCount)
 	writeExecutable(t, filepath.Join(binDir, "ssh"), `#!/usr/bin/env bash
 set -euo pipefail
 command="${!#}"
@@ -867,8 +871,22 @@ if [[ "$command" == *"docker info"* ]]; then
   exit 0
 fi
 if [[ "$command" == *"desired-state set-override"* ]]; then
-  echo 'remote write failed' >&2
-  exit 1
+  count=0
+  if [[ -s "${DEVOPSELLENCE_ROLLBACK_WRITE_COUNT}" ]]; then
+    count="$(cat "${DEVOPSELLENCE_ROLLBACK_WRITE_COUNT}")"
+  fi
+  count=$((count + 1))
+  printf '%s\n' "$count" >"${DEVOPSELLENCE_ROLLBACK_WRITE_COUNT}"
+  {
+    printf -- '--- write %s ---\n' "$count"
+    cat
+    printf '\n'
+  } >>"${DEVOPSELLENCE_ROLLBACK_WRITE_LOG}"
+  if [[ "$count" -eq 1 ]]; then
+    echo 'remote write failed' >&2
+    exit 1
+  fi
+  exit 0
 fi
 echo "unexpected ssh command: $command" >&2
 exit 1
@@ -919,6 +937,21 @@ exit 1
 	}
 	if loaded.NodeHasAttachments("prod-1") {
 		t.Fatalf("attachment was kept after failed existing-SSH create/attach: %#v", loaded.Attachments)
+	}
+	countBytes, err := os.ReadFile(writeCount)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(string(countBytes)) != "2" {
+		logBytes, _ := os.ReadFile(writeLog)
+		t.Fatalf("desired-state writes = %q, want original write plus remote rollback; log:\n%s", strings.TrimSpace(string(countBytes)), string(logBytes))
+	}
+	logBytes, err := os.ReadFile(writeLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(logBytes), "--- write 2 ---") {
+		t.Fatalf("desired-state write log = %s, want rollback write", string(logBytes))
 	}
 }
 
@@ -4952,7 +4985,7 @@ func TestSoloStatusComparesRemoteStatusToPublishedDesiredStateRevision(t *testin
 	}
 }
 
-func TestSoloStatusRejectsExpectedRevisionWhenStatusTimePredatesDeployment(t *testing.T) {
+func TestSoloStatusAcceptsExpectedRevisionWhenStatusTimePredatesDeployment(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")
 	if _, err := config.Write(workspaceRoot, cfg); err != nil {
@@ -5005,23 +5038,15 @@ func TestSoloStatusRejectsExpectedRevisionWhenStatusTimePredatesDeployment(t *te
 
 	var stdout bytes.Buffer
 	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState, ConfigStore: config.NewStore(), Cwd: workspaceRoot}
-	err = app.SoloStatus(context.Background(), SoloStatusOptions{})
-	if err == nil {
-		t.Fatal("expected stale status-time failure")
-	}
-	var exitErr ExitError
-	if !errors.As(err, &exitErr) || exitErr.Code != 1 {
-		t.Fatalf("error = %#v, want ExitError code 1", err)
+	if err := app.SoloStatus(context.Background(), SoloStatusOptions{}); err != nil {
+		t.Fatalf("SoloStatus() error = %v", err)
 	}
 	payload := decodeJSONOutput(t, &stdout)
 	nodes := jsonArrayFromMap(t, payload, "nodes")
 	node := jsonMapFromAny(t, nodes[0])
-	message := stringValueAny(node["message"])
-	if node["status"] != nil || !strings.Contains(message, "predates current local deployment") || !strings.Contains(message, "2000-01-01T00:00:00Z") || !strings.Contains(message, "2026-04-30T12:00:00Z") {
-		t.Fatalf("node = %#v, want stale status-time message", node)
-	}
-	if strings.Contains(message, "does not match current local deployment") {
-		t.Fatalf("message = %q, want freshness diagnostic instead of revision mismatch", message)
+	status := jsonMapFromAny(t, node["status"])
+	if status["revision"] != "current-desired-state" || status["time"] != "2000-01-01T00:00:00Z" {
+		t.Fatalf("node = %#v, want matching revision accepted despite remote clock skew", node)
 	}
 }
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -761,6 +761,42 @@ func TestSoloNodeCreateRegistersExistingSSHNode(t *testing.T) {
 	}
 }
 
+func TestSoloNodeCreateMissingSSHKeyPathIsUsageError(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	if err := soloState.Write(solo.State{}); err != nil {
+		t.Fatal(err)
+	}
+	app := &App{
+		Printer:     output.New(io.Discard, io.Discard),
+		SoloState:   soloState,
+		ConfigStore: config.NewStore(),
+		Cwd:         workspaceRoot,
+	}
+
+	err := app.SoloNodeCreate(context.Background(), SoloNodeCreateOptions{
+		Name:   "prod-1",
+		Host:   "203.0.113.10",
+		User:   "root",
+		Port:   22,
+		SSHKey: filepath.Join(t.TempDir(), "missing-key"),
+	})
+	if err == nil {
+		t.Fatal("SoloNodeCreate() error = nil, want missing ssh key usage error")
+	}
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 2 {
+		t.Fatalf("error = %#v, want ExitError code 2", err)
+	}
+	if !strings.Contains(err.Error(), "ssh key path") || !strings.Contains(err.Error(), "does not exist") {
+		t.Fatalf("error = %q, want missing ssh key path context", err.Error())
+	}
+}
+
 func TestSoloNodeAttachUsesSavedCurrentEnvironment(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")
@@ -4017,6 +4053,22 @@ func TestNodeRemoveForManualNodeForgetsLocalState(t *testing.T) {
 	payload := decodeJSONOutput(t, &stdout)
 	if payload["node"] != "manual-a" || payload["action"] != "forgotten" {
 		t.Fatalf("payload = %#v, want forgotten manual node", payload)
+	}
+}
+
+func TestNodeRemoveRequiresConfirmationUsageError(t *testing.T) {
+	app := &App{SoloState: solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))}
+
+	err := app.SoloNodeRemove(context.Background(), SoloNodeRemoveOptions{Name: "manual-a"})
+	if err == nil {
+		t.Fatal("SoloNodeRemove() error = nil, want confirmation error")
+	}
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 2 {
+		t.Fatalf("error = %#v, want ExitError code 2", err)
+	}
+	if !strings.Contains(err.Error(), "--yes") {
+		t.Fatalf("error = %q, want --yes hint", err.Error())
 	}
 }
 

--- a/docs/agent-primary.md
+++ b/docs/agent-primary.md
@@ -60,8 +60,8 @@ devopsellence deploy --dry-run
 devopsellence apply <plan-id>
 devopsellence status
 devopsellence doctor
-devopsellence logs --service web
-devopsellence rollback --dry-run --to <release-id>
+devopsellence logs web
+devopsellence release rollback --dry-run <release-id>
 ```
 
 All of these should emit structured JSON without requiring `--json`.
@@ -90,7 +90,7 @@ Command results should converge toward a common envelope:
       "next_actions": [
         {
           "label": "set secret reference",
-          "command": "devopsellence secrets set DATABASE_URL --stdin"
+          "command": "devopsellence secret set DATABASE_URL --service web --stdin"
         }
       ]
     }


### PR DESCRIPTION
## What changed

- Tightened solo CLI diagnostics for stale/missing remote status, runtime revision mismatches, and release rollback selector errors.
- Scoped generated next steps and support guidance to the active solo environment.
- Fixed operator footguns around `exec -- ...`, `node exec -- ...`, negative release-list limits, and default workload-log service selection.
- Added rollback for failed existing-SSH `node create --attach` republish and coverage for co-hosted detach republish behavior.
- Updated README/docs examples for current secret/logs/rollback syntax.

## Why

Dogfood passes found cases where agent operators could copy commands against the wrong environment, get misleading stale-status output, or leave local node state behind after a failed create+attach flow.

## Validation

- `mise run test:cli`
- `mise run e2e-solo`
- `git diff --check`
- dogfood-solo QA artifacts:
  - `/tmp/devopsellence-dogfood-solo/20260430T165719304998Z-rollback-release-json/report.md`
  - `/tmp/devopsellence-dogfood-solo/20260430T171016565132Z-guidance-regression-qa/report.md`

## Notes

- Did not run `e2e-shared`; changes are solo CLI/docs only.
- Untracked `control-plane/devopsellence.yml` was not included.
