### PR TITLE
fix: write devopsellence config with two-space YAML indentation

### DIFF
--- a/deployment-core/pkg/deploycore/config/config.go
+++ b/deployment-core/pkg/deploycore/config/config.go
@@ -268,11 +268,17 @@ func Write(workspaceRoot string, cfg ProjectConfig) (ProjectConfig, error) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return ProjectConfig{}, err
 	}
-	data, err := yaml.Marshal(cfg)
-	if err != nil {
+	var buffer bytes.Buffer
+	encoder := yaml.NewEncoder(&buffer)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(cfg); err != nil {
+		_ = encoder.Close()
 		return ProjectConfig{}, err
 	}
-	if err := os.WriteFile(path, data, 0o644); err != nil {
+	if err := encoder.Close(); err != nil {
+		return ProjectConfig{}, err
+	}
+	if err := os.WriteFile(path, buffer.Bytes(), 0o644); err != nil {
 		return ProjectConfig{}, err
 	}
 	return cfg, nil

--- a/deployment-core/pkg/deploycore/config/config_test.go
+++ b/deployment-core/pkg/deploycore/config/config_test.go
@@ -61,6 +61,38 @@ func TestWriteAndLoadFromRoot(t *testing.T) {
 	}
 }
 
+func TestWriteUsesTwoSpaceYAMLIndentation(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	project := DefaultProjectConfig("acme", "ShopApp", "staging")
+	project.Services["jobs"] = ServiceConfig{
+		Command: []string{"./bin/jobs"},
+		Ports:   []ServicePort{{Name: "metrics", Port: 9394}},
+	}
+
+	if _, err := Write(root, project); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(root, FilePath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	for _, want := range []string{
+		"build:\n  context: .\n  dockerfile: Dockerfile\n  platforms:\n    - linux/amd64\n",
+		"services:\n  jobs:\n    command:\n      - ./bin/jobs\n    ports:\n      - name: metrics\n        port: 9394\n",
+		"  web:\n    ports:\n      - name: http\n        port: 3000\n    healthcheck:\n      path: /up\n      port: 3000\n",
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("written config missing two-space YAML block %q in:\n%s", want, content)
+		}
+	}
+	if strings.Contains(content, "\n    platforms:\n        - ") || strings.Contains(content, "\n    ports:\n        - ") {
+		t.Fatalf("written config used four-space sequence indentation:\n%s", content)
+	}
+}
+
 func TestLoadRejectsSchemaWithoutRootConfig(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- write devopsellence.yml through yaml.Encoder with SetIndent(2)
- add regression coverage for two-space nested map and sequence indentation

## Test Plan
- mise x -- go test ./pkg/deploycore/config (from deployment-core)
- mise x -- go test ./internal/workflow -run 'TestInitModeFlagPersistsWorkspaceModeAndWritesConfig' (from cli)