### PR TITLE
[codex] improve solo runtime verification output

### DIFF
--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -583,7 +583,8 @@ func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 		return err
 	}
 
-	runtimeVerified := soloDeployRuntimeVerified(false, false)
+	verifiedURLs, endpointProbeVerified, tlsVerified := a.soloVerifiedPublicURLs(workspaceRoot, environmentName, cfg, nodes)
+	runtimeVerified := soloDeployRuntimeVerified(endpointProbeVerified, tlsVerified, ingressRequiresTLSReadiness(cfg))
 	payload := map[string]any{
 		"release_id":              release.ID,
 		"deployment_id":           deployment.ID,
@@ -596,16 +597,19 @@ func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 		"rollout_contract":        soloDeployRolloutContract(cfg),
 		"runtime_verified":        runtimeVerified,
 	}
-	if urls, endpointProbeVerified, tlsVerified := a.soloVerifiedPublicURLs(workspaceRoot, environmentName, cfg, nodes); len(urls) > 0 {
-		payload["public_urls"] = urls
-		runtimeVerified["endpoint_probe"] = endpointProbeVerified
-		runtimeVerified["tls"] = tlsVerified
-		payload["next_steps"] = append([]string{"devopsellence status" + soloEnvFlag(environmentName), "curl " + urls[0]}, soloNodeLogNextSteps(environmentName, nodes)...)
+	if len(verifiedURLs) > 0 {
+		payload["public_urls"] = verifiedURLs
+		payload["next_steps"] = append([]string{"devopsellence status" + soloEnvFlag(environmentName), "curl " + verifiedURLs[0]}, soloNodeLogNextSteps(environmentName, nodes)...)
 	} else if urls := soloStatusPublicURLs(cfg, nodes); len(urls) > 0 {
 		payload["configured_public_urls"] = urls
 		payload["public_url_status"] = soloPublicURLStatus(cfg)
 		payload["warnings"] = []string{soloPublicURLWarning(cfg, environmentName)}
-		payload["next_steps"] = append([]string{"devopsellence status" + soloEnvFlag(environmentName)}, soloNodeLogNextSteps(environmentName, nodes)...)
+		nextSteps := []string{"devopsellence status" + soloEnvFlag(environmentName)}
+		if ingressRequiresTLSReadiness(cfg) {
+			nextSteps = append(nextSteps, "devopsellence ingress check"+soloEnvFlag(environmentName)+" --wait 5m")
+		}
+		nextSteps = append(nextSteps, soloNodeLogNextSteps(environmentName, nodes)...)
+		payload["next_steps"] = nextSteps
 	} else {
 		payload["next_steps"] = append([]string{"devopsellence status" + soloEnvFlag(environmentName)}, soloNodeLogNextSteps(environmentName, nodes)...)
 	}
@@ -613,14 +617,73 @@ func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 
 }
 
-func soloDeployRuntimeVerified(endpointProbe, tls bool) map[string]any {
-	return map[string]any{
-		"desired_state_revision": true,
-		"container_replaced":     false,
-		"healthcheck":            true,
-		"endpoint_probe":         endpointProbe,
-		"tls":                    tls,
+type soloRuntimeVerification struct {
+	DesiredStateRevision bool
+	Healthcheck          bool
+	ContainerReplaced    bool
+	EndpointProbe        bool
+	TLS                  bool
+	PublicEndpointNeeded bool
+}
+
+func soloDeployRuntimeVerified(endpointProbe, tls, publicEndpointNeeded bool) map[string]any {
+	return soloRuntimeVerifiedPayload(soloRuntimeVerification{
+		DesiredStateRevision: true,
+		Healthcheck:          true,
+		ContainerReplaced:    false,
+		EndpointProbe:        endpointProbe,
+		TLS:                  tls,
+		PublicEndpointNeeded: publicEndpointNeeded,
+	})
+}
+
+func soloRuntimeVerifiedPayload(verification soloRuntimeVerification) map[string]any {
+	ready := verification.DesiredStateRevision && verification.Healthcheck
+	if verification.PublicEndpointNeeded {
+		ready = ready && verification.EndpointProbe && verification.TLS
 	}
+	payload := map[string]any{
+		"desired_state_revision": verification.DesiredStateRevision,
+		"container_replaced":     verification.ContainerReplaced,
+		"healthcheck":            verification.Healthcheck,
+		"endpoint_probe":         verification.EndpointProbe,
+		"tls":                    verification.TLS,
+		"ready":                  ready,
+		"confidence": map[string]string{
+			"desired_state_revision": soloRuntimeVerificationConfidence(verification.DesiredStateRevision, true),
+			"container_replaced":     soloRuntimeVerificationConfidence(verification.ContainerReplaced, true),
+			"healthcheck":            soloRuntimeVerificationConfidence(verification.Healthcheck, true),
+			"endpoint_probe":         soloRuntimeVerificationConfidence(verification.EndpointProbe, verification.PublicEndpointNeeded),
+			"tls":                    soloRuntimeVerificationConfidence(verification.TLS, verification.PublicEndpointNeeded),
+		},
+	}
+	pending := []string{}
+	if !verification.DesiredStateRevision {
+		pending = append(pending, "desired_state_revision")
+	}
+	if !verification.Healthcheck {
+		pending = append(pending, "healthcheck")
+	}
+	if verification.PublicEndpointNeeded && !verification.EndpointProbe {
+		pending = append(pending, "endpoint_probe")
+	}
+	if verification.PublicEndpointNeeded && !verification.TLS {
+		pending = append(pending, "tls")
+	}
+	if len(pending) > 0 {
+		payload["pending"] = pending
+	}
+	return payload
+}
+
+func soloRuntimeVerificationConfidence(verified, required bool) string {
+	if verified {
+		return "verified"
+	}
+	if !required {
+		return "not_required"
+	}
+	return "not_verified"
 }
 
 func soloDeployRolloutContract(cfg *config.ProjectConfig) []map[string]any {
@@ -1795,7 +1858,26 @@ func (a *App) soloProgress(operation string, fields map[string]any) func(string)
 		for key, value := range fields {
 			payload[key] = value
 		}
+		if _, ok := payload["step"]; !ok {
+			if step := soloProgressStep(message); step != "" {
+				payload["step"] = step
+			}
+		}
 		_ = a.Printer.PrintEvent("progress", payload)
+	}
+}
+
+func soloProgressStep(message string) string {
+	message = strings.ToLower(strings.TrimSpace(message))
+	switch {
+	case strings.Contains(message, "docker image"):
+		return "image_build"
+	case strings.Contains(message, "ready"):
+		return "node_ready"
+	case strings.Contains(message, "create"):
+		return "node_create"
+	default:
+		return ""
 	}
 }
 
@@ -1937,7 +2019,8 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 	if len(nodes) == 0 {
 		return fmt.Errorf("no nodes attached to the current environment")
 	}
-	verifiedPublicURLs, _, _ := a.soloVerifiedPublicURLs(workspaceRoot, environmentName, cfg, nodes)
+	verifiedPublicURLs, endpointProbeVerified, tlsVerified := a.soloVerifiedPublicURLs(workspaceRoot, environmentName, cfg, nodes)
+	configuredPublicURLs := soloStatusPublicURLs(cfg, nodes)
 	releaseRequired := workspaceRoot != "" && environmentName != "" && (len(opts.Nodes) == 0 || strings.TrimSpace(opts.Environment) != "")
 	localReleaseKnown := len(opts.Nodes) > 0 && !releaseRequired
 	expectedRevisions := map[string]string{}
@@ -2096,11 +2179,20 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 			payload["configured_public_urls"] = verifiedPublicURLs
 			appendPayloadWarning("public URLs are configured, but one or more nodes are not settled; check `devopsellence status" + soloEnvFlag(environmentName) + "` before testing reachability")
 		}
-	} else if urls := soloStatusPublicURLs(cfg, nodes); len(urls) > 0 {
-		payload["configured_public_urls"] = urls
+	} else if len(configuredPublicURLs) > 0 {
+		payload["configured_public_urls"] = configuredPublicURLs
 		payload["public_url_status"] = soloPublicURLStatus(cfg)
 		appendPayloadWarning(soloPublicURLWarning(cfg, environmentName))
 	}
+	statusRuntimeVerified := allSettled && hasCurrent && readErrors == 0 && statusErrors == 0 && statusMismatches == 0 && missingStatuses == 0
+	payload["runtime_verified"] = soloRuntimeVerifiedPayload(soloRuntimeVerification{
+		DesiredStateRevision: statusRuntimeVerified,
+		Healthcheck:          statusRuntimeVerified,
+		ContainerReplaced:    false,
+		EndpointProbe:        endpointProbeVerified,
+		TLS:                  tlsVerified,
+		PublicEndpointNeeded: ingressRequiresTLSReadiness(cfg),
+	})
 	if allSettled && hasCurrent && hasRecoveryCandidate && len(opts.Nodes) == 0 && soloRecoveryTargetsChecked(recoveryTargets, recoveryChecked) {
 		var recovered corerelease.Deployment
 		var recoveredState solo.State

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -1261,6 +1261,14 @@ func TestSoloStatusUsesResolvedEnvironmentOverlay(t *testing.T) {
 	if len(urls) != 1 || urls[0] != "http://staging.example.com/" {
 		t.Fatalf("public_urls = %#v, want staging host only", urls)
 	}
+	runtimeVerified := jsonMapFromAny(t, payload["runtime_verified"])
+	if runtimeVerified["ready"] != true || runtimeVerified["desired_state_revision"] != true || runtimeVerified["healthcheck"] != true {
+		t.Fatalf("runtime_verified = %#v, want status to confirm current settled release", runtimeVerified)
+	}
+	confidence := jsonMapFromAny(t, runtimeVerified["confidence"])
+	if confidence["endpoint_probe"] != "not_required" || confidence["tls"] != "not_required" {
+		t.Fatalf("confidence = %#v, want public endpoint checks marked not required for HTTP", confidence)
+	}
 }
 
 func TestSoloStatusUsesExplicitEnvironment(t *testing.T) {
@@ -1494,6 +1502,14 @@ func TestSoloStatusDoesNotTreatDNSOnlyTLSCheckAsVerifiedPublicURL(t *testing.T) 
 	if payload["public_url_status"] != "configured_tls_pending" {
 		t.Fatalf("public_url_status = %#v, want configured_tls_pending", payload["public_url_status"])
 	}
+	runtimeVerified := jsonMapFromAny(t, payload["runtime_verified"])
+	if runtimeVerified["ready"] != false || runtimeVerified["endpoint_probe"] != false || runtimeVerified["tls"] != false {
+		t.Fatalf("runtime_verified = %#v, want TLS endpoint still pending", runtimeVerified)
+	}
+	pending := jsonArrayFromMap(t, runtimeVerified, "pending")
+	if !jsonArrayContains(pending, "endpoint_probe") || !jsonArrayContains(pending, "tls") {
+		t.Fatalf("pending = %#v, want endpoint_probe and tls", pending)
+	}
 }
 
 func TestSoloStatusTreatsTLSVerifiedCheckAsReadyPublicURL(t *testing.T) {
@@ -1547,6 +1563,10 @@ func TestSoloStatusTreatsTLSVerifiedCheckAsReadyPublicURL(t *testing.T) {
 	}
 	if _, ok := payload["public_url_status"]; ok {
 		t.Fatalf("payload = %#v, did not want pending public_url_status after TLS verification", payload)
+	}
+	runtimeVerified := jsonMapFromAny(t, payload["runtime_verified"])
+	if runtimeVerified["ready"] != true || runtimeVerified["endpoint_probe"] != true || runtimeVerified["tls"] != true {
+		t.Fatalf("runtime_verified = %#v, want TLS endpoint verified", runtimeVerified)
 	}
 }
 
@@ -7468,6 +7488,22 @@ func TestSoloDeployWaitsForSettledStatusBeforeSuccess(t *testing.T) {
 	if runtimeVerified["tls"] != false {
 		t.Fatalf("runtime_verified = %#v, plain HTTP deploy must not report TLS verified", runtimeVerified)
 	}
+	if runtimeVerified["ready"] != true {
+		t.Fatalf("runtime_verified = %#v, want deploy runtime ready after settled rollout", runtimeVerified)
+	}
+	confidence := jsonMapFromAny(t, runtimeVerified["confidence"])
+	if confidence["desired_state_revision"] != "verified" || confidence["endpoint_probe"] != "not_required" || confidence["tls"] != "not_required" {
+		t.Fatalf("confidence = %#v, want verified runtime and non-required public endpoint checks", confidence)
+	}
+	var sawBuildStep bool
+	for _, event := range events {
+		if event["event"] == "progress" && event["step"] == "image_build" {
+			sawBuildStep = true
+		}
+	}
+	if !sawBuildStep {
+		t.Fatalf("events = %#v, want machine-readable image_build progress step", events)
+	}
 	nextSteps := jsonArrayFromMap(t, payload, "next_steps")
 	if len(nextSteps) != 4 || nextSteps[0] != "devopsellence status --env 'production'" || nextSteps[1] != "curl http://203.0.113.10/" || nextSteps[2] != "devopsellence logs --env 'production' --node 'node-a' --lines 100" || nextSteps[3] != "devopsellence node logs 'node-a' --lines 100" {
 		t.Fatalf("next_steps = %#v, want status, curl, and logs commands", nextSteps)
@@ -7571,6 +7607,14 @@ func TestSoloDeployDoesNotTreatDNSOnlyTLSCheckAsVerifiedPublicURL(t *testing.T) 
 	warnings := jsonArrayFromMap(t, payload, "warnings")
 	if len(warnings) != 1 || !strings.Contains(stringValueAny(warnings[0]), "devopsellence status --env 'production'") {
 		t.Fatalf("warnings = %#v, want env-qualified status guidance", warnings)
+	}
+	runtimeVerified := jsonMapFromAny(t, payload["runtime_verified"])
+	if runtimeVerified["ready"] != false || runtimeVerified["endpoint_probe"] != false || runtimeVerified["tls"] != false {
+		t.Fatalf("runtime_verified = %#v, want pending public endpoint verification", runtimeVerified)
+	}
+	nextSteps := jsonArrayFromMap(t, payload, "next_steps")
+	if len(nextSteps) < 2 || nextSteps[1] != "devopsellence ingress check --env 'production' --wait 5m" {
+		t.Fatalf("next_steps = %#v, want env-scoped ingress check before logs", nextSteps)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a shared solo runtime verification payload with ready, confidence, and pending fields
- include runtime_verified on solo status as well as deploy
- add machine-readable progress steps and env-scoped ingress follow-up commands for pending TLS checks

Closes #148

## Tests
- cd cli && mise run test -- ./internal/workflow