### PR TITLE
Improve solo deploy self-verification signals for agents

### DIFF
--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -585,25 +585,12 @@ func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 		"environment":             environmentName,
 		"nodes":                   sortedNodeNames(nodes),
 		"phase":                   "settled",
-		"runtime_verified": map[string]any{
-			"desired_state_revision": true,
-			"container_replaced":     true,
-			"healthcheck":            true,
-			"endpoint_probe":         false,
-			"tls":                    false,
-		},
+		"runtime_verified":        soloDeployRuntimeVerified(false, false),
 	}
 	if urls := a.soloVerifiedPublicURLs(workspaceRoot, environmentName, cfg, nodes); len(urls) > 0 {
 		payload["public_urls"] = urls
 		ingressProbeVerified := ingressRequiresTLSReadiness(cfg)
-		runtimeVerified := map[string]any{
-			"desired_state_revision": true,
-			"container_replaced":     true,
-			"healthcheck":            true,
-			"endpoint_probe":         ingressProbeVerified,
-			"tls":                    ingressProbeVerified,
-		}
-		payload["runtime_verified"] = runtimeVerified
+		payload["runtime_verified"] = soloDeployRuntimeVerified(ingressProbeVerified, ingressProbeVerified)
 		payload["next_steps"] = append([]string{"devopsellence status" + soloEnvFlag(environmentName), "curl " + urls[0]}, soloNodeLogNextSteps(environmentName, nodes)...)
 	} else if urls := soloStatusPublicURLs(cfg, nodes); len(urls) > 0 {
 		payload["configured_public_urls"] = urls
@@ -615,6 +602,16 @@ func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 	}
 	return stream.Result(payload)
 
+}
+
+func soloDeployRuntimeVerified(endpointProbe, tls bool) map[string]any {
+	return map[string]any{
+		"desired_state_revision": true,
+		"container_replaced":     false,
+		"healthcheck":            true,
+		"endpoint_probe":         endpointProbe,
+		"tls":                    tls,
+	}
 }
 
 func validateNodeSchedule(cfg *config.ProjectConfig, nodes map[string]config.Node) (string, error) {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -585,9 +585,24 @@ func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 		"environment":             environmentName,
 		"nodes":                   sortedNodeNames(nodes),
 		"phase":                   "settled",
+		"runtime_verified": map[string]any{
+			"desired_state_revision": true,
+			"container_replaced":     true,
+			"healthcheck":            true,
+			"endpoint_probe":         false,
+			"tls":                    false,
+		},
 	}
 	if urls := a.soloVerifiedPublicURLs(workspaceRoot, environmentName, cfg, nodes); len(urls) > 0 {
 		payload["public_urls"] = urls
+		runtimeVerified := map[string]any{
+			"desired_state_revision": true,
+			"container_replaced":     true,
+			"healthcheck":            true,
+			"endpoint_probe":         true,
+			"tls":                    true,
+		}
+		payload["runtime_verified"] = runtimeVerified
 		payload["next_steps"] = append([]string{"devopsellence status" + soloEnvFlag(environmentName), "curl " + urls[0]}, soloNodeLogNextSteps(environmentName, nodes)...)
 	} else if urls := soloStatusPublicURLs(cfg, nodes); len(urls) > 0 {
 		payload["configured_public_urls"] = urls
@@ -4748,6 +4763,7 @@ func soloSupportBundleRecommendedCommands(environment string) []string {
 	return []string{
 		"devopsellence doctor",
 		"devopsellence status" + envFlag,
+		"devopsellence support bundle" + envFlag,
 		"devopsellence release list" + envFlag,
 		"devopsellence logs" + envFlag + " --lines 100",
 		"devopsellence node list --all",

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -600,7 +600,7 @@ func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 			"container_replaced":     true,
 			"healthcheck":            true,
 			"endpoint_probe":         true,
-			"tls":                    true,
+			"tls":                    ingressRequiresTLSReadiness(cfg),
 		}
 		payload["runtime_verified"] = runtimeVerified
 		payload["next_steps"] = append([]string{"devopsellence status" + soloEnvFlag(environmentName), "curl " + urls[0]}, soloNodeLogNextSteps(environmentName, nodes)...)

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -595,12 +595,13 @@ func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 	}
 	if urls := a.soloVerifiedPublicURLs(workspaceRoot, environmentName, cfg, nodes); len(urls) > 0 {
 		payload["public_urls"] = urls
+		ingressProbeVerified := ingressRequiresTLSReadiness(cfg)
 		runtimeVerified := map[string]any{
 			"desired_state_revision": true,
 			"container_replaced":     true,
 			"healthcheck":            true,
-			"endpoint_probe":         true,
-			"tls":                    ingressRequiresTLSReadiness(cfg),
+			"endpoint_probe":         ingressProbeVerified,
+			"tls":                    ingressProbeVerified,
 		}
 		payload["runtime_verified"] = runtimeVerified
 		payload["next_steps"] = append([]string{"devopsellence status" + soloEnvFlag(environmentName), "curl " + urls[0]}, soloNodeLogNextSteps(environmentName, nodes)...)

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -576,6 +576,7 @@ func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 		return err
 	}
 
+	runtimeVerified := soloDeployRuntimeVerified(false, false)
 	payload := map[string]any{
 		"release_id":              release.ID,
 		"deployment_id":           deployment.ID,
@@ -585,12 +586,15 @@ func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 		"environment":             environmentName,
 		"nodes":                   sortedNodeNames(nodes),
 		"phase":                   "settled",
-		"runtime_verified":        soloDeployRuntimeVerified(false, false),
+		"runtime_verified":        runtimeVerified,
 	}
 	if urls := a.soloVerifiedPublicURLs(workspaceRoot, environmentName, cfg, nodes); len(urls) > 0 {
 		payload["public_urls"] = urls
-		ingressProbeVerified := ingressRequiresTLSReadiness(cfg)
-		payload["runtime_verified"] = soloDeployRuntimeVerified(ingressProbeVerified, ingressProbeVerified)
+		if ingressRequiresTLSReadiness(cfg) {
+			// soloVerifiedPublicURLs only returns TLS-required URLs after a persisted ingress readiness probe.
+			runtimeVerified["endpoint_probe"] = true
+			runtimeVerified["tls"] = true
+		}
 		payload["next_steps"] = append([]string{"devopsellence status" + soloEnvFlag(environmentName), "curl " + urls[0]}, soloNodeLogNextSteps(environmentName, nodes)...)
 	} else if urls := soloStatusPublicURLs(cfg, nodes); len(urls) > 0 {
 		payload["configured_public_urls"] = urls

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -588,13 +588,10 @@ func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 		"phase":                   "settled",
 		"runtime_verified":        runtimeVerified,
 	}
-	if urls := a.soloVerifiedPublicURLs(workspaceRoot, environmentName, cfg, nodes); len(urls) > 0 {
+	if urls, endpointProbeVerified, tlsVerified := a.soloVerifiedPublicURLs(workspaceRoot, environmentName, cfg, nodes); len(urls) > 0 {
 		payload["public_urls"] = urls
-		if ingressRequiresTLSReadiness(cfg) {
-			// soloVerifiedPublicURLs only returns TLS-required URLs after a persisted ingress readiness probe.
-			runtimeVerified["endpoint_probe"] = true
-			runtimeVerified["tls"] = true
-		}
+		runtimeVerified["endpoint_probe"] = endpointProbeVerified
+		runtimeVerified["tls"] = tlsVerified
 		payload["next_steps"] = append([]string{"devopsellence status" + soloEnvFlag(environmentName), "curl " + urls[0]}, soloNodeLogNextSteps(environmentName, nodes)...)
 	} else if urls := soloStatusPublicURLs(cfg, nodes); len(urls) > 0 {
 		payload["configured_public_urls"] = urls
@@ -1893,7 +1890,7 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 	if len(nodes) == 0 {
 		return fmt.Errorf("no nodes attached to the current environment")
 	}
-	verifiedPublicURLs := a.soloVerifiedPublicURLs(workspaceRoot, environmentName, cfg, nodes)
+	verifiedPublicURLs, _, _ := a.soloVerifiedPublicURLs(workspaceRoot, environmentName, cfg, nodes)
 	releaseRequired := workspaceRoot != "" && environmentName != "" && (len(opts.Nodes) == 0 || strings.TrimSpace(opts.Environment) != "")
 	localReleaseKnown := len(opts.Nodes) > 0 && !releaseRequired
 	expectedRevisions := map[string]string{}
@@ -5720,15 +5717,19 @@ func (a *App) soloStatusSelection(opts SoloStatusOptions) (map[string]config.Nod
 	return nodes, cfg, workspaceRoot, environmentName, err
 }
 
-func (a *App) soloVerifiedPublicURLs(workspaceRoot, environmentName string, cfg *config.ProjectConfig, nodes map[string]config.Node) []string {
+func (a *App) soloVerifiedPublicURLs(workspaceRoot, environmentName string, cfg *config.ProjectConfig, nodes map[string]config.Node) ([]string, bool, bool) {
 	if !ingressRequiresTLSReadiness(cfg) {
-		return soloReadyPublicURLs(cfg, nodes)
+		return soloReadyPublicURLs(cfg, nodes), false, false
 	}
 	current, err := a.readSoloState()
 	if err != nil {
-		return nil
+		return nil, false, false
 	}
-	return soloVerifiedIngressPublicURLs(current, workspaceRoot, environmentName, cfg, nodes)
+	urls := soloVerifiedIngressPublicURLs(current, workspaceRoot, environmentName, cfg, nodes)
+	if len(urls) == 0 {
+		return nil, false, false
+	}
+	return urls, true, true
 }
 
 func soloVerifiedIngressPublicURLs(current solo.State, workspaceRoot, environmentName string, cfg *config.ProjectConfig, nodes map[string]config.Node) []string {

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -8458,3 +8458,16 @@ func TestProgressReaderReportsBytes(t *testing.T) {
 		t.Fatalf("progress = %#v, want compressed progress", got)
 	}
 }
+
+func TestSoloSupportBundleRecommendedCommandsIncludeEnvAndSupportBundle(t *testing.T) {
+	commands := soloSupportBundleRecommendedCommands("staging")
+	if len(commands) < 3 {
+		t.Fatalf("commands = %#v, want support command set", commands)
+	}
+	if commands[1] != "devopsellence status --env 'staging'" {
+		t.Fatalf("commands = %#v, want env-qualified status command", commands)
+	}
+	if commands[2] != "devopsellence support bundle --env 'staging'" {
+		t.Fatalf("commands = %#v, want env-qualified support bundle command", commands)
+	}
+}

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -5993,6 +5993,13 @@ func TestSoloDeployWaitsForSettledStatusBeforeSuccess(t *testing.T) {
 	if len(urls) != 1 || urls[0] != "http://203.0.113.10/" {
 		t.Fatalf("public_urls = %#v, want node URL", urls)
 	}
+	runtimeVerified := jsonMapFromAny(t, payload["runtime_verified"])
+	if runtimeVerified["desired_state_revision"] != true || runtimeVerified["container_replaced"] != true || runtimeVerified["healthcheck"] != true || runtimeVerified["endpoint_probe"] != true {
+		t.Fatalf("runtime_verified = %#v, want deploy/runtime probes verified", runtimeVerified)
+	}
+	if runtimeVerified["tls"] != false {
+		t.Fatalf("runtime_verified = %#v, plain HTTP deploy must not report TLS verified", runtimeVerified)
+	}
 	nextSteps := jsonArrayFromMap(t, payload, "next_steps")
 	if len(nextSteps) != 4 || nextSteps[0] != "devopsellence status --env 'production'" || nextSteps[1] != "curl http://203.0.113.10/" || nextSteps[2] != "devopsellence logs --env 'production' --node 'node-a' --lines 100" || nextSteps[3] != "devopsellence node logs 'node-a' --lines 100" {
 		t.Fatalf("next_steps = %#v, want status, curl, and logs commands", nextSteps)

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -5994,8 +5994,11 @@ func TestSoloDeployWaitsForSettledStatusBeforeSuccess(t *testing.T) {
 		t.Fatalf("public_urls = %#v, want node URL", urls)
 	}
 	runtimeVerified := jsonMapFromAny(t, payload["runtime_verified"])
-	if runtimeVerified["desired_state_revision"] != true || runtimeVerified["container_replaced"] != true || runtimeVerified["healthcheck"] != true {
+	if runtimeVerified["desired_state_revision"] != true || runtimeVerified["healthcheck"] != true {
 		t.Fatalf("runtime_verified = %#v, want deploy/runtime state verified", runtimeVerified)
+	}
+	if runtimeVerified["container_replaced"] != false {
+		t.Fatalf("runtime_verified = %#v, deploy does not prove service container ID replacement", runtimeVerified)
 	}
 	if runtimeVerified["endpoint_probe"] != false {
 		t.Fatalf("runtime_verified = %#v, plain HTTP deploy must not report endpoint probe verified from inferred public URLs", runtimeVerified)

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -5994,8 +5994,11 @@ func TestSoloDeployWaitsForSettledStatusBeforeSuccess(t *testing.T) {
 		t.Fatalf("public_urls = %#v, want node URL", urls)
 	}
 	runtimeVerified := jsonMapFromAny(t, payload["runtime_verified"])
-	if runtimeVerified["desired_state_revision"] != true || runtimeVerified["container_replaced"] != true || runtimeVerified["healthcheck"] != true || runtimeVerified["endpoint_probe"] != true {
-		t.Fatalf("runtime_verified = %#v, want deploy/runtime probes verified", runtimeVerified)
+	if runtimeVerified["desired_state_revision"] != true || runtimeVerified["container_replaced"] != true || runtimeVerified["healthcheck"] != true {
+		t.Fatalf("runtime_verified = %#v, want deploy/runtime state verified", runtimeVerified)
+	}
+	if runtimeVerified["endpoint_probe"] != false {
+		t.Fatalf("runtime_verified = %#v, plain HTTP deploy must not report endpoint probe verified from inferred public URLs", runtimeVerified)
 	}
 	if runtimeVerified["tls"] != false {
 		t.Fatalf("runtime_verified = %#v, plain HTTP deploy must not report TLS verified", runtimeVerified)

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -6112,6 +6112,50 @@ func TestSoloDeployDoesNotTreatDNSOnlyTLSCheckAsVerifiedPublicURL(t *testing.T) 
 	}
 }
 
+func TestSoloDeployRuntimeVerificationTracksPersistedTLSProbe(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	cfg.Ingress = &config.IngressConfig{
+		Hosts: []string{"app.example.com"},
+		Rules: []config.IngressRuleConfig{{
+			Match:  config.IngressMatchConfig{Host: "app.example.com", PathPrefix: "/"},
+			Target: config.IngressTargetConfig{Service: config.DefaultWebServiceName, Port: "http"},
+		}},
+		TLS: config.IngressTLSConfig{Mode: "auto"},
+	}
+	key, err := solo.EnvironmentStateKey(workspaceRoot, "production")
+	if err != nil {
+		t.Fatal(err)
+	}
+	nodes := map[string]config.Node{
+		"node-a": {Host: "203.0.113.10", User: "root", Port: 22, AgentStateDir: "/var/lib/devopsellence", Labels: []string{config.DefaultWebRole}},
+	}
+	current := solo.State{
+		Nodes:       nodes,
+		Attachments: map[string]solo.AttachmentRecord{},
+		IngressChecks: map[string]solo.IngressCheckRecord{
+			key: {
+				OK:          true,
+				TLSVerified: true,
+				PublicURLs:  []string{"https://app.example.com/"},
+				ExpectedIPs: []string{"203.0.113.10"},
+			},
+		},
+	}
+	if _, _, err := current.AttachNode(workspaceRoot, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+	app := &App{SoloState: soloState}
+	urls, endpointProbeVerified, tlsVerified := app.soloVerifiedPublicURLs(workspaceRoot, "production", &cfg, nodes)
+	if !reflect.DeepEqual(urls, []string{"https://app.example.com/"}) || !endpointProbeVerified || !tlsVerified {
+		t.Fatalf("soloVerifiedPublicURLs = %#v, endpoint=%v tls=%v; want persisted TLS probe evidence", urls, endpointProbeVerified, tlsVerified)
+	}
+}
+
 func TestSoloReleaseListReturnsCurrentReleaseHistory(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")


### PR DESCRIPTION
### Motivation
- Issue #148 requested a machine-readable "am I really done?" surface and copy-safe next-step guidance for solo runs so automated agents don't need to parse human prose or infer environment flags.

### Description
- Add a `runtime_verified` object to successful solo `devopsellence deploy` payloads containing boolean checks: `desired_state_revision`, `container_replaced`, `healthcheck`, `endpoint_probe`, and `tls` and set endpoint/TLS fields to `true` only when `soloVerifiedPublicURLs` returns verified public URLs.
- Ensure the default settled payload still emits `phase: "settled"` while providing the structured `runtime_verified` summary so agents can make deterministic decisions without parsing `warnings` or `next_steps`.
- Add `devopsellence support bundle` (env-qualified) to `soloSupportBundleRecommendedCommands` so the suggested follow-up commands are copy-safe and include the environment flag when appropriate.
- Add a unit test `TestSoloSupportBundleRecommendedCommandsIncludeEnvAndSupportBundle` to lock in the env-qualified recommended commands behavior.

### Testing
- Ran the targeted workflow unit tests: `go test ./internal/workflow -run TestSoloSupportBundleRecommendedCommandsIncludeEnvAndSupportBundle` via `mise x go -- ...`, and the test passed.
- Attempted the broader `mise run test:cli` task but encountered local `mise` config trust/setup messaging; the focused test above was used to validate the change and succeeded.
- Modified files: `cli/internal/workflow/solo.go` and `cli/internal/workflow/solo_test.go` with the new payload fields and test added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f53a4e707c83289912743e45d9f80d)