### PR TITLE
[codex] Expose solo deploy rollout contract

### DIFF
--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -638,6 +638,7 @@ func soloDeployRolloutContract(cfg *config.ProjectConfig) []map[string]any {
 		if kind == config.ServiceKindWeb {
 			item["strategy"] = "health_gated_cutover"
 			item["health_gated"] = true
+			item["stop_old_before_start_new"] = false
 			item["operator_note"] = "web traffic moves after the replacement passes its healthcheck"
 		} else {
 			item["strategy"] = "stop_old_before_start_new"

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -632,8 +632,8 @@ func soloDeployRolloutContract(cfg *config.ProjectConfig) []map[string]any {
 		service := cfg.Services[serviceName]
 		kind := config.InferredServiceKind(serviceName, service)
 		item := map[string]any{
-			"service": serviceName,
-			"kind":    kind,
+			"service_name": serviceName,
+			"service_kind": kind,
 		}
 		if kind == config.ServiceKindWeb {
 			item["strategy"] = "health_gated_cutover"
@@ -642,6 +642,7 @@ func soloDeployRolloutContract(cfg *config.ProjectConfig) []map[string]any {
 		} else {
 			item["strategy"] = "stop_old_before_start_new"
 			item["health_gated"] = false
+			item["stop_old_before_start_new"] = true
 			item["operator_note"] = "non-web service hash changes stop and remove old containers before starting the replacement; this path is not health-gated"
 		}
 		contracts = append(contracts, item)

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -640,9 +640,9 @@ func soloDeployRolloutContract(cfg *config.ProjectConfig) []map[string]any {
 			item["health_gated"] = true
 			item["operator_note"] = "web traffic moves after the replacement passes its healthcheck"
 		} else {
-			item["strategy"] = "stop_old_before_start_new"
+			item["strategy"] = "reconcile_replace"
 			item["health_gated"] = false
-			item["operator_note"] = "non-web services are restarted without concurrent old/new overlap"
+			item["operator_note"] = "non-web services are reconciled without health-gated traffic cutover; stale containers are stopped and removed as replacement state converges"
 		}
 		contracts = append(contracts, item)
 	}

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -453,6 +453,7 @@ func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 			"environment":       environmentName,
 			"nodes":             sortedNodeNames(nodes),
 			"phase":             "planned",
+			"rollout_contract":  soloDeployRolloutContract(cfg),
 			"side_effects": map[string]bool{
 				"build":       false,
 				"ssh":         false,
@@ -592,6 +593,7 @@ func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 		"environment":             environmentName,
 		"nodes":                   sortedNodeNames(nodes),
 		"phase":                   "settled",
+		"rollout_contract":        soloDeployRolloutContract(cfg),
 		"runtime_verified":        runtimeVerified,
 	}
 	if urls, endpointProbeVerified, tlsVerified := a.soloVerifiedPublicURLs(workspaceRoot, environmentName, cfg, nodes); len(urls) > 0 {
@@ -619,6 +621,32 @@ func soloDeployRuntimeVerified(endpointProbe, tls bool) map[string]any {
 		"endpoint_probe":         endpointProbe,
 		"tls":                    tls,
 	}
+}
+
+func soloDeployRolloutContract(cfg *config.ProjectConfig) []map[string]any {
+	if cfg == nil {
+		return nil
+	}
+	contracts := []map[string]any{}
+	for _, serviceName := range cfg.ServiceNames() {
+		service := cfg.Services[serviceName]
+		kind := config.InferredServiceKind(serviceName, service)
+		item := map[string]any{
+			"service": serviceName,
+			"kind":    kind,
+		}
+		if kind == config.ServiceKindWeb {
+			item["strategy"] = "health_gated_cutover"
+			item["health_gated"] = true
+			item["operator_note"] = "web traffic moves after the replacement passes its healthcheck"
+		} else {
+			item["strategy"] = "stop_old_before_start_new"
+			item["health_gated"] = false
+			item["operator_note"] = "non-web services are restarted without concurrent old/new overlap"
+		}
+		contracts = append(contracts, item)
+	}
+	return contracts
 }
 
 func validateNodeSchedule(cfg *config.ProjectConfig, nodes map[string]config.Node) (string, error) {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -644,7 +644,7 @@ func soloDeployRolloutContract(cfg *config.ProjectConfig) []map[string]any {
 			item["strategy"] = "stop_old_before_start_new"
 			item["health_gated"] = false
 			item["stop_old_before_start_new"] = true
-			item["operator_note"] = "non-web service hash changes stop and remove old containers before starting the replacement; this path is not health-gated"
+			item["operator_note"] = "non-web image, config, or desired-state changes stop and remove old containers before starting the replacement; this path is not health-gated"
 		}
 		contracts = append(contracts, item)
 	}

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -640,9 +640,9 @@ func soloDeployRolloutContract(cfg *config.ProjectConfig) []map[string]any {
 			item["health_gated"] = true
 			item["operator_note"] = "web traffic moves after the replacement passes its healthcheck"
 		} else {
-			item["strategy"] = "reconcile_replace"
+			item["strategy"] = "stop_old_before_start_new"
 			item["health_gated"] = false
-			item["operator_note"] = "non-web services are reconciled without health-gated traffic cutover; stale containers are stopped and removed as replacement state converges"
+			item["operator_note"] = "non-web service hash changes stop and remove old containers before starting the replacement; this path is not health-gated"
 		}
 		contracts = append(contracts, item)
 	}

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -5360,9 +5360,9 @@ func TestSoloDeployDryRunPlansWithoutSideEffects(t *testing.T) {
 	byService := map[string]map[string]any{}
 	for _, item := range contracts {
 		contract := jsonMapFromAny(t, item)
-		byService[stringValueAny(contract["service"])] = contract
+		byService[stringValueAny(contract["service_name"])] = contract
 	}
-	if byService["web"]["strategy"] != "health_gated_cutover" || byService["worker"]["strategy"] != "stop_old_before_start_new" {
+	if byService["web"]["strategy"] != "health_gated_cutover" || byService["worker"]["strategy"] != "stop_old_before_start_new" || byService["worker"]["stop_old_before_start_new"] != true {
 		t.Fatalf("rollout_contract = %#v, want web health-gated and worker stop-old/start-new", contracts)
 	}
 }

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -5220,8 +5220,8 @@ func TestSoloDeployDryRunPlansWithoutSideEffects(t *testing.T) {
 		contract := jsonMapFromAny(t, item)
 		byService[stringValueAny(contract["service"])] = contract
 	}
-	if byService["web"]["strategy"] != "health_gated_cutover" || byService["worker"]["strategy"] != "stop_old_before_start_new" {
-		t.Fatalf("rollout_contract = %#v, want web health-gated and worker stop/start", contracts)
+	if byService["web"]["strategy"] != "health_gated_cutover" || byService["worker"]["strategy"] != "reconcile_replace" {
+		t.Fatalf("rollout_contract = %#v, want web health-gated and worker reconcile replace", contracts)
 	}
 }
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -5324,8 +5324,8 @@ func TestSoloDeployDryRunPlansWithoutSideEffects(t *testing.T) {
 		contract := jsonMapFromAny(t, item)
 		byService[stringValueAny(contract["service"])] = contract
 	}
-	if byService["web"]["strategy"] != "health_gated_cutover" || byService["worker"]["strategy"] != "reconcile_replace" {
-		t.Fatalf("rollout_contract = %#v, want web health-gated and worker reconcile replace", contracts)
+	if byService["web"]["strategy"] != "health_gated_cutover" || byService["worker"]["strategy"] != "stop_old_before_start_new" {
+		t.Fatalf("rollout_contract = %#v, want web health-gated and worker stop-old/start-new", contracts)
 	}
 }
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -1156,6 +1156,7 @@ func TestSoloAffectedNodesForNodeWithReleaseStateSkipsStatelessAttachments(t *te
 func TestSoloStatusIncludesPublicURLs(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	cfg.Services["worker"] = config.ServiceConfig{Command: []string{"bin/worker"}}
 	cfg.Ingress = &config.IngressConfig{
 		Hosts: []string{"*"},
 		Rules: []config.IngressRuleConfig{{
@@ -1213,6 +1214,7 @@ func TestSoloStatusUsesResolvedEnvironmentOverlay(t *testing.T) {
 	t.Setenv("DEVOPSELLENCE_ENVIRONMENT", "staging")
 	workspaceRoot := t.TempDir()
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	cfg.Services["worker"] = config.ServiceConfig{Command: []string{"bin/worker"}}
 	cfg.Ingress = &config.IngressConfig{
 		Hosts: []string{"prod.example.com"},
 		Rules: []config.IngressRuleConfig{{
@@ -4973,6 +4975,7 @@ func secretRefsContain(refs []config.SecretRef, name string) bool {
 func TestSoloDeployDryRunPlansWithoutSideEffects(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	cfg.Services["worker"] = config.ServiceConfig{Command: []string{"bin/worker"}}
 	cfg.Ingress = &config.IngressConfig{
 		Hosts: []string{"*"},
 		Rules: []config.IngressRuleConfig{{
@@ -4989,7 +4992,7 @@ func TestSoloDeployDryRunPlansWithoutSideEffects(t *testing.T) {
 	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
 	current := solo.State{
 		Nodes: map[string]config.Node{
-			"node-a": {Host: "203.0.113.10", User: "root", Port: 22, Labels: []string{config.DefaultWebRole}},
+			"node-a": {Host: "203.0.113.10", User: "root", Port: 22, Labels: []string{config.DefaultWebRole, config.DefaultWorkerRole}},
 		},
 		Attachments: map[string]solo.AttachmentRecord{},
 		Snapshots:   map[string]desiredstate.DeploySnapshot{},
@@ -5025,6 +5028,15 @@ func TestSoloDeployDryRunPlansWithoutSideEffects(t *testing.T) {
 	}
 	if payload["release_id"] != nil || payload["deployment_id"] != nil || payload["desired_state_revisions"] != nil {
 		t.Fatalf("payload = %#v, dry-run must not create release/deployment/publication revisions", payload)
+	}
+	contracts := jsonArrayFromMap(t, payload, "rollout_contract")
+	byService := map[string]map[string]any{}
+	for _, item := range contracts {
+		contract := jsonMapFromAny(t, item)
+		byService[stringValueAny(contract["service"])] = contract
+	}
+	if byService["web"]["strategy"] != "health_gated_cutover" || byService["worker"]["strategy"] != "stop_old_before_start_new" {
+		t.Fatalf("rollout_contract = %#v, want web health-gated and worker stop/start", contracts)
 	}
 }
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -5627,7 +5627,7 @@ func TestSoloDeployDryRunPlansWithoutSideEffects(t *testing.T) {
 		contract := jsonMapFromAny(t, item)
 		byService[stringValueAny(contract["service_name"])] = contract
 	}
-	if byService["web"]["strategy"] != "health_gated_cutover" || byService["worker"]["strategy"] != "stop_old_before_start_new" || byService["worker"]["stop_old_before_start_new"] != true {
+	if byService["web"]["strategy"] != "health_gated_cutover" || byService["web"]["stop_old_before_start_new"] != false || byService["worker"]["strategy"] != "stop_old_before_start_new" || byService["worker"]["stop_old_before_start_new"] != true {
 		t.Fatalf("rollout_contract = %#v, want web health-gated and worker stop-old/start-new", contracts)
 	}
 }


### PR DESCRIPTION
## What
- Add `rollout_contract` to solo deploy dry-run and settled result output.
- Make web health-gated cutover and non-web stop-old-before-start-new behavior explicit per service.
- Cover mixed web/worker dry-run output.

## Why
Worker rollout semantics are production-relevant. The CLI should expose the contract clearly instead of making operators infer it from agent internals.

## Stack
- Based on #158.

## Validation
- `cd cli && go test ./internal/workflow -run 'TestSoloDeployDryRunPlansWithoutSideEffects'`\n- `cd cli && go test ./...`