### PR TITLE
fix: install bundled agent skill without npx

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ cd my-app
 codex "deploy with devopsellence solo"
 ```
 
+`--install-agent-skill` installs the matching devopsellence agent skill from
+the CLI itself; it does not require npm or `npx`.
+
 Full docs: [docs.devopsellence.com](https://docs.devopsellence.com/).
 
 ## Modes

--- a/cli/internal/agentskill/agentskill.go
+++ b/cli/internal/agentskill/agentskill.go
@@ -1,0 +1,70 @@
+package agentskill
+
+import (
+	"embed"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+const Name = "devopsellence"
+
+//go:embed all:devopsellence
+var bundled embed.FS
+
+type InstallResult struct {
+	Name    string
+	Path    string
+	Version string
+	Source  string
+}
+
+func DefaultSkillsDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".agents", "skills"), nil
+}
+
+func Install(skillsDir string, version string) (InstallResult, error) {
+	if skillsDir == "" {
+		defaultDir, err := DefaultSkillsDir()
+		if err != nil {
+			return InstallResult{}, err
+		}
+		skillsDir = defaultDir
+	}
+	dest := filepath.Join(skillsDir, Name)
+	if err := os.RemoveAll(dest); err != nil {
+		return InstallResult{}, fmt.Errorf("remove existing skill: %w", err)
+	}
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		return InstallResult{}, fmt.Errorf("create skill dir: %w", err)
+	}
+	if err := fs.WalkDir(bundled, Name, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		rel, err := filepath.Rel(Name, path)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return nil
+		}
+		target := filepath.Join(dest, rel)
+		if entry.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		data, err := bundled.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(target, data, 0o644)
+	}); err != nil {
+		return InstallResult{}, fmt.Errorf("write bundled skill: %w", err)
+	}
+	return InstallResult{Name: Name, Path: dest, Version: version, Source: "embedded"}, nil
+}

--- a/cli/internal/agentskill/agentskill_test.go
+++ b/cli/internal/agentskill/agentskill_test.go
@@ -1,0 +1,40 @@
+package agentskill
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestInstallWritesBundledSkill(t *testing.T) {
+	dir := t.TempDir()
+	result, err := Install(dir, "v1-test")
+	if err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+	if result.Name != Name || result.Version != "v1-test" || result.Source != "embedded" {
+		t.Fatalf("result = %#v, want bundled devopsellence skill", result)
+	}
+	path := filepath.Join(dir, Name, "SKILL.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", path, err)
+	}
+	if len(data) == 0 {
+		t.Fatalf("%s is empty", path)
+	}
+}
+
+func TestBundledSkillMatchesPublicSkill(t *testing.T) {
+	bundled, err := os.ReadFile(filepath.Join("devopsellence", "SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	public, err := os.ReadFile(filepath.Join("..", "..", "..", "skills", "devopsellence", "SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(bundled) != string(public) {
+		t.Fatal("bundled devopsellence skill differs from skills/devopsellence/SKILL.md")
+	}
+}

--- a/cli/internal/agentskill/devopsellence/SKILL.md
+++ b/cli/internal/agentskill/devopsellence/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: devopsellence
+description: Use the devopsellence CLI to choose solo or shared workspace mode, deploy the current app, inspect status, and manage secrets or nodes.
+homepage: https://www.devopsellence.com
+---
+
+# devopsellence
+
+Use this skill when the user wants to deploy an app with devopsellence, check deployment state, manage secrets, register and attach their own nodes, or edit the main lifecycle-hook config.
+
+## Default flow
+
+1. Work in the app directory the user wants to deploy.
+2. Check whether the CLI is already available:
+
+```sh
+command -v devopsellence
+```
+
+If the command is missing, tell the user the devopsellence CLI is required and point them to the official docs. Do not run setup scripts from this skill.
+
+3. Choose the workspace mode before initializing. First inspect any existing mode/context:
+
+```sh
+devopsellence mode show || true
+devopsellence context show || true
+```
+
+If a mode is already configured, use it. If no mode is configured and the user has not explicitly chosen one, do not default silently. Ask a short mode-selection question, make a recommendation, and wait for confirmation before running `devopsellence init`:
+
+> devopsellence has two workspace modes:
+>
+> - `solo`: SSH-first, single-operator, existing or provider-created VMs, local node state, local secrets, direct Docker image streaming over SSH.
+> - `shared`: hosted sign-in, org/project/env context, team workflows, shared encrypted secrets, and control-plane-managed nodes.
+>
+> Based on what you’ve told me, I recommend `<solo|shared>` because `<reason>`. Should I initialize this repo in `<solo|shared>` mode?
+
+Recommend `solo` when the user mentions their own VM/server, SSH, single-operator usage, local secrets, direct image streaming, or avoiding hosted/team workflows.
+
+Recommend `shared` when the user mentions teams, org/project/env context, browser sign-in, hosted control plane, shared encrypted secrets, managed nodes, auditability, or collaboration.
+
+If intent is still ambiguous, ask whether they are deploying SSH-first to their own VM as one operator or want the hosted/team workflow.
+
+4. Initialize the workspace before the first deploy only after mode confirmation. For solo:
+
+```sh
+devopsellence init --mode solo
+```
+
+For shared:
+
+```sh
+devopsellence auth whoami || devopsellence auth login
+devopsellence init --mode shared
+```
+
+If the user already knows the shared target workspace values, prefer explicit flags:
+
+```sh
+devopsellence init --mode shared --org acme --project shop --env staging
+```
+
+5. Validate local state after initialization and before deploy:
+
+```sh
+devopsellence doctor
+```
+
+6. Deploy the app:
+
+```sh
+devopsellence deploy
+```
+
+In shared mode, if the user wants to deploy an existing image digest instead of building locally:
+
+```sh
+devopsellence deploy --image docker.io/example/app@sha256:...
+```
+
+7. Verify the result:
+
+```sh
+devopsellence status
+```
+
+## CLI output contract
+
+The devopsellence CLI is agent-primary. Treat stdout as the primary machine-readable contract.
+
+- Bounded successful commands emit one JSON document on stdout.
+- Long-running commands typically emit newline-delimited JSON events on stdout.
+- Some commands may also emit optional structured progress or diagnostic events on stderr, for example during auth flows. Treat stderr events as supplemental rather than the primary contract, and do not scrape human prose from stderr unless diagnosing a CLI/runtime failure.
+- On command failure, stdout uses a structured `event: "error"` envelope with `ok: false` and `error` details even for otherwise bounded commands.
+- Streaming event envelopes always include `schema_version`; bounded JSON results often include it, but some legacy bounded results may omit it.
+- When `schema_version` is present, check it before relying on command-specific fields; if it is missing from a bounded result, be tolerant and treat command-specific fields cautiously.
+- For schema version 1, streaming events use a common envelope:
+  - `event`: `started`, `progress`, `result`, or `error`
+  - `operation`: stable operation name when available
+  - final success events include `ok: true`
+  - final failure events include `ok: false` and `error`
+- Structured errors use `error.code`, `error.message`, and `error.exit_code`.
+- Command-specific fields are top-level. Tolerate unknown fields, but do not assume undocumented fields are stable.
+- Prefer explaining failures from structured `code`, `message`, evidence fields, and suggested next actions when present.
+- If `schema_version` is unsupported, do not make high-risk decisions from command-specific fields; summarize the raw structured output and ask for updated docs or skill guidance. If `schema_version` is missing from a bounded result, treat common fields cautiously and avoid assuming undocumented command-specific fields are stable.
+- Keep secret values out of logs and chat output.
+
+## Secrets
+
+Prefer stdin over literal secret values in prompts or shell history:
+
+```sh
+printf '%s' "$VALUE" | devopsellence secret set NAME --service web --stdin
+devopsellence secret list --env production
+devopsellence secret delete NAME --service web
+```
+
+In solo mode, 1Password references are also supported:
+
+```sh
+devopsellence secret set NAME --service web --store 1password --op-ref op://vault/item/field
+```
+
+## Bring your own node
+
+Use these in shared mode for a provider-created node. By default, `node create` registers and attaches the node to the current environment:
+
+```sh
+devopsellence init --mode shared
+printf '%s' "$HCLOUD_TOKEN" | devopsellence provider login hetzner --stdin
+# or: devopsellence provider login hetzner --token "$HCLOUD_TOKEN"
+devopsellence node create prod-1 --provider hetzner
+devopsellence node list
+devopsellence node detach <id>
+devopsellence node remove <id>
+```
+
+If you intentionally create an unassigned shared node, attach it later:
+
+```sh
+devopsellence node create prod-1 --provider hetzner --unassigned
+devopsellence node attach <id>
+```
+
+Use this in shared mode for an existing server that you will install manually:
+
+```sh
+devopsellence node register
+```
+
+Use these in solo mode when the user wants SSH-first workflows without the control plane on an existing VM:
+
+```sh
+devopsellence init --mode solo
+devopsellence node create prod-1 --host <ip> --user root --ssh-key ~/.ssh/id_ed25519
+devopsellence agent install prod-1
+devopsellence node attach prod-1
+devopsellence doctor
+devopsellence deploy
+```
+
+Use these in solo mode for a provider-created node:
+
+```sh
+devopsellence init --mode solo
+printf '%s' "$HCLOUD_TOKEN" | devopsellence provider login hetzner --stdin
+# or: devopsellence provider login hetzner --token "$HCLOUD_TOKEN"
+devopsellence node create prod-1 --provider hetzner --install --attach
+devopsellence doctor
+devopsellence deploy
+```
+
+For solo diagnostics:
+
+```sh
+devopsellence status
+devopsellence logs --node prod-1 --lines 100
+devopsellence node diagnose prod-1
+devopsellence node logs prod-1 --lines 100
+```
+
+For solo cleanup:
+
+```sh
+devopsellence node detach prod-1
+devopsellence agent uninstall prod-1 --yes
+devopsellence node remove prod-1 --yes
+```
+
+## Lifecycle hooks
+
+When the user is editing `devopsellence.yml`, recognize these deploy-time hooks:
+
+- `tasks.release`: one-shot task that runs before rollout. Good for migrations. It reuses the configured service image, env, secrets, and volumes.
+- For per-node prep work, prefer the image entrypoint or boot-time scripts; the config-level `init` hook is no longer supported.
+
+## Heuristics
+
+- Prefer `devopsellence doctor` after init and before `devopsellence deploy`.
+- If Docker is missing or not running, surface the problem clearly. In shared mode, switch to `devopsellence deploy --image ...` when the user already has a pushed image digest.
+- If the workspace is not a git checkout and the CLI needs git metadata, stop and ask before creating a repo or commit.
+- Keep secrets out of logs and chat output. Use environment variables plus `--stdin`.

--- a/cli/internal/workflow/root.go
+++ b/cli/internal/workflow/root.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/devopsellence/cli/internal/agentskill"
 	"github.com/devopsellence/cli/internal/version"
 
 	"github.com/spf13/cobra"
@@ -509,6 +510,30 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 		RunE:  withTimeout(app.AliasLFG),
 	})
 	root.AddCommand(aliasCommand)
+
+	var skillInstallDir string
+	skillCommand := &cobra.Command{Use: "skill", Short: "Manage bundled AI agent skill"}
+	skillInstallCommand := &cobra.Command{
+		Use:   "install",
+		Short: "Install the bundled devopsellence agent skill",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			result, installErr := agentskill.Install(skillInstallDir, version.String())
+			if installErr != nil {
+				return ExitError{Code: 1, Err: installErr}
+			}
+			return app.Printer.PrintJSON(map[string]any{
+				"schema_version": outputSchemaVersion,
+				"action":         "installed",
+				"skill":          result.Name,
+				"path":           result.Path,
+				"version":        result.Version,
+				"source":         result.Source,
+			})
+		},
+	}
+	skillInstallCommand.Flags().StringVar(&skillInstallDir, "dir", "", "Parent skills directory (default ~/.agents/skills)")
+	skillCommand.AddCommand(skillInstallCommand)
+	root.AddCommand(skillCommand)
 
 	var initSharedOpts InitOptions
 	var initMode string

--- a/cli/internal/workflow/root_test.go
+++ b/cli/internal/workflow/root_test.go
@@ -71,6 +71,30 @@ func TestRootVersionCommandIncludesReleaseProvenanceFields(t *testing.T) {
 	}
 }
 
+func TestRootSkillInstallWritesBundledSkill(t *testing.T) {
+	skillsDir := t.TempDir()
+	var stdout bytes.Buffer
+	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, t.TempDir())
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{"skill", "install", "--dir", skillsDir})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	if payload["schema_version"] != float64(outputSchemaVersion) || payload["action"] != "installed" || payload["skill"] != "devopsellence" || payload["source"] != "embedded" {
+		t.Fatalf("payload = %#v, want embedded skill install result", payload)
+	}
+	path := filepath.Join(skillsDir, "devopsellence", "SKILL.md")
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected bundled skill at %s: %v", path, err)
+	}
+	if payload["path"] != filepath.Join(skillsDir, "devopsellence") {
+		t.Fatalf("path = %#v, want %q", payload["path"], filepath.Join(skillsDir, "devopsellence"))
+	}
+}
+
 func TestRootModeFlagIsNotGlobal(t *testing.T) {
 	t.Parallel()
 

--- a/cli/scripts/release-local.sh
+++ b/cli/scripts/release-local.sh
@@ -6,6 +6,7 @@ CLI_DIR="$ROOT_DIR/cli"
 TARGET_NAME="devopsellence"
 INSTALL_DIR="${DEVOPSELLENCE_CLI_INSTALL_DIR:-}"
 INSTALL_AGENT_SKILL="${DEVOPSELLENCE_INSTALL_AGENT_SKILL:-}"
+AGENT_SKILLS_DIR="${DEVOPSELLENCE_AGENT_SKILLS_DIR:-}"
 
 OS_RAW="$(uname -s | tr '[:upper:]' '[:lower:]')"
 ARCH_RAW="$(uname -m)"
@@ -113,26 +114,22 @@ case ":$PATH:" in
     ;;
 esac
 
+install_agent_skill() {
+  local skill_args=()
+
+  if [[ -n "$AGENT_SKILLS_DIR" ]]; then
+    skill_args+=(--dir "$AGENT_SKILLS_DIR")
+  fi
+
+  echo "installing devopsellence agent skill..."
+  "$INSTALL_DIR/$TARGET_NAME" skill install "${skill_args[@]}"
+}
+
 case "$INSTALL_AGENT_SKILL" in
   1|true|TRUE|yes|YES)
-    if command -v npx >/dev/null 2>&1; then
-      echo "installing devopsellence agent skill..."
-      npx --yes skills add devopsellence/devopsellence --skill devopsellence -g --yes
-      printf '{"schema_version":1,"event":"result","operation":"devopsellence release-local","cli_installed":true,"cli_path":'
-      json_string "$INSTALL_DIR/$TARGET_NAME"
-      printf ',"commit":'
-      json_string "$COMMIT"
-      printf ',"agent_skill_requested":true,"agent_skill_installed":true,"agent_skill":"devopsellence"}\n'
-    else
-      echo "devopsellence CLI installed. Agent skill install requested, but npx was not found." >&2
-      echo "Install the skill later with:" >&2
-      echo "  npx --yes skills add devopsellence/devopsellence --skill devopsellence -g --yes" >&2
-      exit 1
-    fi
+    install_agent_skill
     ;;
   *)
-    echo "agent skill available:"
-    echo "  npx --yes skills add devopsellence/devopsellence --skill devopsellence -g --yes"
-    echo "or rerun installer with DEVOPSELLENCE_INSTALL_AGENT_SKILL=1"
+    echo "agent skill available; rerun installer with DEVOPSELLENCE_INSTALL_AGENT_SKILL=1"
     ;;
 esac

--- a/control-plane/app/controllers/cli_installs_controller.rb
+++ b/control-plane/app/controllers/cli_installs_controller.rb
@@ -30,6 +30,7 @@ class CliInstallsController < ActionController::Base
       CLI_CHECKSUM_URL="${DEVOPSELLENCE_CLI_CHECKSUM_URL:-}"
       INSTALL_DIR="${DEVOPSELLENCE_CLI_INSTALL_DIR:-}"
       INSTALL_AGENT_SKILL="${DEVOPSELLENCE_INSTALL_AGENT_SKILL:-}"
+      AGENT_SKILLS_DIR="${DEVOPSELLENCE_AGENT_SKILLS_DIR:-}"
       TARGET_NAME="devopsellence"
 
       while [[ $# -gt 0 ]]; do
@@ -165,6 +166,17 @@ class CliInstallsController < ActionController::Base
         printf '"%s"' "$value"
       }
 
+      install_agent_skill() {
+        local skill_args=()
+
+        if [[ -n "$AGENT_SKILLS_DIR" ]]; then
+          skill_args+=(--dir "$AGENT_SKILLS_DIR")
+        fi
+
+        echo "installing devopsellence agent skill..."
+        "$INSTALL_DIR/$TARGET_NAME" skill install "${skill_args[@]}"
+      }
+
       echo "downloading devopsellence CLI..."
       curl -fsSL "$DOWNLOAD_URL" -o "$TMP_BIN"
       curl -fsSL "$CHECKSUM_URL" -o "$TMP_SUMS"
@@ -220,23 +232,10 @@ class CliInstallsController < ActionController::Base
 
       case "$INSTALL_AGENT_SKILL" in
         1|true|TRUE|yes|YES)
-          if command -v npx >/dev/null 2>&1; then
-            echo "installing devopsellence agent skill..."
-            npx --yes skills add devopsellence/devopsellence --skill devopsellence -g --yes
-            printf '{"schema_version":1,"event":"result","operation":"devopsellence install","cli_installed":true,"cli_path":'
-            json_string "$INSTALL_DIR/$TARGET_NAME"
-            printf ',"agent_skill_requested":true,"agent_skill_installed":true,"agent_skill":"devopsellence"}\\n'
-          else
-            echo "devopsellence CLI installed. Agent skill install requested, but npx was not found." >&2
-            echo "Install the skill later with:" >&2
-            echo "  npx --yes skills add devopsellence/devopsellence --skill devopsellence -g --yes" >&2
-            exit 1
-          fi
+          install_agent_skill
           ;;
         *)
-          echo "agent skill available:"
-          echo "  npx --yes skills add devopsellence/devopsellence --skill devopsellence -g --yes"
-          echo "or install CLI + skill together with:"
+          echo "agent skill available; install CLI + skill together with:"
           echo "  curl -fsSL \"$INSTALL_SCRIPT_URL?version=$CLI_VERSION\" | bash -s -- --install-agent-skill"
           ;;
       esac

--- a/control-plane/test/integration/installs_test.rb
+++ b/control-plane/test/integration/installs_test.rb
@@ -58,6 +58,7 @@ class InstallsTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "BASE_URL='https://dev.devopsellence.com'"
     assert_includes response.body, 'INSTALL_DIR="${DEVOPSELLENCE_CLI_INSTALL_DIR:-}"'
     assert_includes response.body, 'INSTALL_AGENT_SKILL="${DEVOPSELLENCE_INSTALL_AGENT_SKILL:-}"'
+    assert_includes response.body, 'AGENT_SKILLS_DIR="${DEVOPSELLENCE_AGENT_SKILLS_DIR:-}"'
     assert_includes response.body, "INSTALL_SCRIPT_URL='https://dev.devopsellence.com/lfg.sh'"
     assert_includes response.body, "--install-agent-skill"
     assert_includes response.body, 'INSTALL_DIR="$HOME/.local/bin"'
@@ -65,7 +66,8 @@ class InstallsTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "PATH_EXPORT='export PATH=\"'\"$INSTALL_DIR\"':$PATH\"'"
     assert_includes response.body, "echo '$PATH_EXPORT' >> $RC_FILE"
     assert_includes response.body, "source $RC_FILE"
-    assert_includes response.body, "npx --yes skills add devopsellence/devopsellence --skill devopsellence -g --yes"
+    assert_includes response.body, '"$INSTALL_DIR/$TARGET_NAME" skill install'
+    refute_includes response.body, "npx --yes skills add"
     assert_includes response.body, 'curl -fsSL "$INSTALL_SCRIPT_URL?version=$CLI_VERSION" | bash -s -- --install-agent-skill'
   end
 
@@ -118,15 +120,15 @@ class InstallsTest < ActionDispatch::IntegrationTest
 
     assert_predicate status, :success?, -> { "stdout:\n#{stdout}\nstderr:\n#{stderr}" }
     assert_includes stdout, "devopsellence CLI installed"
-    assert_equal "prerelease build\n", installed_cli
+    assert_includes installed_cli, "prerelease build"
   end
 
-  test "cli install script can install the agent skill when requested" do
+  test "cli install script can install the embedded agent skill when requested" do
     get "/lfg.sh", params: { version: "master-0053792f6aec" }
 
     assert_response :success
 
-    stdout, stderr, status, installed_cli, skill_args = run_cli_install_script(
+    stdout, stderr, status, installed_cli, installed_skill = run_cli_install_script(
       response.body,
       version: "master-0053792f6aec",
       install_agent_skill: true
@@ -134,29 +136,29 @@ class InstallsTest < ActionDispatch::IntegrationTest
 
     assert_predicate status, :success?, -> { "stdout:\n#{stdout}\nstderr:\n#{stderr}" }
     assert_includes stdout, "installing devopsellence agent skill"
-    assert_includes stdout, '"operation":"devopsellence install"'
-    assert_includes stdout, '"agent_skill_installed":true'
-    assert_includes stdout, '"agent_skill":"devopsellence"'
-    assert_equal "prerelease build\n", installed_cli
-    assert_equal [ "--yes", "skills", "add", "devopsellence/devopsellence", "--skill", "devopsellence", "-g", "--yes" ], skill_args
+    assert_includes stdout, '"action":"installed"'
+    assert_includes stdout, '"source":"embedded"'
+    assert_includes installed_cli, "prerelease build"
+    assert_equal "skill for master-0053792f6aec\n", installed_skill
   end
 
-  test "cli install script fails when requested agent skill cannot install without npx" do
+  test "cli install script installs requested agent skill without npx" do
     get "/lfg.sh", params: { version: "master-0053792f6aec" }
 
     assert_response :success
 
-    stdout, stderr, status, installed_cli, skill_args = run_cli_install_script(
+    stdout, stderr, status, installed_cli, installed_skill = run_cli_install_script(
       response.body,
       version: "master-0053792f6aec",
       install_agent_skill: true,
       include_npx: false
     )
 
-    refute_predicate status, :success?, -> { "stdout:\n#{stdout}\nstderr:\n#{stderr}" }
-    assert_includes stderr, "Agent skill install requested, but npx was not found"
-    assert_equal "prerelease build\n", installed_cli
-    assert_nil skill_args
+    assert_predicate status, :success?, -> { "stdout:\n#{stdout}\nstderr:\n#{stderr}" }
+    assert_includes stdout, '"action":"installed"'
+    assert_includes stdout, '"source":"embedded"'
+    assert_includes installed_cli, "prerelease build"
+    assert_equal "skill for master-0053792f6aec\n", installed_skill
   end
 
   test "cli install script defaults to user local bin on linux" do
@@ -172,7 +174,7 @@ class InstallsTest < ActionDispatch::IntegrationTest
 
     assert_predicate status, :success?, -> { "stdout:\n#{stdout}\nstderr:\n#{stderr}" }
     assert_includes stdout, "/.local/bin/devopsellence"
-    assert_equal "prerelease build\n", installed_cli
+    assert_includes installed_cli, "prerelease build"
   end
 
   test "cli install script normalizes relative install dir before path advice" do
@@ -189,7 +191,7 @@ class InstallsTest < ActionDispatch::IntegrationTest
     assert_predicate status, :success?, -> { "stdout:\n#{stdout}\nstderr:\n#{stderr}" }
     assert_includes stdout, "/bin/devopsellence"
     refute_includes stdout, "installed to bin/devopsellence"
-    assert_equal "prerelease build\n", installed_cli
+    assert_includes installed_cli, "prerelease build"
   end
 
   test "cli install script derives checksum url after parsing base url overrides" do
@@ -300,7 +302,7 @@ class InstallsTest < ActionDispatch::IntegrationTest
       script_path = File.join(tmpdir, "lfg.sh")
       artifact_path = File.join(fixtures_dir, "cli-linux-amd64")
       checksums_path = File.join(fixtures_dir, "cli-SHA256SUMS")
-      skill_args_path = File.join(tmpdir, "skill-args")
+      installed_skill_path = File.join(tmpdir, ".agents", "skills", "devopsellence", "SKILL.md")
 
       FileUtils.mkdir_p(fixtures_dir)
       FileUtils.mkdir_p(fakebin_dir)
@@ -352,7 +354,33 @@ class InstallsTest < ActionDispatch::IntegrationTest
         FileUtils.chmod("u+x", shasum_shim_path)
       end
 
-      File.write(artifact_path, "prerelease build\n")
+      File.write(artifact_path, <<~SH)
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        if [[ "${1:-}" == "skill" && "${2:-}" == "install" ]]; then
+          shift 2
+          skills_dir="$HOME/.agents/skills"
+          while [[ $# -gt 0 ]]; do
+            case "$1" in
+              --dir)
+                skills_dir="$2"
+                shift 2
+                ;;
+              *)
+                echo "unexpected skill arg: $1" >&2
+                exit 1
+                ;;
+            esac
+          done
+          mkdir -p "$skills_dir/devopsellence"
+          printf 'skill for #{version}\n' > "$skills_dir/devopsellence/SKILL.md"
+          printf '{"schema_version":1,"action":"installed","skill":"devopsellence","path":"%s","version":"%s","source":"embedded"}\n' "$skills_dir/devopsellence" #{version.inspect}
+          exit 0
+        fi
+
+        printf 'prerelease build\n'
+      SH
       digest = Digest::SHA256.file(artifact_path).hexdigest
       File.write(checksums_path, "#{digest}  cli-linux-amd64\n")
       File.write(script_path, script_body)
@@ -421,7 +449,8 @@ class InstallsTest < ActionDispatch::IntegrationTest
           #!/usr/bin/env bash
           set -euo pipefail
 
-          printf '%s\\n' "$@" > #{skill_args_path.inspect}
+          echo "unexpected npx invocation" >&2
+          exit 1
         SH
         FileUtils.chmod("u+x", npx_path)
       end
@@ -451,8 +480,8 @@ class InstallsTest < ActionDispatch::IntegrationTest
           File.expand_path(effective_install_dir, working_dir)
         end
       installed_cli = File.exist?(File.join(expected_install_dir, "devopsellence")) ? File.read(File.join(expected_install_dir, "devopsellence")) : nil
-      skill_args = File.exist?(skill_args_path) ? File.readlines(skill_args_path, chomp: true) : nil
-      [ stdout, stderr, status, installed_cli, skill_args ]
+      installed_skill = File.exist?(installed_skill_path) ? File.read(installed_skill_path) : nil
+      [ stdout, stderr, status, installed_cli, installed_skill ]
     end
   end
 end

--- a/docs-website/src/content/docs/getting-started/install.md
+++ b/docs-website/src/content/docs/getting-started/install.md
@@ -12,7 +12,8 @@ curl -fsSL https://www.devopsellence.com/lfg.sh | bash
 The installer writes to `~/.local/bin` by default. If that directory is not on
 your `PATH`, it prints the shell command to add it.
 
-devopsellence is AI-operator-first. To install the CLI and Codex skill together:
+devopsellence is AI-operator-first. To install the CLI and matching Codex skill
+together without requiring npm or `npx`:
 
 ```bash
 curl -fsSL https://www.devopsellence.com/lfg.sh | bash -s -- --install-agent-skill

--- a/docs-website/src/content/docs/index.md
+++ b/docs-website/src/content/docs/index.md
@@ -25,6 +25,9 @@ cd my-app
 codex e "Deploy this app with devopsellence solo."
 ```
 
+`--install-agent-skill` installs the matching skill from the CLI itself; it does
+not require npm or `npx`.
+
 - [Solo quickstart](/getting-started/solo-quickstart/) for the shortest path to
   one VM.
 - [Basecamp Fizzy on Rails](/examples/fizzy-rails-solo/) for a real Rails app


### PR DESCRIPTION
## Summary
- add `devopsellence skill install` to write the bundled matching devopsellence agent skill
- update public and local installers to call the installed CLI instead of `npx`
- update install docs and installer tests for the embedded skill flow

Supersedes the skill-install portion of #88.

## Tests
- `cd cli && mise run test -- ./internal/agentskill ./internal/workflow`
- `cd control-plane && mise run test -- test/integration/installs_test.rb`
- `cd docs-website && mise run build`
- `git diff --check`