### PR TITLE
docs: clarify AI operator model

### DIFF
--- a/docs-website/src/content/docs/concepts/agent-primary.md
+++ b/docs-website/src/content/docs/concepts/agent-primary.md
@@ -11,6 +11,17 @@ with ordinary tools.
 In these docs, **AI operator** means the AI assistant using devopsellence on a
 human's behalf. **Node agent** means the daemon running on a VM.
 
+## Why This Model Matters
+
+Traditional deployment tools often assume a human is reading prose logs,
+remembering the right follow-up command, and manually wiring several systems
+together. AI operators can help, but only when the tools they call expose
+explicit state, safe boundaries, and actionable next steps.
+
+devopsellence makes that the product contract. The CLI should tell the AI
+operator what happened, what is still pending, what failed, which action is safe
+to take next, and which facts should be passed to another tool.
+
 AI-operator-first operations need:
 
 - JSON output by default;
@@ -26,3 +37,31 @@ AI-operator-first operations need:
 The rule: AI operators should not invent live production mutations. They should
 inspect config, produce plans, publish desired state after approval, observe
 node-agent reconciliation, and propose repairs through devopsellence contracts.
+
+## Compose With Ordinary Tools
+
+AI-operator-first does not mean devopsellence owns every cloud integration. It
+means devopsellence exposes deployment truth clearly enough for an AI operator to
+compose it with the rest of the user's stack.
+
+For example, a user can ask an AI operator to deploy an app and point a hostname
+at it. The operator can:
+
+1. run `devopsellence deploy`;
+2. read the structured result for node IPs, ingress state, warnings, and DNS
+   requirements;
+3. call the user's DNS provider through an ordinary CLI or API;
+4. run `devopsellence ingress check --wait` to wait for DNS and TLS readiness;
+5. verify the public URL with an HTTP check;
+6. report the final URL, evidence, and any remaining caveats.
+
+The boundary stays narrow: devopsellence deploys and reconciles containerized
+apps on VMs, while AI operators combine it with DNS, GitHub Actions, secret
+stores, monitoring, incident tools, and other tools the user already has.
+
+## Transparent For Humans
+
+The same contracts that help AI operators also help humans. JSON output,
+dry-run plans, stable error codes, and explicit next actions make it easier to
+review what happened, approve risky steps, reproduce a workflow locally, and
+recover with SSH, Docker, files, and logs when automation is not enough.

--- a/docs-website/src/content/docs/index.md
+++ b/docs-website/src/content/docs/index.md
@@ -32,6 +32,9 @@ not require npm or `npx`.
   one VM.
 - [Basecamp Fizzy on Rails](/examples/fizzy-rails-solo/) for a real Rails app
   example that maps a Kamal-style deployment to devopsellence solo.
+- [AI operator model](/concepts/agent-primary/) for the product thesis: a CLI
+  that gives AI operators structured feedback, safe boundaries, and facts they
+  can compose with the user's tools.
 - [Runtime model](/concepts/runtime-model/) for desired state, releases,
   services, nodes, and status.
 - [CLI reference](/reference/cli/) for the AI-operator-safe command surface.


### PR DESCRIPTION
## Summary
- keep the established AI operator model naming instead of renaming it to agent-first DevOps
- explain why structured state, safe boundaries, and next actions matter for AI operators
- add a concise composability/human recovery section and homepage link

Supersedes the useful positioning slice from #141 on current master.

## Verification
- cd docs-website && mise run build
- git diff --check