### PR TITLE
fix(cli): expose devopsellence state home

### DIFF
--- a/cli/internal/state/store.go
+++ b/cli/internal/state/store.go
@@ -11,18 +11,35 @@ type Store struct {
 	Path string
 }
 
+const (
+	HomeEnv         = "DEVOPSELLENCE_STATE_HOME"
+	FallbackHomeEnv = "XDG_STATE_HOME"
+)
+
 func New(path string) *Store {
 	return &Store{Path: path}
 }
 
-func DefaultPath(rel string) string {
-	base := os.Getenv("XDG_STATE_HOME")
+func DefaultHome() string {
+	base := os.Getenv(HomeEnv)
+	if base != "" {
+		return base
+	}
+	base = os.Getenv(FallbackHomeEnv)
 	if base == "" {
 		home, err := os.UserHomeDir()
 		if err != nil {
-			return rel
+			return ""
 		}
 		base = filepath.Join(home, ".local", "state")
+	}
+	return base
+}
+
+func DefaultPath(rel string) string {
+	base := DefaultHome()
+	if base == "" {
+		return rel
 	}
 	return filepath.Join(base, rel)
 }

--- a/cli/internal/state/store_test.go
+++ b/cli/internal/state/store_test.go
@@ -40,3 +40,28 @@ func TestStoreWriteReadDelete(t *testing.T) {
 		t.Fatal("Delete() = false, want true")
 	}
 }
+
+func TestDefaultPathPrefersDevopsellenceStateHome(t *testing.T) {
+	preferred := filepath.Join(t.TempDir(), "devopsellence-state")
+	fallback := filepath.Join(t.TempDir(), "xdg-state")
+	t.Setenv(HomeEnv, preferred)
+	t.Setenv(FallbackHomeEnv, fallback)
+
+	got := DefaultPath(filepath.Join("devopsellence", "solo", "state.json"))
+	want := filepath.Join(preferred, "devopsellence", "solo", "state.json")
+	if got != want {
+		t.Fatalf("DefaultPath() = %q, want %q", got, want)
+	}
+}
+
+func TestDefaultPathUsesXDGStateHomeAsFallback(t *testing.T) {
+	fallback := filepath.Join(t.TempDir(), "xdg-state")
+	t.Setenv(HomeEnv, "")
+	t.Setenv(FallbackHomeEnv, fallback)
+
+	got := DefaultPath(filepath.Join("devopsellence", "workspace.json"))
+	want := filepath.Join(fallback, "devopsellence", "workspace.json")
+	if got != want {
+		t.Fatalf("DefaultPath() = %q, want %q", got, want)
+	}
+}

--- a/cli/internal/workflow/mode.go
+++ b/cli/internal/workflow/mode.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/devopsellence/cli/internal/discovery"
 	"github.com/devopsellence/cli/internal/solo"
+	"github.com/devopsellence/cli/internal/state"
 	"github.com/devopsellence/devopsellence/deployment-core/pkg/deploycore/config"
 )
 
@@ -163,6 +164,31 @@ func (a *App) workspaceHasSoloState(workspaceRoot string) bool {
 	return false
 }
 
+func storePath(store *state.Store) string {
+	if store == nil {
+		return ""
+	}
+	return strings.TrimSpace(store.Path)
+}
+
+func soloStorePath(store *solo.StateStore) string {
+	if store == nil {
+		return ""
+	}
+	return strings.TrimSpace(store.Path)
+}
+
+func (a *App) addLocalStateMetadata(payload map[string]any) {
+	payload["state_home_env"] = state.HomeEnv
+	payload["state_home_fallback_env"] = state.FallbackHomeEnv
+	if path := storePath(a.WorkspaceState); path != "" {
+		payload["workspace_state_path"] = path
+	}
+	if path := soloStorePath(a.SoloState); path != "" {
+		payload["solo_state_path"] = path
+	}
+}
+
 func (a *App) ResolveMode() (Mode, error) {
 	if saved, ok, err := a.savedMode(); err != nil {
 		return "", ExitError{Code: 1, Err: err}
@@ -197,6 +223,7 @@ func (a *App) ModeShow() error {
 		"workspace_key":  a.modeWorkspaceKey(),
 		"set":            ok,
 	}
+	a.addLocalStateMetadata(payload)
 	if ok {
 		payload["mode"] = string(mode)
 	}
@@ -220,6 +247,7 @@ func (a *App) ContextShow() error {
 		"workspace_root": discovered.WorkspaceRoot,
 		"mode_set":       ok,
 	}
+	a.addLocalStateMetadata(result)
 	if ok {
 		result["mode"] = string(mode)
 	}

--- a/cli/internal/workflow/root.go
+++ b/cli/internal/workflow/root.go
@@ -152,11 +152,13 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 			if err := app.SetMode(mode); err != nil {
 				return ExitError{Code: 1, Err: err}
 			}
-			return app.Printer.PrintJSON(map[string]any{
+			payload := map[string]any{
 				"schema_version": outputSchemaVersion,
 				"mode":           string(mode),
 				"workspace_key":  app.modeWorkspaceKey(),
-			})
+			}
+			app.addLocalStateMetadata(payload)
+			return app.Printer.PrintJSON(payload)
 		},
 	})
 	root.AddCommand(modeCommand)

--- a/cli/internal/workflow/root_test.go
+++ b/cli/internal/workflow/root_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/devopsellence/cli/internal/solo"
+	"github.com/devopsellence/cli/internal/state"
 	cliversion "github.com/devopsellence/cli/internal/version"
 	"github.com/devopsellence/devopsellence/deployment-core/pkg/deploycore/config"
 )
@@ -36,6 +37,32 @@ func TestRootVersionCommand(t *testing.T) {
 				t.Fatalf("version = %v, want non-empty string", payload["version"])
 			}
 		})
+	}
+}
+
+func TestRootModeUseIncludesLocalStateMetadata(t *testing.T) {
+	stateHome := filepath.Join(t.TempDir(), "devopsellence-state")
+	t.Setenv(state.HomeEnv, stateHome)
+	t.Setenv(state.FallbackHomeEnv, filepath.Join(t.TempDir(), "xdg-state"))
+
+	var stdout bytes.Buffer
+	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, t.TempDir())
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{"mode", "use", "solo"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	if payload["state_home_env"] != state.HomeEnv || payload["state_home_fallback_env"] != state.FallbackHomeEnv {
+		t.Fatalf("state env metadata = %#v", payload)
+	}
+	if payload["workspace_state_path"] != filepath.Join(stateHome, "devopsellence", "workspace.json") {
+		t.Fatalf("workspace_state_path = %#v", payload["workspace_state_path"])
+	}
+	if payload["solo_state_path"] != filepath.Join(stateHome, "devopsellence", "solo", "state.json") {
+		t.Fatalf("solo_state_path = %#v", payload["solo_state_path"])
 	}
 }
 

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -3282,6 +3282,7 @@ func (a *App) SoloNodeList(_ context.Context, opts SoloNodeListOptions) error {
 		"nodes":          nodes,
 		"node_items":     items,
 	}
+	a.addLocalStateMetadata(payload)
 	if warnings := soloNodeListDuplicateHostWarnings(current, nodeNames); len(warnings) > 0 {
 		payload["warnings"] = warnings
 	}
@@ -5932,7 +5933,7 @@ func (a *App) SoloInit(context.Context, SoloInitOptions) error {
 		"devopsellence doctor",
 		"devopsellence deploy",
 	}
-	return a.Printer.PrintJSON(map[string]any{
+	payload := map[string]any{
 		"schema_version":   outputSchemaVersion,
 		"mode":             string(ModeSolo),
 		"workspace_root":   discovered.WorkspaceRoot,
@@ -5948,7 +5949,9 @@ func (a *App) SoloInit(context.Context, SoloInitOptions) error {
 		"ready":       ready,
 		"missing":     missing,
 		"next_steps":  nextSteps,
-	})
+	}
+	a.addLocalStateMetadata(payload)
+	return a.Printer.PrintJSON(payload)
 }
 
 type runtimeContractProvenance struct {

--- a/docs-website/src/content/docs/reference/environment-variables.md
+++ b/docs-website/src/content/docs/reference/environment-variables.md
@@ -10,8 +10,9 @@ grow as CLI and release contracts stabilize.
 | --- | --- |
 | `DEVOPSELLENCE_TOKEN` | Shared-mode API token for non-interactive workflows. |
 | `DEVOPSELLENCE_STABLE_VERSION` | Shared stable release version for public installer/runtime surfaces. |
+| `DEVOPSELLENCE_STATE_HOME` | Base directory for local CLI, workspace, solo, SSH, and provider state. Takes precedence over `XDG_STATE_HOME`. |
 | `HCLOUD_TOKEN` | Hetzner token consumed by provider login examples. |
-| `XDG_STATE_HOME` | Base directory for local solo state when set. |
+| `XDG_STATE_HOME` | Fallback base directory for local state when `DEVOPSELLENCE_STATE_HOME` is unset. |
 
 Keep private tenant data, live credentials, cloud project IDs, and maintainer
 runtime environment details out of this public docs site.


### PR DESCRIPTION
## Summary
- add DEVOPSELLENCE_STATE_HOME as the devopsellence-specific state root, ahead of XDG_STATE_HOME
- include workspace/solo state paths and state-home env names in mode/context and solo node/init JSON outputs
- document the new env var in the public docs site

This is the state-home slice from #88, kept separate from skill install and ingress hints.

## Verification
- cd cli && mise run test -- ./internal/state ./internal/workflow
- cd docs-website && mise run build
- git diff --check