### PR TITLE
[codex] Add solo rollback migration contract

### DIFF
--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -2300,6 +2300,13 @@ func (a *App) SoloReleaseRollback(ctx context.Context, opts SoloReleaseRollbackO
 	if err != nil {
 		return err
 	}
+	_, attachment, _, err := current.Attachment(workspaceRoot, environmentName)
+	if err != nil {
+		return err
+	}
+	if _, err := releaseNodeForSnapshot(selected.Snapshot, attachment, current.Nodes); err != nil {
+		return err
+	}
 	nodes, err := a.resolveNodes(current, rollbackTargetNodeNames)
 	if err != nil {
 		return err

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1865,12 +1865,16 @@ func soloAttachmentHasReleaseState(current solo.State, attachment solo.Attachmen
 }
 
 func releaseNodeForSnapshot(snapshot desiredstate.DeploySnapshot, attachment solo.AttachmentRecord, nodes map[string]config.Node) (string, error) {
+	return releaseNodeForSnapshotTargets(snapshot, attachment.NodeNames, nodes)
+}
+
+func releaseNodeForSnapshotTargets(snapshot desiredstate.DeploySnapshot, nodeNames []string, nodes map[string]config.Node) (string, error) {
 	if snapshot.ReleaseTask == nil {
 		return "", nil
 	}
-	nodeNames := append([]string(nil), attachment.NodeNames...)
-	sort.Strings(nodeNames)
-	for _, nodeName := range nodeNames {
+	sortedNames := append([]string(nil), nodeNames...)
+	sort.Strings(sortedNames)
+	for _, nodeName := range sortedNames {
 		node, ok := nodes[nodeName]
 		if ok && soloNodeCanRunKind(node, snapshot.ReleaseServiceKind) {
 			return nodeName, nil
@@ -2300,11 +2304,7 @@ func (a *App) SoloReleaseRollback(ctx context.Context, opts SoloReleaseRollbackO
 	if err != nil {
 		return err
 	}
-	_, attachment, _, err := current.Attachment(workspaceRoot, environmentName)
-	if err != nil {
-		return err
-	}
-	if _, err := releaseNodeForSnapshot(selected.Snapshot, attachment, current.Nodes); err != nil {
+	if _, err := releaseNodeForSnapshotTargets(selected.Snapshot, rollbackTargetNodeNames, current.Nodes); err != nil {
 		return err
 	}
 	nodes, err := a.resolveNodes(current, rollbackTargetNodeNames)

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -2304,8 +2304,9 @@ func (a *App) SoloReleaseRollback(ctx context.Context, opts SoloReleaseRollbackO
 	if err != nil {
 		return err
 	}
+	rollbackContract := soloRollbackContract(currentRelease, selected)
 	if opts.DryRun {
-		return stream.Result(map[string]any{
+		result := map[string]any{
 			"action":            "rollback",
 			"dry_run":           true,
 			"release_id":        selected.ID,
@@ -2322,7 +2323,11 @@ func (a *App) SoloReleaseRollback(ctx context.Context, opts SoloReleaseRollbackO
 				"state_write": false,
 			},
 			"next_steps": []string{"devopsellence release rollback" + soloEnvFlag(environmentName) + " " + selected.ID},
-		})
+		}
+		if rollbackContract != nil {
+			result["rollback_contract"] = rollbackContract
+		}
+		return stream.Result(result)
 	}
 	now := time.Now().UTC()
 	deployment, err := corerelease.NewDeployment(corerelease.DeploymentCreateInput{
@@ -2397,7 +2402,7 @@ func (a *App) SoloReleaseRollback(ctx context.Context, opts SoloReleaseRollbackO
 	if err := a.writeSoloState(current); err != nil {
 		return err
 	}
-	return stream.Result(map[string]any{
+	result := map[string]any{
 		"release_id":              selected.ID,
 		"deployment_id":           deployment.ID,
 		"rolled_back_from":        currentRelease.ID,
@@ -2406,7 +2411,29 @@ func (a *App) SoloReleaseRollback(ctx context.Context, opts SoloReleaseRollbackO
 		"environment":             environmentName,
 		"nodes":                   sortedNodeNames(nodes),
 		"phase":                   "settled",
-	})
+	}
+	if rollbackContract != nil {
+		result["rollback_contract"] = rollbackContract
+	}
+	return stream.Result(result)
+}
+
+func soloRollbackContract(currentRelease, selectedRelease corerelease.Release) map[string]any {
+	selectedTask := selectedRelease.Snapshot.ReleaseTask != nil
+	currentTask := currentRelease.Snapshot.ReleaseTask != nil
+	if !selectedTask && !currentTask {
+		return nil
+	}
+	return map[string]any{
+		"data_rollback_automatic":       false,
+		"selected_release_task":         selectedTask,
+		"current_release_task":          currentTask,
+		"selected_release_task_reruns":  selectedTask,
+		"message":                       "rollback republishes selected desired state; devopsellence does not reverse database or data migrations",
+		"operator_responsibility":       "verify data compatibility before rollback; restore from backup if the current migration is not backward-compatible",
+		"recommended_dry_run_first":     true,
+		"recommended_backup_before_run": true,
+	}
 }
 
 func soloReadyPublicURLs(cfg *config.ProjectConfig, nodes map[string]config.Node) []string {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -2365,6 +2365,7 @@ func (a *App) SoloReleaseRollback(ctx context.Context, opts SoloReleaseRollbackO
 	if _, err := publishState.SaveRelease(selected); err != nil {
 		return err
 	}
+	publishState = soloStateScopedToRollbackTargets(publishState, environmentID, rollbackTargetNodeNames)
 	statusBaselines := a.soloNodeStatusTimes(ctx, nodes)
 	desiredStateRevisions, err := a.republishNodes(ctx, publishState, rollbackTargetNodeNames)
 	if err != nil {
@@ -2441,6 +2442,16 @@ func soloRollbackContract(currentRelease, selectedRelease corerelease.Release) m
 		"recommended_dry_run_first":     true,
 		"recommended_backup_before_run": true,
 	}
+}
+
+func soloStateScopedToRollbackTargets(current solo.State, environmentID string, nodeNames []string) solo.State {
+	attachment, ok := current.Attachments[environmentID]
+	if !ok {
+		return current
+	}
+	attachment.NodeNames = normalizeSoloNames(nodeNames)
+	current.Attachments[environmentID] = attachment
+	return current
 }
 
 func soloReadyPublicURLs(cfg *config.ProjectConfig, nodes map[string]config.Node) []string {

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -6574,6 +6574,40 @@ func TestSoloReleaseRollbackDryRunPlansWithoutSideEffects(t *testing.T) {
 	}
 }
 
+func TestSoloReleaseRollbackReportsMigrationContract(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := soloReleaseWorkflowState(workspaceRoot)
+	previous := current.Releases["rel-1"]
+	previous.Snapshot.ReleaseTask = &desiredstate.TaskJSON{Name: "release", Image: "demo:aaa1111", Command: []string{"bin/migrate"}}
+	current.Releases["rel-1"] = previous
+	active := current.Releases["rel-2"]
+	active.Snapshot.ReleaseTask = &desiredstate.TaskJSON{Name: "release", Image: "demo:bbb2222", Command: []string{"bin/migrate"}}
+	current.Releases["rel-2"] = active
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState, ConfigStore: config.NewStore(), Cwd: workspaceRoot}
+	if err := app.SoloReleaseRollback(context.Background(), SoloReleaseRollbackOptions{Selector: "aaa1111", DryRun: true}); err != nil {
+		t.Fatal(err)
+	}
+	events := decodeNDJSONOutput(t, &stdout)
+	payload := events[len(events)-1]
+	contract := jsonMapFromAny(t, payload["rollback_contract"])
+	if contract["data_rollback_automatic"] != false || contract["selected_release_task_reruns"] != true {
+		t.Fatalf("rollback_contract = %#v, want release task/data contract", contract)
+	}
+	if !strings.Contains(stringValueAny(contract["operator_responsibility"]), "backup") || !strings.Contains(stringValueAny(contract["message"]), "does not reverse") {
+		t.Fatalf("rollback_contract = %#v, want migration warning", contract)
+	}
+}
+
 func TestSoloReleaseRollbackUnknownSelectorSuggestsReleaseList(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -6389,6 +6389,11 @@ func TestSoloReleaseListReturnsCurrentReleaseHistory(t *testing.T) {
 	}
 	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
 	current := soloReleaseWorkflowState(workspaceRoot)
+	previous := current.Releases["rel-1"]
+	previous.Snapshot.ReleaseTask = &desiredstate.TaskJSON{Name: "release", Image: "demo:aaa1111", Command: []string{"bin/migrate"}}
+	previous.Snapshot.ReleaseService = "web"
+	previous.Snapshot.ReleaseServiceKind = config.ServiceKindWeb
+	current.Releases["rel-1"] = previous
 	if err := soloState.Write(current); err != nil {
 		t.Fatal(err)
 	}
@@ -6561,6 +6566,11 @@ func TestSoloReleaseRollbackDryRunPlansWithoutSideEffects(t *testing.T) {
 	}
 	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
 	current := soloReleaseWorkflowState(workspaceRoot)
+	previous := current.Releases["rel-1"]
+	previous.Snapshot.ReleaseTask = &desiredstate.TaskJSON{Name: "release", Image: "demo:aaa1111", Command: []string{"bin/migrate"}}
+	previous.Snapshot.ReleaseService = "web"
+	previous.Snapshot.ReleaseServiceKind = config.ServiceKindWeb
+	current.Releases["rel-1"] = previous
 	if err := soloState.Write(current); err != nil {
 		t.Fatal(err)
 	}
@@ -6604,9 +6614,13 @@ func TestSoloReleaseRollbackReportsMigrationContract(t *testing.T) {
 	current := soloReleaseWorkflowState(workspaceRoot)
 	previous := current.Releases["rel-1"]
 	previous.Snapshot.ReleaseTask = &desiredstate.TaskJSON{Name: "release", Image: "demo:aaa1111", Command: []string{"bin/migrate"}}
+	previous.Snapshot.ReleaseService = "web"
+	previous.Snapshot.ReleaseServiceKind = config.ServiceKindWeb
 	current.Releases["rel-1"] = previous
 	active := current.Releases["rel-2"]
 	active.Snapshot.ReleaseTask = &desiredstate.TaskJSON{Name: "release", Image: "demo:bbb2222", Command: []string{"bin/migrate"}}
+	active.Snapshot.ReleaseService = "web"
+	active.Snapshot.ReleaseServiceKind = config.ServiceKindWeb
 	current.Releases["rel-2"] = active
 	if err := soloState.Write(current); err != nil {
 		t.Fatal(err)
@@ -6628,6 +6642,33 @@ func TestSoloReleaseRollbackReportsMigrationContract(t *testing.T) {
 	}
 }
 
+func TestSoloReleaseRollbackDryRunValidatesReleaseTaskPlacement(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := soloReleaseWorkflowState(workspaceRoot)
+	previous := current.Releases["rel-1"]
+	previous.Snapshot.ReleaseTask = &desiredstate.TaskJSON{Name: "release", Image: "demo:aaa1111", Command: []string{"bin/migrate"}}
+	previous.Snapshot.ReleaseService = "worker"
+	previous.Snapshot.ReleaseServiceKind = config.ServiceKindWorker
+	current.Releases["rel-1"] = previous
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	app := &App{Printer: output.New(io.Discard, io.Discard), SoloState: soloState, ConfigStore: config.NewStore(), Cwd: workspaceRoot}
+	err := app.SoloReleaseRollback(context.Background(), SoloReleaseRollbackOptions{Selector: "aaa1111", DryRun: true})
+	if err == nil {
+		t.Fatal("SoloReleaseRollback() error = nil, want release task placement failure")
+	}
+	if !strings.Contains(err.Error(), "requires at least one attached node labeled") || !strings.Contains(err.Error(), "worker") {
+		t.Fatalf("error = %v, want release task placement guidance", err)
+	}
+}
+
 func TestSoloReleaseRollbackUnknownSelectorSuggestsReleaseList(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")
@@ -6636,6 +6677,11 @@ func TestSoloReleaseRollbackUnknownSelectorSuggestsReleaseList(t *testing.T) {
 	}
 	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
 	current := soloReleaseWorkflowState(workspaceRoot)
+	previous := current.Releases["rel-1"]
+	previous.Snapshot.ReleaseTask = &desiredstate.TaskJSON{Name: "release", Image: "demo:aaa1111", Command: []string{"bin/migrate"}}
+	previous.Snapshot.ReleaseService = "web"
+	previous.Snapshot.ReleaseServiceKind = config.ServiceKindWeb
+	current.Releases["rel-1"] = previous
 	if err := soloState.Write(current); err != nil {
 		t.Fatal(err)
 	}
@@ -6761,6 +6807,11 @@ func TestSoloReleaseRollbackUsesSelectedReleaseTargets(t *testing.T) {
 	}
 	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
 	current := soloReleaseWorkflowState(workspaceRoot)
+	previous := current.Releases["rel-1"]
+	previous.Snapshot.ReleaseTask = &desiredstate.TaskJSON{Name: "release", Image: "demo:aaa1111", Command: []string{"bin/migrate"}}
+	previous.Snapshot.ReleaseService = "web"
+	previous.Snapshot.ReleaseServiceKind = config.ServiceKindWeb
+	current.Releases["rel-1"] = previous
 	if err := soloState.Write(current); err != nil {
 		t.Fatal(err)
 	}
@@ -6786,6 +6837,10 @@ func TestSoloReleaseRollbackUsesSelectedReleaseTargets(t *testing.T) {
 	payload := events[len(events)-1]
 	if payload["release_id"] != "rel-1" || payload["rolled_back_from"] != "rel-2" || payload["phase"] != "settled" {
 		t.Fatalf("payload = %#v, want settled rollback to rel-1", payload)
+	}
+	contract := jsonMapFromAny(t, payload["rollback_contract"])
+	if contract["selected_release_task_reruns"] != true || contract["data_rollback_automatic"] != false {
+		t.Fatalf("rollback_contract = %#v, want settled rollback contract", contract)
 	}
 	nodes := jsonArrayFromMap(t, payload, "nodes")
 	if !reflect.DeepEqual(nodes, []any{"node-a"}) {

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -6758,6 +6758,39 @@ func TestSoloReleaseRollbackReportsMigrationContract(t *testing.T) {
 	}
 }
 
+func TestSoloReleaseRollbackWarnsWhenOnlyCurrentReleaseHasTask(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := soloReleaseWorkflowState(workspaceRoot)
+	active := current.Releases["rel-2"]
+	active.Snapshot.ReleaseTask = &desiredstate.TaskJSON{Name: "release", Image: "demo:bbb2222", Command: []string{"bin/migrate"}}
+	active.Snapshot.ReleaseService = "web"
+	active.Snapshot.ReleaseServiceKind = config.ServiceKindWeb
+	current.Releases["rel-2"] = active
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState, ConfigStore: config.NewStore(), Cwd: workspaceRoot}
+	if err := app.SoloReleaseRollback(context.Background(), SoloReleaseRollbackOptions{Selector: "aaa1111", DryRun: true}); err != nil {
+		t.Fatal(err)
+	}
+	events := decodeNDJSONOutput(t, &stdout)
+	payload := events[len(events)-1]
+	contract := jsonMapFromAny(t, payload["rollback_contract"])
+	if contract["current_release_task"] != true || contract["selected_release_task"] != false || contract["selected_release_task_reruns"] != false {
+		t.Fatalf("rollback_contract = %#v, want current-task-only warning", contract)
+	}
+	if !strings.Contains(stringValueAny(contract["operator_responsibility"]), "backup") {
+		t.Fatalf("rollback_contract = %#v, want backup responsibility", contract)
+	}
+}
+
 func TestSoloReleaseRollbackDryRunValidatesReleaseTaskPlacement(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")
@@ -6779,6 +6812,36 @@ func TestSoloReleaseRollbackDryRunValidatesReleaseTaskPlacement(t *testing.T) {
 	err := app.SoloReleaseRollback(context.Background(), SoloReleaseRollbackOptions{Selector: "aaa1111", DryRun: true})
 	if err == nil {
 		t.Fatal("SoloReleaseRollback() error = nil, want release task placement failure")
+	}
+	if !strings.Contains(err.Error(), "requires at least one attached node labeled") || !strings.Contains(err.Error(), "worker") {
+		t.Fatalf("error = %v, want release task placement guidance", err)
+	}
+}
+
+func TestSoloReleaseRollbackValidatesReleaseTaskPlacementAgainstTargets(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := soloReleaseWorkflowState(workspaceRoot)
+	worker := current.Nodes["node-b"]
+	worker.Labels = []string{config.DefaultWorkerRole}
+	current.Nodes["node-b"] = worker
+	previous := current.Releases["rel-1"]
+	previous.Snapshot.ReleaseTask = &desiredstate.TaskJSON{Name: "release", Image: "demo:aaa1111", Command: []string{"bin/migrate"}}
+	previous.Snapshot.ReleaseService = "worker"
+	previous.Snapshot.ReleaseServiceKind = config.ServiceKindWorker
+	current.Releases["rel-1"] = previous
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	app := &App{Printer: output.New(io.Discard, io.Discard), SoloState: soloState, ConfigStore: config.NewStore(), Cwd: workspaceRoot}
+	err := app.SoloReleaseRollback(context.Background(), SoloReleaseRollbackOptions{Selector: "aaa1111", DryRun: true})
+	if err == nil {
+		t.Fatal("SoloReleaseRollback() error = nil, want release task target placement failure")
 	}
 	if !strings.Contains(err.Error(), "requires at least one attached node labeled") || !strings.Contains(err.Error(), "worker") {
 		t.Fatalf("error = %v, want release task placement guidance", err)

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -7131,6 +7131,28 @@ func TestSoloReleaseRollbackUsesSelectedReleaseTargets(t *testing.T) {
 	}
 }
 
+func TestSoloRollbackScopedStateKeepsReleaseTaskOnTargetNode(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	current := soloReleaseWorkflowState(workspaceRoot)
+	key := workspaceRoot + "\nproduction"
+	previous := current.Releases["rel-1"]
+	previous.TargetNodeIDs = []string{"node-b"}
+	previous.Snapshot.ReleaseTask = &desiredstate.TaskJSON{Name: "release", Image: "demo:aaa1111", Command: []string{"bin/migrate"}}
+	previous.Snapshot.ReleaseService = "web"
+	previous.Snapshot.ReleaseServiceKind = config.ServiceKindWeb
+	current.Releases["rel-1"] = previous
+	current.Current[key] = "rel-1"
+
+	scoped := soloStateScopedToRollbackTargets(current, key, []string{"node-b"})
+	_, releaseNodes, _, _, err := soloNodeDesiredStateInputs(scoped, "node-b")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if releaseNodes[key] != "node-b" {
+		t.Fatalf("releaseNodes = %#v, want release task on rollback target node-b", releaseNodes)
+	}
+}
+
 func TestSoloReleaseRollbackRepublishFailureDoesNotSwitchCurrentRelease(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")


### PR DESCRIPTION
## What
- Add structured `rollback_contract` output to solo rollback plans/results when release tasks are involved.
- Make the contract explicit that devopsellence republished desired state does not reverse database/data migrations.
- Cover the dry-run output with a release-task rollback test.

## Why
Rollback is production-critical, but container rollback and data rollback are different operations. Agents and humans need this surfaced in the command payload before relying on rollback around migrations.

## Stack
- Based on #154.

## Validation
- `cd cli && go test ./internal/workflow -run 'TestSoloReleaseRollback'`\n- `cd cli && go test ./...`