### PR TITLE
[codex] Add solo agent upgrade diagnostics

### DIFF
--- a/cli/internal/workflow/install_logs.go
+++ b/cli/internal/workflow/install_logs.go
@@ -16,6 +16,10 @@ type soloInstallReporter struct {
 }
 
 func newSoloInstallReporter(_ context.Context, printer output.Printer, node string) soloInstallReporter {
+	return newSoloAgentReporter(printer, node, "devopsellence agent install")
+}
+
+func newSoloAgentReporter(printer output.Printer, node, operation string) soloInstallReporter {
 	return soloInstallReporter{
 		progress: func(message string) {
 			message = strings.TrimSpace(message)
@@ -23,7 +27,7 @@ func newSoloInstallReporter(_ context.Context, printer output.Printer, node stri
 				return
 			}
 			_ = printer.PrintEvent("progress", map[string]any{
-				"operation": "devopsellence agent install",
+				"operation": operation,
 				"node":      node,
 				"message":   message,
 			})

--- a/cli/internal/workflow/root.go
+++ b/cli/internal/workflow/root.go
@@ -1161,6 +1161,7 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 		Long: strings.Join([]string{
 			"Upgrade the agent on a solo node over SSH.",
 			"This reinstalls the agent binary and systemd service using the same release source as agent install.",
+			"It writes newline-delimited JSON progress events to stdout followed by a final result event.",
 		}, "\n"),
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/internal/workflow/root.go
+++ b/cli/internal/workflow/root.go
@@ -1132,6 +1132,7 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 	root.AddCommand(execCommand)
 
 	var agentInstallOpts SoloAgentInstallOptions
+	var agentUpgradeOpts SoloAgentUpgradeOptions
 	var agentUninstallOpts SoloAgentUninstallOptions
 	agentCommand := &cobra.Command{
 		Use:   "agent",
@@ -1154,6 +1155,23 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 	}
 	agentInstallCommand.Flags().StringVar(&agentInstallOpts.AgentBinary, "agent-binary", "", "Local agent binary to upload instead of downloading")
 	agentInstallCommand.Flags().StringVar(&agentInstallOpts.BaseURL, "base-url", "", "Agent download base URL")
+	agentUpgradeCommand := &cobra.Command{
+		Use:   "upgrade <name>",
+		Short: "Upgrade the agent on a solo node",
+		Long: strings.Join([]string{
+			"Upgrade the agent on a solo node over SSH.",
+			"This reinstalls the agent binary and systemd service using the same release source as agent install.",
+		}, "\n"),
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			agentUpgradeOpts.Node = args[0]
+			return runSoloOnly("agent upgrade", func(ctx context.Context) error {
+				return app.SoloAgentUpgrade(ctx, agentUpgradeOpts)
+			})(cmd, args)
+		},
+	}
+	agentUpgradeCommand.Flags().StringVar(&agentUpgradeOpts.AgentBinary, "agent-binary", "", "Local agent binary to upload instead of downloading")
+	agentUpgradeCommand.Flags().StringVar(&agentUpgradeOpts.BaseURL, "base-url", "", "Agent download base URL")
 	agentUninstallCommand := &cobra.Command{
 		Use:   "uninstall <name>",
 		Short: "Uninstall the solo agent from a node",
@@ -1172,7 +1190,7 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 	}
 	agentUninstallCommand.Flags().BoolVar(&agentUninstallOpts.Yes, "yes", false, "Confirm agent uninstall and cleanup")
 	agentUninstallCommand.Flags().BoolVar(&agentUninstallOpts.KeepWorkloads, "keep-workloads", false, "Stop and remove the agent but leave workloads and agent state on the node")
-	agentCommand.AddCommand(agentInstallCommand, agentUninstallCommand)
+	agentCommand.AddCommand(agentInstallCommand, agentUpgradeCommand, agentUninstallCommand)
 	root.AddCommand(agentCommand)
 
 	var supportBundleOpts SoloSupportBundleOptions

--- a/cli/internal/workflow/root_test.go
+++ b/cli/internal/workflow/root_test.go
@@ -819,6 +819,26 @@ func TestNodeDiagnoseAcceptsSoloNodeName(t *testing.T) {
 	}
 }
 
+func TestAgentUpgradeHelp(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, t.TempDir())
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{"agent", "upgrade", "--help"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	output := stdout.String()
+	for _, want := range []string{"Upgrade the agent", "--agent-binary", "--base-url"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("help output = %q, want %q", output, want)
+		}
+	}
+}
+
 func TestNodeLogsHelpDocumentsBoundedJSONSnapshot(t *testing.T) {
 	t.Parallel()
 

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -152,6 +152,12 @@ type SoloAgentInstallOptions struct {
 	BaseURL     string
 }
 
+type SoloAgentUpgradeOptions struct {
+	Node        string
+	AgentBinary string
+	BaseURL     string
+}
+
 type SoloAgentUninstallOptions struct {
 	Node          string
 	Yes           bool
@@ -3648,10 +3654,14 @@ func (a *App) SoloNodeDiagnose(ctx context.Context, opts SoloNodeDiagnoseOptions
 		payload["next_steps"] = []string{fmt.Sprintf("ssh -p %d %s true", node.Port, shellQuote(node.User+"@"+node.Host))}
 		return a.printSoloDiagnoseResult(payload, diagnoseOK)
 	}
+	agentVersion := collectRemoteText(ctx, node, remoteAgentVersionCommand())
 	agent := map[string]any{
-		"active": collectRemoteText(ctx, node, "systemctl is-active devopsellence-agent"),
-		"status": collectRemoteLines(ctx, node, remoteSystemctlStatusCommand("devopsellence-agent", 40)),
+		"active":         collectRemoteText(ctx, node, "systemctl is-active devopsellence-agent"),
+		"status":         collectRemoteLines(ctx, node, remoteSystemctlStatusCommand("devopsellence-agent", 40)),
+		"version":        agentVersion,
+		"target_version": soloAgentTargetVersion(),
 	}
+	agent["version_status"] = soloAgentVersionStatus(stringFromMap(agentVersion, "value"), stringFromAny(agent["target_version"]))
 	payload["agent"] = agent
 	dockerSnapshot := map[string]any{
 		"containers": collectRemoteJSONLines(ctx, node, remoteDockerPSJSONCommand(), soloDiagnoseDockerItemLimit),
@@ -3799,6 +3809,46 @@ type soloSecurityCheck struct {
 	Severity   string
 	Observed   string
 	NextAction string
+}
+
+func soloAgentVersionCheck(ctx context.Context, node config.Node) soloSecurityCheck {
+	target := soloAgentTargetVersion()
+	diag := runRemoteDiagnostic(ctx, node, remoteAgentVersionCommand())
+	check := soloSecurityCheck{Name: "agent_version", OK: true}
+	if diag.Err != nil || diag.ExitCode != 0 {
+		check.Observed = "unknown: " + diagnosticErrorMessage(diag)
+		return check
+	}
+	observed := strings.TrimSpace(diag.Stdout)
+	if observed == "" {
+		check.Observed = "unknown: agent version not reported"
+		return check
+	}
+	check.Observed = observed
+	if soloAgentVersionStatus(observed, target) == "mismatch" {
+		check.OK = false
+		check.NextAction = "run devopsellence agent upgrade <node>"
+	}
+	return check
+}
+
+func soloAgentTargetVersion() string {
+	return releasedAgentVersionForInstall()
+}
+
+func soloAgentVersionStatus(observed, target string) string {
+	observed = strings.TrimSpace(observed)
+	target = strings.TrimSpace(target)
+	if observed == "" || observed == "missing" || strings.HasPrefix(observed, "unknown:") {
+		return "unknown"
+	}
+	if target == "" {
+		return "target_unknown"
+	}
+	if strings.Contains(observed, target) {
+		return "current"
+	}
+	return "mismatch"
 }
 
 func (a *App) soloNodeSecurityDiagnostics(ctx context.Context, node config.Node) map[string]any {
@@ -4339,6 +4389,38 @@ func (a *App) SoloAgentInstall(ctx context.Context, opts SoloAgentInstallOptions
 
 }
 
+func (a *App) SoloAgentUpgrade(ctx context.Context, opts SoloAgentUpgradeOptions) error {
+	current, err := a.readSoloState()
+	if err != nil {
+		return err
+	}
+	node, ok := current.Nodes[opts.Node]
+	if !ok {
+		return fmt.Errorf("node %q not found", opts.Node)
+	}
+
+	before := stringFromMap(collectRemoteText(ctx, node, remoteAgentVersionCommand()), "value")
+	reporter := newSoloAgentReporter(a.Printer, opts.Node, "devopsellence agent upgrade")
+	defer reporter.Close()
+	if err := installSoloAgent(ctx, node, SoloAgentInstallOptions{
+		Node:        opts.Node,
+		AgentBinary: opts.AgentBinary,
+		BaseURL:     opts.BaseURL,
+	}, reporter); err != nil {
+		return err
+	}
+	after := stringFromMap(collectRemoteText(ctx, node, remoteAgentVersionCommand()), "value")
+	target := soloAgentTargetVersion()
+	return a.Printer.PrintResultEvent("devopsellence agent upgrade", map[string]any{
+		"node":             opts.Node,
+		"action":           "upgraded",
+		"previous_version": before,
+		"agent_version":    after,
+		"target_version":   target,
+		"version_status":   soloAgentVersionStatus(after, target),
+	})
+}
+
 func (a *App) SoloAgentUninstall(ctx context.Context, opts SoloAgentUninstallOptions) error {
 	if !opts.Yes {
 		return ExitError{Code: 2, Err: errors.New("agent uninstall requires --yes; rerun with --yes to confirm remote cleanup")}
@@ -4423,6 +4505,20 @@ func (a *App) soloRuntimeDoctorChecks(ctx context.Context, opts SoloDoctorOption
 			}
 			results = append(results, result)
 		}
+		versionCheck := soloAgentVersionCheck(ctx, node)
+		versionResult := map[string]any{
+			"node":   name,
+			"check":  "agent_version",
+			"ok":     versionCheck.OK,
+			"detail": versionCheck.Observed,
+		}
+		if versionCheck.NextAction != "" {
+			versionResult["next_action"] = versionCheck.NextAction
+		}
+		if !versionCheck.OK {
+			failed = true
+		}
+		results = append(results, versionResult)
 		for _, check := range soloNodeSecurityChecks(ctx, node) {
 			result := map[string]any{
 				"node":     name,
@@ -7490,6 +7586,10 @@ func withRemoteLineLimit(command string, limit int) string {
 
 func remoteListeningPortsCommand() string {
 	return withRemoteLineLimit("if command -v ss >/dev/null 2>&1; then ss -ltnp || ss -ltn; elif command -v netstat >/dev/null 2>&1; then netstat -ltnp || netstat -ltn; else echo 'no ss or netstat available'; fi", soloDiagnosePortsLineLimit)
+}
+
+func remoteAgentVersionCommand() string {
+	return "if command -v devopsellence-agent >/dev/null 2>&1; then devopsellence-agent --version; elif [ -x /usr/local/bin/devopsellence-agent ]; then /usr/local/bin/devopsellence-agent --version; else echo missing; fi"
 }
 
 func remoteSSHPasswordAuthCommand() string {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -3823,18 +3823,26 @@ func soloAgentVersionCheck(ctx context.Context, node config.Node) soloRuntimeChe
 	diag := runRemoteDiagnostic(ctx, node, remoteAgentVersionCommand())
 	check := soloRuntimeCheck{OK: true}
 	if diag.Err != nil || diag.ExitCode != 0 {
+		check.OK = false
 		check.Observed = "unknown: " + diagnosticErrorMessage(diag)
+		check.NextAction = "run devopsellence node diagnose <node>"
 		return check
 	}
 	observed := strings.TrimSpace(diag.Stdout)
 	if observed == "" {
+		check.OK = false
 		check.Observed = "unknown: agent version not reported"
+		check.NextAction = "run devopsellence node diagnose <node>"
 		return check
 	}
 	check.Observed = observed
-	if soloAgentVersionStatus(observed, target) == "mismatch" {
+	switch soloAgentVersionStatus(observed, target) {
+	case "mismatch":
 		check.OK = false
 		check.NextAction = "run devopsellence agent upgrade <node>"
+	case "unknown":
+		check.OK = false
+		check.NextAction = "run devopsellence node diagnose <node>"
 	}
 	return check
 }
@@ -4442,7 +4450,8 @@ func (a *App) SoloAgentUpgrade(ctx context.Context, opts SoloAgentUpgradeOptions
 		return fmt.Errorf("node %q not found", opts.Node)
 	}
 
-	before := stringFromMap(collectRemoteText(ctx, node, remoteAgentVersionCommand()), "value")
+	beforeResult := collectRemoteText(ctx, node, remoteAgentVersionCommand())
+	before := stringFromMap(beforeResult, "value")
 	reporter := newSoloAgentReporter(a.Printer, opts.Node, "devopsellence agent upgrade")
 	defer reporter.Close()
 	if err := installSoloAgent(ctx, node, SoloAgentInstallOptions{
@@ -4452,16 +4461,34 @@ func (a *App) SoloAgentUpgrade(ctx context.Context, opts SoloAgentUpgradeOptions
 	}, reporter); err != nil {
 		return err
 	}
-	after := stringFromMap(collectRemoteText(ctx, node, remoteAgentVersionCommand()), "value")
+	afterResult := collectRemoteText(ctx, node, remoteAgentVersionCommand())
+	after := stringFromMap(afterResult, "value")
+	if afterResult["ok"] != true || strings.TrimSpace(after) == "" {
+		return fmt.Errorf("agent upgrade verification failed: %s", collectRemoteTextFailure(afterResult))
+	}
 	target := soloAgentTargetVersion()
-	return a.Printer.PrintResultEvent("devopsellence agent upgrade", map[string]any{
+	payload := map[string]any{
 		"node":             opts.Node,
 		"action":           "upgraded",
 		"previous_version": before,
 		"agent_version":    after,
 		"target_version":   target,
 		"version_status":   soloAgentVersionStatus(after, target),
-	})
+	}
+	if beforeResult["ok"] != true {
+		payload["previous_version_probe"] = beforeResult
+	}
+	return a.Printer.PrintResultEvent("devopsellence agent upgrade", payload)
+}
+
+func collectRemoteTextFailure(result map[string]any) string {
+	if message := stringFromMap(result, "error"); message != "" {
+		return message
+	}
+	if stringFromMap(result, "value") == "" {
+		return "remote command returned empty output"
+	}
+	return "remote command failed"
 }
 
 func (a *App) SoloAgentUninstall(ctx context.Context, opts SoloAgentUninstallOptions) error {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -3861,7 +3861,11 @@ func soloAgentVersionStatus(observed, target string) string {
 	if target == "" {
 		return "target_unknown"
 	}
-	if soloAgentObservedVersion(observed) == target {
+	observedVersion := soloAgentObservedVersion(observed)
+	if observedVersion == "" {
+		return "unknown"
+	}
+	if observedVersion == target {
 		return "current"
 	}
 	return "mismatch"
@@ -4511,17 +4515,24 @@ func (a *App) SoloAgentUpgrade(ctx context.Context, opts SoloAgentUpgradeOptions
 	}
 	afterResult := collectRemoteText(ctx, node, remoteAgentVersionCommand())
 	after := stringFromMap(afterResult, "value")
+	target := soloAgentTargetVersion()
+	versionStatus := soloAgentVersionStatus(after, target)
 	if afterResult["ok"] != true || strings.TrimSpace(after) == "" {
 		return fmt.Errorf("agent upgrade verification failed: %s", collectRemoteTextFailure(afterResult))
 	}
-	target := soloAgentTargetVersion()
+	if versionStatus == "unknown" {
+		return fmt.Errorf("agent upgrade verification failed: remote agent version is unknown: %s", after)
+	}
+	if versionStatus == "mismatch" {
+		return fmt.Errorf("agent upgrade verification failed: remote agent version %q does not match target %q", after, target)
+	}
 	payload := map[string]any{
 		"node":             opts.Node,
 		"action":           "upgraded",
 		"previous_version": before,
 		"agent_version":    after,
 		"target_version":   target,
-		"version_status":   soloAgentVersionStatus(after, target),
+		"version_status":   versionStatus,
 	}
 	if beforeResult["ok"] != true {
 		payload["previous_version_probe"] = beforeResult

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -3812,10 +3812,16 @@ type soloSecurityCheck struct {
 	NextAction string
 }
 
-func soloAgentVersionCheck(ctx context.Context, node config.Node) soloSecurityCheck {
+type soloRuntimeCheck struct {
+	OK         bool
+	Observed   string
+	NextAction string
+}
+
+func soloAgentVersionCheck(ctx context.Context, node config.Node) soloRuntimeCheck {
 	target := soloAgentTargetVersion()
 	diag := runRemoteDiagnostic(ctx, node, remoteAgentVersionCommand())
-	check := soloSecurityCheck{Name: "agent_version", OK: true}
+	check := soloRuntimeCheck{OK: true}
 	if diag.Err != nil || diag.ExitCode != 0 {
 		check.Observed = "unknown: " + diagnosticErrorMessage(diag)
 		return check
@@ -3846,10 +3852,31 @@ func soloAgentVersionStatus(observed, target string) string {
 	if target == "" {
 		return "target_unknown"
 	}
-	if strings.Contains(observed, target) {
+	if soloAgentObservedVersion(observed) == target {
 		return "current"
 	}
 	return "mismatch"
+}
+
+func soloAgentObservedVersion(observed string) string {
+	fields := strings.Fields(strings.TrimSpace(observed))
+	for idx, field := range fields {
+		field = strings.Trim(field, "(),")
+		if field == "devopsellence" && idx+1 < len(fields) {
+			candidate := strings.Trim(fields[idx+1], "(),")
+			if releaseVersionPattern.MatchString(candidate) {
+				return candidate
+			}
+		}
+		if strings.HasPrefix(field, "devopsellence-agent/") {
+			candidate := strings.TrimPrefix(field, "devopsellence-agent/")
+			candidate = strings.Trim(candidate, "(),")
+			if releaseVersionPattern.MatchString(candidate) {
+				return candidate
+			}
+		}
+	}
+	return ""
 }
 
 func (a *App) soloNodeSecurityDiagnostics(ctx context.Context, node config.Node, portLines []string) map[string]any {

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -4079,6 +4079,39 @@ func TestSoloAgentUpgradeFailsWhenVersionVerificationFails(t *testing.T) {
 	}
 }
 
+func TestSoloAgentUpgradeFailsWhenVersionVerificationReturnsMissing(t *testing.T) {
+	originalVersion := cliversion.Version
+	t.Cleanup(func() { cliversion.Version = originalVersion })
+	cliversion.Version = "v2.0.0"
+	scriptPath := filepath.Join(t.TempDir(), "install.sh")
+	installFakeSoloCommands(t, nil)
+	t.Setenv("DEVOPSELLENCE_FAKE_AGENT_VERSION", "missing")
+	t.Setenv("DEVOPSELLENCE_FAKE_SSH_SCRIPT", scriptPath)
+
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.Node{
+			"node-a": {Host: "203.0.113.10", User: "root"},
+		},
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState}
+	err := app.SoloAgentUpgrade(context.Background(), SoloAgentUpgradeOptions{Node: "node-a", BaseURL: "https://example.test"})
+	if err == nil {
+		t.Fatal("SoloAgentUpgrade() error = nil, want missing-version verification failure")
+	}
+	if !strings.Contains(err.Error(), "agent upgrade verification failed") || !strings.Contains(err.Error(), "remote agent version is unknown") {
+		t.Fatalf("error = %v, want missing version failure", err)
+	}
+	if _, readErr := os.ReadFile(scriptPath); readErr != nil {
+		t.Fatalf("install script was not uploaded before verification: %v", readErr)
+	}
+}
+
 func TestSoloAgentUninstallRunsCleanupScript(t *testing.T) {
 	binDir := t.TempDir()
 	scriptPath := filepath.Join(t.TempDir(), "uninstall.sh")
@@ -7601,6 +7634,8 @@ func TestSoloAgentVersionStatusComparesExactObservedVersion(t *testing.T) {
 		{observed: "devopsellence v1.2.3 (commit abc, built now)", target: "v1.2.3", want: "current"},
 		{observed: "devopsellence v1.2.30 (commit abc, built now)", target: "v1.2.3", want: "mismatch"},
 		{observed: "devopsellence v2.0.0-rc.1 (commit abc, built now)", target: "v2.0.0", want: "mismatch"},
+		{observed: "totally different version output", target: "v2.0.0", want: "unknown"},
+		{observed: "missing", target: "v2.0.0", want: "unknown"},
 		{observed: "devopsellence-agent/v1.2.3 (linux; amd64)", target: "v1.2.3", want: "current"},
 	}
 	for _, tc := range cases {

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -2356,6 +2356,58 @@ func TestSoloDoctorReportsSecurityFindings(t *testing.T) {
 	t.Fatalf("runtime_checks = %#v, want security_ssh_password_auth", checks)
 }
 
+func TestSoloDoctorReportsAgentVersionSkew(t *testing.T) {
+	originalVersion := cliversion.Version
+	t.Cleanup(func() { cliversion.Version = originalVersion })
+	cliversion.Version = "v2.0.0"
+	installFakeSoloCommands(t, nil)
+	t.Setenv("DEVOPSELLENCE_FAKE_AGENT_VERSION", "devopsellence v1.9.0 (commit old, built earlier)")
+
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	commitTestRepo(t, workspaceRoot)
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.Node{
+			"node-a": {Host: "203.0.113.10", User: "root"},
+		},
+	}
+	if _, _, err := current.AttachNode(workspaceRoot, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{
+		Printer:     output.New(&stdout, io.Discard),
+		Docker:      &fakeDocker{},
+		SoloState:   soloState,
+		ConfigStore: config.NewStore(),
+		Cwd:         workspaceRoot,
+	}
+	err := app.SoloDoctor(context.Background())
+	if err == nil {
+		t.Fatal("SoloDoctor() error = nil, want version skew failure")
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	checks := jsonArrayFromMap(t, payload, "runtime_checks")
+	for _, item := range checks {
+		check := jsonMapFromAny(t, item)
+		if check["check"] == "agent_version" {
+			if check["ok"] != false || !strings.Contains(stringValueAny(check["next_action"]), "agent upgrade") {
+				t.Fatalf("agent_version = %#v, want upgrade guidance", check)
+			}
+			return
+		}
+	}
+	t.Fatalf("runtime_checks = %#v, want agent_version", checks)
+}
+
 func TestSoloStatusReturnsFailureWhenNodeStatusReadFails(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")
@@ -3672,6 +3724,11 @@ func TestSoloNodeDiagnoseCollectsRuntimeSnapshot(t *testing.T) {
 	if len(items) != 1 || jsonMapFromAny(t, items[0])["Names"] != "svc-production-web" {
 		t.Fatalf("containers = %#v, want web container", containers)
 	}
+	agent := jsonMapFromAny(t, payload["agent"])
+	agentVersion := jsonMapFromAny(t, agent["version"])
+	if !strings.Contains(stringValueAny(agentVersion["value"]), "devopsellence dev") || agent["version_status"] != "target_unknown" {
+		t.Fatalf("agent = %#v, want remote version with unknown dev target", agent)
+	}
 	status := jsonMapFromAny(t, payload["status"])
 	if status["phase"] != "settled" {
 		t.Fatalf("status = %#v, want settled phase", status)
@@ -3846,6 +3903,43 @@ func TestSoloAgentUninstallRejectsUnsafeStateDir(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "unsafe devopsellence agent state dir") {
 		t.Fatalf("error = %q, want unsafe state dir", err.Error())
+	}
+}
+
+func TestSoloAgentUpgradeReinstallsAgent(t *testing.T) {
+	originalVersion := cliversion.Version
+	t.Cleanup(func() { cliversion.Version = originalVersion })
+	cliversion.Version = "v2.0.0"
+	scriptPath := filepath.Join(t.TempDir(), "install.sh")
+	installFakeSoloCommands(t, nil)
+	t.Setenv("DEVOPSELLENCE_FAKE_AGENT_VERSION", "devopsellence v2.0.0 (commit new, built now)")
+	t.Setenv("DEVOPSELLENCE_FAKE_SSH_SCRIPT", scriptPath)
+
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.Node{
+			"node-a": {Host: "203.0.113.10", User: "root"},
+		},
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState}
+	if err := app.SoloAgentUpgrade(context.Background(), SoloAgentUpgradeOptions{Node: "node-a", BaseURL: "https://example.test"}); err != nil {
+		t.Fatalf("SoloAgentUpgrade() error = %v", err)
+	}
+	payload := lastNDJSONEvent(t, &stdout)
+	if payload["action"] != "upgraded" || payload["target_version"] != "v2.0.0" || payload["version_status"] != "current" {
+		t.Fatalf("payload = %#v, want upgraded current agent", payload)
+	}
+	scriptBytes, err := os.ReadFile(scriptPath)
+	if err != nil {
+		t.Fatalf("read install script: %v", err)
+	}
+	if !strings.Contains(string(scriptBytes), "AGENT_VERSION='v2.0.0'") {
+		t.Fatalf("install script missing pinned version:\n%s", string(scriptBytes))
 	}
 }
 
@@ -8272,6 +8366,12 @@ if [[ "$command" == *"__DEVOPSELLENCE_EXIT_CODE__"* && "$command" == *"systemctl
   exit 0
 fi
 
+if [[ "$command" == *"__DEVOPSELLENCE_EXIT_CODE__"* && "$command" == *"devopsellence-agent --version"* ]]; then
+  agent_version="${DEVOPSELLENCE_FAKE_AGENT_VERSION:-devopsellence dev (commit unknown, built unknown)}"
+  printf '__DEVOPSELLENCE_EXIT_CODE__0\n__DEVOPSELLENCE_STDOUT__\n%s\n__DEVOPSELLENCE_STDERR__\n' "$agent_version"
+  exit 0
+fi
+
 if [[ "$command" == *"__DEVOPSELLENCE_EXIT_CODE__"* && ( "$command" == *"ss -ltn"* || "$command" == *"netstat -ltn"* ) ]]; then
   printf '__DEVOPSELLENCE_EXIT_CODE__0\n__DEVOPSELLENCE_STDOUT__\nLISTEN 0 4096 0.0.0.0:80 0.0.0.0:*\n__DEVOPSELLENCE_STDERR__\n'
   exit 0
@@ -8288,6 +8388,11 @@ fi
 
 if [[ "$command" == *"systemctl status"* ]]; then
   printf 'devopsellence-agent active\n'
+  exit 0
+fi
+
+if [[ "$command" == *"devopsellence-agent --version"* ]]; then
+  printf '%s\n' "${DEVOPSELLENCE_FAKE_AGENT_VERSION:-devopsellence dev (commit unknown, built unknown)}"
   exit 0
 fi
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -2408,6 +2408,58 @@ func TestSoloDoctorReportsAgentVersionSkew(t *testing.T) {
 	t.Fatalf("runtime_checks = %#v, want agent_version", checks)
 }
 
+func TestSoloDoctorFailsWhenAgentVersionUnknown(t *testing.T) {
+	originalVersion := cliversion.Version
+	t.Cleanup(func() { cliversion.Version = originalVersion })
+	cliversion.Version = "v2.0.0"
+	installFakeSoloCommands(t, nil)
+	t.Setenv("DEVOPSELLENCE_FAKE_AGENT_VERSION", "missing")
+
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	commitTestRepo(t, workspaceRoot)
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.Node{
+			"node-a": {Host: "203.0.113.10", User: "root"},
+		},
+	}
+	if _, _, err := current.AttachNode(workspaceRoot, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{
+		Printer:     output.New(&stdout, io.Discard),
+		Docker:      &fakeDocker{},
+		SoloState:   soloState,
+		ConfigStore: config.NewStore(),
+		Cwd:         workspaceRoot,
+	}
+	err := app.SoloDoctor(context.Background())
+	if err == nil {
+		t.Fatal("SoloDoctor() error = nil, want unknown version failure")
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	checks := jsonArrayFromMap(t, payload, "runtime_checks")
+	for _, item := range checks {
+		check := jsonMapFromAny(t, item)
+		if check["check"] == "agent_version" {
+			if check["ok"] != false || !strings.Contains(stringValueAny(check["next_action"]), "node diagnose") {
+				t.Fatalf("agent_version = %#v, want diagnose guidance", check)
+			}
+			return
+		}
+	}
+	t.Fatalf("runtime_checks = %#v, want agent_version", checks)
+}
+
 func TestSoloStatusReturnsFailureWhenNodeStatusReadFails(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")
@@ -3960,6 +4012,39 @@ func TestSoloAgentUpgradeReinstallsAgent(t *testing.T) {
 	}
 	if !strings.Contains(string(scriptBytes), "AGENT_VERSION='v2.0.0'") {
 		t.Fatalf("install script missing pinned version:\n%s", string(scriptBytes))
+	}
+}
+
+func TestSoloAgentUpgradeFailsWhenVersionVerificationFails(t *testing.T) {
+	originalVersion := cliversion.Version
+	t.Cleanup(func() { cliversion.Version = originalVersion })
+	cliversion.Version = "v2.0.0"
+	scriptPath := filepath.Join(t.TempDir(), "install.sh")
+	installFakeSoloCommands(t, nil)
+	t.Setenv("DEVOPSELLENCE_FAKE_AGENT_VERSION_FAIL", "1")
+	t.Setenv("DEVOPSELLENCE_FAKE_SSH_SCRIPT", scriptPath)
+
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.Node{
+			"node-a": {Host: "203.0.113.10", User: "root"},
+		},
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState}
+	err := app.SoloAgentUpgrade(context.Background(), SoloAgentUpgradeOptions{Node: "node-a", BaseURL: "https://example.test"})
+	if err == nil {
+		t.Fatal("SoloAgentUpgrade() error = nil, want verification failure")
+	}
+	if !strings.Contains(err.Error(), "agent upgrade verification failed") || !strings.Contains(err.Error(), "version probe failed") {
+		t.Fatalf("error = %v, want version probe failure", err)
+	}
+	if _, readErr := os.ReadFile(scriptPath); readErr != nil {
+		t.Fatalf("install script was not uploaded before verification: %v", readErr)
 	}
 }
 
@@ -8405,6 +8490,10 @@ if [[ "$command" == *"__DEVOPSELLENCE_EXIT_CODE__"* && "$command" == *"systemctl
 fi
 
 if [[ "$command" == *"__DEVOPSELLENCE_EXIT_CODE__"* && "$command" == *"devopsellence-agent --version"* ]]; then
+  if [[ -n "${DEVOPSELLENCE_FAKE_AGENT_VERSION_FAIL:-}" ]]; then
+    printf '__DEVOPSELLENCE_EXIT_CODE__42\n__DEVOPSELLENCE_STDOUT__\n\n__DEVOPSELLENCE_STDERR__\nversion probe failed\n'
+    exit 0
+  fi
   agent_version="${DEVOPSELLENCE_FAKE_AGENT_VERSION:-devopsellence dev (commit unknown, built unknown)}"
   printf '__DEVOPSELLENCE_EXIT_CODE__0\n__DEVOPSELLENCE_STDOUT__\n%s\n__DEVOPSELLENCE_STDERR__\n' "$agent_version"
   exit 0
@@ -8430,6 +8519,10 @@ if [[ "$command" == *"systemctl status"* ]]; then
 fi
 
 if [[ "$command" == *"devopsellence-agent --version"* ]]; then
+  if [[ -n "${DEVOPSELLENCE_FAKE_AGENT_VERSION_FAIL:-}" ]]; then
+    printf 'version probe failed\n' >&2
+    exit 42
+  fi
   printf '%s\n' "${DEVOPSELLENCE_FAKE_AGENT_VERSION:-devopsellence dev (commit unknown, built unknown)}"
   exit 0
 fi

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -7476,6 +7476,24 @@ func TestReleasedAgentVersionForInstall(t *testing.T) {
 	}
 }
 
+func TestSoloAgentVersionStatusComparesExactObservedVersion(t *testing.T) {
+	cases := []struct {
+		observed string
+		target   string
+		want     string
+	}{
+		{observed: "devopsellence v1.2.3 (commit abc, built now)", target: "v1.2.3", want: "current"},
+		{observed: "devopsellence v1.2.30 (commit abc, built now)", target: "v1.2.3", want: "mismatch"},
+		{observed: "devopsellence v2.0.0-rc.1 (commit abc, built now)", target: "v2.0.0", want: "mismatch"},
+		{observed: "devopsellence-agent/v1.2.3 (linux; amd64)", target: "v1.2.3", want: "current"},
+	}
+	for _, tc := range cases {
+		if got := soloAgentVersionStatus(tc.observed, tc.target); got != tc.want {
+			t.Fatalf("soloAgentVersionStatus(%q, %q) = %q, want %q", tc.observed, tc.target, got, tc.want)
+		}
+	}
+}
+
 func TestRemoteDockerCommandsSupportPasswordlessSudo(t *testing.T) {
 	for _, command := range []string{remoteDockerCheckCommand(), remoteDockerLoadCommand()} {
 		if !strings.Contains(command, "sudo -n docker info") {


### PR DESCRIPTION
## What
- Add `devopsellence agent upgrade <node>` for explicit solo agent upgrades.
- Include remote agent version and target version status in solo `node diagnose`.
- Add an `agent_version` runtime check to solo `doctor` so released CLIs flag agent version skew with upgrade guidance.

## Why
Production solo nodes need an obvious way to detect and correct agent/CLI skew without reaching for manual reinstall instructions. This keeps upgrades as ordinary SSH/systemd work, aligned with the solo operator model.

## Stack
- Based on #153.

## Validation
- `cd cli && go test ./internal/workflow -run 'TestSolo(Doctor|NodeDiagnose|AgentUpgrade)|TestAgentUpgradeHelp'`\n- `cd cli && go test ./...`