### PR TITLE
[codex] Expose solo status release metadata

### DIFF
--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1911,6 +1911,7 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 	var current solo.State
 	var environmentID string
 	var currentRelease corerelease.Release
+	var statusRelease corerelease.Release
 	var hasCurrent bool
 	var recoveryCandidate corerelease.Deployment
 	hasRecoveryCandidate := false
@@ -1928,12 +1929,18 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 			}
 			if hasCurrent {
 				localReleaseKnown = true
-				expectedRevisions = soloExpectedStatusRevisions(current, currentRelease)
-				cohostedRevisions = soloCohostedStatusRevisions(current, currentRelease)
-				staleRevisions = soloStaleStatusRevisions(current, currentRelease, expectedRevisions)
-				expectedWorkloadRevision = strings.TrimSpace(currentRelease.Revision)
+				statusRelease = currentRelease
+				if runningDeployment, ok := soloLatestRunningDeploymentForEnvironment(current, environmentID); ok {
+					if release, releaseOK := current.Releases[runningDeployment.ReleaseID]; releaseOK {
+						statusRelease = release
+					}
+				}
+				expectedRevisions = soloExpectedStatusRevisions(current, statusRelease)
+				cohostedRevisions = soloCohostedStatusRevisions(current, statusRelease)
+				staleRevisions = soloStaleStatusRevisions(current, statusRelease, expectedRevisions)
+				expectedWorkloadRevision = strings.TrimSpace(statusRelease.Revision)
 				expectedRuntimeEnvironment, _ = soloRuntimeEnvironmentNameForNode(current, workspaceRoot, environmentName, "")
-				recoveryCandidate, hasRecoveryCandidate = soloLatestRunningDeployment(current, environmentID, currentRelease.ID)
+				recoveryCandidate, hasRecoveryCandidate = soloLatestRunningDeployment(current, environmentID, statusRelease.ID)
 				if hasRecoveryCandidate {
 					recoveryTargets = soloDeploymentTargetSet(recoveryCandidate, nodes)
 				}
@@ -2062,7 +2069,7 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 		if err != nil {
 			return err
 		}
-		recovered, recoveredState, ok, err := soloRecoverSettledRunningDeployment(recoveryState, environmentID, currentRelease.ID, recoveryChecked, recoveryRevisions)
+		recovered, recoveredState, ok, err := soloRecoverSettledRunningDeployment(recoveryState, environmentID, statusRelease.ID, recoveryChecked, recoveryRevisions)
 		if err != nil {
 			return err
 		}
@@ -2143,6 +2150,12 @@ func soloLatestDeploymentForEnvironment(current solo.State, environmentID string
 	})
 }
 
+func soloLatestRunningDeploymentForEnvironment(current solo.State, environmentID string) (corerelease.Deployment, bool) {
+	return soloLatestDeploymentMatching(current, func(deployment corerelease.Deployment) bool {
+		return deployment.EnvironmentID == environmentID && deployment.Status == corerelease.DeploymentStatusRunning
+	})
+}
+
 func soloLatestDeploymentMatching(current solo.State, match func(corerelease.Deployment) bool) (corerelease.Deployment, bool) {
 	var selected corerelease.Deployment
 	found := false
@@ -2180,6 +2193,12 @@ func soloRecoverSettledRunningDeployment(current solo.State, environmentID, rele
 	}
 	if err := current.SaveDeployment(selected); err != nil {
 		return corerelease.Deployment{}, current, false, err
+	}
+	if selected.Kind == corerelease.DeploymentKindRollback {
+		current.Current[environmentID] = selected.ReleaseID
+		if release, ok := current.Releases[selected.ReleaseID]; ok {
+			current.Snapshots[environmentID] = release.Snapshot
+		}
 	}
 	return selected, current, true, nil
 }

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -2059,9 +2059,6 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 		warnings, _ := payload["warnings"].([]string)
 		payload["warnings"] = append(warnings, message)
 	}
-	if hasCurrent {
-		payload["current_release"] = soloStatusReleasePayload(currentRelease)
-	}
 	if len(verifiedPublicURLs) > 0 {
 		if allSettled {
 			payload["public_urls"] = verifiedPublicURLs
@@ -2096,6 +2093,13 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 				"status_message": recovered.StatusMessage,
 			}
 		}
+	}
+	if hasCurrent {
+		releasePayload := currentRelease
+		if _, release, ok, err := current.CurrentRelease(workspaceRoot, environmentName); err == nil && ok {
+			releasePayload = release
+		}
+		payload["current_release"] = soloStatusReleasePayload(releasePayload)
 	}
 	if hasCurrent && payload["current_deployment"] == nil {
 		if deployment, ok := soloLatestDeploymentForEnvironment(current, environmentID); ok {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -2077,7 +2077,6 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 				"status":         recovered.Status,
 				"status_message": recovered.StatusMessage,
 			}
-			payload["current_deployment"] = soloStatusDeploymentPayload(current, recovered)
 		}
 	}
 	if hasCurrent && payload["current_deployment"] == nil {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -2021,6 +2021,12 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 		"environment":    environmentName,
 		"nodes":          jsonResults,
 	}
+	if hasCurrent {
+		payload["current_release"] = soloStatusReleasePayload(currentRelease)
+		if deployment, ok := soloLatestDeploymentForRelease(current, environmentID, currentRelease.ID); ok {
+			payload["current_deployment"] = soloStatusDeploymentPayload(deployment)
+		}
+	}
 	if len(verifiedPublicURLs) > 0 {
 		if allSettled {
 			payload["public_urls"] = verifiedPublicURLs
@@ -2065,14 +2071,35 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 	return nil
 }
 
-func soloRecoverSettledRunningDeployment(current solo.State, environmentID, releaseID string) (corerelease.Deployment, solo.State, bool) {
-	if strings.TrimSpace(environmentID) == "" || strings.TrimSpace(releaseID) == "" {
-		return corerelease.Deployment{}, current, false
+func soloStatusReleasePayload(release corerelease.Release) map[string]any {
+	return map[string]any{
+		"id":           release.ID,
+		"revision":     release.Revision,
+		"image":        release.Image.Reference,
+		"created_at":   release.CreatedAt,
+		"target_nodes": release.TargetNodeIDs,
 	}
+}
+
+func soloStatusDeploymentPayload(deployment corerelease.Deployment) map[string]any {
+	return map[string]any{
+		"id":             deployment.ID,
+		"release_id":     deployment.ReleaseID,
+		"kind":           deployment.Kind,
+		"status":         deployment.Status,
+		"status_message": deployment.StatusMessage,
+		"sequence":       deployment.Sequence,
+		"created_at":     deployment.CreatedAt,
+		"finished_at":    deployment.FinishedAt,
+		"target_nodes":   deployment.TargetNodeIDs,
+	}
+}
+
+func soloLatestDeploymentForRelease(current solo.State, environmentID, releaseID string) (corerelease.Deployment, bool) {
 	var selected corerelease.Deployment
 	found := false
 	for _, deployment := range current.Deployments {
-		if deployment.EnvironmentID != environmentID || deployment.ReleaseID != releaseID || deployment.Status != corerelease.DeploymentStatusRunning {
+		if deployment.EnvironmentID != environmentID || deployment.ReleaseID != releaseID {
 			continue
 		}
 		if !found || deployment.Sequence > selected.Sequence || (deployment.Sequence == selected.Sequence && deployment.CreatedAt > selected.CreatedAt) {
@@ -2080,7 +2107,15 @@ func soloRecoverSettledRunningDeployment(current solo.State, environmentID, rele
 			found = true
 		}
 	}
-	if !found {
+	return selected, found
+}
+
+func soloRecoverSettledRunningDeployment(current solo.State, environmentID, releaseID string) (corerelease.Deployment, solo.State, bool) {
+	if strings.TrimSpace(environmentID) == "" || strings.TrimSpace(releaseID) == "" {
+		return corerelease.Deployment{}, current, false
+	}
+	selected, ok := soloLatestDeploymentForRelease(current, environmentID, releaseID)
+	if !ok || selected.Status != corerelease.DeploymentStatusRunning {
 		return corerelease.Deployment{}, current, false
 	}
 	selected.Status = corerelease.DeploymentStatusSettled

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -5353,6 +5353,14 @@ func TestSoloStatusComparesRemoteStatusToPublishedDesiredStateRevision(t *testin
 	if status["revision"] != "desired-state-hash" {
 		t.Fatalf("node = %#v, want published desired-state revision accepted", node)
 	}
+	currentRelease := jsonMapFromAny(t, payload["current_release"])
+	if currentRelease["id"] != release.ID || currentRelease["revision"] != "shortsha" || currentRelease["image"] != "demo:shortsha" {
+		t.Fatalf("current_release = %#v, want local release metadata", currentRelease)
+	}
+	currentDeployment := jsonMapFromAny(t, payload["current_deployment"])
+	if currentDeployment["id"] != "dep_test" || currentDeployment["status"] != corerelease.DeploymentStatusFailed || intValueAny(currentDeployment["sequence"]) != 1 {
+		t.Fatalf("current_deployment = %#v, want latest deployment metadata", currentDeployment)
+	}
 }
 
 func TestSoloStatusAcceptsExpectedRevisionWhenStatusTimePredatesLocalDeploymentClock(t *testing.T) {

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -5599,7 +5599,7 @@ func TestSoloStatusReportsInFlightRollbackDeployment(t *testing.T) {
 	if err := soloState.Write(current); err != nil {
 		t.Fatal(err)
 	}
-	installFakeSoloCommands(t, []fakeSSHResponse{{stdout: `{"revision":"bbb2222","phase":"settled"}` + "\n"}})
+	installFakeSoloCommands(t, []fakeSSHResponse{{stdout: `{"revision":"aaa1111","phase":"settled"}` + "\n"}})
 
 	var stdout bytes.Buffer
 	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState, ConfigStore: config.NewStore(), Cwd: workspaceRoot}

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -5825,6 +5825,69 @@ func TestSoloStatusReportsInFlightRollbackDeployment(t *testing.T) {
 	}
 }
 
+func TestSoloStatusRecoveredRollbackReportsUpdatedCurrentRelease(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := soloReleaseWorkflowState(workspaceRoot)
+	key, err := solo.EnvironmentStateKey(workspaceRoot, "production")
+	if err != nil {
+		t.Fatal(err)
+	}
+	attachment := current.Attachments[key]
+	attachment.NodeNames = []string{"node-a"}
+	current.Attachments[key] = attachment
+	environmentID, _, ok, err := current.CurrentRelease(workspaceRoot, "production")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("current release missing")
+	}
+	rollbackRelease := current.Releases["rel-1"]
+	deployment, err := corerelease.NewDeployment(corerelease.DeploymentCreateInput{
+		ID:            "dep_rollback",
+		EnvironmentID: environmentID,
+		ReleaseID:     rollbackRelease.ID,
+		Kind:          corerelease.DeploymentKindRollback,
+		Sequence:      8,
+		TargetNodeIDs: []string{"node-a"},
+		CreatedAt:     time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	deployment.Status = corerelease.DeploymentStatusRunning
+	if err := current.SaveDeployment(deployment); err != nil {
+		t.Fatal(err)
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+	installFakeSoloCommands(t, []fakeSSHResponse{{stdout: `{"revision":"aaa1111","phase":"settled"}` + "\n"}})
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState, ConfigStore: config.NewStore(), Cwd: workspaceRoot}
+	if err := app.SoloStatus(context.Background(), SoloStatusOptions{}); err != nil {
+		t.Fatalf("SoloStatus() error = %v", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	releasePayload := jsonMapFromAny(t, payload["current_release"])
+	if releasePayload["id"] != rollbackRelease.ID || releasePayload["revision"] != rollbackRelease.Revision {
+		t.Fatalf("current_release = %#v, want recovered rollback release", releasePayload)
+	}
+	updated, err := soloState.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Current[environmentID] != rollbackRelease.ID {
+		t.Fatalf("current release id = %q, want %q", updated.Current[environmentID], rollbackRelease.ID)
+	}
+}
+
 func TestSoloStatusAcceptsExpectedRevisionWhenStatusTimePredatesLocalDeploymentClock(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")


### PR DESCRIPTION
## What
- Add `current_release` and `current_deployment` metadata to solo `status` output.
- Reuse the latest deployment lookup for interrupted-deploy recovery.
- Cover status metadata in the published desired-state status test.

## Why
Production operators and agents need to see local release/deployment intent alongside remote node status without opening the solo state file.

## Stack
- Based on #156.

## Validation
- `cd cli && go test ./internal/workflow -run 'TestSoloStatusComparesRemoteStatusToPublishedDesiredStateRevision|TestSoloStatusRecoversInterruptedRunningDeployment'`\n- `cd cli && go test ./...`