### PR TITLE
docs: explain multi-node auto TLS

### DIFF
--- a/docs-website/src/content/docs/concepts/runtime-model.md
+++ b/docs-website/src/content/docs/concepts/runtime-model.md
@@ -17,7 +17,15 @@ The core objects are:
 - **Desired state**: the per-node document the node agent reconciles.
 - **Status**: observed runtime state reported by the node.
 - **Ingress intent**: hostnames, routes, TLS mode, and HTTP redirect behavior.
+- **Node peers**: the other attached nodes a node may need to know about for
+  peer-aware runtime behavior such as multi-node ACME HTTP-01 challenge
+  forwarding.
 
 Placement is policy, not runtime schema. Solo can co-host environments on a node
 when that is useful. Shared may choose stricter policies for isolation, quotas,
 and operational clarity.
+
+A useful consequence is that solo remains local-only without being single-node
+only. The CLI can publish enough desired state over SSH for nodes to cooperate at
+runtime, while the node agent stays mode-agnostic and reconciles the same shape
+of intent in both solo and shared mode.

--- a/docs-website/src/content/docs/guides/ingress-tls.md
+++ b/docs-website/src/content/docs/guides/ingress-tls.md
@@ -21,6 +21,29 @@ Pass `--service` when the target web service is not obvious.
 `ingress check --wait` checks DNS readiness. After deploy, use
 `devopsellence status` and `curl` to confirm TLS reachability.
 
+## Auto TLS On Multiple Nodes
+
+Auto TLS uses the same node-agent mechanism in solo and shared mode: desired
+state carries ingress intent plus node peers, and each web node runs an ACME
+HTTP-01 challenge responder. If Let's Encrypt asks one node for a challenge token
+that another node created, the node can fetch the challenge response from its web
+peers and serve it back.
+
+This matters most in solo mode because there is no hosted control plane in the
+runtime path. The local CLI can still publish enough desired state over SSH for a
+multi-node, local-only deployment to cooperate at runtime.
+
+Multi-node `tls.mode: auto` requires:
+
+- DNS for the hostname reaches the attached web nodes;
+- port 80 is reachable for HTTP-01 validation;
+- attached web nodes have public addresses in node state;
+- the nodes can reach each other over HTTP for challenge forwarding.
+
+Certificates are stored on each node rather than in a shared hosted certificate
+store. Treat HTTPS as ready only after `devopsellence ingress check --wait`,
+`devopsellence status`, and a direct HTTPS request succeed.
+
 For local experiments without a real hostname, `sslip.io` can be useful when a
 node has one public IP:
 


### PR DESCRIPTION
## Summary
- document node peers as part of the shared runtime model
- explain multi-node ACME HTTP-01 challenge forwarding for solo/shared auto TLS
- keep current sslip.io guidance with explicit --service intact

Supersedes the useful docs slice from #143 on current master.

## Verification
- cd docs-website && npm install
- cd docs-website && mise run build
- git diff --check