### PR TITLE
[codex] Recover interrupted solo deployments from status

### DIFF
--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1904,10 +1904,16 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 	staleRevisions := map[string]map[string]bool{}
 	expectedRuntimeEnvironment := ""
 	expectedWorkloadRevision := ""
+	var current solo.State
+	var environmentID string
+	var currentRelease corerelease.Release
+	var hasCurrent bool
 	if workspaceRoot != "" && environmentName != "" {
-		current, stateErr := a.readSoloState()
+		var stateErr error
+		current, stateErr = a.readSoloState()
 		if stateErr == nil {
-			_, currentRelease, hasCurrent, releaseErr := current.CurrentRelease(workspaceRoot, environmentName)
+			var releaseErr error
+			environmentID, currentRelease, hasCurrent, releaseErr = current.CurrentRelease(workspaceRoot, environmentName)
 			if releaseErr != nil {
 				return releaseErr
 			}
@@ -2027,6 +2033,20 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 		payload["public_url_status"] = soloPublicURLStatus(cfg)
 		payload["warnings"] = []string{soloPublicURLWarning(cfg, environmentName)}
 	}
+	if allSettled && hasCurrent && len(opts.Nodes) == 0 {
+		recovered, recoveredState, ok := soloRecoverSettledRunningDeployment(current, environmentID, currentRelease.ID)
+		if ok {
+			if err := a.writeSoloState(recoveredState); err != nil {
+				return err
+			}
+			payload["recovered_deployment"] = map[string]any{
+				"id":             recovered.ID,
+				"release_id":     recovered.ReleaseID,
+				"status":         recovered.Status,
+				"status_message": recovered.StatusMessage,
+			}
+		}
+	}
 	if err := a.Printer.PrintJSON(payload); err != nil {
 		return err
 	}
@@ -2043,6 +2063,33 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 		return ExitError{Code: 1, Err: RenderedError{Err: fmt.Errorf("status missing for current local deployment on %d node(s)", missingStatuses)}}
 	}
 	return nil
+}
+
+func soloRecoverSettledRunningDeployment(current solo.State, environmentID, releaseID string) (corerelease.Deployment, solo.State, bool) {
+	if strings.TrimSpace(environmentID) == "" || strings.TrimSpace(releaseID) == "" {
+		return corerelease.Deployment{}, current, false
+	}
+	var selected corerelease.Deployment
+	found := false
+	for _, deployment := range current.Deployments {
+		if deployment.EnvironmentID != environmentID || deployment.ReleaseID != releaseID || deployment.Status != corerelease.DeploymentStatusRunning {
+			continue
+		}
+		if !found || deployment.Sequence > selected.Sequence || (deployment.Sequence == selected.Sequence && deployment.CreatedAt > selected.CreatedAt) {
+			selected = deployment
+			found = true
+		}
+	}
+	if !found {
+		return corerelease.Deployment{}, current, false
+	}
+	selected.Status = corerelease.DeploymentStatusSettled
+	selected.StatusMessage = "release settled by status recovery"
+	selected.FinishedAt = time.Now().UTC().Format(time.RFC3339)
+	if err := current.SaveDeployment(selected); err != nil {
+		return corerelease.Deployment{}, current, false
+	}
+	return selected, current, true
 }
 
 func soloStatusMismatchMessage(status soloNodeStatus, expectedDesiredStateRevision string, runtime soloRuntimeStatusResult, expectedRuntimeEnvironment, expectedWorkloadRevision, logicalEnvironment string) string {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -2048,29 +2048,32 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 		"environment":    environmentName,
 		"nodes":          jsonResults,
 	}
+	appendPayloadWarning := func(message string) {
+		warnings, _ := payload["warnings"].([]string)
+		payload["warnings"] = append(warnings, message)
+	}
 	if len(verifiedPublicURLs) > 0 {
 		if allSettled {
 			payload["public_urls"] = verifiedPublicURLs
 		} else {
 			payload["configured_public_urls"] = verifiedPublicURLs
-			payload["warnings"] = []string{"public URLs are configured, but one or more nodes are not settled; check `devopsellence status" + soloEnvFlag(environmentName) + "` before testing reachability"}
+			appendPayloadWarning("public URLs are configured, but one or more nodes are not settled; check `devopsellence status" + soloEnvFlag(environmentName) + "` before testing reachability")
 		}
 	} else if urls := soloStatusPublicURLs(cfg, nodes); len(urls) > 0 {
 		payload["configured_public_urls"] = urls
 		payload["public_url_status"] = soloPublicURLStatus(cfg)
-		payload["warnings"] = []string{soloPublicURLWarning(cfg, environmentName)}
+		appendPayloadWarning(soloPublicURLWarning(cfg, environmentName))
 	}
-	if allSettled && hasCurrent && len(opts.Nodes) == 0 {
+	if allSettled && hasCurrent && hasRecoveryCandidate && len(opts.Nodes) == 0 {
 		var recovered corerelease.Deployment
 		recoveredOK := false
 		if err := a.updateSoloState(func(recoveryState *solo.State) error {
 			var err error
-			recovered, recoveredOK, err = soloRecoverSettledRunningDeployment(recoveryState, environmentID, currentRelease.ID, recoveryChecked, recoveryRevisions)
+			recovered, recoveredOK, err = soloRecoverSettledRunningDeployment(recoveryState, environmentID, currentRelease.ID, nodes, recoveryChecked, recoveryRevisions)
 			return err
 		}); err != nil {
-			return err
-		}
-		if recoveredOK {
+			appendPayloadWarning("remote status is settled, but local deployment recovery could not be persisted: " + err.Error())
+		} else if recoveredOK {
 			payload["recovered_deployment"] = map[string]any{
 				"id":             recovered.ID,
 				"release_id":     recovered.ReleaseID,
@@ -2115,16 +2118,16 @@ func soloLatestRunningDeployment(current solo.State, environmentID, releaseID st
 	return selected, found
 }
 
-func soloRecoverSettledRunningDeployment(current *solo.State, environmentID, releaseID string, checkedTargets map[string]bool, revisions map[string]string) (corerelease.Deployment, bool, error) {
+func soloRecoverSettledRunningDeployment(current *solo.State, environmentID, releaseID string, nodes map[string]config.Node, checkedTargets map[string]bool, revisions map[string]string) (corerelease.Deployment, bool, error) {
 	selected, found := soloLatestRunningDeployment(*current, environmentID, releaseID)
 	if !found {
 		return corerelease.Deployment{}, false, nil
 	}
-	for _, nodeName := range selected.TargetNodeIDs {
-		nodeName = strings.TrimSpace(nodeName)
-		if nodeName == "" {
-			continue
-		}
+	targets := soloDeploymentTargetSet(selected, nodes)
+	if len(targets) == 0 {
+		return corerelease.Deployment{}, false, nil
+	}
+	for nodeName := range targets {
 		if !checkedTargets[nodeName] {
 			return corerelease.Deployment{}, false, nil
 		}

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1996,10 +1996,10 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 		recoveryMatch := false
 		if hasRecoveryCandidate && recoveryTargets[name] && strings.TrimSpace(result.Status.Phase) == "settled" && runtime.State == "settled" {
 			recoveryChecked[name] = true
-			if revision := strings.TrimSpace(result.Status.Revision); revision != "" {
+			if revision := strings.TrimSpace(result.Status.Revision); revision != "" && len(cohostedRevisions[name]) == 0 {
 				recoveryRevisions[name] = revision
 			}
-			recoveryMatch = recoveryCandidate.PublicationResult == nil && strings.TrimSpace(result.Status.Revision) != ""
+			recoveryMatch = recoveryCandidate.PublicationResult == nil && strings.TrimSpace(result.Status.Revision) != "" && len(cohostedRevisions[name]) == 0
 		}
 		if expectedRevision != "" && !soloNodeStatusMatchesExpectedRelease(result.Status, expectedRevision, expectedRuntimeEnvironment, expectedWorkloadRevision, cohostedRevisions[name], staleRevisions[name]) && !recoveryMatch {
 			allSettled = false

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -2055,7 +2055,14 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 		payload["warnings"] = []string{soloPublicURLWarning(cfg, environmentName)}
 	}
 	if allSettled && hasCurrent && len(opts.Nodes) == 0 {
-		recovered, recoveredState, ok := soloRecoverSettledRunningDeployment(current, environmentID, currentRelease.ID, recoveryChecked, recoveryRevisions)
+		recoveryState, err := a.readSoloState()
+		if err != nil {
+			return err
+		}
+		recovered, recoveredState, ok, err := soloRecoverSettledRunningDeployment(recoveryState, environmentID, currentRelease.ID, recoveryChecked, recoveryRevisions)
+		if err != nil {
+			return err
+		}
 		if ok {
 			if err := a.writeSoloState(recoveredState); err != nil {
 				return err
@@ -2104,10 +2111,10 @@ func soloLatestRunningDeployment(current solo.State, environmentID, releaseID st
 	return selected, found
 }
 
-func soloRecoverSettledRunningDeployment(current solo.State, environmentID, releaseID string, checkedTargets map[string]bool, revisions map[string]string) (corerelease.Deployment, solo.State, bool) {
+func soloRecoverSettledRunningDeployment(current solo.State, environmentID, releaseID string, checkedTargets map[string]bool, revisions map[string]string) (corerelease.Deployment, solo.State, bool, error) {
 	selected, found := soloLatestRunningDeployment(current, environmentID, releaseID)
 	if !found {
-		return corerelease.Deployment{}, current, false
+		return corerelease.Deployment{}, current, false, nil
 	}
 	for _, nodeName := range selected.TargetNodeIDs {
 		nodeName = strings.TrimSpace(nodeName)
@@ -2115,7 +2122,7 @@ func soloRecoverSettledRunningDeployment(current solo.State, environmentID, rele
 			continue
 		}
 		if !checkedTargets[nodeName] {
-			return corerelease.Deployment{}, current, false
+			return corerelease.Deployment{}, current, false, nil
 		}
 	}
 	selected.Status = corerelease.DeploymentStatusSettled
@@ -2125,9 +2132,9 @@ func soloRecoverSettledRunningDeployment(current solo.State, environmentID, rele
 		selected.PublicationResult = soloDeploymentPublicationResult(revisions, nil)
 	}
 	if err := current.SaveDeployment(selected); err != nil {
-		return corerelease.Deployment{}, current, false
+		return corerelease.Deployment{}, current, false, err
 	}
-	return selected, current, true
+	return selected, current, true, nil
 }
 
 func soloDeploymentTargetSet(deployment corerelease.Deployment, nodes map[string]config.Node) map[string]bool {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -2000,7 +2000,7 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 		}
 		expectedRevision := soloExpectedStatusRevision(expectedRevisions, name)
 		runtime := soloRuntimeEnvironmentStatus(result.Status, expectedRuntimeEnvironment, expectedWorkloadRevision)
-		statusMatches := soloNodeStatusMatchesExpectedRelease(result.Status, expectedRevision, expectedRuntimeEnvironment, expectedWorkloadRevision, cohostedRevisions[name], staleRevisions[name])
+		statusMatches := soloNodeStatusMatchesExpectedRelease(result.Status, expectedRevision, runtime, cohostedRevisions[name], staleRevisions[name])
 		if hasRecoveryCandidate && recoveryTargets[name] && statusMatches && strings.TrimSpace(result.Status.Phase) == "settled" && soloRecoveryRuntimeSettled(runtime) {
 			recoveryChecked[name] = true
 			if revision := strings.TrimSpace(result.Status.Revision); revision != "" && len(cohostedRevisions[name]) == 0 {
@@ -2323,8 +2323,7 @@ func soloCohostedStatusRevisions(current solo.State, release corerelease.Release
 	return cohosted
 }
 
-func soloNodeStatusMatchesExpectedRelease(status soloNodeStatus, expectedDesiredStateRevision, expectedRuntimeEnvironment, expectedWorkloadRevision string, cohostedDesiredStateRevisions, staleDesiredStateRevisions map[string]bool) bool {
-	runtime := soloRuntimeEnvironmentStatus(status, expectedRuntimeEnvironment, expectedWorkloadRevision)
+func soloNodeStatusMatchesExpectedRelease(status soloNodeStatus, expectedDesiredStateRevision string, runtime soloRuntimeStatusResult, cohostedDesiredStateRevisions, staleDesiredStateRevisions map[string]bool) bool {
 	if runtime.State != "" {
 		if runtime.State != "settled" {
 			return false

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -2001,7 +2001,7 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 		expectedRevision := soloExpectedStatusRevision(expectedRevisions, name)
 		runtime := soloRuntimeEnvironmentStatus(result.Status, expectedRuntimeEnvironment, expectedWorkloadRevision)
 		statusMatches := soloNodeStatusMatchesExpectedRelease(result.Status, expectedRevision, expectedRuntimeEnvironment, expectedWorkloadRevision, cohostedRevisions[name], staleRevisions[name])
-		if hasRecoveryCandidate && recoveryTargets[name] && statusMatches && strings.TrimSpace(result.Status.Phase) == "settled" && runtime.State == "settled" {
+		if hasRecoveryCandidate && recoveryTargets[name] && statusMatches && strings.TrimSpace(result.Status.Phase) == "settled" && soloRecoveryRuntimeSettled(runtime) {
 			recoveryChecked[name] = true
 			if revision := strings.TrimSpace(result.Status.Revision); revision != "" && len(cohostedRevisions[name]) == 0 {
 				recoveryRevisions[name] = revision
@@ -2144,11 +2144,15 @@ func soloRecoverSettledRunningDeployment(current *solo.State, environmentID, rel
 	return selected, true, nil
 }
 
+func soloRecoveryRuntimeSettled(runtime soloRuntimeStatusResult) bool {
+	return runtime.State == "" || runtime.State == "settled"
+}
+
 func soloDeploymentTargetSet(deployment corerelease.Deployment, nodes map[string]config.Node) map[string]bool {
 	targets := map[string]bool{}
 	for _, nodeName := range deployment.TargetNodeIDs {
 		nodeName = strings.TrimSpace(nodeName)
-		if nodeName != "" {
+		if _, ok := nodes[nodeName]; nodeName != "" && ok {
 			targets[nodeName] = true
 		}
 	}

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -2064,7 +2064,7 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 		payload["public_url_status"] = soloPublicURLStatus(cfg)
 		appendPayloadWarning(soloPublicURLWarning(cfg, environmentName))
 	}
-	if allSettled && hasCurrent && hasRecoveryCandidate && len(opts.Nodes) == 0 {
+	if allSettled && hasCurrent && hasRecoveryCandidate && len(opts.Nodes) == 0 && soloRecoveryTargetsChecked(recoveryTargets, recoveryChecked) {
 		var recovered corerelease.Deployment
 		recoveredOK := false
 		if err := a.updateSoloState(func(recoveryState *solo.State) error {
@@ -2169,6 +2169,18 @@ func soloRecoverSettledRunningDeployment(current *solo.State, environmentID, rel
 
 func soloRecoveryRuntimeSettled(runtime soloRuntimeStatusResult) bool {
 	return runtime.State == "" || runtime.State == "settled"
+}
+
+func soloRecoveryTargetsChecked(targets, checked map[string]bool) bool {
+	if len(targets) == 0 {
+		return false
+	}
+	for nodeName := range targets {
+		if !checked[nodeName] {
+			return false
+		}
+	}
+	return true
 }
 
 func soloDeploymentTargetSet(deployment corerelease.Deployment, nodes map[string]config.Node) map[string]bool {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1993,15 +1993,14 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 		}
 		expectedRevision := soloExpectedStatusRevision(expectedRevisions, name)
 		runtime := soloRuntimeEnvironmentStatus(result.Status, expectedRuntimeEnvironment, expectedWorkloadRevision)
-		recoveryMatch := false
-		if hasRecoveryCandidate && recoveryTargets[name] && strings.TrimSpace(result.Status.Phase) == "settled" && runtime.State == "settled" {
+		statusMatches := soloNodeStatusMatchesExpectedRelease(result.Status, expectedRevision, expectedRuntimeEnvironment, expectedWorkloadRevision, cohostedRevisions[name], staleRevisions[name])
+		if hasRecoveryCandidate && recoveryTargets[name] && statusMatches && strings.TrimSpace(result.Status.Phase) == "settled" && runtime.State == "settled" {
 			recoveryChecked[name] = true
 			if revision := strings.TrimSpace(result.Status.Revision); revision != "" && len(cohostedRevisions[name]) == 0 {
 				recoveryRevisions[name] = revision
 			}
-			recoveryMatch = recoveryCandidate.PublicationResult == nil && strings.TrimSpace(result.Status.Revision) != "" && len(cohostedRevisions[name]) == 0
 		}
-		if expectedRevision != "" && !soloNodeStatusMatchesExpectedRelease(result.Status, expectedRevision, expectedRuntimeEnvironment, expectedWorkloadRevision, cohostedRevisions[name], staleRevisions[name]) && !recoveryMatch {
+		if expectedRevision != "" && !statusMatches {
 			allSettled = false
 			message := soloStatusMismatchMessage(result.Status, expectedRevision, runtime, expectedRuntimeEnvironment, expectedWorkloadRevision, environmentName)
 			if runtime.State == "error" {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1912,6 +1912,11 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 	var environmentID string
 	var currentRelease corerelease.Release
 	var hasCurrent bool
+	var recoveryCandidate corerelease.Deployment
+	hasRecoveryCandidate := false
+	recoveryTargets := map[string]bool{}
+	recoveryChecked := map[string]bool{}
+	recoveryRevisions := map[string]string{}
 	if workspaceRoot != "" && environmentName != "" {
 		var stateErr error
 		current, stateErr = a.readSoloState()
@@ -1928,6 +1933,10 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 				staleRevisions = soloStaleStatusRevisions(current, currentRelease, expectedRevisions)
 				expectedWorkloadRevision = strings.TrimSpace(currentRelease.Revision)
 				expectedRuntimeEnvironment, _ = soloRuntimeEnvironmentNameForNode(current, workspaceRoot, environmentName, "")
+				recoveryCandidate, hasRecoveryCandidate = soloLatestRunningDeployment(current, environmentID, currentRelease.ID)
+				if hasRecoveryCandidate {
+					recoveryTargets = soloDeploymentTargetSet(recoveryCandidate, nodes)
+				}
 			}
 		}
 	} else if len(opts.Nodes) > 0 {
@@ -1983,9 +1992,17 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 			continue
 		}
 		expectedRevision := soloExpectedStatusRevision(expectedRevisions, name)
-		if expectedRevision != "" && !soloNodeStatusMatchesExpectedRelease(result.Status, expectedRevision, expectedRuntimeEnvironment, expectedWorkloadRevision, cohostedRevisions[name], staleRevisions[name]) {
+		runtime := soloRuntimeEnvironmentStatus(result.Status, expectedRuntimeEnvironment, expectedWorkloadRevision)
+		recoveryMatch := false
+		if hasRecoveryCandidate && recoveryTargets[name] && strings.TrimSpace(result.Status.Phase) == "settled" && runtime.State == "settled" {
+			recoveryChecked[name] = true
+			if revision := strings.TrimSpace(result.Status.Revision); revision != "" {
+				recoveryRevisions[name] = revision
+			}
+			recoveryMatch = recoveryCandidate.PublicationResult == nil && strings.TrimSpace(result.Status.Revision) != ""
+		}
+		if expectedRevision != "" && !soloNodeStatusMatchesExpectedRelease(result.Status, expectedRevision, expectedRuntimeEnvironment, expectedWorkloadRevision, cohostedRevisions[name], staleRevisions[name]) && !recoveryMatch {
 			allSettled = false
-			runtime := soloRuntimeEnvironmentStatus(result.Status, expectedRuntimeEnvironment, expectedWorkloadRevision)
 			message := soloStatusMismatchMessage(result.Status, expectedRevision, runtime, expectedRuntimeEnvironment, expectedWorkloadRevision, environmentName)
 			if runtime.State == "error" {
 				statusErrors++
@@ -2038,7 +2055,7 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 		payload["warnings"] = []string{soloPublicURLWarning(cfg, environmentName)}
 	}
 	if allSettled && hasCurrent && len(opts.Nodes) == 0 {
-		recovered, recoveredState, ok := soloRecoverSettledRunningDeployment(current, environmentID, currentRelease.ID)
+		recovered, recoveredState, ok := soloRecoverSettledRunningDeployment(current, environmentID, currentRelease.ID, recoveryChecked, recoveryRevisions)
 		if ok {
 			if err := a.writeSoloState(recoveredState); err != nil {
 				return err
@@ -2069,9 +2086,9 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 	return nil
 }
 
-func soloRecoverSettledRunningDeployment(current solo.State, environmentID, releaseID string) (corerelease.Deployment, solo.State, bool) {
+func soloLatestRunningDeployment(current solo.State, environmentID, releaseID string) (corerelease.Deployment, bool) {
 	if strings.TrimSpace(environmentID) == "" || strings.TrimSpace(releaseID) == "" {
-		return corerelease.Deployment{}, current, false
+		return corerelease.Deployment{}, false
 	}
 	var selected corerelease.Deployment
 	found := false
@@ -2084,16 +2101,50 @@ func soloRecoverSettledRunningDeployment(current solo.State, environmentID, rele
 			found = true
 		}
 	}
+	return selected, found
+}
+
+func soloRecoverSettledRunningDeployment(current solo.State, environmentID, releaseID string, checkedTargets map[string]bool, revisions map[string]string) (corerelease.Deployment, solo.State, bool) {
+	selected, found := soloLatestRunningDeployment(current, environmentID, releaseID)
 	if !found {
 		return corerelease.Deployment{}, current, false
+	}
+	for _, nodeName := range selected.TargetNodeIDs {
+		nodeName = strings.TrimSpace(nodeName)
+		if nodeName == "" {
+			continue
+		}
+		if !checkedTargets[nodeName] {
+			return corerelease.Deployment{}, current, false
+		}
 	}
 	selected.Status = corerelease.DeploymentStatusSettled
 	selected.StatusMessage = "release settled by status recovery"
 	selected.FinishedAt = time.Now().UTC().Format(time.RFC3339)
+	if selected.PublicationResult == nil && len(revisions) > 0 {
+		selected.PublicationResult = soloDeploymentPublicationResult(revisions, nil)
+	}
 	if err := current.SaveDeployment(selected); err != nil {
 		return corerelease.Deployment{}, current, false
 	}
 	return selected, current, true
+}
+
+func soloDeploymentTargetSet(deployment corerelease.Deployment, nodes map[string]config.Node) map[string]bool {
+	targets := map[string]bool{}
+	for _, nodeName := range deployment.TargetNodeIDs {
+		nodeName = strings.TrimSpace(nodeName)
+		if nodeName != "" {
+			targets[nodeName] = true
+		}
+	}
+	if len(targets) > 0 {
+		return targets
+	}
+	for nodeName := range nodes {
+		targets[nodeName] = true
+	}
+	return targets
 }
 
 func soloStatusMismatchMessage(status soloNodeStatus, expectedDesiredStateRevision string, runtime soloRuntimeStatusResult, expectedRuntimeEnvironment, expectedWorkloadRevision, logicalEnvironment string) string {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -2110,12 +2110,35 @@ func soloLatestRunningDeployment(current solo.State, environmentID, releaseID st
 		if deployment.EnvironmentID != environmentID || deployment.ReleaseID != releaseID || deployment.Status != corerelease.DeploymentStatusRunning {
 			continue
 		}
-		if !found || deployment.Sequence > selected.Sequence || (deployment.Sequence == selected.Sequence && deployment.CreatedAt > selected.CreatedAt) {
+		if !found || soloDeploymentSortsAfter(deployment, selected) {
 			selected = deployment
 			found = true
 		}
 	}
 	return selected, found
+}
+
+func soloDeploymentSortsAfter(candidate, selected corerelease.Deployment) bool {
+	if candidate.Sequence != selected.Sequence {
+		return candidate.Sequence > selected.Sequence
+	}
+	candidateCreatedAt, candidateOK := parseSoloDeploymentCreatedAt(candidate.CreatedAt)
+	selectedCreatedAt, selectedOK := parseSoloDeploymentCreatedAt(selected.CreatedAt)
+	if candidateOK && selectedOK && !candidateCreatedAt.Equal(selectedCreatedAt) {
+		return candidateCreatedAt.After(selectedCreatedAt)
+	}
+	if candidateOK != selectedOK {
+		return candidateOK
+	}
+	return candidate.ID > selected.ID
+}
+
+func parseSoloDeploymentCreatedAt(value string) (time.Time, bool) {
+	createdAt, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(value))
+	if err != nil {
+		return time.Time{}, false
+	}
+	return createdAt, true
 }
 
 func soloRecoverSettledRunningDeployment(current *solo.State, environmentID, releaseID string, nodes map[string]config.Node, checkedTargets map[string]bool, revisions map[string]string) (corerelease.Deployment, bool, error) {
@@ -2150,13 +2173,18 @@ func soloRecoveryRuntimeSettled(runtime soloRuntimeStatusResult) bool {
 
 func soloDeploymentTargetSet(deployment corerelease.Deployment, nodes map[string]config.Node) map[string]bool {
 	targets := map[string]bool{}
+	hasExplicitTargets := false
 	for _, nodeName := range deployment.TargetNodeIDs {
 		nodeName = strings.TrimSpace(nodeName)
+		if nodeName == "" {
+			continue
+		}
+		hasExplicitTargets = true
 		if _, ok := nodes[nodeName]; nodeName != "" && ok {
 			targets[nodeName] = true
 		}
 	}
-	if len(targets) > 0 {
+	if hasExplicitTargets {
 		return targets
 	}
 	for nodeName := range nodes {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1058,6 +1058,13 @@ func (a *App) writeSoloState(current solo.State) error {
 	return a.SoloState.Write(current)
 }
 
+func (a *App) updateSoloState(fn func(*solo.State) error) error {
+	if a.SoloState == nil {
+		return fmt.Errorf("solo state store is required")
+	}
+	return a.SoloState.Update(fn)
+}
+
 func (a *App) resolveNodes(current solo.State, names []string) (map[string]config.Node, error) {
 	if len(names) == 0 {
 		result := make(map[string]config.Node, len(current.Nodes))
@@ -2054,18 +2061,16 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 		payload["warnings"] = []string{soloPublicURLWarning(cfg, environmentName)}
 	}
 	if allSettled && hasCurrent && len(opts.Nodes) == 0 {
-		recoveryState, err := a.readSoloState()
-		if err != nil {
+		var recovered corerelease.Deployment
+		recoveredOK := false
+		if err := a.updateSoloState(func(recoveryState *solo.State) error {
+			var err error
+			recovered, recoveredOK, err = soloRecoverSettledRunningDeployment(recoveryState, environmentID, currentRelease.ID, recoveryChecked, recoveryRevisions)
+			return err
+		}); err != nil {
 			return err
 		}
-		recovered, recoveredState, ok, err := soloRecoverSettledRunningDeployment(recoveryState, environmentID, currentRelease.ID, recoveryChecked, recoveryRevisions)
-		if err != nil {
-			return err
-		}
-		if ok {
-			if err := a.writeSoloState(recoveredState); err != nil {
-				return err
-			}
+		if recoveredOK {
 			payload["recovered_deployment"] = map[string]any{
 				"id":             recovered.ID,
 				"release_id":     recovered.ReleaseID,
@@ -2110,10 +2115,10 @@ func soloLatestRunningDeployment(current solo.State, environmentID, releaseID st
 	return selected, found
 }
 
-func soloRecoverSettledRunningDeployment(current solo.State, environmentID, releaseID string, checkedTargets map[string]bool, revisions map[string]string) (corerelease.Deployment, solo.State, bool, error) {
-	selected, found := soloLatestRunningDeployment(current, environmentID, releaseID)
+func soloRecoverSettledRunningDeployment(current *solo.State, environmentID, releaseID string, checkedTargets map[string]bool, revisions map[string]string) (corerelease.Deployment, bool, error) {
+	selected, found := soloLatestRunningDeployment(*current, environmentID, releaseID)
 	if !found {
-		return corerelease.Deployment{}, current, false, nil
+		return corerelease.Deployment{}, false, nil
 	}
 	for _, nodeName := range selected.TargetNodeIDs {
 		nodeName = strings.TrimSpace(nodeName)
@@ -2121,7 +2126,7 @@ func soloRecoverSettledRunningDeployment(current solo.State, environmentID, rele
 			continue
 		}
 		if !checkedTargets[nodeName] {
-			return corerelease.Deployment{}, current, false, nil
+			return corerelease.Deployment{}, false, nil
 		}
 	}
 	selected.Status = corerelease.DeploymentStatusSettled
@@ -2131,9 +2136,9 @@ func soloRecoverSettledRunningDeployment(current solo.State, environmentID, rele
 		selected.PublicationResult = soloDeploymentPublicationResult(revisions, nil)
 	}
 	if err := current.SaveDeployment(selected); err != nil {
-		return corerelease.Deployment{}, current, false, err
+		return corerelease.Deployment{}, false, err
 	}
-	return selected, current, true, nil
+	return selected, true, nil
 }
 
 func soloDeploymentTargetSet(deployment corerelease.Deployment, nodes map[string]config.Node) map[string]bool {

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -6223,6 +6223,41 @@ func TestSoloRecoverSettledRunningDeploymentIgnoresDetachedTargets(t *testing.T)
 	}
 }
 
+func TestSoloRecoverSettledRunningDeploymentSkipsEmptyAttachedTargetIntersection(t *testing.T) {
+	current := solo.State{}
+	deployment := corerelease.Deployment{
+		ID:            "dep_interrupted",
+		EnvironmentID: "env",
+		ReleaseID:     "rel",
+		Kind:          corerelease.DeploymentKindDeploy,
+		Sequence:      7,
+		TargetNodeIDs: []string{"node-old"},
+		Status:        corerelease.DeploymentStatusRunning,
+		CreatedAt:     time.Now().UTC().Format(time.RFC3339),
+	}
+	if err := current.SaveDeployment(deployment); err != nil {
+		t.Fatal(err)
+	}
+
+	recovered, ok, err := soloRecoverSettledRunningDeployment(
+		&current,
+		"env",
+		"rel",
+		map[string]config.Node{"node-a": {Host: "203.0.113.10"}},
+		map[string]bool{"node-a": true},
+		nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
+		t.Fatalf("recovered = %#v, want no recovery when explicit targets are detached", recovered)
+	}
+	if current.Deployments["dep_interrupted"].Status != corerelease.DeploymentStatusRunning {
+		t.Fatalf("deployment = %#v, want running status preserved", current.Deployments["dep_interrupted"])
+	}
+}
+
 func TestSoloRecoverSettledRunningDeploymentRequiresFallbackTargets(t *testing.T) {
 	current := solo.State{}
 	deployment := corerelease.Deployment{
@@ -6257,6 +6292,42 @@ func TestSoloRecoverSettledRunningDeploymentRequiresFallbackTargets(t *testing.T
 	}
 	if current.Deployments["dep_interrupted"].Status != corerelease.DeploymentStatusRunning {
 		t.Fatalf("deployment = %#v, want running status preserved", current.Deployments["dep_interrupted"])
+	}
+}
+
+func TestSoloLatestRunningDeploymentComparesCreatedAtAsTime(t *testing.T) {
+	current := solo.State{}
+	for _, deployment := range []corerelease.Deployment{
+		{
+			ID:            "dep_late_offset",
+			EnvironmentID: "env",
+			ReleaseID:     "rel",
+			Kind:          corerelease.DeploymentKindDeploy,
+			Sequence:      7,
+			Status:        corerelease.DeploymentStatusRunning,
+			CreatedAt:     "2026-05-06T00:30:00-01:00",
+		},
+		{
+			ID:            "dep_early_utc",
+			EnvironmentID: "env",
+			ReleaseID:     "rel",
+			Kind:          corerelease.DeploymentKindDeploy,
+			Sequence:      7,
+			Status:        corerelease.DeploymentStatusRunning,
+			CreatedAt:     "2026-05-06T01:00:00Z",
+		},
+	} {
+		if err := current.SaveDeployment(deployment); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	selected, ok := soloLatestRunningDeployment(current, "env", "rel")
+	if !ok {
+		t.Fatal("soloLatestRunningDeployment() ok = false, want true")
+	}
+	if selected.ID != "dep_late_offset" {
+		t.Fatalf("selected.ID = %q, want dep_late_offset", selected.ID)
 	}
 }
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -5950,6 +5950,53 @@ func TestSoloStatusFailsWhenCurrentDeploymentStatusIsMissing(t *testing.T) {
 	}
 }
 
+func TestSoloStatusDoesNotWriteStateWithoutRecoveryCandidate(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	stateDir := t.TempDir()
+	soloState := solo.NewStateStore(filepath.Join(stateDir, "solo-state.json"))
+	current := solo.State{
+		Nodes:       map[string]config.Node{"node-a": {Host: "203.0.113.10", User: "root", Port: 22, AgentStateDir: "/var/lib/devopsellence", Labels: []string{config.DefaultWebRole}}},
+		Attachments: map[string]solo.AttachmentRecord{},
+	}
+	if _, _, err := current.AttachNode(workspaceRoot, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	seedSoloCurrentRelease(t, &current, workspaceRoot, "production", "shortsha")
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chmod(stateDir, 0o700)
+		_ = os.Chmod(soloState.Path, 0o600)
+	})
+	if err := os.Chmod(soloState.Path, 0o400); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(stateDir, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	runtimeEnvironment, err := soloRuntimeEnvironmentNameForNode(current, workspaceRoot, "production", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	statusJSON := fmt.Sprintf(`{"revision":"shortsha","phase":"settled","environments":[{"name":%q,"revision":"shortsha","phase":"settled","services":[{"name":"web","phase":"settled","state":"running"}]}]}`, runtimeEnvironment)
+	installFakeSoloCommands(t, []fakeSSHResponse{{stdout: statusJSON + "\n"}})
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState, ConfigStore: config.NewStore(), Cwd: workspaceRoot}
+	if err := app.SoloStatus(context.Background(), SoloStatusOptions{}); err != nil {
+		t.Fatalf("SoloStatus() error = %v", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	if warnings, ok := payload["warnings"]; ok {
+		t.Fatalf("warnings = %#v, want no state-write recovery warning", warnings)
+	}
+}
+
 func TestSoloStatusRecoversInterruptedRunningDeployment(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")
@@ -6085,6 +6132,43 @@ func TestSoloStatusDoesNotRecoverUncheckedInterruptedDeploymentTarget(t *testing
 	}
 	if updated.Deployments["dep_interrupted"].Status != corerelease.DeploymentStatusRunning {
 		t.Fatalf("deployment = %#v, want running deployment preserved", updated.Deployments["dep_interrupted"])
+	}
+}
+
+func TestSoloRecoverSettledRunningDeploymentRequiresFallbackTargets(t *testing.T) {
+	current := solo.State{}
+	deployment := corerelease.Deployment{
+		ID:            "dep_interrupted",
+		EnvironmentID: "env",
+		ReleaseID:     "rel",
+		Kind:          corerelease.DeploymentKindDeploy,
+		Sequence:      7,
+		Status:        corerelease.DeploymentStatusRunning,
+		CreatedAt:     time.Now().UTC().Format(time.RFC3339),
+	}
+	if err := current.SaveDeployment(deployment); err != nil {
+		t.Fatal(err)
+	}
+
+	recovered, ok, err := soloRecoverSettledRunningDeployment(
+		&current,
+		"env",
+		"rel",
+		map[string]config.Node{
+			"node-a": {Host: "203.0.113.10"},
+			"node-b": {Host: "203.0.113.11"},
+		},
+		map[string]bool{"node-a": true},
+		nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
+		t.Fatalf("recovered = %#v, want no recovery until every fallback target is checked", recovered)
+	}
+	if current.Deployments["dep_interrupted"].Status != corerelease.DeploymentStatusRunning {
+		t.Fatalf("deployment = %#v, want running status preserved", current.Deployments["dep_interrupted"])
 	}
 }
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -5788,7 +5788,7 @@ func TestSoloStatusRecoversInterruptedRunningDeployment(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	statusJSON := fmt.Sprintf(`{"revision":"desired-state-hash","phase":"settled","environments":[{"name":%q,"revision":"shortsha","phase":"settled","services":[{"name":"web","phase":"settled","state":"running"}]}]}`, runtimeEnvironment)
+	statusJSON := fmt.Sprintf(`{"revision":"shortsha","phase":"settled","environments":[{"name":%q,"revision":"shortsha","phase":"settled","services":[{"name":"web","phase":"settled","state":"running"}]}]}`, runtimeEnvironment)
 	installFakeSoloCommands(t, []fakeSSHResponse{{stdout: statusJSON + "\n"}})
 
 	var stdout bytes.Buffer
@@ -5809,7 +5809,7 @@ func TestSoloStatusRecoversInterruptedRunningDeployment(t *testing.T) {
 	if recoveredDeployment.Status != corerelease.DeploymentStatusSettled || recoveredDeployment.FinishedAt == "" {
 		t.Fatalf("deployment = %#v, want persisted recovery", recoveredDeployment)
 	}
-	if recoveredDeployment.PublicationResult == nil || len(recoveredDeployment.PublicationResult.NodeResults) != 1 || recoveredDeployment.PublicationResult.NodeResults[0].Revision != "desired-state-hash" {
+	if recoveredDeployment.PublicationResult == nil || len(recoveredDeployment.PublicationResult.NodeResults) != 1 || recoveredDeployment.PublicationResult.NodeResults[0].Revision != "shortsha" {
 		t.Fatalf("publication_result = %#v, want recovered desired-state revision", recoveredDeployment.PublicationResult)
 	}
 }
@@ -5859,7 +5859,7 @@ func TestSoloStatusDoesNotRecoverUncheckedInterruptedDeploymentTarget(t *testing
 	if err != nil {
 		t.Fatal(err)
 	}
-	statusJSON := fmt.Sprintf(`{"revision":"desired-state-hash","phase":"settled","environments":[{"name":%q,"revision":"shortsha","phase":"settled","services":[{"name":"web","phase":"settled","state":"running"}]}]}`, runtimeEnvironment)
+	statusJSON := fmt.Sprintf(`{"revision":"shortsha","phase":"settled","environments":[{"name":%q,"revision":"shortsha","phase":"settled","services":[{"name":"web","phase":"settled","state":"running"}]}]}`, runtimeEnvironment)
 	installFakeSoloCommands(t, []fakeSSHResponse{{stdout: statusJSON + "\n"}})
 
 	var stdout bytes.Buffer
@@ -5870,6 +5870,69 @@ func TestSoloStatusDoesNotRecoverUncheckedInterruptedDeploymentTarget(t *testing
 	payload := decodeJSONOutput(t, &stdout)
 	if payload["recovered_deployment"] != nil {
 		t.Fatalf("payload = %#v, want no recovery for unchecked target", payload)
+	}
+	updated, err := soloState.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Deployments["dep_interrupted"].Status != corerelease.DeploymentStatusRunning {
+		t.Fatalf("deployment = %#v, want running deployment preserved", updated.Deployments["dep_interrupted"])
+	}
+}
+
+func TestSoloStatusDoesNotRecoverConfigOnlyStaleDesiredState(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes:       map[string]config.Node{"node-a": {Host: "203.0.113.10", User: "root", Port: 22, AgentStateDir: "/var/lib/devopsellence", Labels: []string{config.DefaultWebRole}}},
+		Attachments: map[string]solo.AttachmentRecord{},
+	}
+	if _, _, err := current.AttachNode(workspaceRoot, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	seedSoloCurrentRelease(t, &current, workspaceRoot, "production", "shortsha")
+	environmentID, release, ok, err := current.CurrentRelease(workspaceRoot, "production")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("current release missing")
+	}
+	deployment, err := corerelease.NewDeployment(corerelease.DeploymentCreateInput{
+		ID:            "dep_interrupted",
+		EnvironmentID: environmentID,
+		ReleaseID:     release.ID,
+		Kind:          corerelease.DeploymentKindDeploy,
+		Sequence:      7,
+		TargetNodeIDs: []string{"node-a"},
+		CreatedAt:     time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	deployment.Status = corerelease.DeploymentStatusRunning
+	if err := current.SaveDeployment(deployment); err != nil {
+		t.Fatal(err)
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+	runtimeEnvironment, err := soloRuntimeEnvironmentNameForNode(current, workspaceRoot, "production", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	statusJSON := fmt.Sprintf(`{"revision":"old-desired-state","phase":"settled","environments":[{"name":%q,"revision":"shortsha","phase":"settled","services":[{"name":"web","phase":"settled","state":"running"}]}]}`, runtimeEnvironment)
+	installFakeSoloCommands(t, []fakeSSHResponse{{stdout: statusJSON + "\n"}})
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState, ConfigStore: config.NewStore(), Cwd: workspaceRoot}
+	err = app.SoloStatus(context.Background(), SoloStatusOptions{})
+	if err == nil {
+		t.Fatal("SoloStatus() error = nil, want stale desired-state mismatch")
 	}
 	updated, err := soloState.Read()
 	if err != nil {

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -5703,7 +5703,7 @@ func TestSoloStatusRecoversInterruptedRunningDeployment(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	statusJSON := fmt.Sprintf(`{"revision":"shortsha","phase":"settled","environments":[{"name":%q,"revision":"shortsha","phase":"settled","services":[{"name":"web","phase":"settled","state":"running"}]}]}`, runtimeEnvironment)
+	statusJSON := fmt.Sprintf(`{"revision":"desired-state-hash","phase":"settled","environments":[{"name":%q,"revision":"shortsha","phase":"settled","services":[{"name":"web","phase":"settled","state":"running"}]}]}`, runtimeEnvironment)
 	installFakeSoloCommands(t, []fakeSSHResponse{{stdout: statusJSON + "\n"}})
 
 	var stdout bytes.Buffer
@@ -5720,8 +5720,78 @@ func TestSoloStatusRecoversInterruptedRunningDeployment(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if updated.Deployments["dep_interrupted"].Status != corerelease.DeploymentStatusSettled || updated.Deployments["dep_interrupted"].FinishedAt == "" {
-		t.Fatalf("deployment = %#v, want persisted recovery", updated.Deployments["dep_interrupted"])
+	recoveredDeployment := updated.Deployments["dep_interrupted"]
+	if recoveredDeployment.Status != corerelease.DeploymentStatusSettled || recoveredDeployment.FinishedAt == "" {
+		t.Fatalf("deployment = %#v, want persisted recovery", recoveredDeployment)
+	}
+	if recoveredDeployment.PublicationResult == nil || len(recoveredDeployment.PublicationResult.NodeResults) != 1 || recoveredDeployment.PublicationResult.NodeResults[0].Revision != "desired-state-hash" {
+		t.Fatalf("publication_result = %#v, want recovered desired-state revision", recoveredDeployment.PublicationResult)
+	}
+}
+
+func TestSoloStatusDoesNotRecoverUncheckedInterruptedDeploymentTarget(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes:       map[string]config.Node{"node-a": {Host: "203.0.113.10", User: "root", Port: 22, AgentStateDir: "/var/lib/devopsellence", Labels: []string{config.DefaultWebRole}}},
+		Attachments: map[string]solo.AttachmentRecord{},
+	}
+	if _, _, err := current.AttachNode(workspaceRoot, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	seedSoloCurrentRelease(t, &current, workspaceRoot, "production", "shortsha")
+	environmentID, release, ok, err := current.CurrentRelease(workspaceRoot, "production")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("current release missing")
+	}
+	deployment, err := corerelease.NewDeployment(corerelease.DeploymentCreateInput{
+		ID:            "dep_interrupted",
+		EnvironmentID: environmentID,
+		ReleaseID:     release.ID,
+		Kind:          corerelease.DeploymentKindDeploy,
+		Sequence:      7,
+		TargetNodeIDs: []string{"node-a", "node-b"},
+		CreatedAt:     time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	deployment.Status = corerelease.DeploymentStatusRunning
+	if err := current.SaveDeployment(deployment); err != nil {
+		t.Fatal(err)
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+	runtimeEnvironment, err := soloRuntimeEnvironmentNameForNode(current, workspaceRoot, "production", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	statusJSON := fmt.Sprintf(`{"revision":"desired-state-hash","phase":"settled","environments":[{"name":%q,"revision":"shortsha","phase":"settled","services":[{"name":"web","phase":"settled","state":"running"}]}]}`, runtimeEnvironment)
+	installFakeSoloCommands(t, []fakeSSHResponse{{stdout: statusJSON + "\n"}})
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState, ConfigStore: config.NewStore(), Cwd: workspaceRoot}
+	if err := app.SoloStatus(context.Background(), SoloStatusOptions{}); err != nil {
+		t.Fatalf("SoloStatus() error = %v", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	if payload["recovered_deployment"] != nil {
+		t.Fatalf("payload = %#v, want no recovery for unchecked target", payload)
+	}
+	updated, err := soloState.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Deployments["dep_interrupted"].Status != corerelease.DeploymentStatusRunning {
+		t.Fatalf("deployment = %#v, want running deployment preserved", updated.Deployments["dep_interrupted"])
 	}
 }
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -6069,7 +6069,62 @@ func TestSoloStatusRecoversInterruptedRunningDeployment(t *testing.T) {
 	}
 }
 
-func TestSoloStatusDoesNotRecoverUncheckedInterruptedDeploymentTarget(t *testing.T) {
+func TestSoloStatusRecoversInterruptedRunningDeploymentWithMinimalStatus(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes:       map[string]config.Node{"node-a": {Host: "203.0.113.10", User: "root", Port: 22, AgentStateDir: "/var/lib/devopsellence", Labels: []string{config.DefaultWebRole}}},
+		Attachments: map[string]solo.AttachmentRecord{},
+	}
+	if _, _, err := current.AttachNode(workspaceRoot, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	seedSoloCurrentRelease(t, &current, workspaceRoot, "production", "shortsha")
+	environmentID, release, ok, err := current.CurrentRelease(workspaceRoot, "production")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("current release missing")
+	}
+	deployment, err := corerelease.NewDeployment(corerelease.DeploymentCreateInput{
+		ID:            "dep_interrupted",
+		EnvironmentID: environmentID,
+		ReleaseID:     release.ID,
+		Kind:          corerelease.DeploymentKindDeploy,
+		Sequence:      7,
+		TargetNodeIDs: []string{"node-a"},
+		CreatedAt:     time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	deployment.Status = corerelease.DeploymentStatusRunning
+	if err := current.SaveDeployment(deployment); err != nil {
+		t.Fatal(err)
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+	installFakeSoloCommands(t, []fakeSSHResponse{{stdout: `{"revision":"shortsha","phase":"settled"}` + "\n"}})
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState, ConfigStore: config.NewStore(), Cwd: workspaceRoot}
+	if err := app.SoloStatus(context.Background(), SoloStatusOptions{}); err != nil {
+		t.Fatalf("SoloStatus() error = %v", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	recovered := jsonMapFromAny(t, payload["recovered_deployment"])
+	if recovered["id"] != "dep_interrupted" || recovered["status"] != corerelease.DeploymentStatusSettled {
+		t.Fatalf("recovered_deployment = %#v, want settled interrupted deployment", recovered)
+	}
+}
+
+func TestSoloStatusRecoversInterruptedDeploymentWhenStaleTargetDetached(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")
 	if _, err := config.Write(workspaceRoot, cfg); err != nil {
@@ -6123,15 +6178,48 @@ func TestSoloStatusDoesNotRecoverUncheckedInterruptedDeploymentTarget(t *testing
 		t.Fatalf("SoloStatus() error = %v", err)
 	}
 	payload := decodeJSONOutput(t, &stdout)
-	if payload["recovered_deployment"] != nil {
-		t.Fatalf("payload = %#v, want no recovery for unchecked target", payload)
+	recovered := jsonMapFromAny(t, payload["recovered_deployment"])
+	if recovered["id"] != "dep_interrupted" || recovered["status"] != corerelease.DeploymentStatusSettled {
+		t.Fatalf("recovered_deployment = %#v, want settled interrupted deployment", recovered)
 	}
 	updated, err := soloState.Read()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if updated.Deployments["dep_interrupted"].Status != corerelease.DeploymentStatusRunning {
-		t.Fatalf("deployment = %#v, want running deployment preserved", updated.Deployments["dep_interrupted"])
+	if updated.Deployments["dep_interrupted"].Status != corerelease.DeploymentStatusSettled {
+		t.Fatalf("deployment = %#v, want settled deployment", updated.Deployments["dep_interrupted"])
+	}
+}
+
+func TestSoloRecoverSettledRunningDeploymentIgnoresDetachedTargets(t *testing.T) {
+	current := solo.State{}
+	deployment := corerelease.Deployment{
+		ID:            "dep_interrupted",
+		EnvironmentID: "env",
+		ReleaseID:     "rel",
+		Kind:          corerelease.DeploymentKindDeploy,
+		Sequence:      7,
+		TargetNodeIDs: []string{"node-a", "node-old"},
+		Status:        corerelease.DeploymentStatusRunning,
+		CreatedAt:     time.Now().UTC().Format(time.RFC3339),
+	}
+	if err := current.SaveDeployment(deployment); err != nil {
+		t.Fatal(err)
+	}
+
+	recovered, ok, err := soloRecoverSettledRunningDeployment(
+		&current,
+		"env",
+		"rel",
+		map[string]config.Node{"node-a": {Host: "203.0.113.10"}},
+		map[string]bool{"node-a": true},
+		nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || recovered.Status != corerelease.DeploymentStatusSettled {
+		t.Fatalf("recovered = %#v ok=%v, want settled recovery from attached target", recovered, ok)
 	}
 }
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -5541,6 +5541,74 @@ func TestSoloStatusFailsWhenCurrentDeploymentStatusIsMissing(t *testing.T) {
 	}
 }
 
+func TestSoloStatusRecoversInterruptedRunningDeployment(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes:       map[string]config.Node{"node-a": {Host: "203.0.113.10", User: "root", Port: 22, AgentStateDir: "/var/lib/devopsellence", Labels: []string{config.DefaultWebRole}}},
+		Attachments: map[string]solo.AttachmentRecord{},
+	}
+	if _, _, err := current.AttachNode(workspaceRoot, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	seedSoloCurrentRelease(t, &current, workspaceRoot, "production", "shortsha")
+	environmentID, release, ok, err := current.CurrentRelease(workspaceRoot, "production")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("current release missing")
+	}
+	deployment, err := corerelease.NewDeployment(corerelease.DeploymentCreateInput{
+		ID:            "dep_interrupted",
+		EnvironmentID: environmentID,
+		ReleaseID:     release.ID,
+		Kind:          corerelease.DeploymentKindDeploy,
+		Sequence:      7,
+		TargetNodeIDs: []string{"node-a"},
+		CreatedAt:     time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	deployment.Status = corerelease.DeploymentStatusRunning
+	deployment.StatusMessage = "publishing desired state"
+	if err := current.SaveDeployment(deployment); err != nil {
+		t.Fatal(err)
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+	runtimeEnvironment, err := soloRuntimeEnvironmentNameForNode(current, workspaceRoot, "production", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	statusJSON := fmt.Sprintf(`{"revision":"shortsha","phase":"settled","environments":[{"name":%q,"revision":"shortsha","phase":"settled","services":[{"name":"web","phase":"settled","state":"running"}]}]}`, runtimeEnvironment)
+	installFakeSoloCommands(t, []fakeSSHResponse{{stdout: statusJSON + "\n"}})
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState, ConfigStore: config.NewStore(), Cwd: workspaceRoot}
+	if err := app.SoloStatus(context.Background(), SoloStatusOptions{}); err != nil {
+		t.Fatalf("SoloStatus() error = %v", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	recovered := jsonMapFromAny(t, payload["recovered_deployment"])
+	if recovered["id"] != "dep_interrupted" || recovered["status"] != corerelease.DeploymentStatusSettled {
+		t.Fatalf("recovered_deployment = %#v, want settled interrupted deployment", recovered)
+	}
+	updated, err := soloState.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Deployments["dep_interrupted"].Status != corerelease.DeploymentStatusSettled || updated.Deployments["dep_interrupted"].FinishedAt == "" {
+		t.Fatalf("deployment = %#v, want persisted recovery", updated.Deployments["dep_interrupted"])
+	}
+}
+
 func TestSoloStatusFailsWhenCurrentDeploymentStatusIsError(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -6258,6 +6258,18 @@ func TestSoloRecoverSettledRunningDeploymentSkipsEmptyAttachedTargetIntersection
 	}
 }
 
+func TestSoloRecoveryTargetsCheckedRequiresEveryTarget(t *testing.T) {
+	if soloRecoveryTargetsChecked(map[string]bool{}, map[string]bool{"node-a": true}) {
+		t.Fatal("soloRecoveryTargetsChecked() = true for empty targets, want false")
+	}
+	if soloRecoveryTargetsChecked(map[string]bool{"node-a": true, "node-b": true}, map[string]bool{"node-a": true}) {
+		t.Fatal("soloRecoveryTargetsChecked() = true for unchecked target, want false")
+	}
+	if !soloRecoveryTargetsChecked(map[string]bool{"node-a": true, "node-b": true}, map[string]bool{"node-a": true, "node-b": true}) {
+		t.Fatal("soloRecoveryTargetsChecked() = false for checked targets, want true")
+	}
+}
+
 func TestSoloRecoverSettledRunningDeploymentRequiresFallbackTargets(t *testing.T) {
 	current := solo.State{}
 	deployment := corerelease.Deployment{


### PR DESCRIPTION
## What
- Let solo `status` mark an interrupted `running` deployment as settled when all attached nodes report the current release as settled.
- Emit `recovered_deployment` in the status payload when that state repair happens.
- Cover the recovery path with a status test.

## Why
If the CLI process is interrupted after desired state is published but before rollout wait completes, local state can remain stuck at `running` even though the node converged. Status is the natural recovery command because it already reads remote truth.

## Stack
- Based on #155.

## Validation
- `cd cli && go test ./internal/workflow -run 'TestSoloStatusRecoversInterruptedRunningDeployment|TestSoloStatus'`\n- `cd cli && go test ./...`