### PR TITLE
[codex] Verify solo agent install result

### DIFF
--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -4861,6 +4861,8 @@ func (a *App) SoloAgentInstall(ctx context.Context, opts SoloAgentInstallOptions
 		versionStatus = "custom"
 	} else if versionStatus == "unknown" {
 		return fmt.Errorf("agent install verification failed: remote agent version is unknown or unparseable: %q", strings.TrimSpace(agentVersion))
+	} else if versionStatus == "mismatch" {
+		return fmt.Errorf("agent install verification failed: remote agent version %q does not match target %q", agentVersion, target)
 	}
 	activeProbe := collectRemoteText(ctx, node, "systemctl is-active devopsellence-agent")
 	agentActive := activeProbe["ok"] == true && stringFromMap(activeProbe, "value") == "active"

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -4677,16 +4677,23 @@ func (a *App) SoloAgentInstall(ctx context.Context, opts SoloAgentInstallOptions
 		return err
 	}
 
-	agentVersion := stringFromMap(collectRemoteText(ctx, node, remoteAgentVersionCommand()), "value")
+	agentVersionProbe := collectRemoteText(ctx, node, remoteAgentVersionCommand())
+	agentVersion := stringFromMap(agentVersionProbe, "value")
+	if agentVersionProbe["ok"] != true || strings.TrimSpace(agentVersion) == "" {
+		return fmt.Errorf("agent install verification failed: %s", collectRemoteTextFailure(agentVersionProbe))
+	}
 	target := soloAgentTargetVersion()
-	active := collectRemoteText(ctx, node, "systemctl is-active devopsellence-agent")
+	activeProbe := collectRemoteText(ctx, node, "systemctl is-active devopsellence-agent")
 	return a.Printer.PrintResultEvent("devopsellence agent install", map[string]any{
-		"node":           opts.Node,
-		"action":         "installed",
-		"agent_version":  agentVersion,
-		"target_version": target,
-		"version_status": soloAgentVersionStatus(agentVersion, target),
-		"agent_active":   stringFromMap(active, "value") == "active",
+		"node":                  opts.Node,
+		"action":                "installed",
+		"agent_version":         agentVersion,
+		"agent_version_probe":   agentVersionProbe,
+		"target_version":        target,
+		"version_status":        soloAgentVersionStatus(agentVersion, target),
+		"agent_active":          stringFromMap(activeProbe, "value") == "active",
+		"agent_active_check":    activeProbe,
+		"agent_active_check_ok": activeProbe["ok"] == true,
 	})
 
 }

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -4853,12 +4853,11 @@ func (a *App) SoloAgentInstall(ctx context.Context, opts SoloAgentInstallOptions
 	}
 	target := soloAgentTargetVersion()
 	versionStatus := soloAgentVersionStatus(agentVersion, target)
-	if versionStatus == "unknown" {
-		return fmt.Errorf("agent install verification failed: remote agent version is unknown or unparseable: %q", strings.TrimSpace(agentVersion))
-	}
 	if strings.TrimSpace(opts.AgentBinary) != "" {
 		target = "custom"
 		versionStatus = "custom"
+	} else if versionStatus == "unknown" {
+		return fmt.Errorf("agent install verification failed: remote agent version is unknown or unparseable: %q", strings.TrimSpace(agentVersion))
 	}
 	activeProbe := collectRemoteText(ctx, node, "systemctl is-active devopsellence-agent")
 	agentActive := activeProbe["ok"] == true && stringFromMap(activeProbe, "value") == "active"

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -4544,7 +4544,17 @@ func (a *App) SoloAgentInstall(ctx context.Context, opts SoloAgentInstallOptions
 		return err
 	}
 
-	return a.Printer.PrintResultEvent("devopsellence agent install", map[string]any{"node": opts.Node, "action": "installed"})
+	agentVersion := stringFromMap(collectRemoteText(ctx, node, remoteAgentVersionCommand()), "value")
+	target := soloAgentTargetVersion()
+	active := collectRemoteText(ctx, node, "systemctl is-active devopsellence-agent")
+	return a.Printer.PrintResultEvent("devopsellence agent install", map[string]any{
+		"node":           opts.Node,
+		"action":         "installed",
+		"agent_version":  agentVersion,
+		"target_version": target,
+		"version_status": soloAgentVersionStatus(agentVersion, target),
+		"agent_active":   stringFromMap(active, "value") == "active",
+	})
 
 }
 

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -4696,6 +4696,10 @@ func (a *App) SoloAgentInstall(ctx context.Context, opts SoloAgentInstallOptions
 		return fmt.Errorf("agent install verification failed: %s", collectRemoteTextFailure(agentVersionProbe))
 	}
 	target := soloAgentTargetVersion()
+	versionStatus := soloAgentVersionStatus(agentVersion, target)
+	if versionStatus == "unknown" {
+		return fmt.Errorf("agent install verification failed: %s", agentVersion)
+	}
 	activeProbe := collectRemoteText(ctx, node, "systemctl is-active devopsellence-agent")
 	return a.Printer.PrintResultEvent("devopsellence agent install", map[string]any{
 		"node":                  opts.Node,
@@ -4703,7 +4707,7 @@ func (a *App) SoloAgentInstall(ctx context.Context, opts SoloAgentInstallOptions
 		"agent_version":         agentVersion,
 		"agent_version_probe":   agentVersionProbe,
 		"target_version":        target,
-		"version_status":        soloAgentVersionStatus(agentVersion, target),
+		"version_status":        versionStatus,
 		"agent_active":          stringFromMap(activeProbe, "value") == "active",
 		"agent_active_check":    activeProbe,
 		"agent_active_check_ok": activeProbe["ok"] == true,

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -4705,7 +4705,12 @@ func (a *App) SoloAgentInstall(ctx context.Context, opts SoloAgentInstallOptions
 	if versionStatus == "unknown" {
 		return fmt.Errorf("agent install verification failed: %s", agentVersion)
 	}
+	if strings.TrimSpace(opts.AgentBinary) != "" {
+		target = "custom"
+		versionStatus = "custom"
+	}
 	activeProbe := collectRemoteText(ctx, node, "systemctl is-active devopsellence-agent")
+	agentActive := activeProbe["ok"] == true && stringFromMap(activeProbe, "value") == "active"
 	return a.Printer.PrintResultEvent("devopsellence agent install", map[string]any{
 		"node":                  opts.Node,
 		"action":                "installed",
@@ -4713,7 +4718,7 @@ func (a *App) SoloAgentInstall(ctx context.Context, opts SoloAgentInstallOptions
 		"agent_version_probe":   agentVersionProbe,
 		"target_version":        target,
 		"version_status":        versionStatus,
-		"agent_active":          stringFromMap(activeProbe, "value") == "active",
+		"agent_active":          agentActive,
 		"agent_active_check":    activeProbe,
 		"agent_active_check_ok": activeProbe["ok"] == true,
 	})

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -4853,6 +4853,9 @@ func (a *App) SoloAgentInstall(ctx context.Context, opts SoloAgentInstallOptions
 	}
 	target := soloAgentTargetVersion()
 	versionStatus := soloAgentVersionStatus(agentVersion, target)
+	if strings.TrimSpace(agentVersion) == "missing" {
+		return fmt.Errorf("agent install verification failed: remote agent version is missing after install")
+	}
 	if strings.TrimSpace(opts.AgentBinary) != "" {
 		target = "custom"
 		versionStatus = "custom"

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -4854,7 +4854,7 @@ func (a *App) SoloAgentInstall(ctx context.Context, opts SoloAgentInstallOptions
 	target := soloAgentTargetVersion()
 	versionStatus := soloAgentVersionStatus(agentVersion, target)
 	if versionStatus == "unknown" {
-		return fmt.Errorf("agent install verification failed: %s", agentVersion)
+		return fmt.Errorf("agent install verification failed: remote agent version is unknown or unparseable: %q", strings.TrimSpace(agentVersion))
 	}
 	if strings.TrimSpace(opts.AgentBinary) != "" {
 		target = "custom"
@@ -4905,7 +4905,7 @@ func (a *App) SoloAgentUpgrade(ctx context.Context, opts SoloAgentUpgradeOptions
 		return fmt.Errorf("agent upgrade verification failed: %s", collectRemoteTextFailure(afterResult))
 	}
 	if versionStatus == "unknown" {
-		return fmt.Errorf("agent upgrade verification failed: remote agent version is unknown: %s", after)
+		return fmt.Errorf("agent upgrade verification failed: remote agent version is unknown or unparseable: %q", strings.TrimSpace(after))
 	}
 	if versionStatus == "mismatch" {
 		return fmt.Errorf("agent upgrade verification failed: remote agent version %q does not match target %q", after, target)

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -3963,6 +3963,34 @@ func TestSoloAgentUpgradeReinstallsAgent(t *testing.T) {
 	}
 }
 
+func TestSoloAgentInstallReportsVerification(t *testing.T) {
+	originalVersion := cliversion.Version
+	t.Cleanup(func() { cliversion.Version = originalVersion })
+	cliversion.Version = "v2.0.0"
+	installFakeSoloCommands(t, nil)
+	t.Setenv("DEVOPSELLENCE_FAKE_AGENT_VERSION", "devopsellence v2.0.0 (commit new, built now)")
+
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.Node{
+			"node-a": {Host: "203.0.113.10", User: "root"},
+		},
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState}
+	if err := app.SoloAgentInstall(context.Background(), SoloAgentInstallOptions{Node: "node-a", BaseURL: "https://example.test"}); err != nil {
+		t.Fatalf("SoloAgentInstall() error = %v", err)
+	}
+	payload := lastNDJSONEvent(t, &stdout)
+	if payload["action"] != "installed" || payload["target_version"] != "v2.0.0" || payload["version_status"] != "current" || payload["agent_active"] != true {
+		t.Fatalf("payload = %#v, want verified installed agent", payload)
+	}
+}
+
 func TestSoloAgentUninstallRunsCleanupScript(t *testing.T) {
 	binDir := t.TempDir()
 	scriptPath := filepath.Join(t.TempDir(), "uninstall.sh")

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -4432,12 +4432,12 @@ func TestSoloAgentInstallFailsWhenVersionVerificationFails(t *testing.T) {
 	}
 }
 
-func TestSoloAgentInstallFailsWhenVersionIsMissing(t *testing.T) {
+func TestSoloAgentInstallFailsWhenVersionIsUnknown(t *testing.T) {
 	originalVersion := cliversion.Version
 	t.Cleanup(func() { cliversion.Version = originalVersion })
 	cliversion.Version = "v2.0.0"
 	installFakeSoloCommands(t, nil)
-	t.Setenv("DEVOPSELLENCE_FAKE_AGENT_VERSION", "missing")
+	t.Setenv("DEVOPSELLENCE_FAKE_AGENT_VERSION", "totally different\nsecond line")
 
 	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
 	current := solo.State{
@@ -4453,10 +4453,10 @@ func TestSoloAgentInstallFailsWhenVersionIsMissing(t *testing.T) {
 	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState}
 	err := app.SoloAgentInstall(context.Background(), SoloAgentInstallOptions{Node: "node-a", BaseURL: "https://example.test"})
 	if err == nil {
-		t.Fatal("SoloAgentInstall() error = nil, want missing version failure")
+		t.Fatal("SoloAgentInstall() error = nil, want unknown version failure")
 	}
-	if !strings.Contains(err.Error(), "agent install verification failed") || !strings.Contains(err.Error(), "missing") {
-		t.Fatalf("error = %v, want missing version failure", err)
+	if !strings.Contains(err.Error(), "agent install verification failed") || !strings.Contains(err.Error(), "unknown or unparseable") || !strings.Contains(err.Error(), `\n`) {
+		t.Fatalf("error = %v, want quoted unknown version failure", err)
 	}
 }
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -4167,6 +4167,35 @@ func TestSoloAgentInstallReportsActiveVerificationFailure(t *testing.T) {
 	}
 }
 
+func TestSoloAgentInstallReportsCustomBinaryTarget(t *testing.T) {
+	installFakeSoloCommands(t, nil)
+	t.Setenv("DEVOPSELLENCE_FAKE_AGENT_VERSION", "devopsellence v9.9.9-custom (commit local, built now)")
+	binaryPath := filepath.Join(t.TempDir(), "agent")
+	if err := os.WriteFile(binaryPath, []byte("agent binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.Node{
+			"node-a": {Host: "203.0.113.10", User: "root"},
+		},
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState}
+	if err := app.SoloAgentInstall(context.Background(), SoloAgentInstallOptions{Node: "node-a", AgentBinary: binaryPath}); err != nil {
+		t.Fatalf("SoloAgentInstall() error = %v", err)
+	}
+	payload := lastNDJSONEvent(t, &stdout)
+	if payload["target_version"] != "custom" || payload["version_status"] != "custom" {
+		t.Fatalf("payload = %#v, want custom target status", payload)
+	}
+}
+
 func TestSoloAgentInstallFailsWhenVersionVerificationFails(t *testing.T) {
 	originalVersion := cliversion.Version
 	t.Cleanup(func() { cliversion.Version = originalVersion })

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -4489,6 +4489,34 @@ func TestSoloAgentInstallFailsWhenVersionIsUnknown(t *testing.T) {
 	}
 }
 
+func TestSoloAgentInstallFailsWhenVersionMismatchesTarget(t *testing.T) {
+	originalVersion := cliversion.Version
+	t.Cleanup(func() { cliversion.Version = originalVersion })
+	cliversion.Version = "v2.0.0"
+	installFakeSoloCommands(t, nil)
+	t.Setenv("DEVOPSELLENCE_FAKE_AGENT_VERSION", "devopsellence v1.9.0 (commit old, built then)")
+
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.Node{
+			"node-a": {Host: "203.0.113.10", User: "root"},
+		},
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState}
+	err := app.SoloAgentInstall(context.Background(), SoloAgentInstallOptions{Node: "node-a", BaseURL: "https://example.test"})
+	if err == nil {
+		t.Fatal("SoloAgentInstall() error = nil, want mismatch failure")
+	}
+	if !strings.Contains(err.Error(), "agent install verification failed") || !strings.Contains(err.Error(), "does not match target") {
+		t.Fatalf("error = %v, want version mismatch failure", err)
+	}
+}
+
 func TestSoloAgentUpgradeFailsWhenVersionVerificationFails(t *testing.T) {
 	originalVersion := cliversion.Version
 	t.Cleanup(func() { cliversion.Version = originalVersion })

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -4377,7 +4377,7 @@ func TestSoloAgentInstallReportsActiveVerificationFailure(t *testing.T) {
 
 func TestSoloAgentInstallReportsCustomBinaryTarget(t *testing.T) {
 	installFakeSoloCommands(t, nil)
-	t.Setenv("DEVOPSELLENCE_FAKE_AGENT_VERSION", "devopsellence v9.9.9-custom (commit local, built now)")
+	t.Setenv("DEVOPSELLENCE_FAKE_AGENT_VERSION", "custom build\nsecond line")
 	binaryPath := filepath.Join(t.TempDir(), "agent")
 	if err := os.WriteFile(binaryPath, []byte("agent binary"), 0o755); err != nil {
 		t.Fatal(err)

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -4404,6 +4404,35 @@ func TestSoloAgentInstallReportsCustomBinaryTarget(t *testing.T) {
 	}
 }
 
+func TestSoloAgentInstallCustomBinaryFailsWhenVersionIsMissing(t *testing.T) {
+	installFakeSoloCommands(t, nil)
+	t.Setenv("DEVOPSELLENCE_FAKE_AGENT_VERSION", "missing")
+	binaryPath := filepath.Join(t.TempDir(), "agent")
+	if err := os.WriteFile(binaryPath, []byte("agent binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.Node{
+			"node-a": {Host: "203.0.113.10", User: "root"},
+		},
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState}
+	err := app.SoloAgentInstall(context.Background(), SoloAgentInstallOptions{Node: "node-a", AgentBinary: binaryPath})
+	if err == nil {
+		t.Fatal("SoloAgentInstall() error = nil, want missing version failure")
+	}
+	if !strings.Contains(err.Error(), "agent install verification failed") || !strings.Contains(err.Error(), "missing after install") {
+		t.Fatalf("error = %v, want missing custom install failure", err)
+	}
+}
+
 func TestSoloAgentInstallFailsWhenVersionVerificationFails(t *testing.T) {
 	originalVersion := cliversion.Version
 	t.Cleanup(func() { cliversion.Version = originalVersion })

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -4069,8 +4069,77 @@ func TestSoloAgentInstallReportsVerification(t *testing.T) {
 		t.Fatalf("SoloAgentInstall() error = %v", err)
 	}
 	payload := lastNDJSONEvent(t, &stdout)
-	if payload["action"] != "installed" || payload["target_version"] != "v2.0.0" || payload["version_status"] != "current" || payload["agent_active"] != true {
+	if payload["action"] != "installed" || payload["agent_version"] != "devopsellence v2.0.0 (commit new, built now)" || payload["target_version"] != "v2.0.0" || payload["version_status"] != "current" || payload["agent_active"] != true || payload["agent_active_check_ok"] != true {
 		t.Fatalf("payload = %#v, want verified installed agent", payload)
+	}
+	versionProbe := jsonMapFromAny(t, payload["agent_version_probe"])
+	if versionProbe["ok"] != true || versionProbe["value"] != "devopsellence v2.0.0 (commit new, built now)" {
+		t.Fatalf("agent_version_probe = %#v, want version probe details", versionProbe)
+	}
+	activeProbe := jsonMapFromAny(t, payload["agent_active_check"])
+	if activeProbe["ok"] != true || activeProbe["value"] != "active" {
+		t.Fatalf("agent_active_check = %#v, want active probe details", activeProbe)
+	}
+}
+
+func TestSoloAgentInstallReportsActiveVerificationFailure(t *testing.T) {
+	originalVersion := cliversion.Version
+	t.Cleanup(func() { cliversion.Version = originalVersion })
+	cliversion.Version = "v2.0.0"
+	installFakeSoloCommands(t, nil)
+	t.Setenv("DEVOPSELLENCE_FAKE_AGENT_VERSION", "devopsellence v2.0.0 (commit new, built now)")
+	t.Setenv("DEVOPSELLENCE_FAKE_AGENT_ACTIVE_FAIL", "1")
+
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.Node{
+			"node-a": {Host: "203.0.113.10", User: "root"},
+		},
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState}
+	if err := app.SoloAgentInstall(context.Background(), SoloAgentInstallOptions{Node: "node-a", BaseURL: "https://example.test"}); err != nil {
+		t.Fatalf("SoloAgentInstall() error = %v", err)
+	}
+	payload := lastNDJSONEvent(t, &stdout)
+	if payload["agent_active"] != false || payload["agent_active_check_ok"] != false {
+		t.Fatalf("payload = %#v, want inactive verification failure details", payload)
+	}
+	activeProbe := jsonMapFromAny(t, payload["agent_active_check"])
+	if activeProbe["ok"] != false || !strings.Contains(stringValueAny(activeProbe["error"]), "agent inactive") {
+		t.Fatalf("agent_active_check = %#v, want active probe error", activeProbe)
+	}
+}
+
+func TestSoloAgentInstallFailsWhenVersionVerificationFails(t *testing.T) {
+	originalVersion := cliversion.Version
+	t.Cleanup(func() { cliversion.Version = originalVersion })
+	cliversion.Version = "v2.0.0"
+	installFakeSoloCommands(t, nil)
+	t.Setenv("DEVOPSELLENCE_FAKE_AGENT_VERSION_FAIL", "1")
+
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.Node{
+			"node-a": {Host: "203.0.113.10", User: "root"},
+		},
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState}
+	err := app.SoloAgentInstall(context.Background(), SoloAgentInstallOptions{Node: "node-a", BaseURL: "https://example.test"})
+	if err == nil {
+		t.Fatal("SoloAgentInstall() error = nil, want verification failure")
+	}
+	if !strings.Contains(err.Error(), "agent install verification failed") || !strings.Contains(err.Error(), "version probe failed") {
+		t.Fatalf("error = %v, want version probe failure", err)
 	}
 }
 
@@ -8895,6 +8964,10 @@ if [[ "$command" == *"docker info"* ]]; then
 fi
 
 if [[ "$command" == *"__DEVOPSELLENCE_EXIT_CODE__"* && "$command" == *"systemctl is-active devopsellence-agent"* ]]; then
+  if [[ -n "${DEVOPSELLENCE_FAKE_AGENT_ACTIVE_FAIL:-}" ]]; then
+    printf '__DEVOPSELLENCE_EXIT_CODE__3\n__DEVOPSELLENCE_STDOUT__\n\n__DEVOPSELLENCE_STDERR__\nagent inactive\n'
+    exit 0
+  fi
   printf '__DEVOPSELLENCE_EXIT_CODE__0\n__DEVOPSELLENCE_STDOUT__\nactive\n__DEVOPSELLENCE_STDERR__\n'
   exit 0
 fi

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -4186,6 +4186,34 @@ func TestSoloAgentInstallFailsWhenVersionVerificationFails(t *testing.T) {
 	}
 }
 
+func TestSoloAgentInstallFailsWhenVersionIsMissing(t *testing.T) {
+	originalVersion := cliversion.Version
+	t.Cleanup(func() { cliversion.Version = originalVersion })
+	cliversion.Version = "v2.0.0"
+	installFakeSoloCommands(t, nil)
+	t.Setenv("DEVOPSELLENCE_FAKE_AGENT_VERSION", "missing")
+
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.Node{
+			"node-a": {Host: "203.0.113.10", User: "root"},
+		},
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState}
+	err := app.SoloAgentInstall(context.Background(), SoloAgentInstallOptions{Node: "node-a", BaseURL: "https://example.test"})
+	if err == nil {
+		t.Fatal("SoloAgentInstall() error = nil, want missing version failure")
+	}
+	if !strings.Contains(err.Error(), "agent install verification failed") || !strings.Contains(err.Error(), "missing") {
+		t.Fatalf("error = %v, want missing version failure", err)
+	}
+}
+
 func TestSoloAgentUpgradeFailsWhenVersionVerificationFails(t *testing.T) {
 	originalVersion := cliversion.Version
 	t.Cleanup(func() { cliversion.Version = originalVersion })


### PR DESCRIPTION
## What
- Add post-install verification fields to solo `agent install` result output.
- Report installed agent version, target version, exact version status, and whether systemd reports the agent active.
- Cover install verification output in workflow tests.

## Why
Agent install should prove what landed on the VM instead of only saying the install script completed.

## Stack
- Based on #157.

## Validation
- `cd cli && go test ./internal/workflow -run 'TestSoloAgent(InstallReportsVerification|UpgradeReinstallsAgent)'`\n- `cd cli && go test ./...`