### PR TITLE
fix(cli): include service in temporary DNS hint

### DIFF
--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -7204,7 +7204,28 @@ func temporaryDNSHostname(_ *config.ProjectConfig, ip string) string {
 }
 
 func temporaryDNSCommand(cfg *config.ProjectConfig, hostname string, environment ...string) string {
-	return "devopsellence ingress set" + soloEnvFlag(firstNonEmpty(environment...)) + " --host " + shellQuote(hostname) + " --tls-mode " + shellQuote(temporaryDNSTLSMode(cfg))
+	return "devopsellence ingress set" + soloEnvFlag(firstNonEmpty(environment...)) + temporaryDNSServiceFlag(cfg) + " --host " + shellQuote(hostname) + " --tls-mode " + shellQuote(temporaryDNSTLSMode(cfg))
+}
+
+func temporaryDNSServiceFlag(cfg *config.ProjectConfig) string {
+	if cfg == nil || cfg.Ingress == nil {
+		return ""
+	}
+	services := map[string]bool{}
+	for _, rule := range cfg.Ingress.Rules {
+		serviceName := strings.TrimSpace(rule.Target.Service)
+		if serviceName == "" {
+			continue
+		}
+		services[serviceName] = true
+	}
+	if len(services) != 1 {
+		return ""
+	}
+	for serviceName := range services {
+		return " --service " + shellQuote(serviceName)
+	}
+	return ""
 }
 
 func temporaryDNSTLSMode(cfg *config.ProjectConfig) string {

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -1999,7 +1999,7 @@ func TestIngressDNSReportIncludesSSLIPHintForPublicIPWithoutConcreteHostnames(t 
 	if got, want := hint.SuggestedAction.Hostname, "8.8.8.8.sslip.io"; got != want {
 		t.Fatalf("suggested hostname = %q, want %q", got, want)
 	}
-	if !strings.Contains(hint.SuggestedAction.Command, "devopsellence ingress set --host '8.8.8.8.sslip.io' --tls-mode 'auto'") {
+	if !strings.Contains(hint.SuggestedAction.Command, "devopsellence ingress set --service 'web' --host '8.8.8.8.sslip.io' --tls-mode 'auto'") {
 		t.Fatalf("command = %q, want ingress set command", hint.SuggestedAction.Command)
 	}
 	if len(hint.SuggestedAction.Risks) == 0 {
@@ -2039,10 +2039,31 @@ func TestTemporaryDNSHostnameUsesPlainIPHost(t *testing.T) {
 
 func TestTemporaryDNSCommandPreservesConfiguredTLSMode(t *testing.T) {
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")
-	cfg.Ingress = &config.IngressConfig{TLS: config.IngressTLSConfig{Mode: " OFF "}}
+	cfg.Ingress = &config.IngressConfig{
+		Rules: []config.IngressRuleConfig{{
+			Target: config.IngressTargetConfig{Service: "api"},
+		}},
+		TLS: config.IngressTLSConfig{Mode: " OFF "},
+	}
 
 	got := temporaryDNSCommand(&cfg, "8.8.8.8.sslip.io")
-	want := "devopsellence ingress set --host '8.8.8.8.sslip.io' --tls-mode 'off'"
+	want := "devopsellence ingress set --service 'api' --host '8.8.8.8.sslip.io' --tls-mode 'off'"
+	if got != want {
+		t.Fatalf("temporaryDNSCommand() = %q, want %q", got, want)
+	}
+}
+
+func TestTemporaryDNSCommandOmitsServiceWhenAmbiguous(t *testing.T) {
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	cfg.Ingress = &config.IngressConfig{
+		Rules: []config.IngressRuleConfig{
+			{Target: config.IngressTargetConfig{Service: "api"}},
+			{Target: config.IngressTargetConfig{Service: "admin"}},
+		},
+	}
+
+	got := temporaryDNSCommand(&cfg, "8.8.8.8.sslip.io")
+	want := "devopsellence ingress set --host '8.8.8.8.sslip.io' --tls-mode 'auto'"
 	if got != want {
 		t.Fatalf("temporaryDNSCommand() = %q, want %q", got, want)
 	}

--- a/docs-website/src/content/docs/guides/ingress-tls.md
+++ b/docs-website/src/content/docs/guides/ingress-tls.md
@@ -25,5 +25,5 @@ For local experiments without a real hostname, `sslip.io` can be useful when a
 node has one public IP:
 
 ```bash
-devopsellence ingress set --host '203.0.113.10.sslip.io' --tls-mode auto
+devopsellence ingress set --service web --host '203.0.113.10.sslip.io' --tls-mode auto
 ```


### PR DESCRIPTION
## Summary
- include --service in solo sslip.io temporary-DNS hint commands when one ingress target service is known
- keep the command service-less when ingress targets are ambiguous
- update the ingress/TLS docs example to use --service explicitly

This is the remaining tiny ingress-hint slice from #88, separated from skill install and state-home work.

## Verification
- cd cli && mise run test -- ./internal/workflow
- cd docs-website && mise run build
- git diff --check