### PR TITLE
docs: recommend 1Password for solo production secrets

### DIFF
--- a/docs-website/src/content/docs/guides/secrets.md
+++ b/docs-website/src/content/docs/guides/secrets.md
@@ -7,22 +7,35 @@ Application config should refer to secrets by name. Secret values should live in
 a local operator-controlled store, an external password manager, or a shared
 secret manager depending on mode.
 
-Set a solo secret from standard input:
+## Solo mode
+
+For production apps in solo mode, prefer 1Password references instead of storing
+plaintext secrets in devopsellence's local solo state. This keeps secret values
+out of devopsellence state at rest while preserving the SSH-first, single-operator
+workflow.
+
+```bash
+devopsellence secret set DATABASE_URL --service web --store 1password --op-ref "op://vault/item/field"
+```
+
+The operator machine must have the 1Password CLI (`op`) installed and signed in.
+During deploy, rollback, or desired-state republish, devopsellence runs
+`op read` locally, resolves the value, and sends it to the node as runtime
+environment. The node does not need access to 1Password.
+
+For local development or low-risk apps, you can also store a solo plaintext
+secret from standard input:
 
 ```bash
 printf '%s' "$RAILS_MASTER_KEY" | devopsellence secret set RAILS_MASTER_KEY --service web --stdin
 devopsellence secret list
 ```
 
-By default, solo plaintext secrets are stored in the local solo state file with
-`0600` permissions. This fits single-operator SSH workflows, not shared team
-secret management.
+Solo plaintext secrets are stored in the local solo state file with `0600`
+permissions. This fits quick single-operator SSH workflows, but 1Password is the
+safer default for production secrets.
 
-Use an external reference when you do not want plaintext in local state:
-
-```bash
-devopsellence secret set DATABASE_URL --service web --store 1password --op-ref "$OP_REF"
-```
+## Shared mode
 
 Use shared mode when server-side encrypted team secrets and deploy tokens are
 part of the workflow.


### PR DESCRIPTION
## Summary
- Recommend 1Password references as the safer default for production solo secrets
- Explain that devopsellence stores the `op://...` reference locally and resolves it with `op read` on the operator machine
- Clarify that plaintext solo secrets remain supported for local development or low-risk apps

## Test Plan
- Docs-only change; not run
