### PR TITLE
fix(cli): preserve init runtime contract provenance

### DIFF
--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -17,6 +17,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"sort"
 	"strconv"
@@ -5011,9 +5012,10 @@ func initRuntimeContractProvenance(base config.ProjectConfig, resolved config.Pr
 		return provenance
 	}
 	provenance.ConfigFieldPrefix = fmt.Sprintf("services.%s", serviceName)
-	if baseService, ok := base.Services[serviceName]; ok {
-		provenance.PortExplicit = hasNonDefaultHTTPPortConfig(baseService.Ports)
-		provenance.HealthcheckPathExplicit = hasNonDefaultHealthcheckPathConfig(baseService.Healthcheck)
+	if baseService, ok := base.Services[serviceName]; ok && !isGeneratedDefaultBaseService(base, serviceName, baseService) {
+		nonRuntimeEdited := hasNonRuntimeBaseServiceEdits(base, serviceName, baseService)
+		provenance.PortExplicit = hasNonDefaultHTTPPortConfig(baseService.Ports) || (nonRuntimeEdited && hasHTTPPortConfig(baseService.Ports))
+		provenance.HealthcheckPathExplicit = hasNonDefaultHealthcheckPathConfig(baseService.Healthcheck) || (nonRuntimeEdited && hasHealthcheckPathConfig(baseService.Healthcheck))
 	}
 	envName := strings.TrimSpace(environmentName)
 	if envName == "" {
@@ -5021,12 +5023,31 @@ func initRuntimeContractProvenance(base config.ProjectConfig, resolved config.Pr
 	}
 	if overlay, ok := base.Environments[envName]; ok {
 		if serviceOverlay, ok := overlay.Services[serviceName]; ok {
-			provenance.ConfigFieldPrefix = fmt.Sprintf("environments.%s.services.%s", envName, serviceName)
-			provenance.PortExplicit = provenance.PortExplicit || hasHTTPPortConfig(serviceOverlay.Ports)
-			provenance.HealthcheckPathExplicit = provenance.HealthcheckPathExplicit || hasHealthcheckPathOverlayConfig(serviceOverlay.Healthcheck)
+			portExplicit := hasHTTPPortConfig(serviceOverlay.Ports)
+			healthcheckPathExplicit := hasHealthcheckPathOverlayConfig(serviceOverlay.Healthcheck)
+			if portExplicit || healthcheckPathExplicit {
+				provenance.ConfigFieldPrefix = fmt.Sprintf("environments.%s.services.%s", envName, serviceName)
+			}
+			provenance.PortExplicit = provenance.PortExplicit || portExplicit
+			provenance.HealthcheckPathExplicit = provenance.HealthcheckPathExplicit || healthcheckPathExplicit
 		}
 	}
 	return provenance
+}
+
+func isGeneratedDefaultBaseService(cfg config.ProjectConfig, serviceName string, service config.ServiceConfig) bool {
+	defaultService, ok := config.DefaultProjectConfig(cfg.Organization, cfg.Project, cfg.DefaultEnvironment).Services[serviceName]
+	return ok && reflect.DeepEqual(service, defaultService)
+}
+
+func hasNonRuntimeBaseServiceEdits(cfg config.ProjectConfig, serviceName string, service config.ServiceConfig) bool {
+	defaultService, ok := config.DefaultProjectConfig(cfg.Organization, cfg.Project, cfg.DefaultEnvironment).Services[serviceName]
+	if !ok {
+		return true
+	}
+	service.Ports = defaultService.Ports
+	service.Healthcheck = defaultService.Healthcheck
+	return !reflect.DeepEqual(service, defaultService)
 }
 
 func hasNonDefaultHTTPPortConfig(ports []config.ServicePort) bool {
@@ -5049,6 +5070,10 @@ func hasHTTPPortConfig(ports []config.ServicePort) bool {
 
 func hasNonDefaultHealthcheckPathConfig(healthcheck *config.HTTPHealthcheck) bool {
 	return healthcheck != nil && strings.TrimSpace(healthcheck.Path) != "" && strings.TrimSpace(healthcheck.Path) != config.DefaultHealthcheckPath
+}
+
+func hasHealthcheckPathConfig(healthcheck *config.HTTPHealthcheck) bool {
+	return healthcheck != nil && strings.TrimSpace(healthcheck.Path) != ""
 }
 
 func hasHealthcheckPathOverlayConfig(healthcheck *config.HTTPHealthcheckOverlay) bool {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -17,7 +17,6 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
-	"reflect"
 	"regexp"
 	"sort"
 	"strconv"
@@ -5012,11 +5011,13 @@ func initRuntimeContractProvenance(base config.ProjectConfig, resolved config.Pr
 	if !ok || created {
 		return provenance
 	}
-	provenance.GeneratedDefault = isGeneratedDefaultProjectConfig(base)
 	provenance.ConfigFieldPrefix = fmt.Sprintf("services.%s", serviceName)
-	if baseService, ok := base.Services[serviceName]; ok && !provenance.GeneratedDefault {
-		provenance.PortExplicit = hasHTTPPortConfig(baseService.Ports)
-		provenance.HealthcheckPathExplicit = hasHealthcheckPathConfig(baseService.Healthcheck)
+	if baseService, ok := base.Services[serviceName]; ok {
+		provenance.GeneratedDefault = hasGeneratedDefaultRuntimeContract(baseService)
+		if !provenance.GeneratedDefault {
+			provenance.PortExplicit = hasHTTPPortConfig(baseService.Ports)
+			provenance.HealthcheckPathExplicit = hasHealthcheckPathConfig(baseService.Healthcheck)
+		}
 	}
 	envName := strings.TrimSpace(environmentName)
 	if envName == "" {
@@ -5032,8 +5033,15 @@ func initRuntimeContractProvenance(base config.ProjectConfig, resolved config.Pr
 	return provenance
 }
 
-func isGeneratedDefaultProjectConfig(cfg config.ProjectConfig) bool {
-	return reflect.DeepEqual(cfg, config.DefaultProjectConfig(cfg.Organization, cfg.Project, cfg.DefaultEnvironment))
+func hasGeneratedDefaultRuntimeContract(service config.ServiceConfig) bool {
+	if len(service.Ports) != 1 {
+		return false
+	}
+	port := service.Ports[0]
+	if strings.TrimSpace(port.Name) != "http" || port.Port != config.DefaultWebPort {
+		return false
+	}
+	return service.Healthcheck != nil && strings.TrimSpace(service.Healthcheck.Path) == config.DefaultHealthcheckPath && service.Healthcheck.Port == config.DefaultWebPort
 }
 
 func hasHTTPPortConfig(ports []config.ServicePort) bool {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -17,6 +17,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"sort"
 	"strconv"
@@ -4999,6 +5000,7 @@ func (a *App) SoloInit(context.Context, SoloInitOptions) error {
 
 type runtimeContractProvenance struct {
 	Created                 bool
+	GeneratedDefault        bool
 	PortExplicit            bool
 	HealthcheckPathExplicit bool
 	ConfigFieldPrefix       string
@@ -5010,8 +5012,9 @@ func initRuntimeContractProvenance(base config.ProjectConfig, resolved config.Pr
 	if !ok || created {
 		return provenance
 	}
+	provenance.GeneratedDefault = isGeneratedDefaultProjectConfig(base)
 	provenance.ConfigFieldPrefix = fmt.Sprintf("services.%s", serviceName)
-	if baseService, ok := base.Services[serviceName]; ok {
+	if baseService, ok := base.Services[serviceName]; ok && !provenance.GeneratedDefault {
 		provenance.PortExplicit = hasHTTPPortConfig(baseService.Ports)
 		provenance.HealthcheckPathExplicit = hasHealthcheckPathConfig(baseService.Healthcheck)
 	}
@@ -5027,6 +5030,10 @@ func initRuntimeContractProvenance(base config.ProjectConfig, resolved config.Pr
 		}
 	}
 	return provenance
+}
+
+func isGeneratedDefaultProjectConfig(cfg config.ProjectConfig) bool {
+	return reflect.DeepEqual(cfg, config.DefaultProjectConfig(cfg.Organization, cfg.Project, cfg.DefaultEnvironment))
 }
 
 func hasHTTPPortConfig(ports []config.ServicePort) bool {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -5001,6 +5001,7 @@ type runtimeContractProvenance struct {
 	Created                 bool
 	PortExplicit            bool
 	HealthcheckPathExplicit bool
+	ConfigFieldPrefix       string
 }
 
 func initRuntimeContractProvenance(base config.ProjectConfig, resolved config.ProjectConfig, environmentName string, created bool) runtimeContractProvenance {
@@ -5009,9 +5010,10 @@ func initRuntimeContractProvenance(base config.ProjectConfig, resolved config.Pr
 	if !ok || created {
 		return provenance
 	}
+	provenance.ConfigFieldPrefix = fmt.Sprintf("services.%s", serviceName)
 	if baseService, ok := base.Services[serviceName]; ok {
-		provenance.PortExplicit = hasNonDefaultHTTPPortConfig(baseService.Ports)
-		provenance.HealthcheckPathExplicit = hasNonDefaultHealthcheckPathConfig(baseService.Healthcheck)
+		provenance.PortExplicit = hasHTTPPortConfig(baseService.Ports)
+		provenance.HealthcheckPathExplicit = hasHealthcheckPathConfig(baseService.Healthcheck)
 	}
 	envName := strings.TrimSpace(environmentName)
 	if envName == "" {
@@ -5019,20 +5021,12 @@ func initRuntimeContractProvenance(base config.ProjectConfig, resolved config.Pr
 	}
 	if overlay, ok := base.Environments[envName]; ok {
 		if serviceOverlay, ok := overlay.Services[serviceName]; ok {
+			provenance.ConfigFieldPrefix = fmt.Sprintf("environments.%s.services.%s", envName, serviceName)
 			provenance.PortExplicit = provenance.PortExplicit || hasHTTPPortConfig(serviceOverlay.Ports)
 			provenance.HealthcheckPathExplicit = provenance.HealthcheckPathExplicit || hasHealthcheckPathOverlayConfig(serviceOverlay.Healthcheck)
 		}
 	}
 	return provenance
-}
-
-func hasNonDefaultHTTPPortConfig(ports []config.ServicePort) bool {
-	for _, port := range ports {
-		if strings.TrimSpace(port.Name) == "http" && port.Port > 0 && port.Port != config.DefaultWebPort {
-			return true
-		}
-	}
-	return false
 }
 
 func hasHTTPPortConfig(ports []config.ServicePort) bool {
@@ -5044,12 +5038,12 @@ func hasHTTPPortConfig(ports []config.ServicePort) bool {
 	return false
 }
 
-func hasNonDefaultHealthcheckPathConfig(healthcheck *config.HTTPHealthcheck) bool {
-	return healthcheck != nil && strings.TrimSpace(healthcheck.Path) != "" && strings.TrimSpace(healthcheck.Path) != config.DefaultHealthcheckPath
+func hasHealthcheckPathConfig(healthcheck *config.HTTPHealthcheck) bool {
+	return healthcheck != nil && strings.TrimSpace(healthcheck.Path) != ""
 }
 
 func hasHealthcheckPathOverlayConfig(healthcheck *config.HTTPHealthcheckOverlay) bool {
-	return healthcheck != nil && healthcheck.Path != nil && strings.TrimSpace(*healthcheck.Path) != ""
+	return healthcheck != nil && healthcheck.Path != nil
 }
 
 func initRuntimeContract(cfg config.ProjectConfig, discovered discovery.Result, provenance runtimeContractProvenance) map[string]any {
@@ -5098,12 +5092,15 @@ func initRuntimeContract(cfg config.ProjectConfig, discovered discovery.Result, 
 		contract["healthcheck_path_source"] = healthcheckPathSource
 		contract["healthcheck_confidence"] = healthcheckConfidence
 	}
-	contract["agent_hints"] = initRuntimeAgentHints(serviceName, contract)
+	contract["agent_hints"] = initRuntimeAgentHints(serviceName, provenance.ConfigFieldPrefix, contract)
 	return contract
 }
 
-func initRuntimeAgentHints(serviceName string, contract map[string]any) []map[string]any {
+func initRuntimeAgentHints(serviceName string, configFieldPrefix string, contract map[string]any) []map[string]any {
 	hints := []map[string]any{}
+	if configFieldPrefix == "" {
+		configFieldPrefix = fmt.Sprintf("services.%s", serviceName)
+	}
 	if contract["port_source"] == "default" {
 		hints = append(hints, map[string]any{
 			"action": "inspect_app_port",
@@ -5114,8 +5111,8 @@ func initRuntimeAgentHints(serviceName string, contract map[string]any) []map[st
 				"Alternatively add EXPOSE <port> to the Dockerfile so future init/deploy runs can infer it deterministically.",
 			},
 			"config_fields": []string{
-				fmt.Sprintf("services.%s.ports[http].port", serviceName),
-				fmt.Sprintf("services.%s.healthcheck.port", serviceName),
+				fmt.Sprintf("%s.ports[http].port", configFieldPrefix),
+				fmt.Sprintf("%s.healthcheck.port", configFieldPrefix),
 			},
 		})
 	}
@@ -5129,7 +5126,7 @@ func initRuntimeAgentHints(serviceName string, contract map[string]any) []map[st
 				"If the app has no health endpoint, add one or configure a path that returns HTTP 2xx when the service is ready.",
 			},
 			"config_fields": []string{
-				fmt.Sprintf("services.%s.healthcheck.path", serviceName),
+				fmt.Sprintf("%s.healthcheck.path", configFieldPrefix),
 			},
 		})
 	}

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -4999,7 +4999,6 @@ func (a *App) SoloInit(context.Context, SoloInitOptions) error {
 
 type runtimeContractProvenance struct {
 	Created                 bool
-	GeneratedDefault        bool
 	PortExplicit            bool
 	HealthcheckPathExplicit bool
 	ConfigFieldPrefix       string
@@ -5013,11 +5012,8 @@ func initRuntimeContractProvenance(base config.ProjectConfig, resolved config.Pr
 	}
 	provenance.ConfigFieldPrefix = fmt.Sprintf("services.%s", serviceName)
 	if baseService, ok := base.Services[serviceName]; ok {
-		provenance.GeneratedDefault = hasGeneratedDefaultRuntimeContract(baseService)
-		if !provenance.GeneratedDefault {
-			provenance.PortExplicit = hasHTTPPortConfig(baseService.Ports)
-			provenance.HealthcheckPathExplicit = hasHealthcheckPathConfig(baseService.Healthcheck)
-		}
+		provenance.PortExplicit = hasNonDefaultHTTPPortConfig(baseService.Ports)
+		provenance.HealthcheckPathExplicit = hasNonDefaultHealthcheckPathConfig(baseService.Healthcheck)
 	}
 	envName := strings.TrimSpace(environmentName)
 	if envName == "" {
@@ -5033,15 +5029,13 @@ func initRuntimeContractProvenance(base config.ProjectConfig, resolved config.Pr
 	return provenance
 }
 
-func hasGeneratedDefaultRuntimeContract(service config.ServiceConfig) bool {
-	if len(service.Ports) != 1 {
-		return false
+func hasNonDefaultHTTPPortConfig(ports []config.ServicePort) bool {
+	for _, port := range ports {
+		if strings.TrimSpace(port.Name) == "http" && port.Port > 0 && port.Port != config.DefaultWebPort {
+			return true
+		}
 	}
-	port := service.Ports[0]
-	if strings.TrimSpace(port.Name) != "http" || port.Port != config.DefaultWebPort {
-		return false
-	}
-	return service.Healthcheck != nil && strings.TrimSpace(service.Healthcheck.Path) == config.DefaultHealthcheckPath && service.Healthcheck.Port == config.DefaultWebPort
+	return false
 }
 
 func hasHTTPPortConfig(ports []config.ServicePort) bool {
@@ -5053,8 +5047,8 @@ func hasHTTPPortConfig(ports []config.ServicePort) bool {
 	return false
 }
 
-func hasHealthcheckPathConfig(healthcheck *config.HTTPHealthcheck) bool {
-	return healthcheck != nil && strings.TrimSpace(healthcheck.Path) != ""
+func hasNonDefaultHealthcheckPathConfig(healthcheck *config.HTTPHealthcheck) bool {
+	return healthcheck != nil && strings.TrimSpace(healthcheck.Path) != "" && strings.TrimSpace(healthcheck.Path) != config.DefaultHealthcheckPath
 }
 
 func hasHealthcheckPathOverlayConfig(healthcheck *config.HTTPHealthcheckOverlay) bool {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -17,7 +17,6 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
-	"reflect"
 	"regexp"
 	"sort"
 	"strconv"
@@ -5012,10 +5011,9 @@ func initRuntimeContractProvenance(base config.ProjectConfig, resolved config.Pr
 		return provenance
 	}
 	provenance.ConfigFieldPrefix = fmt.Sprintf("services.%s", serviceName)
-	if baseService, ok := base.Services[serviceName]; ok && !isGeneratedDefaultBaseService(base, serviceName, baseService) {
-		nonRuntimeEdited := hasNonRuntimeBaseServiceEdits(base, serviceName, baseService)
-		provenance.PortExplicit = hasNonDefaultHTTPPortConfig(baseService.Ports) || (nonRuntimeEdited && hasHTTPPortConfig(baseService.Ports))
-		provenance.HealthcheckPathExplicit = hasNonDefaultHealthcheckPathConfig(baseService.Healthcheck) || (nonRuntimeEdited && hasHealthcheckPathConfig(baseService.Healthcheck))
+	if baseService, ok := base.Services[serviceName]; ok {
+		provenance.PortExplicit = hasNonDefaultHTTPPortConfig(baseService.Ports)
+		provenance.HealthcheckPathExplicit = hasNonDefaultHealthcheckPathConfig(baseService.Healthcheck)
 	}
 	envName := strings.TrimSpace(environmentName)
 	if envName == "" {
@@ -5033,21 +5031,6 @@ func initRuntimeContractProvenance(base config.ProjectConfig, resolved config.Pr
 		}
 	}
 	return provenance
-}
-
-func isGeneratedDefaultBaseService(cfg config.ProjectConfig, serviceName string, service config.ServiceConfig) bool {
-	defaultService, ok := config.DefaultProjectConfig(cfg.Organization, cfg.Project, cfg.DefaultEnvironment).Services[serviceName]
-	return ok && reflect.DeepEqual(service, defaultService)
-}
-
-func hasNonRuntimeBaseServiceEdits(cfg config.ProjectConfig, serviceName string, service config.ServiceConfig) bool {
-	defaultService, ok := config.DefaultProjectConfig(cfg.Organization, cfg.Project, cfg.DefaultEnvironment).Services[serviceName]
-	if !ok {
-		return true
-	}
-	service.Ports = defaultService.Ports
-	service.Healthcheck = defaultService.Healthcheck
-	return !reflect.DeepEqual(service, defaultService)
 }
 
 func hasNonDefaultHTTPPortConfig(ports []config.ServicePort) bool {

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -7677,7 +7677,7 @@ func TestSoloInitCreatesWorkspaceConfig(t *testing.T) {
 	}
 }
 
-func TestSoloInitReportsExistingDefaultConfigContractAsExplicit(t *testing.T) {
+func TestSoloInitKeepsGeneratedDefaultConfigContractLowConfidence(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")
 	if _, err := config.Write(workspaceRoot, cfg); err != nil {
@@ -7696,11 +7696,11 @@ func TestSoloInitReportsExistingDefaultConfigContractAsExplicit(t *testing.T) {
 	}
 	payload := decodeJSONOutput(t, &stdout)
 	runtimeContract := jsonMapFromAny(t, payload["runtime_contract"])
-	if runtimeContract["port_source"] != "config" || runtimeContract["port_confidence"] != "high" || runtimeContract["healthcheck_path_source"] != "config" || runtimeContract["healthcheck_confidence"] != "high" {
-		t.Fatalf("runtime_contract = %#v, want existing default config values reported as high-confidence config", runtimeContract)
+	if runtimeContract["port_source"] != "default" || runtimeContract["port_confidence"] != "low" || runtimeContract["healthcheck_path_source"] != "default" || runtimeContract["healthcheck_confidence"] != "low" {
+		t.Fatalf("runtime_contract = %#v, want generated defaults to stay low-confidence", runtimeContract)
 	}
-	if hints := jsonArrayFromMap(t, runtimeContract, "agent_hints"); len(hints) != 0 {
-		t.Fatalf("runtime_contract.agent_hints = %#v, want no hints for existing config values", hints)
+	if hints := jsonArrayFromMap(t, runtimeContract, "agent_hints"); len(hints) != 2 {
+		t.Fatalf("runtime_contract.agent_hints = %#v, want default config hints", hints)
 	}
 }
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -7740,6 +7740,36 @@ func TestSoloInitKeepsGeneratedDefaultsLowConfidenceWithUnrelatedOverlay(t *test
 	}
 }
 
+func TestSoloInitTreatsEditedBaseDefaultRuntimeContractAsExplicit(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	web := cfg.Services["web"]
+	web.Env = map[string]string{"RAILS_ENV": "production"}
+	cfg.Services["web"] = web
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{
+		Printer:     output.New(&stdout, io.Discard),
+		ConfigStore: config.NewStore(),
+		Cwd:         workspaceRoot,
+	}
+
+	if err := app.SoloInit(context.Background(), SoloInitOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	runtimeContract := jsonMapFromAny(t, payload["runtime_contract"])
+	if runtimeContract["port_source"] != "config" || runtimeContract["port_confidence"] != "high" || runtimeContract["healthcheck_path_source"] != "config" || runtimeContract["healthcheck_confidence"] != "high" {
+		t.Fatalf("runtime_contract = %#v, want edited base service default runtime contract values treated as explicit config", runtimeContract)
+	}
+	if hints := jsonArrayFromMap(t, runtimeContract, "agent_hints"); len(hints) != 0 {
+		t.Fatalf("runtime_contract.agent_hints = %#v, want no hints for explicit base config", hints)
+	}
+}
+
 func TestSoloInitRuntimeContractTreatsBlankOverlayHealthcheckAsExplicitDefault(t *testing.T) {
 	base := config.DefaultProjectConfig("solo", "demo", "production")
 	web := base.Services["web"]

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -7704,7 +7704,7 @@ func TestSoloInitKeepsGeneratedDefaultConfigContractLowConfidence(t *testing.T) 
 	}
 }
 
-func TestSoloInitKeepsBaseDefaultRuntimeContractExplicitWithUnrelatedOverlay(t *testing.T) {
+func TestSoloInitKeepsGeneratedDefaultsLowConfidenceWithUnrelatedOverlay(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")
 	cfg.Environments = map[string]config.EnvironmentOverlay{
@@ -7732,11 +7732,11 @@ func TestSoloInitKeepsBaseDefaultRuntimeContractExplicitWithUnrelatedOverlay(t *
 	}
 	payload := decodeJSONOutput(t, &stdout)
 	runtimeContract := jsonMapFromAny(t, payload["runtime_contract"])
-	if runtimeContract["port_source"] != "config" || runtimeContract["port_confidence"] != "high" || runtimeContract["healthcheck_path_source"] != "config" || runtimeContract["healthcheck_confidence"] != "high" {
-		t.Fatalf("runtime_contract = %#v, want base default runtime contract values treated as explicit config with unrelated overlay", runtimeContract)
+	if runtimeContract["port_source"] != "default" || runtimeContract["port_confidence"] != "low" || runtimeContract["healthcheck_path_source"] != "default" || runtimeContract["healthcheck_confidence"] != "low" {
+		t.Fatalf("runtime_contract = %#v, want generated base defaults to stay low-confidence with unrelated overlay", runtimeContract)
 	}
-	if hints := jsonArrayFromMap(t, runtimeContract, "agent_hints"); len(hints) != 0 {
-		t.Fatalf("runtime_contract.agent_hints = %#v, want no hints for explicit base config", hints)
+	if hints := jsonArrayFromMap(t, runtimeContract, "agent_hints"); len(hints) != 2 {
+		t.Fatalf("runtime_contract.agent_hints = %#v, want default config hints", hints)
 	}
 }
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -7677,7 +7677,7 @@ func TestSoloInitCreatesWorkspaceConfig(t *testing.T) {
 	}
 }
 
-func TestSoloInitKeepsGeneratedDefaultConfigContractLowConfidence(t *testing.T) {
+func TestSoloInitReportsExistingDefaultConfigContractAsExplicit(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")
 	if _, err := config.Write(workspaceRoot, cfg); err != nil {
@@ -7696,15 +7696,15 @@ func TestSoloInitKeepsGeneratedDefaultConfigContractLowConfidence(t *testing.T) 
 	}
 	payload := decodeJSONOutput(t, &stdout)
 	runtimeContract := jsonMapFromAny(t, payload["runtime_contract"])
-	if runtimeContract["port_source"] != "default" || runtimeContract["port_confidence"] != "low" || runtimeContract["healthcheck_path_source"] != "default" || runtimeContract["healthcheck_confidence"] != "low" {
-		t.Fatalf("runtime_contract = %#v, want generated defaults to stay low-confidence", runtimeContract)
+	if runtimeContract["port_source"] != "config" || runtimeContract["port_confidence"] != "high" || runtimeContract["healthcheck_path_source"] != "config" || runtimeContract["healthcheck_confidence"] != "high" {
+		t.Fatalf("runtime_contract = %#v, want existing default config values reported as high-confidence config", runtimeContract)
 	}
-	if hints := jsonArrayFromMap(t, runtimeContract, "agent_hints"); len(hints) != 2 {
-		t.Fatalf("runtime_contract.agent_hints = %#v, want default config hints", hints)
+	if hints := jsonArrayFromMap(t, runtimeContract, "agent_hints"); len(hints) != 0 {
+		t.Fatalf("runtime_contract.agent_hints = %#v, want no hints for existing config values", hints)
 	}
 }
 
-func TestSoloInitKeepsGeneratedDefaultsLowConfidenceWithUnrelatedOverlay(t *testing.T) {
+func TestSoloInitKeepsBaseDefaultRuntimeContractExplicitWithUnrelatedOverlay(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")
 	cfg.Environments = map[string]config.EnvironmentOverlay{
@@ -7732,11 +7732,40 @@ func TestSoloInitKeepsGeneratedDefaultsLowConfidenceWithUnrelatedOverlay(t *test
 	}
 	payload := decodeJSONOutput(t, &stdout)
 	runtimeContract := jsonMapFromAny(t, payload["runtime_contract"])
-	if runtimeContract["port_source"] != "default" || runtimeContract["port_confidence"] != "low" || runtimeContract["healthcheck_path_source"] != "default" || runtimeContract["healthcheck_confidence"] != "low" {
-		t.Fatalf("runtime_contract = %#v, want generated base defaults to stay low-confidence with unrelated overlay", runtimeContract)
+	if runtimeContract["port_source"] != "config" || runtimeContract["port_confidence"] != "high" || runtimeContract["healthcheck_path_source"] != "config" || runtimeContract["healthcheck_confidence"] != "high" {
+		t.Fatalf("runtime_contract = %#v, want base default runtime contract values treated as explicit config with unrelated overlay", runtimeContract)
 	}
-	if hints := jsonArrayFromMap(t, runtimeContract, "agent_hints"); len(hints) != 2 {
-		t.Fatalf("runtime_contract.agent_hints = %#v, want default config hints", hints)
+	if hints := jsonArrayFromMap(t, runtimeContract, "agent_hints"); len(hints) != 0 {
+		t.Fatalf("runtime_contract.agent_hints = %#v, want no hints for explicit base config", hints)
+	}
+}
+
+func TestSoloInitRuntimeContractTreatsBlankOverlayHealthcheckAsExplicitDefault(t *testing.T) {
+	base := config.DefaultProjectConfig("solo", "demo", "production")
+	web := base.Services["web"]
+	web.Healthcheck = &config.HTTPHealthcheck{Path: "/health", Port: config.DefaultWebPort}
+	base.Services["web"] = web
+	blankPath := "   "
+	base.Environments = map[string]config.EnvironmentOverlay{
+		"staging": {
+			Services: map[string]config.ServiceConfigOverlay{
+				"web": {
+					Healthcheck: &config.HTTPHealthcheckOverlay{Path: &blankPath},
+				},
+			},
+		},
+	}
+	resolved, err := config.ResolveEnvironmentConfig(base, "staging")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	contract := initRuntimeContract(resolved, discovery.Result{}, initRuntimeContractProvenance(base, resolved, "staging", false))
+	if contract["healthcheck_path"] != config.DefaultHealthcheckPath || contract["healthcheck_path_source"] != "config" || contract["healthcheck_confidence"] != "high" {
+		t.Fatalf("runtime_contract = %#v, want blank overlay path treated as explicit default config", contract)
+	}
+	if hints, ok := contract["agent_hints"].([]map[string]any); !ok || len(hints) != 0 {
+		t.Fatalf("runtime_contract.agent_hints = %#v, want no hints for explicit blank overlay reset", contract["agent_hints"])
 	}
 }
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -7740,7 +7740,7 @@ func TestSoloInitKeepsGeneratedDefaultsLowConfidenceWithUnrelatedOverlay(t *test
 	}
 }
 
-func TestSoloInitTreatsEditedBaseDefaultRuntimeContractAsExplicit(t *testing.T) {
+func TestSoloInitKeepsEditedBaseDefaultRuntimeContractLowConfidence(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")
 	web := cfg.Services["web"]
@@ -7762,11 +7762,11 @@ func TestSoloInitTreatsEditedBaseDefaultRuntimeContractAsExplicit(t *testing.T) 
 	}
 	payload := decodeJSONOutput(t, &stdout)
 	runtimeContract := jsonMapFromAny(t, payload["runtime_contract"])
-	if runtimeContract["port_source"] != "config" || runtimeContract["port_confidence"] != "high" || runtimeContract["healthcheck_path_source"] != "config" || runtimeContract["healthcheck_confidence"] != "high" {
-		t.Fatalf("runtime_contract = %#v, want edited base service default runtime contract values treated as explicit config", runtimeContract)
+	if runtimeContract["port_source"] != "default" || runtimeContract["port_confidence"] != "low" || runtimeContract["healthcheck_path_source"] != "default" || runtimeContract["healthcheck_confidence"] != "low" {
+		t.Fatalf("runtime_contract = %#v, want unrelated base service edits to keep default runtime contract values low confidence", runtimeContract)
 	}
-	if hints := jsonArrayFromMap(t, runtimeContract, "agent_hints"); len(hints) != 0 {
-		t.Fatalf("runtime_contract.agent_hints = %#v, want no hints for explicit base config", hints)
+	if hints := jsonArrayFromMap(t, runtimeContract, "agent_hints"); len(hints) != 2 {
+		t.Fatalf("runtime_contract.agent_hints = %#v, want port and healthcheck hints for generated/default runtime fields", hints)
 	}
 }
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -7764,8 +7764,8 @@ func TestSoloInitRuntimeContractTreatsBlankOverlayHealthcheckAsExplicitDefault(t
 	if contract["healthcheck_path"] != config.DefaultHealthcheckPath || contract["healthcheck_path_source"] != "config" || contract["healthcheck_confidence"] != "high" {
 		t.Fatalf("runtime_contract = %#v, want blank overlay path treated as explicit default config", contract)
 	}
-	if hints, ok := contract["agent_hints"].([]map[string]any); !ok || len(hints) != 0 {
-		t.Fatalf("runtime_contract.agent_hints = %#v, want no hints for explicit blank overlay reset", contract["agent_hints"])
+	if hints, ok := contract["agent_hints"].([]map[string]any); !ok || len(hints) != 1 || hints[0]["action"] != "inspect_app_port" {
+		t.Fatalf("runtime_contract.agent_hints = %#v, want only port hint for explicit blank overlay healthcheck reset", contract["agent_hints"])
 	}
 }
 


### PR DESCRIPTION
## Summary
- preserve explicit runtime contract provenance when config intentionally uses built-in default port/path values
- scope init remediation `config_fields` to the selected environment overlay
- treat blank healthcheck overlay paths as explicit default resets

## Tests
- `git diff --check`
- `cd cli && GOCACHE=/tmp/hermes-pr145-followup-pr-gocache mise exec -- go test ./internal/workflow -run 'TestSoloInit(ReportsExistingDefaultConfigContractAsExplicit|KeepsBaseDefaultRuntimeContractExplicitWithUnrelatedOverlay|ReportsExplicitBaseDefaultConfigContract|RuntimeContractTreatsBlankOverlayHealthcheckAsExplicitDefault|ReportsConfigPortContract|CreatesWorkspaceConfig)|TestInitRuntimeContractUsesSelectedEnvironmentOverlay' -count=1`
- `cd cli && GOCACHE=/tmp/hermes-pr145-followup-pr-gocache mise run test`

Follow-up to #145 after it merged before the Copilot feedback fix landed.
