### PR TITLE
[codex] Add solo node security diagnostics

### DIFF
--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -3952,6 +3952,12 @@ func soloDockerSocketMountsCheck(ctx context.Context, node config.Node) soloSecu
 		return check
 	}
 	lines := splitNonFinalEmptyLines(diag.Stdout)
+	if listenOutputHasTruncationMarker(lines) {
+		check.OK = false
+		check.Observed = "unknown: managed container mount output was truncated"
+		check.NextAction = "rerun devopsellence node diagnose after managed containers can be inspected completely"
+		return check
+	}
 	offenders := []string{}
 	for _, line := range lines {
 		if strings.Contains(line, "/var/run/docker.sock") {
@@ -3977,8 +3983,15 @@ func soloPrivilegedContainersCheck(ctx context.Context, node config.Node) soloSe
 		check.NextAction = "rerun devopsellence node diagnose after Docker can be inspected"
 		return check
 	}
+	lines := splitNonFinalEmptyLines(diag.Stdout)
+	if listenOutputHasTruncationMarker(lines) {
+		check.OK = false
+		check.Observed = "unknown: managed container privilege output was truncated"
+		check.NextAction = "rerun devopsellence node diagnose after managed containers can be inspected completely"
+		return check
+	}
 	offenders := []string{}
-	for _, line := range splitNonFinalEmptyLines(diag.Stdout) {
+	for _, line := range lines {
 		fields := strings.Fields(line)
 		if len(fields) >= 2 && fields[1] == "true" {
 			offenders = append(offenders, fields[0])
@@ -4018,7 +4031,7 @@ func soloPublicListeningPortsCheck(ctx context.Context, node config.Node, portLi
 		check.NextAction = "install ss or netstat on the node, then rerun devopsellence node diagnose"
 		return check
 	}
-	ports := unexpectedPublicListeningPorts(portLines)
+	ports := unexpectedPublicListeningPorts(portLines, node.Port)
 	if len(ports) > 0 {
 		check.OK = false
 		check.Observed = "unexpected public listening ports: " + strings.Join(ports, ", ")
@@ -4059,8 +4072,11 @@ func hasListenAddress(line string) bool {
 	return false
 }
 
-func unexpectedPublicListeningPorts(lines []string) []string {
-	expected := map[string]bool{"22": true, "80": true, "443": true}
+func unexpectedPublicListeningPorts(lines []string, sshPort int) []string {
+	if sshPort == 0 {
+		sshPort = 22
+	}
+	expected := map[string]bool{strconv.Itoa(sshPort): true, "80": true, "443": true}
 	seen := map[string]bool{}
 	for _, line := range lines {
 		for _, port := range publicPortsFromListeningLine(line) {
@@ -7586,17 +7602,47 @@ func remoteStatPathCommand(target string) string {
 }
 
 func remoteManagedContainerMountsCommand() string {
-	return `if docker info >/dev/null 2>&1; then docker_cmd=docker; elif command -v sudo >/dev/null 2>&1 && sudo -n docker info >/dev/null 2>&1; then docker_cmd="sudo -n docker"; else echo 'Docker is not reachable' >&2; exit 1; fi
-ids=$($docker_cmd ps -aq --filter label=devopsellence.managed=true | head -n 100)
+	script := `if docker info >/dev/null 2>&1; then docker_cmd=docker; elif command -v sudo >/dev/null 2>&1 && sudo -n docker info >/dev/null 2>&1; then docker_cmd="sudo -n docker"; else echo 'Docker is not reachable' >&2; exit 1; fi
+ids=$($docker_cmd ps -aq --filter label=devopsellence.managed=true 2>&1)
+ps_status=$?
+if [ "$ps_status" -ne 0 ]; then
+  echo "Failed to list managed containers" >&2
+  printf '%s\n' "$ids" >&2
+  exit "$ps_status"
+fi
+ids=$(printf '%s\n' "$ids" | sed '/^$/d' | head -n 100)
 if [ -z "$ids" ]; then exit 0; fi
-$docker_cmd inspect --format '{{.Name}} {{range .Mounts}}{{.Source}}:{{.Destination}} {{end}}' $ids | sed 's#^/##' | grep '/var/run/docker.sock' | head -n 100 || true`
+inspect_out=$($docker_cmd inspect --format '{{.Name}} {{range .Mounts}}{{.Source}}:{{.Destination}} {{end}}' $ids 2>&1)
+inspect_status=$?
+if [ "$inspect_status" -ne 0 ]; then
+  echo "Failed to inspect managed container mounts" >&2
+  printf '%s\n' "$inspect_out" >&2
+  exit "$inspect_status"
+fi
+printf '%s\n' "$inspect_out" | sed 's#^/##' | head -n 100`
+	return "if command -v bash >/dev/null 2>&1; then exec bash -o pipefail -c " + shellQuote(script) + "; fi; echo 'bash is required for managed container mount diagnostics' >&2; exit 1"
 }
 
 func remoteManagedContainerPrivilegesCommand() string {
-	return `if docker info >/dev/null 2>&1; then docker_cmd=docker; elif command -v sudo >/dev/null 2>&1 && sudo -n docker info >/dev/null 2>&1; then docker_cmd="sudo -n docker"; else echo 'Docker is not reachable' >&2; exit 1; fi
-ids=$($docker_cmd ps -aq --filter label=devopsellence.managed=true | head -n 100)
+	script := `if docker info >/dev/null 2>&1; then docker_cmd=docker; elif command -v sudo >/dev/null 2>&1 && sudo -n docker info >/dev/null 2>&1; then docker_cmd="sudo -n docker"; else echo 'Docker is not reachable' >&2; exit 1; fi
+ids=$($docker_cmd ps -aq --filter label=devopsellence.managed=true 2>&1)
+ps_status=$?
+if [ "$ps_status" -ne 0 ]; then
+  echo "Failed to list managed containers" >&2
+  printf '%s\n' "$ids" >&2
+  exit "$ps_status"
+fi
+ids=$(printf '%s\n' "$ids" | sed '/^$/d' | head -n 100)
 if [ -z "$ids" ]; then exit 0; fi
-$docker_cmd inspect --format '{{.Name}} {{.HostConfig.Privileged}}' $ids | sed 's#^/##' | awk '$2 == "true" { print }' | head -n 100`
+inspect_out=$($docker_cmd inspect --format '{{.Name}} {{.HostConfig.Privileged}}' $ids 2>&1)
+inspect_status=$?
+if [ "$inspect_status" -ne 0 ]; then
+  echo "Failed to inspect managed container privileges" >&2
+  printf '%s\n' "$inspect_out" >&2
+  exit "$inspect_status"
+fi
+printf '%s\n' "$inspect_out" | sed 's#^/##' | head -n 100`
+	return "if command -v bash >/dev/null 2>&1; then exec bash -o pipefail -c " + shellQuote(script) + "; fi; echo 'bash is required for managed container privilege diagnostics' >&2; exit 1"
 }
 
 func desiredStateOverridePath(node config.Node) string {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -3883,7 +3883,7 @@ func soloAgentStatePermissionsCheck(ctx context.Context, node config.Node) soloS
 		check.NextAction = "rerun devopsellence node diagnose after the agent state directory can be inspected"
 		return check
 	}
-	fields := strings.Fields(strings.TrimSpace(diag.Stdout))
+	fields := soloStatFields(diag.Stdout)
 	if len(fields) == 0 || fields[0] == "missing" {
 		check.OK = false
 		check.Observed = stateDir + " missing"
@@ -3900,17 +3900,17 @@ func soloAgentStatePermissionsCheck(ctx context.Context, node config.Node) soloS
 	}
 	if len(fields) >= 2 && fields[1] != "root" {
 		check.OK = false
-		check.NextAction = "restore root ownership on the agent state directory, for example chown root:root " + stateDir
+		check.NextAction = "restore root ownership on the agent state directory, for example chown root:root " + shellQuote(stateDir)
 		return check
 	}
 	if len(fields) >= 3 && fields[2] != "root" {
 		check.OK = false
-		check.NextAction = "restore root group ownership on the agent state directory, for example chown root:root " + stateDir
+		check.NextAction = "restore root group ownership on the agent state directory, for example chown root:root " + shellQuote(stateDir)
 		return check
 	}
 	if mode&0o026 != 0 {
 		check.OK = false
-		check.NextAction = "remove group write and other read/write access from the agent state directory, for example chmod g-w,o-rw " + stateDir
+		check.NextAction = "remove group write and other read/write access from the agent state directory, for example chmod g-w,o-rw " + shellQuote(stateDir)
 	}
 	return check
 }
@@ -3925,7 +3925,7 @@ func soloTLSKeyPermissionsCheck(ctx context.Context, node config.Node) soloSecur
 		check.NextAction = "rerun devopsellence node diagnose after the TLS key path can be inspected"
 		return check
 	}
-	fields := strings.Fields(strings.TrimSpace(diag.Stdout))
+	fields := soloStatFields(diag.Stdout)
 	if len(fields) == 0 || fields[0] == "missing" {
 		check.Observed = keyPath + " not present"
 		return check
@@ -3940,9 +3940,20 @@ func soloTLSKeyPermissionsCheck(ctx context.Context, node config.Node) soloSecur
 	}
 	if mode&0o037 != 0 {
 		check.OK = false
-		check.NextAction = "restrict the TLS private key file to the agent or Envoy group, for example chmod 640 " + keyPath
+		check.NextAction = "restrict the TLS private key file to the agent or Envoy group, for example chmod 640 " + shellQuote(keyPath)
 	}
 	return check
+}
+
+func soloStatFields(output string) []string {
+	output = strings.TrimSpace(output)
+	if output == "" {
+		return nil
+	}
+	if strings.Contains(output, "\t") {
+		return strings.SplitN(output, "\t", 4)
+	}
+	return strings.Fields(output)
 }
 
 func soloDockerSocketMountsCheck(ctx context.Context, node config.Node) soloSecurityCheck {
@@ -7601,27 +7612,31 @@ func remoteSSHPasswordAuthCommand() string {
 
 func remoteStatPathCommand(target string) string {
 	quoted := shellQuote(target)
-	return fmt.Sprintf("if [ -e %[1]s ]; then stat -c '%%a %%U %%G %%n' %[1]s; elif command -v sudo >/dev/null 2>&1 && sudo -n test -e %[1]s >/dev/null 2>&1; then sudo -n stat -c '%%a %%U %%G %%n' %[1]s; else echo missing; fi", quoted)
+	return fmt.Sprintf("if [ -e %[1]s ]; then stat -c '%%a\\t%%U\\t%%G\\t%%n' %[1]s; elif command -v sudo >/dev/null 2>&1 && sudo -n test -e %[1]s >/dev/null 2>&1; then sudo -n stat -c '%%a\\t%%U\\t%%G\\t%%n' %[1]s; else echo missing; fi", quoted)
 }
 
 func remoteManagedContainerMountsCommand() string {
 	script := fmt.Sprintf(`if docker info >/dev/null 2>&1; then docker_cmd=docker; elif command -v sudo >/dev/null 2>&1 && sudo -n docker info >/dev/null 2>&1; then docker_cmd="sudo -n docker"; else echo 'Docker is not reachable' >&2; exit 1; fi
-ids=$($docker_cmd ps -aq --filter label=devopsellence.managed=true 2>&1)
+ps_stderr=$(mktemp)
+inspect_stderr=$(mktemp)
+trap 'rm -f "$ps_stderr" "$inspect_stderr"' EXIT
+ids=$($docker_cmd ps -aq --filter label=devopsellence.managed=true 2>"$ps_stderr")
 ps_status=$?
 if [ "$ps_status" -ne 0 ]; then
   echo "Failed to list managed containers" >&2
-  printf '%%s\n' "$ids" >&2
+  cat "$ps_stderr" >&2
   exit "$ps_status"
 fi
 id_count=$(printf '%%s\n' "$ids" | awk 'NF { c++ } END { print c+0 }')
 ids=$(printf '%%s\n' "$ids" | awk 'NF { print; if (++c >= %d) exit }')
 if [ -z "$ids" ]; then exit 0; fi
 if [ "$id_count" -gt %d ]; then printf '%%s\n' %s; fi
-inspect_out=$($docker_cmd inspect --format '{{.Name}} {{range .Mounts}}{{.Source}}:{{.Destination}} {{end}}' $ids 2>&1)
+inspect_out=$($docker_cmd inspect --format '{{.Name}} {{range .Mounts}}{{.Source}}:{{.Destination}} {{end}}' $ids 2>"$inspect_stderr")
 inspect_status=$?
 if [ "$inspect_status" -ne 0 ]; then
   echo "Failed to inspect managed container mounts" >&2
   printf '%%s\n' "$inspect_out" >&2
+  cat "$inspect_stderr" >&2
   exit "$inspect_status"
 fi
 printf '%%s\n' "$inspect_out" | sed 's#^/##' | awk -v marker=%s 'NR <= %d { print } NR == %d { print marker; exit }'`, soloDiagnoseDockerItemLimit, soloDiagnoseDockerItemLimit, shellQuote(soloDiagnoseTruncatedMarker), shellQuote(soloDiagnoseTruncatedMarker), soloDiagnoseDockerItemLimit, soloDiagnoseDockerItemLimit+1)
@@ -7630,22 +7645,26 @@ printf '%%s\n' "$inspect_out" | sed 's#^/##' | awk -v marker=%s 'NR <= %d { prin
 
 func remoteManagedContainerPrivilegesCommand() string {
 	script := fmt.Sprintf(`if docker info >/dev/null 2>&1; then docker_cmd=docker; elif command -v sudo >/dev/null 2>&1 && sudo -n docker info >/dev/null 2>&1; then docker_cmd="sudo -n docker"; else echo 'Docker is not reachable' >&2; exit 1; fi
-ids=$($docker_cmd ps -aq --filter label=devopsellence.managed=true 2>&1)
+ps_stderr=$(mktemp)
+inspect_stderr=$(mktemp)
+trap 'rm -f "$ps_stderr" "$inspect_stderr"' EXIT
+ids=$($docker_cmd ps -aq --filter label=devopsellence.managed=true 2>"$ps_stderr")
 ps_status=$?
 if [ "$ps_status" -ne 0 ]; then
   echo "Failed to list managed containers" >&2
-  printf '%%s\n' "$ids" >&2
+  cat "$ps_stderr" >&2
   exit "$ps_status"
 fi
 id_count=$(printf '%%s\n' "$ids" | awk 'NF { c++ } END { print c+0 }')
 ids=$(printf '%%s\n' "$ids" | awk 'NF { print; if (++c >= %d) exit }')
 if [ -z "$ids" ]; then exit 0; fi
 if [ "$id_count" -gt %d ]; then printf '%%s\n' %s; fi
-inspect_out=$($docker_cmd inspect --format '{{.Name}} {{.HostConfig.Privileged}}' $ids 2>&1)
+inspect_out=$($docker_cmd inspect --format '{{.Name}} {{.HostConfig.Privileged}}' $ids 2>"$inspect_stderr")
 inspect_status=$?
 if [ "$inspect_status" -ne 0 ]; then
   echo "Failed to inspect managed container privileges" >&2
   printf '%%s\n' "$inspect_out" >&2
+  cat "$inspect_stderr" >&2
   exit "$inspect_status"
 fi
 printf '%%s\n' "$inspect_out" | sed 's#^/##' | awk -v marker=%s 'NR <= %d { print } NR == %d { print marker; exit }'`, soloDiagnoseDockerItemLimit, soloDiagnoseDockerItemLimit, shellQuote(soloDiagnoseTruncatedMarker), shellQuote(soloDiagnoseTruncatedMarker), soloDiagnoseDockerItemLimit, soloDiagnoseDockerItemLimit+1)

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -3661,7 +3661,8 @@ func (a *App) SoloNodeDiagnose(ctx context.Context, opts SoloNodeDiagnoseOptions
 	payload["docker"] = dockerSnapshot
 	ports := collectRemoteLimitedLines(ctx, node, remoteListeningPortsCommand(), soloDiagnosePortsLineLimit)
 	payload["ports"] = ports
-	security := a.soloNodeSecurityDiagnostics(ctx, node)
+	portLines, _ := ports["lines"].([]string)
+	security := a.soloNodeSecurityDiagnostics(ctx, node, portLines)
 	payload["security"] = security
 	if !diagnosticSectionsOK(agent, dockerSnapshot, ports) {
 		diagnoseOK = false
@@ -3801,20 +3802,20 @@ type soloSecurityCheck struct {
 	NextAction string
 }
 
-func (a *App) soloNodeSecurityDiagnostics(ctx context.Context, node config.Node) map[string]any {
-	checks := soloNodeSecurityChecks(ctx, node)
+func (a *App) soloNodeSecurityDiagnostics(ctx context.Context, node config.Node, portLines []string) map[string]any {
+	checks := soloNodeSecurityChecks(ctx, node, portLines)
 	items, ok := soloNodeSecurityCheckItems(checks)
 	return map[string]any{"ok": ok, "checks": items}
 }
 
-func soloNodeSecurityChecks(ctx context.Context, node config.Node) []soloSecurityCheck {
+func soloNodeSecurityChecks(ctx context.Context, node config.Node, portLines []string) []soloSecurityCheck {
 	return []soloSecurityCheck{
 		soloSSHPasswordAuthCheck(ctx, node),
 		soloAgentStatePermissionsCheck(ctx, node),
 		soloTLSKeyPermissionsCheck(ctx, node),
 		soloDockerSocketMountsCheck(ctx, node),
 		soloPrivilegedContainersCheck(ctx, node),
-		soloPublicListeningPortsCheck(ctx, node),
+		soloPublicListeningPortsCheck(ctx, node, portLines),
 	}
 }
 
@@ -3843,7 +3844,9 @@ func soloSSHPasswordAuthCheck(ctx context.Context, node config.Node) soloSecurit
 	diag := runRemoteDiagnostic(ctx, node, remoteSSHPasswordAuthCommand())
 	check := soloSecurityCheck{Name: "ssh_password_auth", OK: true, Severity: "high"}
 	if diag.Err != nil || diag.ExitCode != 0 {
+		check.OK = false
 		check.Observed = "unknown: " + diagnosticErrorMessage(diag)
+		check.NextAction = "rerun devopsellence node diagnose after SSH daemon configuration can be inspected"
 		return check
 	}
 	value := strings.ToLower(strings.TrimSpace(diag.Stdout))
@@ -3867,7 +3870,9 @@ func soloAgentStatePermissionsCheck(ctx context.Context, node config.Node) soloS
 	diag := runRemoteDiagnostic(ctx, node, remoteStatPathCommand(stateDir))
 	check := soloSecurityCheck{Name: "agent_state_permissions", OK: true, Severity: "high"}
 	if diag.Err != nil || diag.ExitCode != 0 {
+		check.OK = false
 		check.Observed = "unknown: " + diagnosticErrorMessage(diag)
+		check.NextAction = "rerun devopsellence node diagnose after the agent state directory can be inspected"
 		return check
 	}
 	fields := strings.Fields(strings.TrimSpace(diag.Stdout))
@@ -3900,7 +3905,9 @@ func soloTLSKeyPermissionsCheck(ctx context.Context, node config.Node) soloSecur
 	diag := runRemoteDiagnostic(ctx, node, remoteStatPathCommand(keyPath))
 	check := soloSecurityCheck{Name: "tls_key_permissions", OK: true, Severity: "high"}
 	if diag.Err != nil || diag.ExitCode != 0 {
+		check.OK = false
 		check.Observed = "unknown: " + diagnosticErrorMessage(diag)
+		check.NextAction = "rerun devopsellence node diagnose after the TLS key path can be inspected"
 		return check
 	}
 	fields := strings.Fields(strings.TrimSpace(diag.Stdout))
@@ -3925,7 +3932,9 @@ func soloDockerSocketMountsCheck(ctx context.Context, node config.Node) soloSecu
 	diag := runRemoteDiagnostic(ctx, node, remoteManagedContainerMountsCommand())
 	check := soloSecurityCheck{Name: "docker_socket_mounts", OK: true, Severity: "critical"}
 	if diag.Err != nil || diag.ExitCode != 0 {
+		check.OK = false
 		check.Observed = "unknown: " + diagnosticErrorMessage(diag)
+		check.NextAction = "rerun devopsellence node diagnose after Docker can be inspected"
 		return check
 	}
 	lines := splitNonFinalEmptyLines(diag.Stdout)
@@ -3949,7 +3958,9 @@ func soloPrivilegedContainersCheck(ctx context.Context, node config.Node) soloSe
 	diag := runRemoteDiagnostic(ctx, node, remoteManagedContainerPrivilegesCommand())
 	check := soloSecurityCheck{Name: "privileged_containers", OK: true, Severity: "critical"}
 	if diag.Err != nil || diag.ExitCode != 0 {
+		check.OK = false
 		check.Observed = "unknown: " + diagnosticErrorMessage(diag)
+		check.NextAction = "rerun devopsellence node diagnose after Docker can be inspected"
 		return check
 	}
 	offenders := []string{}
@@ -3969,14 +3980,19 @@ func soloPrivilegedContainersCheck(ctx context.Context, node config.Node) soloSe
 	return check
 }
 
-func soloPublicListeningPortsCheck(ctx context.Context, node config.Node) soloSecurityCheck {
-	diag := runRemoteDiagnostic(ctx, node, remoteListeningPortsCommand())
+func soloPublicListeningPortsCheck(ctx context.Context, node config.Node, portLines []string) soloSecurityCheck {
 	check := soloSecurityCheck{Name: "public_listening_ports", OK: true, Severity: "medium"}
-	if diag.Err != nil || diag.ExitCode != 0 {
-		check.Observed = "unknown: " + diagnosticErrorMessage(diag)
-		return check
+	if portLines == nil {
+		diag := runRemoteDiagnostic(ctx, node, remoteListeningPortsCommand())
+		if diag.Err != nil || diag.ExitCode != 0 {
+			check.OK = false
+			check.Observed = "unknown: " + diagnosticErrorMessage(diag)
+			check.NextAction = "rerun devopsellence node diagnose after listening ports can be inspected"
+			return check
+		}
+		portLines = splitNonFinalEmptyLines(diag.Stdout)
 	}
-	ports := unexpectedPublicListeningPorts(splitNonFinalEmptyLines(diag.Stdout))
+	ports := unexpectedPublicListeningPorts(portLines)
 	if len(ports) > 0 {
 		check.OK = false
 		check.Observed = "unexpected public listening ports: " + strings.Join(ports, ", ")
@@ -4047,7 +4063,7 @@ func isPublicListenHost(host string) bool {
 	if ip == nil {
 		return false
 	}
-	return !ip.IsLoopback()
+	return ip.IsGlobalUnicast() && !ip.IsLoopback() && !ip.IsPrivate() && !ip.IsLinkLocalUnicast() && !ip.IsLinkLocalMulticast()
 }
 
 func soloCheckFailed(checks []map[string]any, name string) bool {
@@ -4423,7 +4439,7 @@ func (a *App) soloRuntimeDoctorChecks(ctx context.Context, opts SoloDoctorOption
 			}
 			results = append(results, result)
 		}
-		for _, check := range soloNodeSecurityChecks(ctx, node) {
+		for _, check := range soloNodeSecurityChecks(ctx, node, nil) {
 			result := map[string]any{
 				"node":     name,
 				"check":    "security_" + check.Name,

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -4009,7 +4009,7 @@ func soloPublicListeningPortsCheck(ctx context.Context, node config.Node, portLi
 	if portsTruncated || listenOutputHasTruncationMarker(portLines) {
 		check.OK = false
 		check.Observed = "unknown: listening port output was truncated"
-		check.NextAction = "rerun listening-port diagnostics with complete output before trusting public port hardening"
+		check.NextAction = "inspect listening ports directly on the node with ss -ltnp or netstat -ltnp before trusting public port hardening"
 		return check
 	}
 	if !listeningPortsInspectable(portLines) {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -3859,7 +3859,9 @@ func soloSSHPasswordAuthCheck(ctx context.Context, node config.Node) soloSecurit
 	case "no":
 		check.Observed = "PasswordAuthentication no"
 	case "":
+		check.OK = false
 		check.Observed = "unknown: sshd password authentication setting not found"
+		check.NextAction = "rerun devopsellence node diagnose after SSH daemon configuration can be inspected"
 	default:
 		check.Observed = "PasswordAuthentication " + value
 	}

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -7612,7 +7612,7 @@ func remoteSSHPasswordAuthCommand() string {
 
 func remoteStatPathCommand(target string) string {
 	quoted := shellQuote(target)
-	return fmt.Sprintf("if [ -e %[1]s ]; then stat -c '%%a\\t%%U\\t%%G\\t%%n' %[1]s; elif command -v sudo >/dev/null 2>&1 && sudo -n test -e %[1]s >/dev/null 2>&1; then sudo -n stat -c '%%a\\t%%U\\t%%G\\t%%n' %[1]s; else echo missing; fi", quoted)
+	return fmt.Sprintf("format='%%a\\t%%U\\t%%G\\t%%n'; if stat -c \"$format\" %[1]s 2>/dev/null; then exit 0; fi; if command -v sudo >/dev/null 2>&1 && sudo -n test -e %[1]s >/dev/null 2>&1; then exec sudo -n stat -c \"$format\" %[1]s; fi; if [ -e %[1]s ]; then exec stat -c \"$format\" %[1]s; fi; echo missing", quoted)
 }
 
 func remoteManagedContainerMountsCommand() string {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -3900,6 +3900,11 @@ func soloAgentStatePermissionsCheck(ctx context.Context, node config.Node) soloS
 		check.NextAction = "restore root ownership on the agent state directory, for example chown root:root " + stateDir
 		return check
 	}
+	if len(fields) >= 3 && fields[2] != "root" {
+		check.OK = false
+		check.NextAction = "restore root group ownership on the agent state directory, for example chown root:root " + stateDir
+		return check
+	}
 	if mode&0o026 != 0 {
 		check.OK = false
 		check.NextAction = "remove group write and other read/write access from the agent state directory, for example chmod g-w,o-rw " + stateDir
@@ -4026,7 +4031,7 @@ func soloPublicListeningPortsCheck(ctx context.Context, node config.Node, portLi
 
 func listenOutputHasTruncationMarker(lines []string) bool {
 	for _, line := range lines {
-		if strings.TrimSpace(line) == "__DEVOPSELLENCE_TRUNCATED__" {
+		if strings.TrimSpace(line) == soloDiagnoseTruncatedMarker {
 			return true
 		}
 	}
@@ -7572,7 +7577,7 @@ func remoteListeningPortsCommand() string {
 }
 
 func remoteSSHPasswordAuthCommand() string {
-	return "if command -v sshd >/dev/null 2>&1; then out=\"$(sshd -T 2>/dev/null | awk 'tolower($1)==\"passwordauthentication\" {print tolower($2); exit}')\"; if [ -z \"$out\" ] && command -v sudo >/dev/null 2>&1; then out=\"$(sudo -n sshd -T 2>/dev/null | awk 'tolower($1)==\"passwordauthentication\" {print tolower($2); exit}')\"; fi; if [ -n \"$out\" ]; then printf '%s\\n' \"$out\"; fi; elif [ -r /etc/ssh/sshd_config ]; then awk 'tolower($1)==\"passwordauthentication\" {print tolower($2)}' /etc/ssh/sshd_config | tail -n1; elif command -v sudo >/dev/null 2>&1 && sudo -n test -r /etc/ssh/sshd_config >/dev/null 2>&1; then sudo -n awk 'tolower($1)==\"passwordauthentication\" {print tolower($2)}' /etc/ssh/sshd_config | tail -n1; fi"
+	return "out=\"\"; if command -v sshd >/dev/null 2>&1; then out=\"$(sshd -T 2>/dev/null | awk 'tolower($1)==\"passwordauthentication\" {print tolower($2); exit}')\"; if [ -z \"$out\" ] && command -v sudo >/dev/null 2>&1; then out=\"$(sudo -n sshd -T 2>/dev/null | awk 'tolower($1)==\"passwordauthentication\" {print tolower($2); exit}')\"; fi; fi; if [ -z \"$out\" ] && [ -r /etc/ssh/sshd_config ]; then out=\"$(awk 'tolower($1)==\"passwordauthentication\" {print tolower($2)}' /etc/ssh/sshd_config | tail -n1)\"; fi; if [ -z \"$out\" ] && command -v sudo >/dev/null 2>&1 && sudo -n test -r /etc/ssh/sshd_config >/dev/null 2>&1; then out=\"$(sudo -n awk 'tolower($1)==\"passwordauthentication\" {print tolower($2)}' /etc/ssh/sshd_config | tail -n1)\"; fi; if [ -n \"$out\" ]; then printf '%s\\n' \"$out\"; fi"
 }
 
 func remoteStatPathCommand(target string) string {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -3661,7 +3661,13 @@ func (a *App) SoloNodeDiagnose(ctx context.Context, opts SoloNodeDiagnoseOptions
 	payload["docker"] = dockerSnapshot
 	ports := collectRemoteLimitedLines(ctx, node, remoteListeningPortsCommand(), soloDiagnosePortsLineLimit)
 	payload["ports"] = ports
+	security := a.soloNodeSecurityDiagnostics(ctx, node)
+	payload["security"] = security
 	if !diagnosticSectionsOK(agent, dockerSnapshot, ports) {
+		diagnoseOK = false
+		payload["ok"] = false
+	}
+	if security["ok"] == false {
 		diagnoseOK = false
 		payload["ok"] = false
 	}
@@ -3785,6 +3791,263 @@ func soloChecksOK(checks []map[string]any) bool {
 		}
 	}
 	return true
+}
+
+type soloSecurityCheck struct {
+	Name       string
+	OK         bool
+	Severity   string
+	Observed   string
+	NextAction string
+}
+
+func (a *App) soloNodeSecurityDiagnostics(ctx context.Context, node config.Node) map[string]any {
+	checks := soloNodeSecurityChecks(ctx, node)
+	items, ok := soloNodeSecurityCheckItems(checks)
+	return map[string]any{"ok": ok, "checks": items}
+}
+
+func soloNodeSecurityChecks(ctx context.Context, node config.Node) []soloSecurityCheck {
+	return []soloSecurityCheck{
+		soloSSHPasswordAuthCheck(ctx, node),
+		soloAgentStatePermissionsCheck(ctx, node),
+		soloTLSKeyPermissionsCheck(ctx, node),
+		soloDockerSocketMountsCheck(ctx, node),
+		soloPrivilegedContainersCheck(ctx, node),
+		soloPublicListeningPortsCheck(ctx, node),
+	}
+}
+
+func soloNodeSecurityCheckItems(checks []soloSecurityCheck) ([]map[string]any, bool) {
+	items := make([]map[string]any, 0, len(checks))
+	ok := true
+	for _, check := range checks {
+		item := map[string]any{
+			"name":     check.Name,
+			"ok":       check.OK,
+			"severity": check.Severity,
+			"observed": check.Observed,
+		}
+		if check.NextAction != "" {
+			item["next_action"] = check.NextAction
+		}
+		items = append(items, item)
+		if !check.OK {
+			ok = false
+		}
+	}
+	return items, ok
+}
+
+func soloSSHPasswordAuthCheck(ctx context.Context, node config.Node) soloSecurityCheck {
+	diag := runRemoteDiagnostic(ctx, node, remoteSSHPasswordAuthCommand())
+	check := soloSecurityCheck{Name: "ssh_password_auth", OK: true, Severity: "high"}
+	if diag.Err != nil || diag.ExitCode != 0 {
+		check.Observed = "unknown: " + diagnosticErrorMessage(diag)
+		return check
+	}
+	value := strings.ToLower(strings.TrimSpace(diag.Stdout))
+	switch value {
+	case "yes":
+		check.OK = false
+		check.Observed = "PasswordAuthentication yes"
+		check.NextAction = "disable SSH password auth or use a provider image with key-only SSH"
+	case "no":
+		check.Observed = "PasswordAuthentication no"
+	case "":
+		check.Observed = "unknown: sshd password authentication setting not found"
+	default:
+		check.Observed = "PasswordAuthentication " + value
+	}
+	return check
+}
+
+func soloAgentStatePermissionsCheck(ctx context.Context, node config.Node) soloSecurityCheck {
+	stateDir := firstNonEmpty(node.AgentStateDir, "/var/lib/devopsellence")
+	diag := runRemoteDiagnostic(ctx, node, remoteStatPathCommand(stateDir))
+	check := soloSecurityCheck{Name: "agent_state_permissions", OK: true, Severity: "high"}
+	if diag.Err != nil || diag.ExitCode != 0 {
+		check.Observed = "unknown: " + diagnosticErrorMessage(diag)
+		return check
+	}
+	fields := strings.Fields(strings.TrimSpace(diag.Stdout))
+	if len(fields) == 0 || fields[0] == "missing" {
+		check.OK = false
+		check.Observed = stateDir + " missing"
+		check.NextAction = "reinstall or restart the devopsellence agent so the state directory exists"
+		return check
+	}
+	check.Observed = strings.TrimSpace(diag.Stdout)
+	mode, err := strconv.ParseInt(fields[0], 8, 64)
+	if err != nil {
+		check.Observed = "unknown: " + strings.TrimSpace(diag.Stdout)
+		return check
+	}
+	if len(fields) >= 2 && fields[1] != "root" {
+		check.OK = false
+		check.NextAction = "restore root ownership on the agent state directory, for example chown root:root " + stateDir
+		return check
+	}
+	if mode&0o022 != 0 {
+		check.OK = false
+		check.NextAction = "remove group/other write access from the agent state directory, for example chmod go-w " + stateDir
+	}
+	return check
+}
+
+func soloTLSKeyPermissionsCheck(ctx context.Context, node config.Node) soloSecurityCheck {
+	keyPath := path.Join(firstNonEmpty(node.AgentStateDir, "/var/lib/devopsellence"), "ingress-key.pem")
+	diag := runRemoteDiagnostic(ctx, node, remoteStatPathCommand(keyPath))
+	check := soloSecurityCheck{Name: "tls_key_permissions", OK: true, Severity: "high"}
+	if diag.Err != nil || diag.ExitCode != 0 {
+		check.Observed = "unknown: " + diagnosticErrorMessage(diag)
+		return check
+	}
+	fields := strings.Fields(strings.TrimSpace(diag.Stdout))
+	if len(fields) == 0 || fields[0] == "missing" {
+		check.Observed = keyPath + " not present"
+		return check
+	}
+	check.Observed = strings.TrimSpace(diag.Stdout)
+	mode, err := strconv.ParseInt(fields[0], 8, 64)
+	if err != nil {
+		check.Observed = "unknown: " + strings.TrimSpace(diag.Stdout)
+		return check
+	}
+	if mode&0o037 != 0 {
+		check.OK = false
+		check.NextAction = "restrict the TLS private key file to the agent or Envoy group, for example chmod 640 " + keyPath
+	}
+	return check
+}
+
+func soloDockerSocketMountsCheck(ctx context.Context, node config.Node) soloSecurityCheck {
+	diag := runRemoteDiagnostic(ctx, node, remoteManagedContainerMountsCommand())
+	check := soloSecurityCheck{Name: "docker_socket_mounts", OK: true, Severity: "critical"}
+	if diag.Err != nil || diag.ExitCode != 0 {
+		check.Observed = "unknown: " + diagnosticErrorMessage(diag)
+		return check
+	}
+	lines := splitNonFinalEmptyLines(diag.Stdout)
+	offenders := []string{}
+	for _, line := range lines {
+		if strings.Contains(line, "/var/run/docker.sock") {
+			offenders = append(offenders, strings.TrimSpace(line))
+		}
+	}
+	if len(offenders) > 0 {
+		check.OK = false
+		check.Observed = strings.Join(offenders, "; ")
+		check.NextAction = "remove Docker socket mounts from managed workload services before redeploying"
+		return check
+	}
+	check.Observed = "no managed workload mounts /var/run/docker.sock"
+	return check
+}
+
+func soloPrivilegedContainersCheck(ctx context.Context, node config.Node) soloSecurityCheck {
+	diag := runRemoteDiagnostic(ctx, node, remoteManagedContainerPrivilegesCommand())
+	check := soloSecurityCheck{Name: "privileged_containers", OK: true, Severity: "critical"}
+	if diag.Err != nil || diag.ExitCode != 0 {
+		check.Observed = "unknown: " + diagnosticErrorMessage(diag)
+		return check
+	}
+	offenders := []string{}
+	for _, line := range splitNonFinalEmptyLines(diag.Stdout) {
+		fields := strings.Fields(line)
+		if len(fields) >= 2 && fields[1] == "true" {
+			offenders = append(offenders, fields[0])
+		}
+	}
+	if len(offenders) > 0 {
+		check.OK = false
+		check.Observed = "privileged managed containers: " + strings.Join(offenders, ", ")
+		check.NextAction = "remove privileged mode from managed workload services before redeploying"
+		return check
+	}
+	check.Observed = "no privileged managed workload containers"
+	return check
+}
+
+func soloPublicListeningPortsCheck(ctx context.Context, node config.Node) soloSecurityCheck {
+	diag := runRemoteDiagnostic(ctx, node, remoteListeningPortsCommand())
+	check := soloSecurityCheck{Name: "public_listening_ports", OK: true, Severity: "medium"}
+	if diag.Err != nil || diag.ExitCode != 0 {
+		check.Observed = "unknown: " + diagnosticErrorMessage(diag)
+		return check
+	}
+	ports := unexpectedPublicListeningPorts(splitNonFinalEmptyLines(diag.Stdout))
+	if len(ports) > 0 {
+		check.OK = false
+		check.Observed = "unexpected public listening ports: " + strings.Join(ports, ", ")
+		check.NextAction = "close unexpected public ports or bind those services to localhost/internal networks"
+		return check
+	}
+	check.Observed = "only expected public ports detected"
+	return check
+}
+
+func unexpectedPublicListeningPorts(lines []string) []string {
+	expected := map[string]bool{"22": true, "80": true, "443": true}
+	seen := map[string]bool{}
+	for _, line := range lines {
+		for _, port := range publicPortsFromListeningLine(line) {
+			if expected[port] || seen[port] {
+				continue
+			}
+			seen[port] = true
+		}
+	}
+	ports := make([]string, 0, len(seen))
+	for port := range seen {
+		ports = append(ports, port)
+	}
+	sort.Strings(ports)
+	return ports
+}
+
+func publicPortsFromListeningLine(line string) []string {
+	fields := strings.Fields(line)
+	ports := []string{}
+	for _, field := range fields {
+		host, port, ok := splitListenAddress(field)
+		if !ok || !isPublicListenHost(host) {
+			continue
+		}
+		ports = append(ports, port)
+	}
+	return ports
+}
+
+func splitListenAddress(value string) (string, string, bool) {
+	value = strings.Trim(value, "[]")
+	idx := strings.LastIndex(value, ":")
+	if idx < 0 || idx == len(value)-1 {
+		return "", "", false
+	}
+	host := strings.Trim(value[:idx], "[]")
+	port := strings.Trim(value[idx+1:], "*")
+	if port == "" {
+		return "", "", false
+	}
+	for _, r := range port {
+		if r < '0' || r > '9' {
+			return "", "", false
+		}
+	}
+	return host, port, true
+}
+
+func isPublicListenHost(host string) bool {
+	host = strings.TrimSpace(strings.Trim(host, "[]"))
+	if host == "" || host == "*" || host == "0.0.0.0" || host == "::" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false
+	}
+	return !ip.IsLoopback()
 }
 
 func soloCheckFailed(checks []map[string]any, name string) bool {
@@ -4157,6 +4420,22 @@ func (a *App) soloRuntimeDoctorChecks(ctx context.Context, opts SoloDoctorOption
 			} else {
 				failed = true
 				result["detail"] = strings.TrimSpace(err.Error())
+			}
+			results = append(results, result)
+		}
+		for _, check := range soloNodeSecurityChecks(ctx, node) {
+			result := map[string]any{
+				"node":     name,
+				"check":    "security_" + check.Name,
+				"ok":       check.OK,
+				"severity": check.Severity,
+				"detail":   check.Observed,
+			}
+			if check.NextAction != "" {
+				result["next_action"] = check.NextAction
+			}
+			if !check.OK {
+				failed = true
 			}
 			results = append(results, result)
 		}
@@ -7211,6 +7490,29 @@ func withRemoteLineLimit(command string, limit int) string {
 
 func remoteListeningPortsCommand() string {
 	return withRemoteLineLimit("if command -v ss >/dev/null 2>&1; then ss -ltnp || ss -ltn; elif command -v netstat >/dev/null 2>&1; then netstat -ltnp || netstat -ltn; else echo 'no ss or netstat available'; fi", soloDiagnosePortsLineLimit)
+}
+
+func remoteSSHPasswordAuthCommand() string {
+	return "if command -v sshd >/dev/null 2>&1; then out=\"$(sshd -T 2>/dev/null | awk 'tolower($1)==\"passwordauthentication\" {print tolower($2); exit}')\"; if [ -z \"$out\" ] && command -v sudo >/dev/null 2>&1; then out=\"$(sudo -n sshd -T 2>/dev/null | awk 'tolower($1)==\"passwordauthentication\" {print tolower($2); exit}')\"; fi; if [ -n \"$out\" ]; then printf '%s\\n' \"$out\"; fi; elif [ -r /etc/ssh/sshd_config ]; then awk 'tolower($1)==\"passwordauthentication\" {print tolower($2)}' /etc/ssh/sshd_config | tail -n1; elif command -v sudo >/dev/null 2>&1 && sudo -n test -r /etc/ssh/sshd_config >/dev/null 2>&1; then sudo -n awk 'tolower($1)==\"passwordauthentication\" {print tolower($2)}' /etc/ssh/sshd_config | tail -n1; fi"
+}
+
+func remoteStatPathCommand(target string) string {
+	quoted := shellQuote(target)
+	return fmt.Sprintf("if [ -e %[1]s ]; then stat -c '%%a %%U %%G %%n' %[1]s; elif command -v sudo >/dev/null 2>&1 && sudo -n test -e %[1]s >/dev/null 2>&1; then sudo -n stat -c '%%a %%U %%G %%n' %[1]s; else echo missing; fi", quoted)
+}
+
+func remoteManagedContainerMountsCommand() string {
+	return `if docker info >/dev/null 2>&1; then docker_cmd=docker; elif command -v sudo >/dev/null 2>&1 && sudo -n docker info >/dev/null 2>&1; then docker_cmd="sudo -n docker"; else echo 'Docker is not reachable' >&2; exit 1; fi
+ids=$($docker_cmd ps -aq --filter label=devopsellence.managed=true)
+if [ -z "$ids" ]; then exit 0; fi
+$docker_cmd inspect --format '{{.Name}} {{range .Mounts}}{{.Source}}:{{.Destination}} {{end}}' $ids | sed 's#^/##'`
+}
+
+func remoteManagedContainerPrivilegesCommand() string {
+	return `if docker info >/dev/null 2>&1; then docker_cmd=docker; elif command -v sudo >/dev/null 2>&1 && sudo -n docker info >/dev/null 2>&1; then docker_cmd="sudo -n docker"; else echo 'Docker is not reachable' >&2; exit 1; fi
+ids=$($docker_cmd ps -aq --filter label=devopsellence.managed=true)
+if [ -z "$ids" ]; then exit 0; fi
+$docker_cmd inspect --format '{{.Name}} {{.HostConfig.Privileged}}' $ids | sed 's#^/##'`
 }
 
 func desiredStateOverridePath(node config.Node) string {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -3662,11 +3662,8 @@ func (a *App) SoloNodeDiagnose(ctx context.Context, opts SoloNodeDiagnoseOptions
 	ports := collectRemoteLimitedLines(ctx, node, remoteListeningPortsCommand(), soloDiagnosePortsLineLimit)
 	payload["ports"] = ports
 	portLines, _ := ports["lines"].([]string)
-	if ports["ok"] != true {
-		portLines = nil
-	}
 	portsTruncated, _ := ports["truncated"].(bool)
-	security := a.soloNodeSecurityDiagnostics(ctx, node, portLines, portsTruncated)
+	security := a.soloNodeSecurityDiagnostics(ctx, node, portLines, portsTruncated, ports)
 	payload["security"] = security
 	if !diagnosticSectionsOK(agent, dockerSnapshot, ports) {
 		diagnoseOK = false
@@ -3806,20 +3803,20 @@ type soloSecurityCheck struct {
 	NextAction string
 }
 
-func (a *App) soloNodeSecurityDiagnostics(ctx context.Context, node config.Node, portLines []string, portsTruncated bool) map[string]any {
-	checks := soloNodeSecurityChecks(ctx, node, portLines, portsTruncated)
+func (a *App) soloNodeSecurityDiagnostics(ctx context.Context, node config.Node, portLines []string, portsTruncated bool, portDiagnostic map[string]any) map[string]any {
+	checks := soloNodeSecurityChecks(ctx, node, portLines, portsTruncated, portDiagnostic)
 	items, ok := soloNodeSecurityCheckItems(checks)
 	return map[string]any{"ok": ok, "checks": items}
 }
 
-func soloNodeSecurityChecks(ctx context.Context, node config.Node, portLines []string, portsTruncated bool) []soloSecurityCheck {
+func soloNodeSecurityChecks(ctx context.Context, node config.Node, portLines []string, portsTruncated bool, portDiagnostic map[string]any) []soloSecurityCheck {
 	return []soloSecurityCheck{
 		soloSSHPasswordAuthCheck(ctx, node),
 		soloAgentStatePermissionsCheck(ctx, node),
 		soloTLSKeyPermissionsCheck(ctx, node),
 		soloDockerSocketMountsCheck(ctx, node),
 		soloPrivilegedContainersCheck(ctx, node),
-		soloPublicListeningPortsCheck(ctx, node, portLines, portsTruncated),
+		soloPublicListeningPortsCheck(ctx, node, portLines, portsTruncated, portDiagnostic),
 	}
 }
 
@@ -4021,8 +4018,14 @@ func soloPrivilegedContainersCheck(ctx context.Context, node config.Node) soloSe
 	return check
 }
 
-func soloPublicListeningPortsCheck(ctx context.Context, node config.Node, portLines []string, portsTruncated bool) soloSecurityCheck {
+func soloPublicListeningPortsCheck(ctx context.Context, node config.Node, portLines []string, portsTruncated bool, portDiagnostic map[string]any) soloSecurityCheck {
 	check := soloSecurityCheck{Name: "public_listening_ports", OK: true, Severity: "medium"}
+	if portDiagnostic != nil && portDiagnostic["ok"] != true {
+		check.OK = false
+		check.Observed = "unknown: " + remoteDiagnosticResultMessage(portDiagnostic)
+		check.NextAction = "rerun devopsellence node diagnose after listening ports can be inspected"
+		return check
+	}
 	if portLines == nil {
 		diag := runRemoteDiagnostic(ctx, node, remoteListeningPortsCommand())
 		if diag.Err != nil || diag.ExitCode != 0 {
@@ -4054,6 +4057,33 @@ func soloPublicListeningPortsCheck(ctx context.Context, node config.Node, portLi
 	}
 	check.Observed = "only expected public ports detected"
 	return check
+}
+
+func remoteDiagnosticResultMessage(result map[string]any) string {
+	if message := diagnosticStringValue(result["error"]); strings.TrimSpace(message) != "" {
+		return strings.TrimSpace(message)
+	}
+	if message := diagnosticStringValue(result["stderr"]); strings.TrimSpace(message) != "" {
+		return strings.TrimSpace(message)
+	}
+	if code, ok := result["exit_code"]; ok {
+		return fmt.Sprintf("command exited with code %v", code)
+	}
+	return "diagnostic failed"
+}
+
+func diagnosticStringValue(value any) string {
+	if value == nil {
+		return ""
+	}
+	switch typed := value.(type) {
+	case string:
+		return typed
+	case fmt.Stringer:
+		return typed.String()
+	default:
+		return fmt.Sprint(typed)
+	}
 }
 
 func listenOutputHasTruncationMarker(lines []string) bool {
@@ -4523,9 +4553,13 @@ func (a *App) soloRuntimeDoctorChecks(ctx context.Context, opts SoloDoctorOption
 			{name: "docker", cmd: remoteDockerCheckCommand()},
 			{name: "agent", cmd: "systemctl is-active --quiet devopsellence-agent"},
 		}
+		sshOK := true
 		for _, check := range checks {
 			out, err := solo.RunSSH(ctx, node, check.cmd, nil)
 			ok := err == nil
+			if check.name == "ssh" {
+				sshOK = ok
+			}
 			result := map[string]any{"node": name, "check": check.name, "ok": ok}
 			if ok {
 				if detail := strings.TrimSpace(out); detail != "" {
@@ -4537,17 +4571,14 @@ func (a *App) soloRuntimeDoctorChecks(ctx context.Context, opts SoloDoctorOption
 			}
 			results = append(results, result)
 		}
-		for _, check := range soloNodeSecurityChecks(ctx, node, nil, false) {
-			result := map[string]any{
-				"node":     name,
-				"check":    "security_" + check.Name,
-				"ok":       check.OK,
-				"severity": check.Severity,
-				"detail":   check.Observed,
+		if !sshOK {
+			for _, check := range soloSkippedSecurityChecksAfterSSHFailure() {
+				results = append(results, soloRuntimeSecurityCheckResult(name, check))
 			}
-			if check.NextAction != "" {
-				result["next_action"] = check.NextAction
-			}
+			continue
+		}
+		for _, check := range soloNodeSecurityChecks(ctx, node, nil, false, nil) {
+			result := soloRuntimeSecurityCheckResult(name, check)
 			if !check.OK {
 				failed = true
 			}
@@ -4555,6 +4586,31 @@ func (a *App) soloRuntimeDoctorChecks(ctx context.Context, opts SoloDoctorOption
 		}
 	}
 	return results, failed, nil
+}
+
+func soloSkippedSecurityChecksAfterSSHFailure() []soloSecurityCheck {
+	return []soloSecurityCheck{
+		{Name: "ssh_password_auth", OK: false, Severity: "high", Observed: "skipped: ssh check failed", NextAction: "fix SSH connectivity, then rerun devopsellence doctor"},
+		{Name: "agent_state_permissions", OK: false, Severity: "high", Observed: "skipped: ssh check failed", NextAction: "fix SSH connectivity, then rerun devopsellence doctor"},
+		{Name: "tls_key_permissions", OK: false, Severity: "high", Observed: "skipped: ssh check failed", NextAction: "fix SSH connectivity, then rerun devopsellence doctor"},
+		{Name: "docker_socket_mounts", OK: false, Severity: "critical", Observed: "skipped: ssh check failed", NextAction: "fix SSH connectivity, then rerun devopsellence doctor"},
+		{Name: "privileged_containers", OK: false, Severity: "critical", Observed: "skipped: ssh check failed", NextAction: "fix SSH connectivity, then rerun devopsellence doctor"},
+		{Name: "public_listening_ports", OK: false, Severity: "medium", Observed: "skipped: ssh check failed", NextAction: "fix SSH connectivity, then rerun devopsellence doctor"},
+	}
+}
+
+func soloRuntimeSecurityCheckResult(nodeName string, check soloSecurityCheck) map[string]any {
+	result := map[string]any{
+		"node":     nodeName,
+		"check":    "security_" + check.Name,
+		"ok":       check.OK,
+		"severity": check.Severity,
+		"detail":   check.Observed,
+	}
+	if check.NextAction != "" {
+		result["next_action"] = check.NextAction
+	}
+	return result
 }
 
 func (a *App) runSoloRuntimeDoctor(ctx context.Context, opts SoloDoctorOptions) error {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -3662,7 +3662,8 @@ func (a *App) SoloNodeDiagnose(ctx context.Context, opts SoloNodeDiagnoseOptions
 	ports := collectRemoteLimitedLines(ctx, node, remoteListeningPortsCommand(), soloDiagnosePortsLineLimit)
 	payload["ports"] = ports
 	portLines, _ := ports["lines"].([]string)
-	security := a.soloNodeSecurityDiagnostics(ctx, node, portLines)
+	portsTruncated, _ := ports["truncated"].(bool)
+	security := a.soloNodeSecurityDiagnostics(ctx, node, portLines, portsTruncated)
 	payload["security"] = security
 	if !diagnosticSectionsOK(agent, dockerSnapshot, ports) {
 		diagnoseOK = false
@@ -3802,20 +3803,20 @@ type soloSecurityCheck struct {
 	NextAction string
 }
 
-func (a *App) soloNodeSecurityDiagnostics(ctx context.Context, node config.Node, portLines []string) map[string]any {
-	checks := soloNodeSecurityChecks(ctx, node, portLines)
+func (a *App) soloNodeSecurityDiagnostics(ctx context.Context, node config.Node, portLines []string, portsTruncated bool) map[string]any {
+	checks := soloNodeSecurityChecks(ctx, node, portLines, portsTruncated)
 	items, ok := soloNodeSecurityCheckItems(checks)
 	return map[string]any{"ok": ok, "checks": items}
 }
 
-func soloNodeSecurityChecks(ctx context.Context, node config.Node, portLines []string) []soloSecurityCheck {
+func soloNodeSecurityChecks(ctx context.Context, node config.Node, portLines []string, portsTruncated bool) []soloSecurityCheck {
 	return []soloSecurityCheck{
 		soloSSHPasswordAuthCheck(ctx, node),
 		soloAgentStatePermissionsCheck(ctx, node),
 		soloTLSKeyPermissionsCheck(ctx, node),
 		soloDockerSocketMountsCheck(ctx, node),
 		soloPrivilegedContainersCheck(ctx, node),
-		soloPublicListeningPortsCheck(ctx, node, portLines),
+		soloPublicListeningPortsCheck(ctx, node, portLines, portsTruncated),
 	}
 }
 
@@ -3893,9 +3894,9 @@ func soloAgentStatePermissionsCheck(ctx context.Context, node config.Node) soloS
 		check.NextAction = "restore root ownership on the agent state directory, for example chown root:root " + stateDir
 		return check
 	}
-	if mode&0o022 != 0 {
+	if mode&0o026 != 0 {
 		check.OK = false
-		check.NextAction = "remove group/other write access from the agent state directory, for example chmod go-w " + stateDir
+		check.NextAction = "remove group write and other read/write access from the agent state directory, for example chmod g-w,o-rw " + stateDir
 	}
 	return check
 }
@@ -3980,7 +3981,7 @@ func soloPrivilegedContainersCheck(ctx context.Context, node config.Node) soloSe
 	return check
 }
 
-func soloPublicListeningPortsCheck(ctx context.Context, node config.Node, portLines []string) soloSecurityCheck {
+func soloPublicListeningPortsCheck(ctx context.Context, node config.Node, portLines []string, portsTruncated bool) soloSecurityCheck {
 	check := soloSecurityCheck{Name: "public_listening_ports", OK: true, Severity: "medium"}
 	if portLines == nil {
 		diag := runRemoteDiagnostic(ctx, node, remoteListeningPortsCommand())
@@ -3992,6 +3993,18 @@ func soloPublicListeningPortsCheck(ctx context.Context, node config.Node, portLi
 		}
 		portLines = splitNonFinalEmptyLines(diag.Stdout)
 	}
+	if portsTruncated {
+		check.OK = false
+		check.Observed = "unknown: listening port output was truncated"
+		check.NextAction = "rerun listening-port diagnostics with complete output before trusting public port hardening"
+		return check
+	}
+	if !listeningPortsInspectable(portLines) {
+		check.OK = false
+		check.Observed = "unknown: listening ports were not inspected"
+		check.NextAction = "install ss or netstat on the node, then rerun devopsellence node diagnose"
+		return check
+	}
 	ports := unexpectedPublicListeningPorts(portLines)
 	if len(ports) > 0 {
 		check.OK = false
@@ -4001,6 +4014,27 @@ func soloPublicListeningPortsCheck(ctx context.Context, node config.Node, portLi
 	}
 	check.Observed = "only expected public ports detected"
 	return check
+}
+
+func listeningPortsInspectable(lines []string) bool {
+	for _, line := range lines {
+		if strings.Contains(strings.ToLower(line), "no ss or netstat available") {
+			return false
+		}
+		if len(publicPortsFromListeningLine(line)) > 0 || hasListenAddress(line) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasListenAddress(line string) bool {
+	for _, field := range strings.Fields(line) {
+		if _, _, ok := splitListenAddress(field); ok {
+			return true
+		}
+	}
+	return false
 }
 
 func unexpectedPublicListeningPorts(lines []string) []string {
@@ -4037,6 +4071,18 @@ func publicPortsFromListeningLine(line string) []string {
 
 func splitListenAddress(value string) (string, string, bool) {
 	value = strings.Trim(value, "[]")
+	if strings.HasPrefix(value, ":::") {
+		port := strings.Trim(strings.TrimPrefix(value, ":::"), "*")
+		if port == "" {
+			return "", "", false
+		}
+		for _, r := range port {
+			if r < '0' || r > '9' {
+				return "", "", false
+			}
+		}
+		return "::", port, true
+	}
 	idx := strings.LastIndex(value, ":")
 	if idx < 0 || idx == len(value)-1 {
 		return "", "", false
@@ -4439,7 +4485,7 @@ func (a *App) soloRuntimeDoctorChecks(ctx context.Context, opts SoloDoctorOption
 			}
 			results = append(results, result)
 		}
-		for _, check := range soloNodeSecurityChecks(ctx, node, nil) {
+		for _, check := range soloNodeSecurityChecks(ctx, node, nil, false) {
 			result := map[string]any{
 				"node":     name,
 				"check":    "security_" + check.Name,

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -3971,7 +3971,7 @@ func soloDockerSocketMountsCheck(ctx context.Context, node config.Node) soloSecu
 	}
 	offenders := []string{}
 	for _, line := range lines {
-		if strings.Contains(line, "/var/run/docker.sock") {
+		if managedDockerSocketMountLine(line) {
 			offenders = append(offenders, strings.TrimSpace(line))
 		}
 	}
@@ -3983,6 +3983,10 @@ func soloDockerSocketMountsCheck(ctx context.Context, node config.Node) soloSecu
 	}
 	check.Observed = "no managed workload mounts /var/run/docker.sock"
 	return check
+}
+
+func managedDockerSocketMountLine(line string) bool {
+	return strings.Contains(line, "/var/run/docker.sock") || strings.Contains(line, "/run/docker.sock")
 }
 
 func soloPrivilegedContainersCheck(ctx context.Context, node config.Node) soloSecurityCheck {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -3662,6 +3662,9 @@ func (a *App) SoloNodeDiagnose(ctx context.Context, opts SoloNodeDiagnoseOptions
 	ports := collectRemoteLimitedLines(ctx, node, remoteListeningPortsCommand(), soloDiagnosePortsLineLimit)
 	payload["ports"] = ports
 	portLines, _ := ports["lines"].([]string)
+	if ports["ok"] != true {
+		portLines = nil
+	}
 	portsTruncated, _ := ports["truncated"].(bool)
 	security := a.soloNodeSecurityDiagnostics(ctx, node, portLines, portsTruncated)
 	payload["security"] = security
@@ -7610,7 +7613,7 @@ if [ "$ps_status" -ne 0 ]; then
   printf '%s\n' "$ids" >&2
   exit "$ps_status"
 fi
-ids=$(printf '%s\n' "$ids" | sed '/^$/d' | head -n 100)
+ids=$(printf '%s\n' "$ids" | sed '/^$/d')
 if [ -z "$ids" ]; then exit 0; fi
 inspect_out=$($docker_cmd inspect --format '{{.Name}} {{range .Mounts}}{{.Source}}:{{.Destination}} {{end}}' $ids 2>&1)
 inspect_status=$?
@@ -7619,8 +7622,8 @@ if [ "$inspect_status" -ne 0 ]; then
   printf '%s\n' "$inspect_out" >&2
   exit "$inspect_status"
 fi
-printf '%s\n' "$inspect_out" | sed 's#^/##' | head -n 100`
-	return "if command -v bash >/dev/null 2>&1; then exec bash -o pipefail -c " + shellQuote(script) + "; fi; echo 'bash is required for managed container mount diagnostics' >&2; exit 1"
+printf '%s\n' "$inspect_out" | sed 's#^/##'`
+	return withRemoteLineLimit(script, soloDiagnoseDockerItemLimit)
 }
 
 func remoteManagedContainerPrivilegesCommand() string {
@@ -7632,7 +7635,7 @@ if [ "$ps_status" -ne 0 ]; then
   printf '%s\n' "$ids" >&2
   exit "$ps_status"
 fi
-ids=$(printf '%s\n' "$ids" | sed '/^$/d' | head -n 100)
+ids=$(printf '%s\n' "$ids" | sed '/^$/d')
 if [ -z "$ids" ]; then exit 0; fi
 inspect_out=$($docker_cmd inspect --format '{{.Name}} {{.HostConfig.Privileged}}' $ids 2>&1)
 inspect_status=$?
@@ -7641,8 +7644,8 @@ if [ "$inspect_status" -ne 0 ]; then
   printf '%s\n' "$inspect_out" >&2
   exit "$inspect_status"
 fi
-printf '%s\n' "$inspect_out" | sed 's#^/##' | head -n 100`
-	return "if command -v bash >/dev/null 2>&1; then exec bash -o pipefail -c " + shellQuote(script) + "; fi; echo 'bash is required for managed container privilege diagnostics' >&2; exit 1"
+printf '%s\n' "$inspect_out" | sed 's#^/##'`
+	return withRemoteLineLimit(script, soloDiagnoseDockerItemLimit)
 }
 
 func desiredStateOverridePath(node config.Node) string {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -7612,7 +7612,7 @@ func remoteSSHPasswordAuthCommand() string {
 
 func remoteStatPathCommand(target string) string {
 	quoted := shellQuote(target)
-	return fmt.Sprintf("format='%%a\\t%%U\\t%%G\\t%%n'; if stat -c \"$format\" %[1]s 2>/dev/null; then exit 0; fi; if command -v sudo >/dev/null 2>&1 && sudo -n test -e %[1]s >/dev/null 2>&1; then exec sudo -n stat -c \"$format\" %[1]s; fi; if [ -e %[1]s ]; then exec stat -c \"$format\" %[1]s; fi; echo missing", quoted)
+	return fmt.Sprintf("format='%%a	%%U	%%G	%%n'; if stat -c \"$format\" %[1]s 2>/dev/null; then exit 0; fi; if command -v sudo >/dev/null 2>&1 && sudo -n test -e %[1]s >/dev/null 2>&1; then exec sudo -n stat -c \"$format\" %[1]s; fi; if [ -e %[1]s ]; then exec stat -c \"$format\" %[1]s; fi; echo missing", quoted)
 }
 
 func remoteManagedContainerMountsCommand() string {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -3852,18 +3852,20 @@ func soloSSHPasswordAuthCheck(ctx context.Context, node config.Node) soloSecurit
 	}
 	value := strings.ToLower(strings.TrimSpace(diag.Stdout))
 	switch value {
-	case "yes":
+	case "yes", "true":
 		check.OK = false
-		check.Observed = "PasswordAuthentication yes"
+		check.Observed = "PasswordAuthentication " + value
 		check.NextAction = "disable SSH password auth or use a provider image with key-only SSH"
-	case "no":
-		check.Observed = "PasswordAuthentication no"
+	case "no", "false":
+		check.Observed = "PasswordAuthentication " + value
 	case "":
 		check.OK = false
 		check.Observed = "unknown: sshd password authentication setting not found"
 		check.NextAction = "rerun devopsellence node diagnose after SSH daemon configuration can be inspected"
 	default:
-		check.Observed = "PasswordAuthentication " + value
+		check.OK = false
+		check.Observed = "unknown: unrecognized SSH PasswordAuthentication value " + value
+		check.NextAction = "inspect SSH daemon configuration on the node and rerun devopsellence node diagnose"
 	}
 	return check
 }
@@ -3888,7 +3890,9 @@ func soloAgentStatePermissionsCheck(ctx context.Context, node config.Node) soloS
 	check.Observed = strings.TrimSpace(diag.Stdout)
 	mode, err := strconv.ParseInt(fields[0], 8, 64)
 	if err != nil {
+		check.OK = false
 		check.Observed = "unknown: " + strings.TrimSpace(diag.Stdout)
+		check.NextAction = "rerun devopsellence node diagnose after the agent state directory mode can be parsed"
 		return check
 	}
 	if len(fields) >= 2 && fields[1] != "root" {
@@ -3921,7 +3925,9 @@ func soloTLSKeyPermissionsCheck(ctx context.Context, node config.Node) soloSecur
 	check.Observed = strings.TrimSpace(diag.Stdout)
 	mode, err := strconv.ParseInt(fields[0], 8, 64)
 	if err != nil {
+		check.OK = false
 		check.Observed = "unknown: " + strings.TrimSpace(diag.Stdout)
+		check.NextAction = "rerun devopsellence node diagnose after the TLS key mode can be parsed"
 		return check
 	}
 	if mode&0o037 != 0 {
@@ -3995,7 +4001,7 @@ func soloPublicListeningPortsCheck(ctx context.Context, node config.Node, portLi
 		}
 		portLines = splitNonFinalEmptyLines(diag.Stdout)
 	}
-	if portsTruncated {
+	if portsTruncated || listenOutputHasTruncationMarker(portLines) {
 		check.OK = false
 		check.Observed = "unknown: listening port output was truncated"
 		check.NextAction = "rerun listening-port diagnostics with complete output before trusting public port hardening"
@@ -4016,6 +4022,15 @@ func soloPublicListeningPortsCheck(ctx context.Context, node config.Node, portLi
 	}
 	check.Observed = "only expected public ports detected"
 	return check
+}
+
+func listenOutputHasTruncationMarker(lines []string) bool {
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "__DEVOPSELLENCE_TRUNCATED__" {
+			return true
+		}
+	}
+	return false
 }
 
 func listeningPortsInspectable(lines []string) bool {
@@ -7567,16 +7582,16 @@ func remoteStatPathCommand(target string) string {
 
 func remoteManagedContainerMountsCommand() string {
 	return `if docker info >/dev/null 2>&1; then docker_cmd=docker; elif command -v sudo >/dev/null 2>&1 && sudo -n docker info >/dev/null 2>&1; then docker_cmd="sudo -n docker"; else echo 'Docker is not reachable' >&2; exit 1; fi
-ids=$($docker_cmd ps -aq --filter label=devopsellence.managed=true)
+ids=$($docker_cmd ps -aq --filter label=devopsellence.managed=true | head -n 100)
 if [ -z "$ids" ]; then exit 0; fi
-$docker_cmd inspect --format '{{.Name}} {{range .Mounts}}{{.Source}}:{{.Destination}} {{end}}' $ids | sed 's#^/##'`
+$docker_cmd inspect --format '{{.Name}} {{range .Mounts}}{{.Source}}:{{.Destination}} {{end}}' $ids | sed 's#^/##' | grep '/var/run/docker.sock' | head -n 100 || true`
 }
 
 func remoteManagedContainerPrivilegesCommand() string {
 	return `if docker info >/dev/null 2>&1; then docker_cmd=docker; elif command -v sudo >/dev/null 2>&1 && sudo -n docker info >/dev/null 2>&1; then docker_cmd="sudo -n docker"; else echo 'Docker is not reachable' >&2; exit 1; fi
-ids=$($docker_cmd ps -aq --filter label=devopsellence.managed=true)
+ids=$($docker_cmd ps -aq --filter label=devopsellence.managed=true | head -n 100)
 if [ -z "$ids" ]; then exit 0; fi
-$docker_cmd inspect --format '{{.Name}} {{.HostConfig.Privileged}}' $ids | sed 's#^/##'`
+$docker_cmd inspect --format '{{.Name}} {{.HostConfig.Privileged}}' $ids | sed 's#^/##' | awk '$2 == "true" { print }' | head -n 100`
 }
 
 func desiredStateOverridePath(node config.Node) string {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -7602,46 +7602,50 @@ func remoteStatPathCommand(target string) string {
 }
 
 func remoteManagedContainerMountsCommand() string {
-	script := `if docker info >/dev/null 2>&1; then docker_cmd=docker; elif command -v sudo >/dev/null 2>&1 && sudo -n docker info >/dev/null 2>&1; then docker_cmd="sudo -n docker"; else echo 'Docker is not reachable' >&2; exit 1; fi
+	script := fmt.Sprintf(`if docker info >/dev/null 2>&1; then docker_cmd=docker; elif command -v sudo >/dev/null 2>&1 && sudo -n docker info >/dev/null 2>&1; then docker_cmd="sudo -n docker"; else echo 'Docker is not reachable' >&2; exit 1; fi
 ids=$($docker_cmd ps -aq --filter label=devopsellence.managed=true 2>&1)
 ps_status=$?
 if [ "$ps_status" -ne 0 ]; then
   echo "Failed to list managed containers" >&2
-  printf '%s\n' "$ids" >&2
+  printf '%%s\n' "$ids" >&2
   exit "$ps_status"
 fi
-ids=$(printf '%s\n' "$ids" | sed '/^$/d' | head -n 100)
+id_count=$(printf '%%s\n' "$ids" | awk 'NF { c++ } END { print c+0 }')
+ids=$(printf '%%s\n' "$ids" | awk 'NF { print; if (++c >= %d) exit }')
 if [ -z "$ids" ]; then exit 0; fi
+if [ "$id_count" -gt %d ]; then printf '%%s\n' %s; fi
 inspect_out=$($docker_cmd inspect --format '{{.Name}} {{range .Mounts}}{{.Source}}:{{.Destination}} {{end}}' $ids 2>&1)
 inspect_status=$?
 if [ "$inspect_status" -ne 0 ]; then
   echo "Failed to inspect managed container mounts" >&2
-  printf '%s\n' "$inspect_out" >&2
+  printf '%%s\n' "$inspect_out" >&2
   exit "$inspect_status"
 fi
-printf '%s\n' "$inspect_out" | sed 's#^/##' | head -n 100`
+printf '%%s\n' "$inspect_out" | sed 's#^/##' | awk -v marker=%s 'NR <= %d { print } NR == %d { print marker; exit }'`, soloDiagnoseDockerItemLimit, soloDiagnoseDockerItemLimit, shellQuote(soloDiagnoseTruncatedMarker), shellQuote(soloDiagnoseTruncatedMarker), soloDiagnoseDockerItemLimit, soloDiagnoseDockerItemLimit+1)
 	return "if command -v bash >/dev/null 2>&1; then exec bash -o pipefail -c " + shellQuote(script) + "; fi; echo 'bash is required for managed container mount diagnostics' >&2; exit 1"
 }
 
 func remoteManagedContainerPrivilegesCommand() string {
-	script := `if docker info >/dev/null 2>&1; then docker_cmd=docker; elif command -v sudo >/dev/null 2>&1 && sudo -n docker info >/dev/null 2>&1; then docker_cmd="sudo -n docker"; else echo 'Docker is not reachable' >&2; exit 1; fi
+	script := fmt.Sprintf(`if docker info >/dev/null 2>&1; then docker_cmd=docker; elif command -v sudo >/dev/null 2>&1 && sudo -n docker info >/dev/null 2>&1; then docker_cmd="sudo -n docker"; else echo 'Docker is not reachable' >&2; exit 1; fi
 ids=$($docker_cmd ps -aq --filter label=devopsellence.managed=true 2>&1)
 ps_status=$?
 if [ "$ps_status" -ne 0 ]; then
   echo "Failed to list managed containers" >&2
-  printf '%s\n' "$ids" >&2
+  printf '%%s\n' "$ids" >&2
   exit "$ps_status"
 fi
-ids=$(printf '%s\n' "$ids" | sed '/^$/d' | head -n 100)
+id_count=$(printf '%%s\n' "$ids" | awk 'NF { c++ } END { print c+0 }')
+ids=$(printf '%%s\n' "$ids" | awk 'NF { print; if (++c >= %d) exit }')
 if [ -z "$ids" ]; then exit 0; fi
+if [ "$id_count" -gt %d ]; then printf '%%s\n' %s; fi
 inspect_out=$($docker_cmd inspect --format '{{.Name}} {{.HostConfig.Privileged}}' $ids 2>&1)
 inspect_status=$?
 if [ "$inspect_status" -ne 0 ]; then
   echo "Failed to inspect managed container privileges" >&2
-  printf '%s\n' "$inspect_out" >&2
+  printf '%%s\n' "$inspect_out" >&2
   exit "$inspect_status"
 fi
-printf '%s\n' "$inspect_out" | sed 's#^/##' | head -n 100`
+printf '%%s\n' "$inspect_out" | sed 's#^/##' | awk -v marker=%s 'NR <= %d { print } NR == %d { print marker; exit }'`, soloDiagnoseDockerItemLimit, soloDiagnoseDockerItemLimit, shellQuote(soloDiagnoseTruncatedMarker), shellQuote(soloDiagnoseTruncatedMarker), soloDiagnoseDockerItemLimit, soloDiagnoseDockerItemLimit+1)
 	return "if command -v bash >/dev/null 2>&1; then exec bash -o pipefail -c " + shellQuote(script) + "; fi; echo 'bash is required for managed container privilege diagnostics' >&2; exit 1"
 }
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -3887,6 +3887,17 @@ func TestSoloDockerSecurityChecksFailWhenManagedContainerOutputTruncated(t *test
 	}
 }
 
+func TestSoloDockerSocketMountsRejectsRunSocketPath(t *testing.T) {
+	installFakeSoloCommands(t, nil)
+	t.Setenv("DEVOPSELLENCE_FAKE_SSH_DOCKER_RUN_SOCKET_MOUNT", "1")
+	node := config.Node{Host: "203.0.113.10", User: "root", Port: 22}
+
+	mounts := soloDockerSocketMountsCheck(context.Background(), node)
+	if mounts.OK || !strings.Contains(mounts.Observed, "/run/docker.sock") {
+		t.Fatalf("docker socket check = %#v, want /run/docker.sock finding", mounts)
+	}
+}
+
 func TestRemoteManagedContainerSecurityCommandsUseBoundedOutputMarker(t *testing.T) {
 	for _, command := range []string{remoteManagedContainerMountsCommand(), remoteManagedContainerPrivilegesCommand()} {
 		if !strings.Contains(command, soloDiagnoseTruncatedMarker) {
@@ -8553,6 +8564,8 @@ if [[ "$command" == *"__DEVOPSELLENCE_EXIT_CODE__"* && "$command" == *"inspect -
     printf '__DEVOPSELLENCE_EXIT_CODE__1\n__DEVOPSELLENCE_STDOUT__\n\n__DEVOPSELLENCE_STDERR__\ninspect failed\n'
   elif [[ -n "${DEVOPSELLENCE_FAKE_SSH_DOCKER_INSPECT_TRUNCATED:-}" ]]; then
     printf '__DEVOPSELLENCE_EXIT_CODE__0\n__DEVOPSELLENCE_STDOUT__\n__DEVOPSELLENCE_TRUNCATED__\n__DEVOPSELLENCE_STDERR__\n'
+  elif [[ -n "${DEVOPSELLENCE_FAKE_SSH_DOCKER_RUN_SOCKET_MOUNT:-}" ]]; then
+    printf '__DEVOPSELLENCE_EXIT_CODE__0\n__DEVOPSELLENCE_STDOUT__\nsvc-production-web /run/docker.sock:/run/docker.sock\n__DEVOPSELLENCE_STDERR__\n'
   elif [[ -n "${DEVOPSELLENCE_FAKE_SSH_DOCKER_SOCKET_MOUNT:-}" ]]; then
     printf '__DEVOPSELLENCE_EXIT_CODE__0\n__DEVOPSELLENCE_STDOUT__\nsvc-production-web /var/run/docker.sock:/var/run/docker.sock\n__DEVOPSELLENCE_STDERR__\n'
   else

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -3681,8 +3681,15 @@ func TestSoloNodeDiagnoseCollectsRuntimeSnapshot(t *testing.T) {
 		t.Fatalf("security = %#v, want ok", security)
 	}
 	securityChecks := jsonArrayFromMap(t, security, "checks")
-	if len(securityChecks) != 6 {
-		t.Fatalf("security checks = %#v, want baseline hardening checks", securityChecks)
+	securityNames := map[string]bool{}
+	for _, item := range securityChecks {
+		check := jsonMapFromAny(t, item)
+		securityNames[stringValueAny(check["name"])] = true
+	}
+	for _, want := range []string{"ssh_password_auth", "agent_state_permissions", "tls_key_permissions", "docker_socket_mounts", "privileged_containers", "public_listening_ports"} {
+		if !securityNames[want] {
+			t.Fatalf("security checks = %#v, missing %s", securityChecks, want)
+		}
 	}
 }
 
@@ -3730,6 +3737,19 @@ func TestSoloNodeDiagnoseReportsSecurityFindings(t *testing.T) {
 	}
 	if findings["docker_socket_mounts"]["ok"] != false || !strings.Contains(stringValueAny(findings["docker_socket_mounts"]["observed"]), "/var/run/docker.sock") {
 		t.Fatalf("docker_socket_mounts = %#v, want socket finding", findings["docker_socket_mounts"])
+	}
+}
+
+func TestUnexpectedPublicListeningPortsIgnoresPrivateInterfaces(t *testing.T) {
+	lines := []string{
+		"LISTEN 0 4096 10.0.0.5:5432 0.0.0.0:*",
+		"LISTEN 0 4096 192.168.1.10:6379 0.0.0.0:*",
+		"LISTEN 0 4096 127.0.0.1:9000 0.0.0.0:*",
+		"LISTEN 0 4096 0.0.0.0:8080 0.0.0.0:*",
+	}
+	ports := unexpectedPublicListeningPorts(lines)
+	if !reflect.DeepEqual(ports, []string{"8080"}) {
+		t.Fatalf("unexpected ports = %#v, want only wildcard public port", ports)
 	}
 }
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -897,6 +897,10 @@ func TestSoloNodeCreateAttachRollsBackExistingSSHStateWhenRepublishFails(t *test
 set -euo pipefail
 command="${!#}"
 if [[ "$command" == "true" ]]; then
+  if [[ -n "${DEVOPSELLENCE_FAKE_SSH_TRUE_FAIL:-}" ]]; then
+    printf 'ssh connect failed\n' >&2
+    exit 255
+  fi
   exit 0
 fi
 if [[ "$command" == *"docker image inspect"* ]]; then
@@ -2354,6 +2358,59 @@ func TestSoloDoctorReportsSecurityFindings(t *testing.T) {
 		}
 	}
 	t.Fatalf("runtime_checks = %#v, want security_ssh_password_auth", checks)
+}
+
+func TestSoloDoctorSkipsSecurityDiagnosticsWhenSSHFails(t *testing.T) {
+	installFakeSoloCommands(t, nil)
+	commandLog := filepath.Join(t.TempDir(), "ssh-commands.log")
+	t.Setenv("DEVOPSELLENCE_FAKE_SSH_COMMAND_LOG", commandLog)
+	t.Setenv("DEVOPSELLENCE_FAKE_SSH_TRUE_FAIL", "1")
+	t.Setenv("DEVOPSELLENCE_FAKE_SSH_PASSWORD_AUTH", "yes")
+
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	commitTestRepo(t, workspaceRoot)
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.Node{
+			"node-a": {Host: "203.0.113.10", User: "root"},
+		},
+	}
+	if _, _, err := current.AttachNode(workspaceRoot, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{
+		Printer:     output.New(&stdout, io.Discard),
+		Docker:      &fakeDocker{},
+		SoloState:   soloState,
+		ConfigStore: config.NewStore(),
+		Cwd:         workspaceRoot,
+	}
+	err := app.SoloDoctor(context.Background())
+	if err == nil {
+		t.Fatal("SoloDoctor() error = nil, want ssh failure")
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	checks := jsonArrayFromMap(t, payload, "runtime_checks")
+	for _, item := range checks {
+		check := jsonMapFromAny(t, item)
+		if check["check"] == "security_ssh_password_auth" {
+			if check["ok"] != false || !strings.Contains(stringValueAny(check["detail"]), "skipped") || strings.Contains(stringValueAny(check["detail"]), "yes") {
+				commands, _ := os.ReadFile(commandLog)
+				t.Fatalf("security_ssh_password_auth = %#v, want skipped security check; commands:\n%s", check, commands)
+			}
+			return
+		}
+	}
+	t.Fatalf("runtime_checks = %#v, want skipped security_ssh_password_auth", checks)
 }
 
 func TestSoloStatusReturnsFailureWhenNodeStatusReadFails(t *testing.T) {
@@ -3861,19 +3918,19 @@ func TestSoloDockerSecurityChecksFailWhenInspectErrors(t *testing.T) {
 }
 
 func TestSoloPublicListeningPortsCheckFailsWhenOutputIncomplete(t *testing.T) {
-	truncated := soloPublicListeningPortsCheck(context.Background(), config.Node{}, []string{"LISTEN 0 4096 0.0.0.0:80 0.0.0.0:*"}, true)
+	truncated := soloPublicListeningPortsCheck(context.Background(), config.Node{}, []string{"LISTEN 0 4096 0.0.0.0:80 0.0.0.0:*"}, true, nil)
 	if truncated.OK || !strings.Contains(truncated.Observed, "truncated") {
 		t.Fatalf("truncated check = %#v, want failed truncated finding", truncated)
 	}
 	if !strings.Contains(truncated.NextAction, "ss -ltnp") || strings.Contains(truncated.NextAction, "rerun listening-port diagnostics") {
 		t.Fatalf("truncated next action = %q, want direct node inspection guidance", truncated.NextAction)
 	}
-	marker := soloPublicListeningPortsCheck(context.Background(), config.Node{}, []string{"LISTEN 0 4096 0.0.0.0:80 0.0.0.0:*", "__DEVOPSELLENCE_TRUNCATED__"}, false)
+	marker := soloPublicListeningPortsCheck(context.Background(), config.Node{}, []string{"LISTEN 0 4096 0.0.0.0:80 0.0.0.0:*", "__DEVOPSELLENCE_TRUNCATED__"}, false, nil)
 	if marker.OK || !strings.Contains(marker.Observed, "truncated") {
 		t.Fatalf("marker check = %#v, want failed truncated finding", marker)
 	}
 
-	unavailable := soloPublicListeningPortsCheck(context.Background(), config.Node{}, []string{"no ss or netstat available"}, false)
+	unavailable := soloPublicListeningPortsCheck(context.Background(), config.Node{}, []string{"no ss or netstat available"}, false, nil)
 	if unavailable.OK || !strings.Contains(unavailable.Observed, "not inspected") {
 		t.Fatalf("unavailable check = %#v, want failed unknown finding", unavailable)
 	}
@@ -8354,8 +8411,15 @@ func installFakeSoloCommands(t *testing.T, statusResponses []fakeSSHResponse) st
 	writeExecutable(t, filepath.Join(binDir, "ssh"), `#!/usr/bin/env bash
 set -euo pipefail
 command="${!#}"
+if [[ -n "${DEVOPSELLENCE_FAKE_SSH_COMMAND_LOG:-}" ]]; then
+  printf '%s\n' "$command" >>"$DEVOPSELLENCE_FAKE_SSH_COMMAND_LOG"
+fi
 
 if [[ "$command" == "true" ]]; then
+  if [[ -n "${DEVOPSELLENCE_FAKE_SSH_TRUE_FAIL:-}" ]]; then
+    printf 'ssh connect failed\n' >&2
+    exit 255
+  fi
   exit 0
 fi
 
@@ -8403,6 +8467,11 @@ fi
 exec_marker=""
 if [[ "$command" =~ (__DEVOPSELLENCE_EXEC_EXIT_CODE__[0-9a-f]+__) ]]; then
   exec_marker="${BASH_REMATCH[1]}"
+fi
+
+if [[ -n "${DEVOPSELLENCE_FAKE_SSH_TRUE_FAIL:-}" && "$command" == *"true"* ]]; then
+  printf 'ssh connect failed\n' >&2
+  exit 255
 fi
 
 if [[ -n "$exec_marker" && "$command" == *"svc-production-web-abc"* ]]; then

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -3746,10 +3746,32 @@ func TestUnexpectedPublicListeningPortsIgnoresPrivateInterfaces(t *testing.T) {
 		"LISTEN 0 4096 192.168.1.10:6379 0.0.0.0:*",
 		"LISTEN 0 4096 127.0.0.1:9000 0.0.0.0:*",
 		"LISTEN 0 4096 0.0.0.0:8080 0.0.0.0:*",
+		"tcp6       0      0 :::9090                 :::*                    LISTEN      1234/demo",
 	}
 	ports := unexpectedPublicListeningPorts(lines)
-	if !reflect.DeepEqual(ports, []string{"8080"}) {
-		t.Fatalf("unexpected ports = %#v, want only wildcard public port", ports)
+	if !reflect.DeepEqual(ports, []string{"8080", "9090"}) {
+		t.Fatalf("unexpected ports = %#v, want wildcard public ports only", ports)
+	}
+}
+
+func TestSoloPublicListeningPortsCheckFailsWhenOutputIncomplete(t *testing.T) {
+	truncated := soloPublicListeningPortsCheck(context.Background(), config.Node{}, []string{"LISTEN 0 4096 0.0.0.0:80 0.0.0.0:*"}, true)
+	if truncated.OK || !strings.Contains(truncated.Observed, "truncated") {
+		t.Fatalf("truncated check = %#v, want failed truncated finding", truncated)
+	}
+
+	unavailable := soloPublicListeningPortsCheck(context.Background(), config.Node{}, []string{"no ss or netstat available"}, false)
+	if unavailable.OK || !strings.Contains(unavailable.Observed, "not inspected") {
+		t.Fatalf("unavailable check = %#v, want failed unknown finding", unavailable)
+	}
+}
+
+func TestSoloAgentStatePermissionsRejectsOtherRead(t *testing.T) {
+	installFakeSoloCommands(t, nil)
+	t.Setenv("DEVOPSELLENCE_FAKE_SSH_AGENT_STATE_STAT", "755 root root /var/lib/devopsellence")
+	check := soloAgentStatePermissionsCheck(context.Background(), config.Node{Host: "203.0.113.10", User: "root"})
+	if check.OK || !strings.Contains(check.NextAction, "other read/write") {
+		t.Fatalf("agent state check = %#v, want other-read finding", check)
 	}
 }
 
@@ -8245,7 +8267,8 @@ if [[ "$command" == *"__DEVOPSELLENCE_EXIT_CODE__"* && "$command" == *"stat -c"*
 fi
 
 if [[ "$command" == *"__DEVOPSELLENCE_EXIT_CODE__"* && "$command" == *"stat -c"* && "$command" == *"/var/lib/devopsellence"* ]]; then
-  printf '__DEVOPSELLENCE_EXIT_CODE__0\n__DEVOPSELLENCE_STDOUT__\n755 root root /var/lib/devopsellence\n__DEVOPSELLENCE_STDERR__\n'
+  state_stat="${DEVOPSELLENCE_FAKE_SSH_AGENT_STATE_STAT:-751 root root /var/lib/devopsellence}"
+  printf '__DEVOPSELLENCE_EXIT_CODE__0\n__DEVOPSELLENCE_STDOUT__\n%s\n__DEVOPSELLENCE_STDERR__\n' "$state_stat"
   exit 0
 fi
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -3838,6 +3838,9 @@ func TestRemoteManagedContainerSecurityCommandsUseBoundedOutputMarker(t *testing
 		if strings.Contains(command, "head -n 100") {
 			t.Fatalf("command = %q, want no silent head truncation", command)
 		}
+		if strings.Contains(command, "ps -aq --filter label=devopsellence.managed=true 2>&1") || strings.Contains(command, "$ids 2>&1") {
+			t.Fatalf("command = %q, want stderr captured separately from IDs/inspect output", command)
+		}
 	}
 }
 
@@ -3900,6 +3903,22 @@ func TestSoloAgentStatePermissionsRejectsOtherRead(t *testing.T) {
 	check := soloAgentStatePermissionsCheck(context.Background(), config.Node{Host: "203.0.113.10", User: "root"})
 	if check.OK || !strings.Contains(check.NextAction, "other read/write") {
 		t.Fatalf("agent state check = %#v, want other-read finding", check)
+	}
+}
+
+func TestSoloStatFieldsPreservesWhitespacePath(t *testing.T) {
+	fields := soloStatFields("750\troot\troot\t/var/lib/dev ops")
+	if len(fields) != 4 || fields[0] != "750" || fields[1] != "root" || fields[2] != "root" || fields[3] != "/var/lib/dev ops" {
+		t.Fatalf("fields = %#v, want tab-delimited stat fields with intact path", fields)
+	}
+}
+
+func TestSoloAgentStatePermissionsQuotesRemediationPath(t *testing.T) {
+	installFakeSoloCommands(t, nil)
+	t.Setenv("DEVOPSELLENCE_FAKE_SSH_STAT", "755 root root /var/lib/dev ops")
+	check := soloAgentStatePermissionsCheck(context.Background(), config.Node{Host: "203.0.113.10", User: "root", AgentStateDir: "/var/lib/dev ops"})
+	if check.OK || !strings.Contains(check.NextAction, "'/var/lib/dev ops'") {
+		t.Fatalf("agent state check = %#v, want shell-quoted remediation path", check)
 	}
 }
 
@@ -8434,6 +8453,11 @@ fi
 if [[ "$command" == *"__DEVOPSELLENCE_EXIT_CODE__"* && "$command" == *"stat -c"* && "$command" == *"/var/lib/devopsellence/ingress-key.pem"* ]]; then
   tls_stat="${DEVOPSELLENCE_FAKE_SSH_TLS_KEY_STAT:-missing}"
   printf '__DEVOPSELLENCE_EXIT_CODE__0\n__DEVOPSELLENCE_STDOUT__\n%s\n__DEVOPSELLENCE_STDERR__\n' "$tls_stat"
+  exit 0
+fi
+
+if [[ "$command" == *"__DEVOPSELLENCE_EXIT_CODE__"* && "$command" == *"stat -c"* && -n "${DEVOPSELLENCE_FAKE_SSH_STAT:-}" ]]; then
+  printf '__DEVOPSELLENCE_EXIT_CODE__0\n__DEVOPSELLENCE_STDOUT__\n%s\n__DEVOPSELLENCE_STDERR__\n' "$DEVOPSELLENCE_FAKE_SSH_STAT"
   exit 0
 fi
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -3766,6 +3766,15 @@ func TestSoloPublicListeningPortsCheckFailsWhenOutputIncomplete(t *testing.T) {
 	}
 }
 
+func TestSoloSSHPasswordAuthCheckFailsWhenSettingUnknown(t *testing.T) {
+	installFakeSoloCommands(t, nil)
+	t.Setenv("DEVOPSELLENCE_FAKE_SSH_PASSWORD_AUTH", "")
+	check := soloSSHPasswordAuthCheck(context.Background(), config.Node{Host: "203.0.113.10", User: "root"})
+	if check.OK || !strings.Contains(check.Observed, "unknown") || !strings.Contains(check.NextAction, "SSH daemon configuration") {
+		t.Fatalf("ssh password auth check = %#v, want failed unknown finding", check)
+	}
+}
+
 func TestSoloAgentStatePermissionsRejectsOtherRead(t *testing.T) {
 	installFakeSoloCommands(t, nil)
 	t.Setenv("DEVOPSELLENCE_FAKE_SSH_AGENT_STATE_STAT", "755 root root /var/lib/devopsellence")
@@ -8256,7 +8265,7 @@ if [[ "$command" == *"__DEVOPSELLENCE_EXIT_CODE__"* && "$command" == *"docker ne
 fi
 
 if [[ "$command" == *"__DEVOPSELLENCE_EXIT_CODE__"* && "$command" == *"sshd -T"* ]]; then
-  password_auth="${DEVOPSELLENCE_FAKE_SSH_PASSWORD_AUTH:-no}"
+  password_auth="${DEVOPSELLENCE_FAKE_SSH_PASSWORD_AUTH-no}"
   printf '__DEVOPSELLENCE_EXIT_CODE__0\n__DEVOPSELLENCE_STDOUT__\n%s\n__DEVOPSELLENCE_STDERR__\n' "$password_auth"
   exit 0
 fi

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -3748,9 +3748,22 @@ func TestUnexpectedPublicListeningPortsIgnoresPrivateInterfaces(t *testing.T) {
 		"LISTEN 0 4096 0.0.0.0:8080 0.0.0.0:*",
 		"tcp6       0      0 :::9090                 :::*                    LISTEN      1234/demo",
 	}
-	ports := unexpectedPublicListeningPorts(lines)
+	ports := unexpectedPublicListeningPorts(lines, 22)
 	if !reflect.DeepEqual(ports, []string{"8080", "9090"}) {
 		t.Fatalf("unexpected ports = %#v, want wildcard public ports only", ports)
+	}
+}
+
+func TestUnexpectedPublicListeningPortsAllowsConfiguredSSHPort(t *testing.T) {
+	lines := []string{
+		"LISTEN 0 4096 0.0.0.0:2222 0.0.0.0:*",
+		"LISTEN 0 4096 0.0.0.0:22 0.0.0.0:*",
+		"LISTEN 0 4096 0.0.0.0:80 0.0.0.0:*",
+		"LISTEN 0 4096 0.0.0.0:443 0.0.0.0:*",
+	}
+	ports := unexpectedPublicListeningPorts(lines, 2222)
+	if !reflect.DeepEqual(ports, []string{"22"}) {
+		t.Fatalf("unexpected ports = %#v, want default SSH port flagged when node uses 2222", ports)
 	}
 }
 
@@ -3763,6 +3776,38 @@ func TestSplitListenAddressSupportsIPv6AnyNotation(t *testing.T) {
 	host, port, ok = splitListenAddress(":::*")
 	if ok || host != "" || port != "" {
 		t.Fatalf("splitListenAddress(\":::*\") = host=%q port=%q ok=%v, want empty host/port and ok=false", host, port, ok)
+	}
+}
+
+func TestSoloDockerSecurityChecksFailWhenManagedContainerOutputTruncated(t *testing.T) {
+	installFakeSoloCommands(t, nil)
+	t.Setenv("DEVOPSELLENCE_FAKE_SSH_DOCKER_INSPECT_TRUNCATED", "1")
+	node := config.Node{Host: "203.0.113.10", User: "root", Port: 22}
+
+	mounts := soloDockerSocketMountsCheck(context.Background(), node)
+	if mounts.OK || !strings.Contains(mounts.Observed, "truncated") {
+		t.Fatalf("docker socket check = %#v, want failed truncated finding", mounts)
+	}
+
+	privileged := soloPrivilegedContainersCheck(context.Background(), node)
+	if privileged.OK || !strings.Contains(privileged.Observed, "truncated") {
+		t.Fatalf("privileged check = %#v, want failed truncated finding", privileged)
+	}
+}
+
+func TestSoloDockerSecurityChecksFailWhenInspectErrors(t *testing.T) {
+	installFakeSoloCommands(t, nil)
+	t.Setenv("DEVOPSELLENCE_FAKE_SSH_DOCKER_INSPECT_ERROR", "1")
+	node := config.Node{Host: "203.0.113.10", User: "root", Port: 22}
+
+	mounts := soloDockerSocketMountsCheck(context.Background(), node)
+	if mounts.OK || !strings.Contains(mounts.Observed, "inspect failed") {
+		t.Fatalf("docker socket check = %#v, want failed inspect finding", mounts)
+	}
+
+	privileged := soloPrivilegedContainersCheck(context.Background(), node)
+	if privileged.OK || !strings.Contains(privileged.Observed, "inspect failed") {
+		t.Fatalf("privileged check = %#v, want failed inspect finding", privileged)
 	}
 }
 
@@ -3833,6 +3878,21 @@ func TestSoloTLSKeyPermissionsFailWhenModeUnparseable(t *testing.T) {
 	check := soloTLSKeyPermissionsCheck(context.Background(), config.Node{Host: "203.0.113.10", User: "root"})
 	if check.OK || !strings.Contains(check.Observed, "unknown") || !strings.Contains(check.NextAction, "mode can be parsed") {
 		t.Fatalf("tls key check = %#v, want failed unknown mode finding", check)
+	}
+}
+
+func TestSoloManagedContainerSecurityChecksFailClosedOnInspectErrors(t *testing.T) {
+	installFakeSoloCommands(t, nil)
+	t.Setenv("DEVOPSELLENCE_FAKE_SSH_DOCKER_INSPECT_ERROR", "1")
+
+	mounts := soloDockerSocketMountsCheck(context.Background(), config.Node{Host: "203.0.113.10", User: "root"})
+	if mounts.OK || !strings.Contains(mounts.Observed, "unknown") || !strings.Contains(mounts.Observed, "inspect failed") || !strings.Contains(mounts.NextAction, "Docker can be inspected") {
+		t.Fatalf("docker socket mounts check = %#v, want failed unknown inspect finding", mounts)
+	}
+
+	privileged := soloPrivilegedContainersCheck(context.Background(), config.Node{Host: "203.0.113.10", User: "root"})
+	if privileged.OK || !strings.Contains(privileged.Observed, "unknown") || !strings.Contains(privileged.Observed, "inspect failed") || !strings.Contains(privileged.NextAction, "Docker can be inspected") {
+		t.Fatalf("privileged containers check = %#v, want failed unknown inspect finding", privileged)
 	}
 }
 
@@ -8335,7 +8395,11 @@ if [[ "$command" == *"__DEVOPSELLENCE_EXIT_CODE__"* && "$command" == *"stat -c"*
 fi
 
 if [[ "$command" == *"__DEVOPSELLENCE_EXIT_CODE__"* && "$command" == *"inspect --format"* && "$command" == *"Mounts"* ]]; then
-  if [[ -n "${DEVOPSELLENCE_FAKE_SSH_DOCKER_SOCKET_MOUNT:-}" ]]; then
+  if [[ -n "${DEVOPSELLENCE_FAKE_SSH_DOCKER_INSPECT_ERROR:-}" ]]; then
+    printf '__DEVOPSELLENCE_EXIT_CODE__1\n__DEVOPSELLENCE_STDOUT__\n\n__DEVOPSELLENCE_STDERR__\ninspect failed\n'
+  elif [[ -n "${DEVOPSELLENCE_FAKE_SSH_DOCKER_INSPECT_TRUNCATED:-}" ]]; then
+    printf '__DEVOPSELLENCE_EXIT_CODE__0\n__DEVOPSELLENCE_STDOUT__\n__DEVOPSELLENCE_TRUNCATED__\n__DEVOPSELLENCE_STDERR__\n'
+  elif [[ -n "${DEVOPSELLENCE_FAKE_SSH_DOCKER_SOCKET_MOUNT:-}" ]]; then
     printf '__DEVOPSELLENCE_EXIT_CODE__0\n__DEVOPSELLENCE_STDOUT__\nsvc-production-web /var/run/docker.sock:/var/run/docker.sock\n__DEVOPSELLENCE_STDERR__\n'
   else
     printf '__DEVOPSELLENCE_EXIT_CODE__0\n__DEVOPSELLENCE_STDOUT__\nsvc-production-web app_storage:/app/storage\n__DEVOPSELLENCE_STDERR__\n'
@@ -8344,7 +8408,13 @@ if [[ "$command" == *"__DEVOPSELLENCE_EXIT_CODE__"* && "$command" == *"inspect -
 fi
 
 if [[ "$command" == *"__DEVOPSELLENCE_EXIT_CODE__"* && "$command" == *"inspect --format"* && "$command" == *".HostConfig.Privileged"* ]]; then
-  printf '__DEVOPSELLENCE_EXIT_CODE__0\n__DEVOPSELLENCE_STDOUT__\nsvc-production-web false\n__DEVOPSELLENCE_STDERR__\n'
+  if [[ -n "${DEVOPSELLENCE_FAKE_SSH_DOCKER_INSPECT_ERROR:-}" ]]; then
+    printf '__DEVOPSELLENCE_EXIT_CODE__1\n__DEVOPSELLENCE_STDOUT__\n\n__DEVOPSELLENCE_STDERR__\ninspect failed\n'
+  elif [[ -n "${DEVOPSELLENCE_FAKE_SSH_DOCKER_INSPECT_TRUNCATED:-}" ]]; then
+    printf '__DEVOPSELLENCE_EXIT_CODE__0\n__DEVOPSELLENCE_STDOUT__\n__DEVOPSELLENCE_TRUNCATED__\n__DEVOPSELLENCE_STDERR__\n'
+  else
+    printf '__DEVOPSELLENCE_EXIT_CODE__0\n__DEVOPSELLENCE_STDOUT__\nsvc-production-web false\n__DEVOPSELLENCE_STDERR__\n'
+  fi
   exit 0
 fi
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -3754,6 +3754,18 @@ func TestUnexpectedPublicListeningPortsIgnoresPrivateInterfaces(t *testing.T) {
 	}
 }
 
+func TestSplitListenAddressSupportsIPv6AnyNotation(t *testing.T) {
+	host, port, ok := splitListenAddress(":::80")
+	if !ok || host != "::" || port != "80" {
+		t.Fatalf("splitListenAddress(\":::80\") = host=%q port=%q ok=%v, want host=\"::\" port=\"80\" ok=true", host, port, ok)
+	}
+
+	host, port, ok = splitListenAddress(":::*")
+	if ok || host != "" || port != "" {
+		t.Fatalf("splitListenAddress(\":::*\") = host=%q port=%q ok=%v, want empty host/port and ok=false", host, port, ok)
+	}
+}
+
 func TestSoloPublicListeningPortsCheckFailsWhenOutputIncomplete(t *testing.T) {
 	truncated := soloPublicListeningPortsCheck(context.Background(), config.Node{}, []string{"LISTEN 0 4096 0.0.0.0:80 0.0.0.0:*"}, true)
 	if truncated.OK || !strings.Contains(truncated.Observed, "truncated") {

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -3771,6 +3771,9 @@ func TestSoloPublicListeningPortsCheckFailsWhenOutputIncomplete(t *testing.T) {
 	if truncated.OK || !strings.Contains(truncated.Observed, "truncated") {
 		t.Fatalf("truncated check = %#v, want failed truncated finding", truncated)
 	}
+	if !strings.Contains(truncated.NextAction, "ss -ltnp") || strings.Contains(truncated.NextAction, "rerun listening-port diagnostics") {
+		t.Fatalf("truncated next action = %q, want direct node inspection guidance", truncated.NextAction)
+	}
 	marker := soloPublicListeningPortsCheck(context.Background(), config.Node{}, []string{"LISTEN 0 4096 0.0.0.0:80 0.0.0.0:*", "__DEVOPSELLENCE_TRUNCATED__"}, false)
 	if marker.OK || !strings.Contains(marker.Observed, "truncated") {
 		t.Fatalf("marker check = %#v, want failed truncated finding", marker)

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -3913,6 +3913,18 @@ func TestSoloStatFieldsPreservesWhitespacePath(t *testing.T) {
 	}
 }
 
+func TestRemoteStatPathCommandRetriesWithSudoAfterDirectStat(t *testing.T) {
+	command := remoteStatPathCommand("/var/lib/dev ops")
+	direct := strings.Index(command, "stat -c \"$format\" '/var/lib/dev ops' 2>/dev/null")
+	sudo := strings.Index(command, "sudo -n stat -c \"$format\" '/var/lib/dev ops'")
+	if direct < 0 || sudo < 0 || sudo < direct {
+		t.Fatalf("command = %q, want direct stat followed by sudo retry", command)
+	}
+	if !strings.Contains(command, "%a\\t%U\\t%G\\t%n") {
+		t.Fatalf("command = %q, want tab-delimited stat format", command)
+	}
+}
+
 func TestSoloAgentStatePermissionsQuotesRemediationPath(t *testing.T) {
 	installFakeSoloCommands(t, nil)
 	t.Setenv("DEVOPSELLENCE_FAKE_SSH_STAT", "755 root root /var/lib/dev ops")

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -2300,6 +2300,62 @@ func TestSoloDoctorScopesRuntimeChecksToCurrentEnvironment(t *testing.T) {
 	}
 }
 
+func TestSoloDoctorReportsSecurityFindings(t *testing.T) {
+	installFakeSoloCommands(t, nil)
+	t.Setenv("DEVOPSELLENCE_FAKE_SSH_PASSWORD_AUTH", "yes")
+
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	commitTestRepo(t, workspaceRoot)
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.Node{
+			"node-a": {Host: "203.0.113.10", User: "root"},
+		},
+	}
+	if _, _, err := current.AttachNode(workspaceRoot, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{
+		Printer:     output.New(&stdout, io.Discard),
+		Docker:      &fakeDocker{},
+		SoloState:   soloState,
+		ConfigStore: config.NewStore(),
+		Cwd:         workspaceRoot,
+	}
+	err := app.SoloDoctor(context.Background())
+	if err == nil {
+		t.Fatal("SoloDoctor() error = nil, want security finding failure")
+	}
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 1 {
+		t.Fatalf("error = %#v, want ExitError code 1", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	if payload["ok"] != false {
+		t.Fatalf("payload ok = %#v, want false", payload["ok"])
+	}
+	checks := jsonArrayFromMap(t, payload, "runtime_checks")
+	for _, item := range checks {
+		check := jsonMapFromAny(t, item)
+		if check["check"] == "security_ssh_password_auth" {
+			if check["ok"] != false || check["severity"] != "high" || !strings.Contains(stringValueAny(check["detail"]), "yes") {
+				t.Fatalf("security_ssh_password_auth = %#v, want high severity finding", check)
+			}
+			return
+		}
+	}
+	t.Fatalf("runtime_checks = %#v, want security_ssh_password_auth", checks)
+}
+
 func TestSoloStatusReturnsFailureWhenNodeStatusReadFails(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")
@@ -3619,6 +3675,61 @@ func TestSoloNodeDiagnoseCollectsRuntimeSnapshot(t *testing.T) {
 	status := jsonMapFromAny(t, payload["status"])
 	if status["phase"] != "settled" {
 		t.Fatalf("status = %#v, want settled phase", status)
+	}
+	security := jsonMapFromAny(t, payload["security"])
+	if security["ok"] != true {
+		t.Fatalf("security = %#v, want ok", security)
+	}
+	securityChecks := jsonArrayFromMap(t, security, "checks")
+	if len(securityChecks) != 6 {
+		t.Fatalf("security checks = %#v, want baseline hardening checks", securityChecks)
+	}
+}
+
+func TestSoloNodeDiagnoseReportsSecurityFindings(t *testing.T) {
+	installFakeSoloCommands(t, []fakeSSHResponse{{stdout: `{"revision":"abc","phase":"settled"}` + "\n"}})
+	t.Setenv("DEVOPSELLENCE_FAKE_SSH_PASSWORD_AUTH", "yes")
+	t.Setenv("DEVOPSELLENCE_FAKE_SSH_DOCKER_SOCKET_MOUNT", "1")
+
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.Node{
+			"node-a": {Host: "203.0.113.10", User: "root", Labels: []string{config.DefaultWebRole}},
+		},
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState}
+	err := app.SoloNodeDiagnose(context.Background(), SoloNodeDiagnoseOptions{Node: "node-a"})
+	if err == nil {
+		t.Fatal("SoloNodeDiagnose() error = nil, want security finding failure")
+	}
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 1 {
+		t.Fatalf("error = %#v, want ExitError code 1", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	if payload["ok"] != false {
+		t.Fatalf("payload ok = %#v, want false", payload["ok"])
+	}
+	security := jsonMapFromAny(t, payload["security"])
+	if security["ok"] != false {
+		t.Fatalf("security = %#v, want not ok", security)
+	}
+	checks := jsonArrayFromMap(t, security, "checks")
+	findings := map[string]map[string]any{}
+	for _, item := range checks {
+		check := jsonMapFromAny(t, item)
+		findings[stringValueAny(check["name"])] = check
+	}
+	if findings["ssh_password_auth"]["ok"] != false || !strings.Contains(stringValueAny(findings["ssh_password_auth"]["observed"]), "yes") {
+		t.Fatalf("ssh_password_auth = %#v, want disabled finding", findings["ssh_password_auth"])
+	}
+	if findings["docker_socket_mounts"]["ok"] != false || !strings.Contains(stringValueAny(findings["docker_socket_mounts"]["observed"]), "/var/run/docker.sock") {
+		t.Fatalf("docker_socket_mounts = %#v, want socket finding", findings["docker_socket_mounts"])
 	}
 }
 
@@ -8087,7 +8198,7 @@ if [[ "$command" == *"__DEVOPSELLENCE_EXIT_CODE__"* && "$command" == *"journalct
   exit 0
 fi
 
-if [[ "$command" == *"__DEVOPSELLENCE_EXIT_CODE__"* && "$command" == *"docker ps -a"* ]]; then
+if [[ "$command" == *"__DEVOPSELLENCE_EXIT_CODE__"* && "$command" == *"docker ps -a --format"* ]]; then
   printf '__DEVOPSELLENCE_EXIT_CODE__0\n__DEVOPSELLENCE_STDOUT__\n{"Names":"svc-production-web","Image":"demo:abc","Status":"Up 1 minute","Ports":"3000/tcp"}\n__DEVOPSELLENCE_STDERR__\n'
   exit 0
 fi
@@ -8102,7 +8213,37 @@ if [[ "$command" == *"__DEVOPSELLENCE_EXIT_CODE__"* && "$command" == *"docker ne
   exit 0
 fi
 
-if [[ "$command" == *"docker ps -a"* ]]; then
+if [[ "$command" == *"__DEVOPSELLENCE_EXIT_CODE__"* && "$command" == *"sshd -T"* ]]; then
+  password_auth="${DEVOPSELLENCE_FAKE_SSH_PASSWORD_AUTH:-no}"
+  printf '__DEVOPSELLENCE_EXIT_CODE__0\n__DEVOPSELLENCE_STDOUT__\n%s\n__DEVOPSELLENCE_STDERR__\n' "$password_auth"
+  exit 0
+fi
+
+if [[ "$command" == *"__DEVOPSELLENCE_EXIT_CODE__"* && "$command" == *"stat -c"* && "$command" == *"/var/lib/devopsellence/ingress-key.pem"* ]]; then
+  printf '__DEVOPSELLENCE_EXIT_CODE__0\n__DEVOPSELLENCE_STDOUT__\nmissing\n__DEVOPSELLENCE_STDERR__\n'
+  exit 0
+fi
+
+if [[ "$command" == *"__DEVOPSELLENCE_EXIT_CODE__"* && "$command" == *"stat -c"* && "$command" == *"/var/lib/devopsellence"* ]]; then
+  printf '__DEVOPSELLENCE_EXIT_CODE__0\n__DEVOPSELLENCE_STDOUT__\n755 root root /var/lib/devopsellence\n__DEVOPSELLENCE_STDERR__\n'
+  exit 0
+fi
+
+if [[ "$command" == *"__DEVOPSELLENCE_EXIT_CODE__"* && "$command" == *"inspect --format"* && "$command" == *"Mounts"* ]]; then
+  if [[ -n "${DEVOPSELLENCE_FAKE_SSH_DOCKER_SOCKET_MOUNT:-}" ]]; then
+    printf '__DEVOPSELLENCE_EXIT_CODE__0\n__DEVOPSELLENCE_STDOUT__\nsvc-production-web /var/run/docker.sock:/var/run/docker.sock\n__DEVOPSELLENCE_STDERR__\n'
+  else
+    printf '__DEVOPSELLENCE_EXIT_CODE__0\n__DEVOPSELLENCE_STDOUT__\nsvc-production-web app_storage:/app/storage\n__DEVOPSELLENCE_STDERR__\n'
+  fi
+  exit 0
+fi
+
+if [[ "$command" == *"__DEVOPSELLENCE_EXIT_CODE__"* && "$command" == *"inspect --format"* && "$command" == *".HostConfig.Privileged"* ]]; then
+  printf '__DEVOPSELLENCE_EXIT_CODE__0\n__DEVOPSELLENCE_STDOUT__\nsvc-production-web false\n__DEVOPSELLENCE_STDERR__\n'
+  exit 0
+fi
+
+if [[ "$command" == *"docker ps -a --format"* ]]; then
   printf '{"Names":"svc-production-web","Image":"demo:abc","Status":"Up 1 minute","Ports":"3000/tcp"}\n'
   exit 0
 fi

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -3809,6 +3809,15 @@ func TestSoloAgentStatePermissionsRejectsOtherRead(t *testing.T) {
 	}
 }
 
+func TestSoloAgentStatePermissionsRejectsNonRootGroup(t *testing.T) {
+	installFakeSoloCommands(t, nil)
+	t.Setenv("DEVOPSELLENCE_FAKE_SSH_AGENT_STATE_STAT", "750 root docker /var/lib/devopsellence")
+	check := soloAgentStatePermissionsCheck(context.Background(), config.Node{Host: "203.0.113.10", User: "root"})
+	if check.OK || !strings.Contains(check.NextAction, "root group ownership") {
+		t.Fatalf("agent state check = %#v, want non-root-group finding", check)
+	}
+}
+
 func TestSoloAgentStatePermissionsFailWhenModeUnparseable(t *testing.T) {
 	installFakeSoloCommands(t, nil)
 	t.Setenv("DEVOPSELLENCE_FAKE_SSH_AGENT_STATE_STAT", "bad root root /var/lib/devopsellence")

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -3759,6 +3759,10 @@ func TestSoloPublicListeningPortsCheckFailsWhenOutputIncomplete(t *testing.T) {
 	if truncated.OK || !strings.Contains(truncated.Observed, "truncated") {
 		t.Fatalf("truncated check = %#v, want failed truncated finding", truncated)
 	}
+	marker := soloPublicListeningPortsCheck(context.Background(), config.Node{}, []string{"LISTEN 0 4096 0.0.0.0:80 0.0.0.0:*", "__DEVOPSELLENCE_TRUNCATED__"}, false)
+	if marker.OK || !strings.Contains(marker.Observed, "truncated") {
+		t.Fatalf("marker check = %#v, want failed truncated finding", marker)
+	}
 
 	unavailable := soloPublicListeningPortsCheck(context.Background(), config.Node{}, []string{"no ss or netstat available"}, false)
 	if unavailable.OK || !strings.Contains(unavailable.Observed, "not inspected") {
@@ -3775,12 +3779,39 @@ func TestSoloSSHPasswordAuthCheckFailsWhenSettingUnknown(t *testing.T) {
 	}
 }
 
+func TestSoloSSHPasswordAuthCheckFailsOnUnrecognizedValue(t *testing.T) {
+	installFakeSoloCommands(t, nil)
+	t.Setenv("DEVOPSELLENCE_FAKE_SSH_PASSWORD_AUTH", "maybe")
+	check := soloSSHPasswordAuthCheck(context.Background(), config.Node{Host: "203.0.113.10", User: "root"})
+	if check.OK || !strings.Contains(check.Observed, "unrecognized") {
+		t.Fatalf("ssh password auth check = %#v, want failed unrecognized finding", check)
+	}
+}
+
 func TestSoloAgentStatePermissionsRejectsOtherRead(t *testing.T) {
 	installFakeSoloCommands(t, nil)
 	t.Setenv("DEVOPSELLENCE_FAKE_SSH_AGENT_STATE_STAT", "755 root root /var/lib/devopsellence")
 	check := soloAgentStatePermissionsCheck(context.Background(), config.Node{Host: "203.0.113.10", User: "root"})
 	if check.OK || !strings.Contains(check.NextAction, "other read/write") {
 		t.Fatalf("agent state check = %#v, want other-read finding", check)
+	}
+}
+
+func TestSoloAgentStatePermissionsFailWhenModeUnparseable(t *testing.T) {
+	installFakeSoloCommands(t, nil)
+	t.Setenv("DEVOPSELLENCE_FAKE_SSH_AGENT_STATE_STAT", "bad root root /var/lib/devopsellence")
+	check := soloAgentStatePermissionsCheck(context.Background(), config.Node{Host: "203.0.113.10", User: "root"})
+	if check.OK || !strings.Contains(check.Observed, "unknown") || !strings.Contains(check.NextAction, "mode can be parsed") {
+		t.Fatalf("agent state check = %#v, want failed unknown mode finding", check)
+	}
+}
+
+func TestSoloTLSKeyPermissionsFailWhenModeUnparseable(t *testing.T) {
+	installFakeSoloCommands(t, nil)
+	t.Setenv("DEVOPSELLENCE_FAKE_SSH_TLS_KEY_STAT", "bad root root /var/lib/devopsellence/ingress-key.pem")
+	check := soloTLSKeyPermissionsCheck(context.Background(), config.Node{Host: "203.0.113.10", User: "root"})
+	if check.OK || !strings.Contains(check.Observed, "unknown") || !strings.Contains(check.NextAction, "mode can be parsed") {
+		t.Fatalf("tls key check = %#v, want failed unknown mode finding", check)
 	}
 }
 
@@ -8271,7 +8302,8 @@ if [[ "$command" == *"__DEVOPSELLENCE_EXIT_CODE__"* && "$command" == *"sshd -T"*
 fi
 
 if [[ "$command" == *"__DEVOPSELLENCE_EXIT_CODE__"* && "$command" == *"stat -c"* && "$command" == *"/var/lib/devopsellence/ingress-key.pem"* ]]; then
-  printf '__DEVOPSELLENCE_EXIT_CODE__0\n__DEVOPSELLENCE_STDOUT__\nmissing\n__DEVOPSELLENCE_STDERR__\n'
+  tls_stat="${DEVOPSELLENCE_FAKE_SSH_TLS_KEY_STAT:-missing}"
+  printf '__DEVOPSELLENCE_EXIT_CODE__0\n__DEVOPSELLENCE_STDOUT__\n%s\n__DEVOPSELLENCE_STDERR__\n' "$tls_stat"
   exit 0
 fi
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -3920,7 +3920,7 @@ func TestRemoteStatPathCommandRetriesWithSudoAfterDirectStat(t *testing.T) {
 	if direct < 0 || sudo < 0 || sudo < direct {
 		t.Fatalf("command = %q, want direct stat followed by sudo retry", command)
 	}
-	if !strings.Contains(command, "%a\\t%U\\t%G\\t%n") {
+	if !strings.Contains(command, "%a\t%U\t%G\t%n") {
 		t.Fatalf("command = %q, want tab-delimited stat format", command)
 	}
 }

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -3740,6 +3740,41 @@ func TestSoloNodeDiagnoseReportsSecurityFindings(t *testing.T) {
 	}
 }
 
+func TestSoloNodeDiagnoseSecurityReportsPortDiagnosticError(t *testing.T) {
+	installFakeSoloCommands(t, []fakeSSHResponse{{stdout: `{"revision":"abc","phase":"settled"}` + "\n"}})
+	t.Setenv("DEVOPSELLENCE_FAKE_SSH_PORTS_FAIL", "1")
+
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.Node{
+			"node-a": {Host: "203.0.113.10", User: "root", Labels: []string{config.DefaultWebRole}},
+		},
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState}
+	err := app.SoloNodeDiagnose(context.Background(), SoloNodeDiagnoseOptions{Node: "node-a"})
+	if err == nil {
+		t.Fatal("SoloNodeDiagnose() error = nil, want port diagnostic failure")
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	security := jsonMapFromAny(t, payload["security"])
+	checks := jsonArrayFromMap(t, security, "checks")
+	for _, item := range checks {
+		check := jsonMapFromAny(t, item)
+		if check["name"] == "public_listening_ports" {
+			if check["ok"] != false || !strings.Contains(stringValueAny(check["observed"]), "ports failed") {
+				t.Fatalf("public_listening_ports = %#v, want concrete port diagnostic error", check)
+			}
+			return
+		}
+	}
+	t.Fatalf("security checks = %#v, want public_listening_ports", checks)
+}
+
 func TestUnexpectedPublicListeningPortsIgnoresPrivateInterfaces(t *testing.T) {
 	lines := []string{
 		"LISTEN 0 4096 10.0.0.5:5432 0.0.0.0:*",
@@ -3792,6 +3827,17 @@ func TestSoloDockerSecurityChecksFailWhenManagedContainerOutputTruncated(t *test
 	privileged := soloPrivilegedContainersCheck(context.Background(), node)
 	if privileged.OK || !strings.Contains(privileged.Observed, "truncated") {
 		t.Fatalf("privileged check = %#v, want failed truncated finding", privileged)
+	}
+}
+
+func TestRemoteManagedContainerSecurityCommandsUseBoundedOutputMarker(t *testing.T) {
+	for _, command := range []string{remoteManagedContainerMountsCommand(), remoteManagedContainerPrivilegesCommand()} {
+		if !strings.Contains(command, soloDiagnoseTruncatedMarker) {
+			t.Fatalf("command = %q, want truncation marker", command)
+		}
+		if strings.Contains(command, "head -n 100") {
+			t.Fatalf("command = %q, want no silent head truncation", command)
+		}
 	}
 }
 
@@ -8451,6 +8497,10 @@ if [[ "$command" == *"__DEVOPSELLENCE_EXIT_CODE__"* && "$command" == *"systemctl
 fi
 
 if [[ "$command" == *"__DEVOPSELLENCE_EXIT_CODE__"* && ( "$command" == *"ss -ltn"* || "$command" == *"netstat -ltn"* ) ]]; then
+  if [[ -n "${DEVOPSELLENCE_FAKE_SSH_PORTS_FAIL:-}" ]]; then
+    printf '__DEVOPSELLENCE_EXIT_CODE__1\n__DEVOPSELLENCE_STDOUT__\n\n__DEVOPSELLENCE_STDERR__\nports failed\n'
+    exit 0
+  fi
   printf '__DEVOPSELLENCE_EXIT_CODE__0\n__DEVOPSELLENCE_STDOUT__\nLISTEN 0 4096 0.0.0.0:80 0.0.0.0:*\n__DEVOPSELLENCE_STDERR__\n'
   exit 0
 fi

--- a/docs/north-star.md
+++ b/docs/north-star.md
@@ -111,6 +111,14 @@ The CLI and control plane should stay thin relative to the core.
 
 Product surfaces matter, but they should not redefine the deploy model.
 
+### CI boundary
+
+Solo mode is for a single operator or agent working from a trusted workstation or admin box. It should be non-interactive, scriptable, structured, and recoverable, but it is not the primary CI/CD surface.
+
+Shared mode should own CI deploys. CI introduces registry auth, digest policy, CI secret handling, deploy locks, provenance, audit trails, and the question of who pushed what. Those concerns fit shared-mode product state and hosted coordination. Adding them deeply to solo weakens the solo/shared boundary and removes one of shared mode's clearest reasons to exist.
+
+Solo should therefore avoid CI-oriented shortcuts such as making `deploy --image` a default production path unless there is a deliberate product decision to expand solo's scope. If solo needs better production reliability, prefer improvements that preserve the single-operator model: dry-run plans, stronger local image identity, interrupted-deploy recovery, richer diagnostics, rollback clarity, and agent upgrade visibility.
+
 ## System shape
 
 The intended shape is:


### PR DESCRIPTION
## What
- Add baseline node hardening checks to solo `node diagnose` output.
- Surface the same security checks through solo `doctor` runtime checks.
- Capture the solo/shared CI boundary in the north-star doc.

## Why
Solo production readiness should include transparent VM hardening drift checks without turning devopsellence into a full security platform. Solo also should stay focused on trusted single-operator workflows; shared mode owns CI deploy concerns.

## Validation
- `cd cli && go test ./internal/workflow -run 'TestSolo(NodeDiagnose|Doctor)'`\n- `cd cli && go test ./...`