### PR TITLE
feat(cli): add init runtime contract hints

### DIFF
--- a/cli/internal/workflow/app.go
+++ b/cli/internal/workflow/app.go
@@ -550,6 +550,10 @@ func (a *App) Init(ctx context.Context, opts InitOptions) error {
 		if initErr != nil {
 			return initErr
 		}
+		resolvedConfig, err := config.ResolveEnvironmentConfig(initialized.Config, initialized.Environment.Name)
+		if err != nil {
+			return ExitError{Code: 1, Err: err}
+		}
 		result = map[string]any{
 			"schema_version":       outputSchemaVersion,
 			"mode":                 string(ModeShared),
@@ -564,7 +568,7 @@ func (a *App) Init(ctx context.Context, opts InitOptions) error {
 			"environment_created":  initialized.CreatedEnv,
 			"config_path":          initialized.ConfigPath,
 			"project_slug":         initialized.Discovered.ProjectSlug,
-			"runtime_contract":     initRuntimeContract(initialized.Config, initialized.Discovered, initialized.CreatedConfig),
+			"runtime_contract":     initRuntimeContract(resolvedConfig, initialized.Discovered, initialized.CreatedConfig),
 			"config":               initialized.Config,
 		}
 		return nil
@@ -2834,6 +2838,7 @@ func (a *App) initializeWorkspace(ctx context.Context, callAuth authCall, opts I
 		projectConfig.Services = existing.Services
 		projectConfig.Tasks = existing.Tasks
 		projectConfig.Ingress = existing.Ingress
+		projectConfig.Environments = existing.Environments
 		projectConfig.Organization = org.Name
 		projectConfig.Project = project.Name
 		projectConfig.DefaultEnvironment = environment.Name

--- a/cli/internal/workflow/app.go
+++ b/cli/internal/workflow/app.go
@@ -568,7 +568,7 @@ func (a *App) Init(ctx context.Context, opts InitOptions) error {
 			"environment_created":  initialized.CreatedEnv,
 			"config_path":          initialized.ConfigPath,
 			"project_slug":         initialized.Discovered.ProjectSlug,
-			"runtime_contract":     initRuntimeContract(resolvedConfig, initialized.Discovered, initialized.CreatedConfig),
+			"runtime_contract":     initRuntimeContract(resolvedConfig, initialized.Discovered, initRuntimeContractProvenance(initialized.Config, resolvedConfig, initialized.Environment.Name, initialized.CreatedConfig)),
 			"config":               initialized.Config,
 		}
 		return nil

--- a/cli/internal/workflow/app.go
+++ b/cli/internal/workflow/app.go
@@ -564,6 +564,7 @@ func (a *App) Init(ctx context.Context, opts InitOptions) error {
 			"environment_created":  initialized.CreatedEnv,
 			"config_path":          initialized.ConfigPath,
 			"project_slug":         initialized.Discovered.ProjectSlug,
+			"runtime_contract":     initRuntimeContract(initialized.Config, initialized.Discovered, initialized.CreatedConfig),
 			"config":               initialized.Config,
 		}
 		return nil

--- a/cli/internal/workflow/management_test.go
+++ b/cli/internal/workflow/management_test.go
@@ -42,6 +42,8 @@ func TestInitWritesConfigOnly(t *testing.T) {
 			return nil, nil
 		}
 	}))
+	var stdout bytes.Buffer
+	app.Printer = output.New(&stdout, io.Discard)
 
 	if err := app.Init(context.Background(), InitOptions{NonInteractive: true}); err != nil {
 		t.Fatalf("Init() error = %v", err)
@@ -54,6 +56,14 @@ func TestInitWritesConfigOnly(t *testing.T) {
 		t.Fatal("AGENTS.md exists, want not exist")
 	} else if !os.IsNotExist(err) {
 		t.Fatalf("stat AGENTS.md: %v", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	runtimeContract := jsonMapFromAny(t, payload["runtime_contract"])
+	if runtimeContract["port_source"] != "default" || runtimeContract["healthcheck_path_source"] != "default" {
+		t.Fatalf("runtime_contract = %#v, want default port and healthcheck sources", runtimeContract)
+	}
+	if hints := jsonArrayFromMap(t, runtimeContract, "agent_hints"); len(hints) != 2 {
+		t.Fatalf("runtime_contract.agent_hints = %#v, want shared init port and healthcheck hints", hints)
 	}
 }
 

--- a/cli/internal/workflow/management_test.go
+++ b/cli/internal/workflow/management_test.go
@@ -67,6 +67,66 @@ func TestInitWritesConfigOnly(t *testing.T) {
 	}
 }
 
+func TestInitRuntimeContractUsesSelectedEnvironmentOverlay(t *testing.T) {
+	t.Parallel()
+
+	root := makeRubyRoot(t, "ShopApp")
+	healthcheckPath := "/healthz"
+	healthcheckPort := 8080
+	project := config.DefaultProjectConfig("default", "ShopApp", "production")
+	project.Environments = map[string]config.EnvironmentOverlay{
+		"staging": {
+			Services: map[string]config.ServiceConfigOverlay{
+				"web": {
+					Ports: []config.ServicePort{{Name: "http", Port: 8080}},
+					Healthcheck: &config.HTTPHealthcheckOverlay{
+						Path: &healthcheckPath,
+						Port: &healthcheckPort,
+					},
+				},
+			},
+		},
+	}
+	if _, err := config.Write(root, project); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	app := newTestApp(t, root, roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/cli/organizations":
+			return jsonResponse(t, map[string]any{"organizations": []map[string]any{{"id": 7, "name": "default", "role": "owner"}}}), nil
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/cli/projects":
+			return jsonResponse(t, map[string]any{"projects": []map[string]any{{"id": 11, "name": "ShopApp"}}}), nil
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/cli/projects/11/environments":
+			return jsonResponse(t, map[string]any{"environments": []map[string]any{
+				{"id": 44, "name": "production"},
+				{"id": 45, "name": "staging"},
+			}}), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+			return nil, nil
+		}
+	}))
+	var stdout bytes.Buffer
+	app.Printer = output.New(&stdout, io.Discard)
+
+	if err := app.Init(context.Background(), InitOptions{Environment: "staging", NonInteractive: true}); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+
+	payload := decodeJSONOutput(t, &stdout)
+	if payload["environment_name"] != "staging" {
+		t.Fatalf("environment_name = %#v, want staging", payload["environment_name"])
+	}
+	runtimeContract := jsonMapFromAny(t, payload["runtime_contract"])
+	if runtimeContract["port"] != float64(8080) || runtimeContract["healthcheck_path"] != "/healthz" || runtimeContract["healthcheck_port"] != float64(8080) {
+		t.Fatalf("runtime_contract = %#v, want selected environment overlay port/healthcheck", runtimeContract)
+	}
+	if hints := jsonArrayFromMap(t, runtimeContract, "agent_hints"); len(hints) != 0 {
+		t.Fatalf("runtime_contract.agent_hints = %#v, want no hints for explicit overlay config", hints)
+	}
+}
+
 func TestInitLeavesExistingAgentsFileAlone(t *testing.T) {
 	t.Parallel()
 

--- a/cli/internal/workflow/management_test.go
+++ b/cli/internal/workflow/management_test.go
@@ -71,14 +71,14 @@ func TestInitRuntimeContractUsesSelectedEnvironmentOverlay(t *testing.T) {
 	t.Parallel()
 
 	root := makeRubyRoot(t, "ShopApp")
-	healthcheckPath := "/healthz"
-	healthcheckPort := 8080
+	healthcheckPath := config.DefaultHealthcheckPath
+	healthcheckPort := config.DefaultWebPort
 	project := config.DefaultProjectConfig("default", "ShopApp", "production")
 	project.Environments = map[string]config.EnvironmentOverlay{
 		"staging": {
 			Services: map[string]config.ServiceConfigOverlay{
 				"web": {
-					Ports: []config.ServicePort{{Name: "http", Port: 8080}},
+					Ports: []config.ServicePort{{Name: "http", Port: config.DefaultWebPort}},
 					Healthcheck: &config.HTTPHealthcheckOverlay{
 						Path: &healthcheckPath,
 						Port: &healthcheckPort,
@@ -119,8 +119,11 @@ func TestInitRuntimeContractUsesSelectedEnvironmentOverlay(t *testing.T) {
 		t.Fatalf("environment_name = %#v, want staging", payload["environment_name"])
 	}
 	runtimeContract := jsonMapFromAny(t, payload["runtime_contract"])
-	if runtimeContract["port"] != float64(8080) || runtimeContract["healthcheck_path"] != "/healthz" || runtimeContract["healthcheck_port"] != float64(8080) {
-		t.Fatalf("runtime_contract = %#v, want selected environment overlay port/healthcheck", runtimeContract)
+	if runtimeContract["port"] != float64(config.DefaultWebPort) || runtimeContract["healthcheck_path"] != config.DefaultHealthcheckPath || runtimeContract["healthcheck_port"] != float64(config.DefaultWebPort) {
+		t.Fatalf("runtime_contract = %#v, want selected environment overlay default port/healthcheck", runtimeContract)
+	}
+	if runtimeContract["port_source"] != "config" || runtimeContract["healthcheck_path_source"] != "config" {
+		t.Fatalf("runtime_contract = %#v, want explicit default overlay values reported as config", runtimeContract)
 	}
 	if hints := jsonArrayFromMap(t, runtimeContract, "agent_hints"); len(hints) != 0 {
 		t.Fatalf("runtime_contract.agent_hints = %#v, want no hints for explicit overlay config", hints)

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -4951,7 +4951,7 @@ func (a *App) SoloInit(context.Context, SoloInitOptions) error {
 		"mode":             string(ModeSolo),
 		"workspace_root":   discovered.WorkspaceRoot,
 		"project_slug":     discovered.ProjectSlug,
-		"runtime_contract": soloInitRuntimeContract(*cfg, discovered, created),
+		"runtime_contract": initRuntimeContract(*cfg, discovered, created),
 		"config": map[string]any{
 			"path":           configPath,
 			"created":        created,
@@ -4965,7 +4965,7 @@ func (a *App) SoloInit(context.Context, SoloInitOptions) error {
 	})
 }
 
-func soloInitRuntimeContract(cfg config.ProjectConfig, discovered discovery.Result, created bool) map[string]any {
+func initRuntimeContract(cfg config.ProjectConfig, discovered discovery.Result, created bool) map[string]any {
 	serviceName, ok := cfg.PrimaryWebServiceName()
 	if !ok {
 		return map[string]any{
@@ -4977,27 +4977,77 @@ func soloInitRuntimeContract(cfg config.ProjectConfig, discovered discovery.Resu
 	}
 	service := cfg.Services[serviceName]
 	port := service.HTTPPort(0)
-	source := "default"
+	portSource := "default"
+	portConfidence := "low"
 	switch {
 	case !created:
-		source = "config"
+		portSource = "config"
+		portConfidence = "high"
 	case discovered.InferredWebPort > 0 && port == discovered.InferredWebPort:
-		source = "dockerfile"
+		portSource = "dockerfile"
+		portConfidence = "high"
 	case port != config.DefaultWebPort:
-		source = "config"
+		portSource = "config"
+		portConfidence = "high"
 	}
 	contract := map[string]any{
-		"web_service": true,
-		"service":     serviceName,
-		"port":        port,
-		"port_source": source,
-		"requirement": "the container must listen on this port; add EXPOSE to the Dockerfile or edit devopsellence.yml if it listens elsewhere",
+		"web_service":     true,
+		"service":         serviceName,
+		"port":            port,
+		"port_source":     portSource,
+		"port_confidence": portConfidence,
+		"requirement":     "the container must listen on this port; add EXPOSE to the Dockerfile or edit devopsellence.yml if it listens elsewhere",
+		"agent_hints":     []map[string]any{},
 	}
 	if service.Healthcheck != nil {
+		healthcheckPath := strings.TrimSpace(service.Healthcheck.Path)
+		healthcheckPathSource := "default"
+		healthcheckConfidence := "low"
+		if !created || healthcheckPath != config.DefaultHealthcheckPath {
+			healthcheckPathSource = "config"
+			healthcheckConfidence = "high"
+		}
 		contract["healthcheck_path"] = service.Healthcheck.Path
 		contract["healthcheck_port"] = service.Healthcheck.Port
+		contract["healthcheck_path_source"] = healthcheckPathSource
+		contract["healthcheck_confidence"] = healthcheckConfidence
 	}
+	contract["agent_hints"] = initRuntimeAgentHints(serviceName, contract)
 	return contract
+}
+
+func initRuntimeAgentHints(serviceName string, contract map[string]any) []map[string]any {
+	hints := []map[string]any{}
+	if contract["port_source"] == "default" {
+		hints = append(hints, map[string]any{
+			"action": "inspect_app_port",
+			"reason": "No Dockerfile EXPOSE directive or image-exposed port was found, so devopsellence used its default web port.",
+			"instructions": []string{
+				"Inspect framework files, package scripts, server bind/listen code, and PORT defaults.",
+				"If the app listens on a different port, update devopsellence.yml before deploying.",
+				"Alternatively add EXPOSE <port> to the Dockerfile so future init/deploy runs can infer it deterministically.",
+			},
+			"config_fields": []string{
+				fmt.Sprintf("services.%s.ports.http", serviceName),
+				fmt.Sprintf("services.%s.healthcheck.port", serviceName),
+			},
+		})
+	}
+	if contract["healthcheck_path_source"] == "default" {
+		hints = append(hints, map[string]any{
+			"action": "inspect_healthcheck_path",
+			"reason": "No explicit healthcheck path was configured, so devopsellence used its default /up path.",
+			"instructions": []string{
+				"Inspect framework routes and existing health/readiness endpoints.",
+				"If the app exposes a different health path, update devopsellence.yml before deploying.",
+				"If the app has no health endpoint, add one or configure a path that returns HTTP 2xx when the service is ready.",
+			},
+			"config_fields": []string{
+				fmt.Sprintf("services.%s.healthcheck.path", serviceName),
+			},
+		})
+	}
+	return hints
 }
 
 func (a *App) IngressSet(_ context.Context, opts IngressSetOptions) error {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -4915,6 +4915,10 @@ func (a *App) SoloInit(context.Context, SoloInitOptions) error {
 	}
 	configPath := a.ConfigStore.PathFor(discovered.WorkspaceRoot)
 	environmentName := soloEnvironmentName(cfg, "")
+	resolvedCfg, err := config.ResolveEnvironmentConfig(*cfg, environmentName)
+	if err != nil {
+		return err
+	}
 	ready := false
 	if a.SoloState != nil {
 		current, stateErr := a.readSoloState()
@@ -4951,7 +4955,7 @@ func (a *App) SoloInit(context.Context, SoloInitOptions) error {
 		"mode":             string(ModeSolo),
 		"workspace_root":   discovered.WorkspaceRoot,
 		"project_slug":     discovered.ProjectSlug,
-		"runtime_contract": initRuntimeContract(*cfg, discovered, created),
+		"runtime_contract": initRuntimeContract(resolvedCfg, discovered, initRuntimeContractProvenance(*cfg, resolvedCfg, environmentName, created)),
 		"config": map[string]any{
 			"path":           configPath,
 			"created":        created,
@@ -4965,7 +4969,53 @@ func (a *App) SoloInit(context.Context, SoloInitOptions) error {
 	})
 }
 
-func initRuntimeContract(cfg config.ProjectConfig, discovered discovery.Result, created bool) map[string]any {
+type runtimeContractProvenance struct {
+	Created                 bool
+	PortExplicit            bool
+	HealthcheckPathExplicit bool
+}
+
+func initRuntimeContractProvenance(base config.ProjectConfig, resolved config.ProjectConfig, environmentName string, created bool) runtimeContractProvenance {
+	provenance := runtimeContractProvenance{Created: created}
+	serviceName, ok := resolved.PrimaryWebServiceName()
+	if !ok || created {
+		return provenance
+	}
+	if baseService, ok := base.Services[serviceName]; ok {
+		provenance.PortExplicit = hasHTTPPortConfig(baseService.Ports)
+		provenance.HealthcheckPathExplicit = hasHealthcheckPathConfig(baseService.Healthcheck)
+	}
+	envName := strings.TrimSpace(environmentName)
+	if envName == "" {
+		envName = strings.TrimSpace(base.DefaultEnvironment)
+	}
+	if overlay, ok := base.Environments[envName]; ok {
+		if serviceOverlay, ok := overlay.Services[serviceName]; ok {
+			provenance.PortExplicit = provenance.PortExplicit || hasHTTPPortConfig(serviceOverlay.Ports)
+			provenance.HealthcheckPathExplicit = provenance.HealthcheckPathExplicit || hasHealthcheckPathOverlayConfig(serviceOverlay.Healthcheck)
+		}
+	}
+	return provenance
+}
+
+func hasHTTPPortConfig(ports []config.ServicePort) bool {
+	for _, port := range ports {
+		if strings.TrimSpace(port.Name) == "http" && port.Port > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func hasHealthcheckPathConfig(healthcheck *config.HTTPHealthcheck) bool {
+	return healthcheck != nil && strings.TrimSpace(healthcheck.Path) != ""
+}
+
+func hasHealthcheckPathOverlayConfig(healthcheck *config.HTTPHealthcheckOverlay) bool {
+	return healthcheck != nil && healthcheck.Path != nil && strings.TrimSpace(*healthcheck.Path) != ""
+}
+
+func initRuntimeContract(cfg config.ProjectConfig, discovered discovery.Result, provenance runtimeContractProvenance) map[string]any {
 	serviceName, ok := cfg.PrimaryWebServiceName()
 	if !ok {
 		return map[string]any{
@@ -4980,7 +5030,7 @@ func initRuntimeContract(cfg config.ProjectConfig, discovered discovery.Result, 
 	portSource := "default"
 	portConfidence := "low"
 	switch {
-	case !created && port != config.DefaultWebPort:
+	case provenance.PortExplicit:
 		portSource = "config"
 		portConfidence = "high"
 	case discovered.InferredWebPort > 0 && port == discovered.InferredWebPort:
@@ -5000,10 +5050,9 @@ func initRuntimeContract(cfg config.ProjectConfig, discovered discovery.Result, 
 		"agent_hints":     []map[string]any{},
 	}
 	if service.Healthcheck != nil {
-		healthcheckPath := strings.TrimSpace(service.Healthcheck.Path)
 		healthcheckPathSource := "default"
 		healthcheckConfidence := "low"
-		if healthcheckPath != config.DefaultHealthcheckPath {
+		if provenance.HealthcheckPathExplicit {
 			healthcheckPathSource = "config"
 			healthcheckConfidence = "high"
 		}
@@ -5021,7 +5070,7 @@ func initRuntimeAgentHints(serviceName string, contract map[string]any) []map[st
 	if contract["port_source"] == "default" {
 		hints = append(hints, map[string]any{
 			"action": "inspect_app_port",
-			"reason": "No Dockerfile EXPOSE directive or image-exposed port was found, so devopsellence used its default web port.",
+			"reason": "No Dockerfile EXPOSE directive was found, so devopsellence used its default web port.",
 			"instructions": []string{
 				"Inspect framework files, package scripts, server bind/listen code, and PORT defaults.",
 				"If the app listens on a different port, update devopsellence.yml before deploying.",

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -4980,7 +4980,7 @@ func initRuntimeContract(cfg config.ProjectConfig, discovered discovery.Result, 
 	portSource := "default"
 	portConfidence := "low"
 	switch {
-	case !created:
+	case !created && port != config.DefaultWebPort:
 		portSource = "config"
 		portConfidence = "high"
 	case discovered.InferredWebPort > 0 && port == discovered.InferredWebPort:
@@ -5003,7 +5003,7 @@ func initRuntimeContract(cfg config.ProjectConfig, discovered discovery.Result, 
 		healthcheckPath := strings.TrimSpace(service.Healthcheck.Path)
 		healthcheckPathSource := "default"
 		healthcheckConfidence := "low"
-		if !created || healthcheckPath != config.DefaultHealthcheckPath {
+		if healthcheckPath != config.DefaultHealthcheckPath {
 			healthcheckPathSource = "config"
 			healthcheckConfidence = "high"
 		}
@@ -5028,7 +5028,7 @@ func initRuntimeAgentHints(serviceName string, contract map[string]any) []map[st
 				"Alternatively add EXPOSE <port> to the Dockerfile so future init/deploy runs can infer it deterministically.",
 			},
 			"config_fields": []string{
-				fmt.Sprintf("services.%s.ports.http", serviceName),
+				fmt.Sprintf("services.%s.ports[http].port", serviceName),
 				fmt.Sprintf("services.%s.healthcheck.port", serviceName),
 			},
 		})

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -4982,8 +4982,8 @@ func initRuntimeContractProvenance(base config.ProjectConfig, resolved config.Pr
 		return provenance
 	}
 	if baseService, ok := base.Services[serviceName]; ok {
-		provenance.PortExplicit = hasHTTPPortConfig(baseService.Ports)
-		provenance.HealthcheckPathExplicit = hasHealthcheckPathConfig(baseService.Healthcheck)
+		provenance.PortExplicit = hasNonDefaultHTTPPortConfig(baseService.Ports)
+		provenance.HealthcheckPathExplicit = hasNonDefaultHealthcheckPathConfig(baseService.Healthcheck)
 	}
 	envName := strings.TrimSpace(environmentName)
 	if envName == "" {
@@ -4998,6 +4998,15 @@ func initRuntimeContractProvenance(base config.ProjectConfig, resolved config.Pr
 	return provenance
 }
 
+func hasNonDefaultHTTPPortConfig(ports []config.ServicePort) bool {
+	for _, port := range ports {
+		if strings.TrimSpace(port.Name) == "http" && port.Port > 0 && port.Port != config.DefaultWebPort {
+			return true
+		}
+	}
+	return false
+}
+
 func hasHTTPPortConfig(ports []config.ServicePort) bool {
 	for _, port := range ports {
 		if strings.TrimSpace(port.Name) == "http" && port.Port > 0 {
@@ -5007,8 +5016,8 @@ func hasHTTPPortConfig(ports []config.ServicePort) bool {
 	return false
 }
 
-func hasHealthcheckPathConfig(healthcheck *config.HTTPHealthcheck) bool {
-	return healthcheck != nil && strings.TrimSpace(healthcheck.Path) != ""
+func hasNonDefaultHealthcheckPathConfig(healthcheck *config.HTTPHealthcheck) bool {
+	return healthcheck != nil && strings.TrimSpace(healthcheck.Path) != "" && strings.TrimSpace(healthcheck.Path) != config.DefaultHealthcheckPath
 }
 
 func hasHealthcheckPathOverlayConfig(healthcheck *config.HTTPHealthcheckOverlay) bool {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -15,7 +15,6 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
-	"reflect"
 	"regexp"
 	"sort"
 	"strconv"
@@ -4983,9 +4982,8 @@ func initRuntimeContractProvenance(base config.ProjectConfig, resolved config.Pr
 		return provenance
 	}
 	if baseService, ok := base.Services[serviceName]; ok {
-		baseLooksGenerated := looksLikeGeneratedDefaultConfig(base)
-		provenance.PortExplicit = hasHTTPPortConfig(baseService.Ports) && !baseLooksGenerated
-		provenance.HealthcheckPathExplicit = hasHealthcheckPathConfig(baseService.Healthcheck) && !baseLooksGenerated
+		provenance.PortExplicit = hasNonDefaultHTTPPortConfig(baseService.Ports)
+		provenance.HealthcheckPathExplicit = hasNonDefaultHealthcheckPathConfig(baseService.Healthcheck)
 	}
 	envName := strings.TrimSpace(environmentName)
 	if envName == "" {
@@ -5000,6 +4998,15 @@ func initRuntimeContractProvenance(base config.ProjectConfig, resolved config.Pr
 	return provenance
 }
 
+func hasNonDefaultHTTPPortConfig(ports []config.ServicePort) bool {
+	for _, port := range ports {
+		if strings.TrimSpace(port.Name) == "http" && port.Port > 0 && port.Port != config.DefaultWebPort {
+			return true
+		}
+	}
+	return false
+}
+
 func hasHTTPPortConfig(ports []config.ServicePort) bool {
 	for _, port := range ports {
 		if strings.TrimSpace(port.Name) == "http" && port.Port > 0 {
@@ -5009,13 +5016,8 @@ func hasHTTPPortConfig(ports []config.ServicePort) bool {
 	return false
 }
 
-func hasHealthcheckPathConfig(healthcheck *config.HTTPHealthcheck) bool {
-	return healthcheck != nil && strings.TrimSpace(healthcheck.Path) != ""
-}
-
-func looksLikeGeneratedDefaultConfig(cfg config.ProjectConfig) bool {
-	defaultCfg := config.DefaultProjectConfig(cfg.Organization, cfg.Project, cfg.DefaultEnvironment)
-	return reflect.DeepEqual(cfg, defaultCfg)
+func hasNonDefaultHealthcheckPathConfig(healthcheck *config.HTTPHealthcheck) bool {
+	return healthcheck != nil && strings.TrimSpace(healthcheck.Path) != "" && strings.TrimSpace(healthcheck.Path) != config.DefaultHealthcheckPath
 }
 
 func hasHealthcheckPathOverlayConfig(healthcheck *config.HTTPHealthcheckOverlay) bool {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -5079,7 +5079,7 @@ func initRuntimeAgentHints(serviceName string, contract map[string]any) []map[st
 	if contract["port_source"] == "default" {
 		hints = append(hints, map[string]any{
 			"action": "inspect_app_port",
-			"reason": "No Dockerfile EXPOSE directive was found, so devopsellence used its default web port.",
+			"reason": "devopsellence is using its default web port because no matching Dockerfile EXPOSE or non-default config value selected another port.",
 			"instructions": []string{
 				"Inspect framework files, package scripts, server bind/listen code, and PORT defaults.",
 				"If the app listens on a different port, update devopsellence.yml before deploying.",

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -15,6 +15,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"sort"
 	"strconv"
@@ -4982,8 +4983,9 @@ func initRuntimeContractProvenance(base config.ProjectConfig, resolved config.Pr
 		return provenance
 	}
 	if baseService, ok := base.Services[serviceName]; ok {
-		provenance.PortExplicit = hasNonDefaultHTTPPortConfig(baseService.Ports)
-		provenance.HealthcheckPathExplicit = hasNonDefaultHealthcheckPathConfig(baseService.Healthcheck)
+		baseLooksGenerated := looksLikeGeneratedDefaultConfig(base)
+		provenance.PortExplicit = hasHTTPPortConfig(baseService.Ports) && !baseLooksGenerated
+		provenance.HealthcheckPathExplicit = hasHealthcheckPathConfig(baseService.Healthcheck) && !baseLooksGenerated
 	}
 	envName := strings.TrimSpace(environmentName)
 	if envName == "" {
@@ -4998,15 +5000,6 @@ func initRuntimeContractProvenance(base config.ProjectConfig, resolved config.Pr
 	return provenance
 }
 
-func hasNonDefaultHTTPPortConfig(ports []config.ServicePort) bool {
-	for _, port := range ports {
-		if strings.TrimSpace(port.Name) == "http" && port.Port > 0 && port.Port != config.DefaultWebPort {
-			return true
-		}
-	}
-	return false
-}
-
 func hasHTTPPortConfig(ports []config.ServicePort) bool {
 	for _, port := range ports {
 		if strings.TrimSpace(port.Name) == "http" && port.Port > 0 {
@@ -5016,8 +5009,13 @@ func hasHTTPPortConfig(ports []config.ServicePort) bool {
 	return false
 }
 
-func hasNonDefaultHealthcheckPathConfig(healthcheck *config.HTTPHealthcheck) bool {
-	return healthcheck != nil && strings.TrimSpace(healthcheck.Path) != "" && strings.TrimSpace(healthcheck.Path) != config.DefaultHealthcheckPath
+func hasHealthcheckPathConfig(healthcheck *config.HTTPHealthcheck) bool {
+	return healthcheck != nil && strings.TrimSpace(healthcheck.Path) != ""
+}
+
+func looksLikeGeneratedDefaultConfig(cfg config.ProjectConfig) bool {
+	defaultCfg := config.DefaultProjectConfig(cfg.Organization, cfg.Project, cfg.DefaultEnvironment)
+	return reflect.DeepEqual(cfg, defaultCfg)
 }
 
 func hasHealthcheckPathOverlayConfig(healthcheck *config.HTTPHealthcheckOverlay) bool {

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -7501,9 +7501,24 @@ func TestSoloInitCreatesWorkspaceConfig(t *testing.T) {
 	if runtimeContract["healthcheck_path"] != config.DefaultHealthcheckPath || runtimeContract["healthcheck_port"] != float64(3000) {
 		t.Fatalf("runtime_contract healthcheck = %#v, want %s on port 3000", runtimeContract, config.DefaultHealthcheckPath)
 	}
+	if runtimeContract["port_confidence"] != "low" || runtimeContract["healthcheck_path_source"] != "default" || runtimeContract["healthcheck_confidence"] != "low" {
+		t.Fatalf("runtime_contract confidence/source = %#v, want low-confidence default port and healthcheck path", runtimeContract)
+	}
 	requirement := stringValueAny(runtimeContract["requirement"])
 	if !strings.Contains(requirement, "EXPOSE") || !strings.Contains(requirement, "devopsellence.yml") {
 		t.Fatalf("runtime_contract.requirement = %q, want Dockerfile/config guidance", requirement)
+	}
+	hints := jsonArrayFromMap(t, runtimeContract, "agent_hints")
+	if len(hints) != 2 {
+		t.Fatalf("runtime_contract.agent_hints = %#v, want port and healthcheck hints", hints)
+	}
+	portHint := jsonMapFromAny(t, hints[0])
+	if portHint["action"] != "inspect_app_port" || portHint["config_fields"] == nil {
+		t.Fatalf("port agent hint = %#v, want inspect_app_port with config fields", portHint)
+	}
+	healthHint := jsonMapFromAny(t, hints[1])
+	if healthHint["action"] != "inspect_healthcheck_path" || healthHint["config_fields"] == nil {
+		t.Fatalf("healthcheck agent hint = %#v, want inspect_healthcheck_path with config fields", healthHint)
 	}
 }
 
@@ -7538,6 +7553,12 @@ func TestSoloInitReportsConfigPortContract(t *testing.T) {
 	}
 	if runtimeContract["healthcheck_path"] != "/health" || runtimeContract["healthcheck_port"] != float64(8080) {
 		t.Fatalf("runtime_contract healthcheck = %#v, want /health on port 8080", runtimeContract)
+	}
+	if runtimeContract["port_confidence"] != "high" || runtimeContract["healthcheck_path_source"] != "config" || runtimeContract["healthcheck_confidence"] != "high" {
+		t.Fatalf("runtime_contract confidence/source = %#v, want high-confidence configured port and healthcheck", runtimeContract)
+	}
+	if hints := jsonArrayFromMap(t, runtimeContract, "agent_hints"); len(hints) != 0 {
+		t.Fatalf("runtime_contract.agent_hints = %#v, want none for explicit config", hints)
 	}
 }
 
@@ -7599,6 +7620,17 @@ func TestSoloInitReportsDockerfileInferredPortContract(t *testing.T) {
 	}
 	if runtimeContract["healthcheck_port"] != float64(80) {
 		t.Fatalf("runtime_contract.healthcheck_port = %#v, want 80", runtimeContract["healthcheck_port"])
+	}
+	if runtimeContract["port_confidence"] != "high" || runtimeContract["healthcheck_path_source"] != "default" || runtimeContract["healthcheck_confidence"] != "low" {
+		t.Fatalf("runtime_contract confidence/source = %#v, want dockerfile port with low-confidence default healthcheck", runtimeContract)
+	}
+	hints := jsonArrayFromMap(t, runtimeContract, "agent_hints")
+	if len(hints) != 1 {
+		t.Fatalf("runtime_contract.agent_hints = %#v, want healthcheck hint only", hints)
+	}
+	healthHint := jsonMapFromAny(t, hints[0])
+	if healthHint["action"] != "inspect_healthcheck_path" {
+		t.Fatalf("healthcheck agent hint = %#v, want inspect_healthcheck_path", healthHint)
 	}
 }
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -7522,6 +7522,39 @@ func TestSoloInitCreatesWorkspaceConfig(t *testing.T) {
 	}
 }
 
+func TestSoloInitKeepsGeneratedDefaultsLowConfidenceOnRerun(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{
+		Printer:     output.New(&stdout, io.Discard),
+		ConfigStore: config.NewStore(),
+		Cwd:         workspaceRoot,
+	}
+
+	if err := app.SoloInit(context.Background(), SoloInitOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	runtimeContract := jsonMapFromAny(t, payload["runtime_contract"])
+	if runtimeContract["port_source"] != "default" || runtimeContract["port_confidence"] != "low" || runtimeContract["healthcheck_path_source"] != "default" || runtimeContract["healthcheck_confidence"] != "low" {
+		t.Fatalf("runtime_contract = %#v, want generated defaults to remain low-confidence on rerun", runtimeContract)
+	}
+	hints := jsonArrayFromMap(t, runtimeContract, "agent_hints")
+	if len(hints) != 2 {
+		t.Fatalf("runtime_contract.agent_hints = %#v, want port and healthcheck hints", hints)
+	}
+	portHint := jsonMapFromAny(t, hints[0])
+	fields := jsonArrayFromMap(t, portHint, "config_fields")
+	if len(fields) == 0 || fields[0] != "services.web.ports[http].port" {
+		t.Fatalf("port hint config_fields = %#v, want schema-addressable http port field", fields)
+	}
+}
+
 func TestSoloInitReportsConfigPortContract(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	if err := os.WriteFile(filepath.Join(workspaceRoot, "Dockerfile"), []byte("FROM nginx:1.27-alpine\nEXPOSE 8080\n"), 0o644); err != nil {

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -7522,7 +7522,7 @@ func TestSoloInitCreatesWorkspaceConfig(t *testing.T) {
 	}
 }
 
-func TestSoloInitKeepsGeneratedDefaultsLowConfidenceOnRerun(t *testing.T) {
+func TestSoloInitReportsExplicitDefaultConfigContract(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")
 	if _, err := config.Write(workspaceRoot, cfg); err != nil {
@@ -7541,17 +7541,11 @@ func TestSoloInitKeepsGeneratedDefaultsLowConfidenceOnRerun(t *testing.T) {
 	}
 	payload := decodeJSONOutput(t, &stdout)
 	runtimeContract := jsonMapFromAny(t, payload["runtime_contract"])
-	if runtimeContract["port_source"] != "default" || runtimeContract["port_confidence"] != "low" || runtimeContract["healthcheck_path_source"] != "default" || runtimeContract["healthcheck_confidence"] != "low" {
-		t.Fatalf("runtime_contract = %#v, want generated defaults to remain low-confidence on rerun", runtimeContract)
+	if runtimeContract["port_source"] != "config" || runtimeContract["port_confidence"] != "high" || runtimeContract["healthcheck_path_source"] != "config" || runtimeContract["healthcheck_confidence"] != "high" {
+		t.Fatalf("runtime_contract = %#v, want explicit default config to be high-confidence", runtimeContract)
 	}
-	hints := jsonArrayFromMap(t, runtimeContract, "agent_hints")
-	if len(hints) != 2 {
-		t.Fatalf("runtime_contract.agent_hints = %#v, want port and healthcheck hints", hints)
-	}
-	portHint := jsonMapFromAny(t, hints[0])
-	fields := jsonArrayFromMap(t, portHint, "config_fields")
-	if len(fields) == 0 || fields[0] != "services.web.ports[http].port" {
-		t.Fatalf("port hint config_fields = %#v, want schema-addressable http port field", fields)
+	if hints := jsonArrayFromMap(t, runtimeContract, "agent_hints"); len(hints) != 0 {
+		t.Fatalf("runtime_contract.agent_hints = %#v, want none for explicit default config", hints)
 	}
 }
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -7549,6 +7549,38 @@ func TestSoloInitKeepsGeneratedDefaultConfigContractLowConfidence(t *testing.T) 
 	}
 }
 
+func TestSoloInitReportsExplicitBaseDefaultConfigContract(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	web := cfg.Services["web"]
+	web.Env = map[string]string{"RAILS_ENV": "production"}
+	web.Ports = []config.ServicePort{{Name: "http", Port: config.DefaultWebPort}}
+	web.Healthcheck = &config.HTTPHealthcheck{Path: config.DefaultHealthcheckPath, Port: config.DefaultWebPort}
+	cfg.Services["web"] = web
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{
+		Printer:     output.New(&stdout, io.Discard),
+		ConfigStore: config.NewStore(),
+		Cwd:         workspaceRoot,
+	}
+
+	if err := app.SoloInit(context.Background(), SoloInitOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	runtimeContract := jsonMapFromAny(t, payload["runtime_contract"])
+	if runtimeContract["port_source"] != "config" || runtimeContract["port_confidence"] != "high" || runtimeContract["healthcheck_path_source"] != "config" || runtimeContract["healthcheck_confidence"] != "high" {
+		t.Fatalf("runtime_contract = %#v, want explicit base default port and healthcheck reported as config", runtimeContract)
+	}
+	if hints := jsonArrayFromMap(t, runtimeContract, "agent_hints"); len(hints) != 0 {
+		t.Fatalf("runtime_contract.agent_hints = %#v, want no hints for explicit base config", hints)
+	}
+}
+
 func TestSoloInitReportsConfigPortContract(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	if err := os.WriteFile(filepath.Join(workspaceRoot, "Dockerfile"), []byte("FROM nginx:1.27-alpine\nEXPOSE 8080\n"), 0o644); err != nil {

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -7522,7 +7522,7 @@ func TestSoloInitCreatesWorkspaceConfig(t *testing.T) {
 	}
 }
 
-func TestSoloInitReportsExplicitDefaultConfigContract(t *testing.T) {
+func TestSoloInitKeepsGeneratedDefaultConfigContractLowConfidence(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")
 	if _, err := config.Write(workspaceRoot, cfg); err != nil {
@@ -7541,11 +7541,11 @@ func TestSoloInitReportsExplicitDefaultConfigContract(t *testing.T) {
 	}
 	payload := decodeJSONOutput(t, &stdout)
 	runtimeContract := jsonMapFromAny(t, payload["runtime_contract"])
-	if runtimeContract["port_source"] != "config" || runtimeContract["port_confidence"] != "high" || runtimeContract["healthcheck_path_source"] != "config" || runtimeContract["healthcheck_confidence"] != "high" {
-		t.Fatalf("runtime_contract = %#v, want explicit default config to be high-confidence", runtimeContract)
+	if runtimeContract["port_source"] != "default" || runtimeContract["port_confidence"] != "low" || runtimeContract["healthcheck_path_source"] != "default" || runtimeContract["healthcheck_confidence"] != "low" {
+		t.Fatalf("runtime_contract = %#v, want generated defaults to stay low-confidence", runtimeContract)
 	}
-	if hints := jsonArrayFromMap(t, runtimeContract, "agent_hints"); len(hints) != 0 {
-		t.Fatalf("runtime_contract.agent_hints = %#v, want none for explicit default config", hints)
+	if hints := jsonArrayFromMap(t, runtimeContract, "agent_hints"); len(hints) != 2 {
+		t.Fatalf("runtime_contract.agent_hints = %#v, want default config hints", hints)
 	}
 }
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -7549,14 +7549,18 @@ func TestSoloInitKeepsGeneratedDefaultConfigContractLowConfidence(t *testing.T) 
 	}
 }
 
-func TestSoloInitReportsExplicitBaseDefaultConfigContract(t *testing.T) {
+func TestSoloInitKeepsGeneratedDefaultsLowConfidenceWithUnrelatedOverlay(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")
-	web := cfg.Services["web"]
-	web.Env = map[string]string{"RAILS_ENV": "production"}
-	web.Ports = []config.ServicePort{{Name: "http", Port: config.DefaultWebPort}}
-	web.Healthcheck = &config.HTTPHealthcheck{Path: config.DefaultHealthcheckPath, Port: config.DefaultWebPort}
-	cfg.Services["web"] = web
+	cfg.Environments = map[string]config.EnvironmentOverlay{
+		"staging": {
+			Services: map[string]config.ServiceConfigOverlay{
+				"web": {
+					Env: map[string]string{"RAILS_ENV": "staging"},
+				},
+			},
+		},
+	}
 	if _, err := config.Write(workspaceRoot, cfg); err != nil {
 		t.Fatal(err)
 	}
@@ -7573,11 +7577,11 @@ func TestSoloInitReportsExplicitBaseDefaultConfigContract(t *testing.T) {
 	}
 	payload := decodeJSONOutput(t, &stdout)
 	runtimeContract := jsonMapFromAny(t, payload["runtime_contract"])
-	if runtimeContract["port_source"] != "config" || runtimeContract["port_confidence"] != "high" || runtimeContract["healthcheck_path_source"] != "config" || runtimeContract["healthcheck_confidence"] != "high" {
-		t.Fatalf("runtime_contract = %#v, want explicit base default port and healthcheck reported as config", runtimeContract)
+	if runtimeContract["port_source"] != "default" || runtimeContract["port_confidence"] != "low" || runtimeContract["healthcheck_path_source"] != "default" || runtimeContract["healthcheck_confidence"] != "low" {
+		t.Fatalf("runtime_contract = %#v, want generated base defaults to stay low-confidence with unrelated overlay", runtimeContract)
 	}
-	if hints := jsonArrayFromMap(t, runtimeContract, "agent_hints"); len(hints) != 0 {
-		t.Fatalf("runtime_contract.agent_hints = %#v, want no hints for explicit base config", hints)
+	if hints := jsonArrayFromMap(t, runtimeContract, "agent_hints"); len(hints) != 2 {
+		t.Fatalf("runtime_contract.agent_hints = %#v, want default config hints", hints)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds structured init runtime contract confidence/source fields for web port and healthcheck path
- Adds machine-actionable agent_hints when init falls back to the default port or default /up healthcheck path
- Includes runtime_contract in shared init output, matching solo init behavior

## Test Plan
- cd cli && mise x -- go test ./internal/workflow -run 'TestInitWritesConfigOnly|TestSoloInitCreatesWorkspaceConfig|TestSoloInitReportsConfigPortContract|TestSoloInitReportsDockerfileInferredPortContract'
- cd cli && mise x -- go test ./...