### PR TITLE
fix(cli): verify TLS ingress and scope support bundles

### DIFF
--- a/cli/internal/solo/state.go
+++ b/cli/internal/solo/state.go
@@ -58,6 +58,8 @@ type IngressCheckRecord struct {
 	WorkspaceKey  string   `json:"workspace_key,omitempty"`
 	Environment   string   `json:"environment,omitempty"`
 	OK            bool     `json:"ok"`
+	CheckScope    string   `json:"check_scope,omitempty"`
+	TLSVerified   bool     `json:"tls_verified,omitempty"`
 	PublicURLs    []string `json:"public_urls,omitempty"`
 	ExpectedIPs   []string `json:"expected_ips,omitempty"`
 	CheckedAt     string   `json:"checked_at,omitempty"`

--- a/cli/internal/workflow/root.go
+++ b/cli/internal/workflow/root.go
@@ -1183,7 +1183,7 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 	supportBundleCommand := &cobra.Command{
 		Use:   "bundle",
 		Short: "Write a redacted solo support bundle JSON file",
-		Long:  "Write a redacted solo support bundle JSON file. Environment resolution uses --env first, then DEVOPSELLENCE_ENVIRONMENT, then the project default environment.",
+		Long:  "Write a redacted solo support bundle JSON file. Environment resolution uses --env first, then DEVOPSELLENCE_ENVIRONMENT, then the saved workspace environment, then the project default environment.",
 		RunE: runSoloOnly("support bundle", func(ctx context.Context) error {
 			return app.SoloSupportBundle(ctx, supportBundleOpts)
 		}),

--- a/cli/internal/workflow/root.go
+++ b/cli/internal/workflow/root.go
@@ -1183,11 +1183,13 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 	supportBundleCommand := &cobra.Command{
 		Use:   "bundle",
 		Short: "Write a redacted solo support bundle JSON file",
+		Long:  "Write a redacted solo support bundle JSON file. Environment resolution uses --env first, then DEVOPSELLENCE_ENVIRONMENT, then the project default environment.",
 		RunE: runSoloOnly("support bundle", func(ctx context.Context) error {
 			return app.SoloSupportBundle(ctx, supportBundleOpts)
 		}),
 	}
 	supportBundleCommand.Flags().StringVar(&supportBundleOpts.Output, "output", "", "Output path for support bundle JSON")
+	supportBundleCommand.Flags().StringVar(&supportBundleOpts.Environment, "env", "", "Environment to scope support evidence")
 	supportCommand.AddCommand(supportBundleCommand)
 	root.AddCommand(supportCommand)
 

--- a/cli/internal/workflow/root_test.go
+++ b/cli/internal/workflow/root_test.go
@@ -116,6 +116,23 @@ func TestInitModeFlagPersistsWorkspaceModeAndWritesConfig(t *testing.T) {
 	}
 }
 
+func TestRootSoloSupportBundleHelpDocumentsEnvironmentResolution(t *testing.T) {
+	var stdout bytes.Buffer
+	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, t.TempDir())
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{"support", "bundle", "--help"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	help := stdout.String()
+	want := "Environment resolution uses --env first, then DEVOPSELLENCE_ENVIRONMENT, then the saved workspace environment, then the project default environment."
+	if !strings.Contains(help, want) {
+		t.Fatalf("help = %q, want environment resolution text %q", help, want)
+	}
+}
+
 func TestRootSoloContextEnvListDoesNotRequireAuth(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	cwd := rootTestWorkspaceWithMode(t, ModeSolo)

--- a/cli/internal/workflow/root_test.go
+++ b/cli/internal/workflow/root_test.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -497,6 +498,57 @@ func rootTestSoloWorkspace(t *testing.T) string {
 		t.Fatal(err)
 	}
 	return cwd
+}
+
+func TestSupportBundleAcceptsEnvFlag(t *testing.T) {
+	cwd := rootTestWorkspaceWithMode(t, ModeSolo)
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	cfg.Environments = map[string]config.EnvironmentOverlay{"staging": {}}
+	if _, err := config.Write(cwd, cfg); err != nil {
+		t.Fatal(err)
+	}
+	current := solo.State{Nodes: map[string]config.Node{
+		"node-prod":    {Host: "203.0.113.10", User: "root", Labels: []string{config.DefaultWebRole}},
+		"node-staging": {Host: "203.0.113.11", User: "root", Labels: []string{config.DefaultWebRole}},
+	}}
+	if _, _, err := current.AttachNode(cwd, "production", "node-prod"); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := current.AttachNode(cwd, "staging", "node-staging"); err != nil {
+		t.Fatal(err)
+	}
+	if err := solo.NewStateStore(solo.DefaultStatePath()).Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	outPath := filepath.Join(t.TempDir(), "support.json")
+	var stdout bytes.Buffer
+	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, cwd)
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{"support", "bundle", "--env", "staging", "--output", outPath})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\n%s", err, stdout.String())
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	if payload["environment"] != "staging" || strings.TrimSpace(stringValueAny(payload["environment_id"])) == "" {
+		t.Fatalf("payload = %#v, want staging environment and environment_id", payload)
+	}
+	data, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var bundle map[string]any
+	if err := json.Unmarshal(data, &bundle); err != nil {
+		t.Fatalf("parse bundle: %v\n%s", err, string(data))
+	}
+	if bundle["environment"] != "staging" || strings.TrimSpace(stringValueAny(bundle["environment_id"])) == "" {
+		t.Fatalf("bundle = %#v, want staging environment and environment_id", bundle)
+	}
+	attached := jsonArrayFromMap(t, bundle, "attached_nodes")
+	if len(attached) != 1 || attached[0] != "node-staging" {
+		t.Fatalf("attached_nodes = %#v, want staging node only", attached)
+	}
 }
 
 func TestNodeHelpShowsSharedAndSoloActions(t *testing.T) {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -6034,18 +6034,18 @@ func defaultIngressTLSProbe(ctx context.Context, publicURL string) ingressTLSPro
 	if err != nil {
 		return ingressTLSProbeResult{Error: err.Error()}
 	}
-	resp, err := http.DefaultClient.Do(req)
+	client := &http.Client{
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return ingressTLSProbeResult{Error: err.Error()}
 	}
 	defer resp.Body.Close()
 	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
-	ok := resp.StatusCode >= 200 && resp.StatusCode < 500
-	result := ingressTLSProbeResult{OK: ok, StatusCode: resp.StatusCode}
-	if !ok {
-		result.Error = fmt.Sprintf("HTTPS probe returned status %d", resp.StatusCode)
-	}
-	return result
+	return ingressTLSProbeResult{OK: true, StatusCode: resp.StatusCode}
 }
 
 func webNodeIPs(cfg *config.ProjectConfig, selected map[string]config.Node) []string {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -11,6 +11,8 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path"
@@ -161,7 +163,8 @@ type SoloDoctorOptions struct {
 }
 
 type SoloSupportBundleOptions struct {
-	Output string
+	Output      string
+	Environment string
 }
 
 type SoloNodeCreateOptions struct {
@@ -4684,10 +4687,12 @@ func (a *App) SoloSupportBundle(_ context.Context, opts SoloSupportBundleOptions
 		return err
 	}
 	environmentName := ""
+	environmentID := ""
 	attachedNodes := []string{}
 	if cfg != nil {
-		environmentName = a.effectiveEnvironment("", cfg)
+		environmentName = a.effectiveEnvironment(opts.Environment, cfg)
 		attachedNodes, _ = current.AttachedNodeNames(discovered.WorkspaceRoot, environmentName)
+		environmentID, _ = soloDisplayEnvironmentID(discovered.WorkspaceRoot, environmentName)
 	}
 	bundle := map[string]any{
 		"schema_version": outputSchemaVersion,
@@ -4699,6 +4704,7 @@ func (a *App) SoloSupportBundle(_ context.Context, opts SoloSupportBundleOptions
 			"slug": discovered.ProjectSlug,
 		},
 		"environment":          environmentName,
+		"environment_id":       environmentID,
 		"config":               redactProjectConfigForSupport(cfg),
 		"solo_state":           redactSoloStateForSupport(current),
 		"attached_nodes":       attachedNodes,
@@ -4718,7 +4724,7 @@ func (a *App) SoloSupportBundle(_ context.Context, opts SoloSupportBundleOptions
 	if err := writePrivateFileAtomic(outputPath, data); err != nil {
 		return err
 	}
-	return a.Printer.PrintJSON(map[string]any{
+	result := map[string]any{
 		"schema_version": outputSchemaVersion,
 		"action":         "support_bundle",
 		"path":           outputPath,
@@ -4727,7 +4733,14 @@ func (a *App) SoloSupportBundle(_ context.Context, opts SoloSupportBundleOptions
 			"Attach this JSON file to a support/debugging issue when it is safe to share machine paths and node hostnames/IPs.",
 			"Run devopsellence node diagnose <node> for live remote runtime details.",
 		},
-	})
+	}
+	if environmentName != "" {
+		result["environment"] = environmentName
+	}
+	if environmentID != "" {
+		result["environment_id"] = environmentID
+	}
+	return a.Printer.PrintJSON(result)
 }
 
 func soloSupportBundleRecommendedCommands(environment string) []string {
@@ -5318,7 +5331,7 @@ func (a *App) IngressCheck(ctx context.Context, opts IngressCheckOptions) error 
 	}
 	deadline := time.Now().Add(opts.Wait)
 	for {
-		report, err := ingressDNSReport(ctx, cfg, nodes, environmentName)
+		report, err := ingressReadinessReport(ctx, cfg, nodes, true, environmentName)
 		if err != nil {
 			return err
 		}
@@ -5369,6 +5382,8 @@ func recordSuccessfulSoloIngressCheck(current *solo.State, workspaceRoot, enviro
 	}
 	current.IngressChecks[key] = solo.IngressCheckRecord{
 		OK:            true,
+		CheckScope:    report.CheckScope,
+		TLSVerified:   report.TLSVerified,
 		PublicURLs:    append([]string(nil), report.PublicURLs...),
 		ExpectedIPs:   append([]string(nil), report.ExpectedIPs...),
 		CheckedAt:     time.Now().UTC().Format(time.RFC3339),
@@ -5699,15 +5714,15 @@ func (a *App) soloVerifiedPublicURLs(workspaceRoot, environmentName string, cfg 
 }
 
 func soloVerifiedIngressPublicURLs(current solo.State, workspaceRoot, environmentName string, cfg *config.ProjectConfig, nodes map[string]config.Node) []string {
-	if ingressRequiresTLSReadiness(cfg) {
-		return nil
-	}
 	key, err := solo.EnvironmentStateKey(workspaceRoot, environmentName)
 	if err != nil {
 		return nil
 	}
 	record, ok := current.IngressChecks[key]
 	if !ok || !record.OK {
+		return nil
+	}
+	if ingressRequiresTLSReadiness(cfg) && !record.TLSVerified {
 		return nil
 	}
 	urls := soloStatusPublicURLs(cfg, nodes)
@@ -5815,12 +5830,22 @@ type ingressDNSReportResult struct {
 }
 
 type ingressDNSHostResult struct {
-	Host     string   `json:"host"`
-	OK       bool     `json:"ok"`
-	Resolved []string `json:"resolved,omitempty"`
-	Missing  []string `json:"missing,omitempty"`
-	Error    string   `json:"error,omitempty"`
+	Host        string   `json:"host"`
+	OK          bool     `json:"ok"`
+	Resolved    []string `json:"resolved,omitempty"`
+	Missing     []string `json:"missing,omitempty"`
+	TLSVerified bool     `json:"tls_verified,omitempty"`
+	TLSError    string   `json:"tls_error,omitempty"`
+	Error       string   `json:"error,omitempty"`
 }
+
+type ingressTLSProbeResult struct {
+	OK         bool
+	StatusCode int
+	Error      string
+}
+
+var ingressTLSProbe = defaultIngressTLSProbe
 
 type ingressHint struct {
 	Code            string            `json:"code"`
@@ -5848,8 +5873,10 @@ func (e ingressDNSReadinessError) Error() string {
 
 func (e ingressDNSReadinessError) ErrorFields() map[string]any {
 	fields := map[string]any{
-		"kind":         "ingress_dns_not_ready",
+		"kind":         firstNonEmpty(ingressReadinessErrorKind(e.report), "ingress_dns_not_ready"),
 		"ok":           e.report.OK,
+		"check_scope":  e.report.CheckScope,
+		"tls_verified": e.report.TLSVerified,
 		"expected_ips": e.report.ExpectedIPs,
 	}
 	if len(e.report.Hosts) > 0 {
@@ -5862,6 +5889,13 @@ func (e ingressDNSReadinessError) ErrorFields() map[string]any {
 		fields["next_steps"] = e.report.NextSteps
 	}
 	return fields
+}
+
+func ingressReadinessErrorKind(report ingressDNSReportResult) string {
+	if report.CheckScope == "dns_tls" && !report.TLSVerified {
+		return "ingress_tls_not_ready"
+	}
+	return "ingress_dns_not_ready"
 }
 
 const soloStatusMissingSentinel = "__DEVOPSELLENCE_STATUS_MISSING__"
@@ -5895,10 +5929,17 @@ func ingressDNSReportError(report ingressDNSReportResult) error {
 	if len(report.Hosts) == 0 {
 		return fmt.Errorf("no ingress hostnames configured")
 	}
+	if report.CheckScope == "dns_tls" && !report.TLSVerified {
+		return fmt.Errorf("ingress TLS is not ready")
+	}
 	return fmt.Errorf("ingress DNS is not ready")
 }
 
 func ingressDNSReport(ctx context.Context, cfg *config.ProjectConfig, selected map[string]config.Node, environment ...string) (ingressDNSReportResult, error) {
+	return ingressReadinessReport(ctx, cfg, selected, false, environment...)
+}
+
+func ingressReadinessReport(ctx context.Context, cfg *config.ProjectConfig, selected map[string]config.Node, verifyTLS bool, environment ...string) (ingressDNSReportResult, error) {
 	hosts := concreteIngressHosts(cfg)
 	expected := webNodeIPs(cfg, selected)
 	if len(expected) == 0 {
@@ -5936,14 +5977,75 @@ func ingressDNSReport(ctx context.Context, cfg *config.ProjectConfig, selected m
 		}
 		report.Hosts = append(report.Hosts, result)
 	}
+	if verifyTLS && report.OK && ingressRequiresTLSReadiness(cfg) {
+		report.CheckScope = "dns_tls"
+		report.TLSVerified = true
+		probeResults := ingressTLSProbeResults(ctx, report.PublicURLs)
+		for i := range report.Hosts {
+			probe, ok := probeResults[report.Hosts[i].Host]
+			if !ok {
+				report.TLSVerified = false
+				report.OK = false
+				report.Hosts[i].OK = false
+				report.Hosts[i].TLSError = "missing HTTPS probe result"
+				continue
+			}
+			report.Hosts[i].TLSVerified = probe.OK
+			if !probe.OK {
+				report.TLSVerified = false
+				report.OK = false
+				report.Hosts[i].OK = false
+				report.Hosts[i].TLSError = probe.Error
+			}
+		}
+	}
 	if len(report.PublicURLs) > 0 {
 		if report.OK {
 			report.NextSteps = []string{"devopsellence status" + envFlag, "curl " + report.PublicURLs[0]}
+		} else if report.CheckScope == "dns_tls" && !report.TLSVerified {
+			report.NextSteps = []string{"devopsellence status" + envFlag, "curl " + report.PublicURLs[0], "devopsellence ingress check" + envFlag + " --wait 5m"}
 		} else {
 			report.NextSteps = []string{"devopsellence status" + envFlag, "update DNS records to point at expected_ips", "devopsellence ingress check" + envFlag + " --wait 5m"}
 		}
 	}
 	return report, nil
+}
+
+func ingressTLSProbeResults(ctx context.Context, publicURLs []string) map[string]ingressTLSProbeResult {
+	results := map[string]ingressTLSProbeResult{}
+	for _, publicURL := range publicURLs {
+		parsed, err := url.Parse(publicURL)
+		if err != nil {
+			continue
+		}
+		host := strings.TrimSpace(parsed.Hostname())
+		if host == "" {
+			continue
+		}
+		results[host] = ingressTLSProbe(ctx, publicURL)
+	}
+	return results
+}
+
+func defaultIngressTLSProbe(ctx context.Context, publicURL string) ingressTLSProbeResult {
+	probeCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(probeCtx, http.MethodGet, publicURL, nil)
+	if err != nil {
+		return ingressTLSProbeResult{Error: err.Error()}
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return ingressTLSProbeResult{Error: err.Error()}
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+	ok := resp.StatusCode >= 200 && resp.StatusCode < 500
+	result := ingressTLSProbeResult{OK: ok, StatusCode: resp.StatusCode}
+	if !ok {
+		result.Error = fmt.Sprintf("HTTPS probe returned status %d", resp.StatusCode)
+	}
+	return result
 }
 
 func webNodeIPs(cfg *config.ProjectConfig, selected map[string]config.Node) []string {

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -1488,6 +1488,60 @@ func TestSoloStatusDoesNotTreatDNSOnlyTLSCheckAsVerifiedPublicURL(t *testing.T) 
 	}
 }
 
+func TestSoloStatusTreatsTLSVerifiedCheckAsReadyPublicURL(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	cfg.Ingress = &config.IngressConfig{
+		Hosts: []string{"app.example.com"},
+		Rules: []config.IngressRuleConfig{{
+			Match:  config.IngressMatchConfig{Host: "app.example.com", PathPrefix: "/"},
+			Target: config.IngressTargetConfig{Service: config.DefaultWebServiceName, Port: "http"},
+		}},
+		TLS: config.IngressTLSConfig{Mode: "auto"},
+	}
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	installFakeSoloCommands(t, []fakeSSHResponse{{stdout: `{"revision":"rev","phase":"settled","summary":{"environments":1,"services":1}}` + "\n"}})
+
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{Nodes: map[string]config.Node{"node-a": {Host: "203.0.113.10", User: "root", Labels: []string{config.DefaultWebRole}}}}
+	if _, _, err := current.AttachNode(workspaceRoot, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	seedSoloCurrentRelease(t, &current, workspaceRoot, "production", "rev")
+	key, err := solo.EnvironmentStateKey(workspaceRoot, "production")
+	if err != nil {
+		t.Fatal(err)
+	}
+	current.IngressChecks = map[string]solo.IngressCheckRecord{
+		key: {
+			OK:          true,
+			TLSVerified: true,
+			CheckScope:  "dns_tls",
+			PublicURLs:  []string{"https://app.example.com/"},
+			ExpectedIPs: []string{"203.0.113.10"},
+		},
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState, ConfigStore: config.NewStore(), Cwd: workspaceRoot}
+	if err := app.SoloStatus(context.Background(), SoloStatusOptions{}); err != nil {
+		t.Fatalf("SoloStatus() error = %v", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	urls := jsonArrayFromMap(t, payload, "public_urls")
+	if len(urls) != 1 || urls[0] != "https://app.example.com/" {
+		t.Fatalf("public_urls = %#v, want verified HTTPS URL", urls)
+	}
+	if _, ok := payload["public_url_status"]; ok {
+		t.Fatalf("payload = %#v, did not want pending public_url_status after TLS verification", payload)
+	}
+}
+
 func TestSoloVerifiedIngressPublicURLsRejectsRecordWhenSelectedNodesHaveNoWebIPs(t *testing.T) {
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")
 	cfg.Ingress = &config.IngressConfig{
@@ -1651,6 +1705,12 @@ func TestIngressCheckPersistsSuccessfulReadinessRecord(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	oldProbe := ingressTLSProbe
+	ingressTLSProbe = func(context.Context, string) ingressTLSProbeResult {
+		return ingressTLSProbeResult{OK: true, StatusCode: 200}
+	}
+	t.Cleanup(func() { ingressTLSProbe = oldProbe })
+
 	var stdout bytes.Buffer
 	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState, ConfigStore: config.NewStore(), Cwd: workspaceRoot}
 	if err := app.IngressCheck(context.Background(), IngressCheckOptions{}); err != nil {
@@ -1659,6 +1719,9 @@ func TestIngressCheckPersistsSuccessfulReadinessRecord(t *testing.T) {
 	payload := decodeJSONOutput(t, &stdout)
 	if payload["ok"] != true {
 		t.Fatalf("payload ok = %v, want true", payload["ok"])
+	}
+	if payload["check_scope"] != "dns_tls" || payload["tls_verified"] != true {
+		t.Fatalf("payload = %#v, want dns_tls scope with TLS verified", payload)
 	}
 	loaded, err := soloState.Read()
 	if err != nil {
@@ -1669,7 +1732,7 @@ func TestIngressCheckPersistsSuccessfulReadinessRecord(t *testing.T) {
 		t.Fatal(err)
 	}
 	record := loaded.IngressChecks[key]
-	if !record.OK || !reflect.DeepEqual(record.PublicURLs, []string{"https://127.0.0.1/"}) || !reflect.DeepEqual(record.ExpectedIPs, []string{"127.0.0.1"}) || strings.TrimSpace(record.CheckedAt) == "" {
+	if !record.OK || !record.TLSVerified || record.CheckScope != "dns_tls" || !reflect.DeepEqual(record.PublicURLs, []string{"https://127.0.0.1/"}) || !reflect.DeepEqual(record.ExpectedIPs, []string{"127.0.0.1"}) || strings.TrimSpace(record.CheckedAt) == "" {
 		t.Fatalf("ingress check record = %#v", record)
 	}
 }

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -1672,6 +1674,39 @@ func TestIngressDNSReportIncludesPublicURLsAndReadyNextSteps(t *testing.T) {
 	}
 	if len(report.NextSteps) != 2 || report.NextSteps[0] != "devopsellence status" || report.NextSteps[1] != "curl https://127.0.0.1/" {
 		t.Fatalf("next_steps = %#v, want status and curl", report.NextSteps)
+	}
+}
+
+func TestDefaultIngressTLSProbeDoesNotFollowRedirects(t *testing.T) {
+	redirectTargetHit := false
+	redirectTarget := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		redirectTargetHit = true
+	}))
+	defer redirectTarget.Close()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, redirectTarget.URL, http.StatusFound)
+	}))
+	defer server.Close()
+
+	result := defaultIngressTLSProbe(context.Background(), server.URL)
+	if !result.OK || result.StatusCode != http.StatusFound || result.Error != "" {
+		t.Fatalf("defaultIngressTLSProbe() = %#v, want redirect response accepted without following it", result)
+	}
+	if redirectTargetHit {
+		t.Fatal("defaultIngressTLSProbe followed redirect target; want original ingress host only")
+	}
+}
+
+func TestDefaultIngressTLSProbeAcceptsServerErrorResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "warming up", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	result := defaultIngressTLSProbe(context.Background(), server.URL)
+	if !result.OK || result.StatusCode != http.StatusServiceUnavailable || result.Error != "" {
+		t.Fatalf("defaultIngressTLSProbe() = %#v, want any completed HTTP response to prove readiness", result)
 	}
 }
 


### PR DESCRIPTION
## Summary
- make `devopsellence ingress check` verify real HTTPS/TLS reachability after DNS resolves and persist `tls_verified` readiness evidence
- let `devopsellence status` trust only TLS-verified ingress records for TLS public URLs, so healthy HTTPS moves from `configured_tls_pending` to `public_urls`
- add `support bundle --env` with scoped `environment` / `environment_id` output and help text for resolution order

Closes #146.
Closes #147.

## Test plan
- `cd cli && mise x -- go test ./internal/solo ./internal/workflow -count=1`
- `mise run test:cli`
- `mise run build:cli`
- live dogfood validation with built CLI against `solo-clean-05012348`:
  - `bin/devopsellence ingress check --env production --wait 30s` returned `check_scope: "dns_tls"`, `tls_verified: true`
  - `bin/devopsellence status --env production` returned `public_urls` for `https://5-161-84-137.sslip.io/` instead of `configured_tls_pending`
  - `bin/devopsellence support bundle --env staging --output <tmp>` returned `environment: "staging"`, an `environment_id`, and staging-scoped attached nodes/recommended commands
