### PR TITLE
[codex] document CloudStack VM nodes

### DIFF
--- a/docs-website/astro.config.mjs
+++ b/docs-website/astro.config.mjs
@@ -42,6 +42,7 @@ export default defineConfig({
           items: [
             { label: "Deploy with solo", link: "/guides/solo-deploy/" },
             { label: "Deploy with shared", link: "/guides/shared-deploy/" },
+            { label: "CloudStack VMs", link: "/guides/cloudstack-vms/" },
             { label: "GitHub Actions", link: "/guides/github-actions/" },
             { label: "Secrets", link: "/guides/secrets/" },
             { label: "Ingress and TLS", link: "/guides/ingress-tls/" },

--- a/docs-website/src/content/docs/guides/cloudstack-vms.md
+++ b/docs-website/src/content/docs/guides/cloudstack-vms.md
@@ -1,0 +1,88 @@
+---
+title: CloudStack VMs
+description: Use an Apache CloudStack instance as a devopsellence node.
+---
+
+devopsellence can run on a VM provisioned by Apache CloudStack. CloudStack
+provides the IaaS layer: instance, network, public IP, firewall or security
+group rules, and SSH access. devopsellence treats that instance as an ordinary
+node.
+
+Use this path when the CloudStack VM already exists or when an operator wants to
+provision the VM through CloudStack, Terraform, cloudmonkey, or another existing
+tool.
+
+## VM requirements
+
+Create an Ubuntu VM with:
+
+- key-based SSH from the workstation or operator host;
+- a user that can install and run Docker;
+- outbound network access for image pulls and agent updates;
+- inbound SSH from the operator host;
+- inbound HTTP and HTTPS if the node will serve public ingress.
+
+CloudStack network setups vary. Before registering the node, confirm that the
+VM's public address, static NAT, firewall rules, port forwarding rules, or
+security group rules expose the ports devopsellence needs.
+
+## Solo mode
+
+Register the CloudStack VM as a normal SSH node:
+
+```bash
+devopsellence node create prod-1 --host 203.0.113.10 --user root --ssh-key ~/.ssh/id_ed25519
+devopsellence agent install prod-1
+devopsellence node attach prod-1
+devopsellence doctor
+```
+
+Then deploy as usual:
+
+```bash
+devopsellence deploy --dry-run
+devopsellence deploy
+devopsellence status
+```
+
+## Shared mode
+
+For shared mode, register the existing CloudStack VM from the workspace:
+
+```bash
+devopsellence node register
+```
+
+Run the install command returned by the CLI on the CloudStack VM. The node agent
+will register with the control plane, receive desired-state assignments, and
+reconcile containers on the VM.
+
+## Boundary
+
+CloudStack should stay the infrastructure provider in this workflow. It creates
+and exposes the VM. devopsellence installs the node agent, publishes desired
+state, resolves secrets through configured adapters, pulls images, configures
+Envoy, and reports status.
+
+Do not use CloudStack user data as the desired-state store. User data is useful
+for first-boot bootstrap, but desired state should remain the devopsellence node
+agent contract.
+
+## Troubleshooting
+
+Check CloudStack first when the node is unreachable:
+
+- the VM is running;
+- the public IP or static NAT target is correct;
+- SSH is open from the operator host;
+- HTTP and HTTPS are open for ingress nodes;
+- the selected network offering provides user data only if bootstrap depends on
+  cloud-init.
+
+Then inspect the node through devopsellence:
+
+```bash
+devopsellence doctor
+devopsellence node diagnose prod-1
+devopsellence node logs prod-1 --lines 100
+```

--- a/docs-website/src/content/docs/guides/shared-deploy.md
+++ b/docs-website/src/content/docs/guides/shared-deploy.md
@@ -24,5 +24,8 @@ By default, registration generates a token scoped to the current environment.
 Run the output command on the server to install the node agent and attach the
 node.
 
+CloudStack VMs use this existing-server path today. See
+[CloudStack VMs](/guides/cloudstack-vms/).
+
 Shared mode is the right default when API tokens, browser auth, team workflows,
 and hosted/self-hosted coordination are part of the product requirement.

--- a/docs-website/src/content/docs/guides/solo-deploy.md
+++ b/docs-website/src/content/docs/guides/solo-deploy.md
@@ -41,3 +41,6 @@ devopsellence provider login hetzner --token "$HCLOUD_TOKEN"
 devopsellence node create prod-1 --provider hetzner --install --attach
 devopsellence doctor
 ```
+
+For CloudStack, create the VM through CloudStack and add it as an existing SSH
+node. See [CloudStack VMs](/guides/cloudstack-vms/).


### PR DESCRIPTION
## Summary

- Add a docs guide for using an Apache CloudStack VM as an existing devopsellence node.
- Link the guide from solo and shared deploy docs.
- Add the guide to the docs website sidebar.

## Validation

- `npm run check`
- `npm run build`

## Notes

This keeps CloudStack scoped to the IaaS/VM boundary: CloudStack provisions and exposes the VM; devopsellence installs the node agent and reconciles desired state.