### PR TITLE
Fix solo dogfood release blockers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ Critical defaults:
 - Desired-state/status payloads backed by protobuf use protobuf JSON casing; Rails-owned JSON/API payloads use snake_case.
 - Product intent: one shared stable release version. Use `DEVOPSELLENCE_STABLE_VERSION`; do not add per-component stable version env vars or defaults.
 - Keep ordinary-tool escape hatches: SSH, Docker, files, logs, JSON, cloud CLIs.
+- CLI operator environments are Linux, macOS, and WSL on Windows. Do not treat native Windows as a supported CLI surface unless product direction explicitly changes.
 
 ## Layout
 

--- a/cli/internal/solo/lock_unix.go
+++ b/cli/internal/solo/lock_unix.go
@@ -1,0 +1,32 @@
+//go:build !windows
+
+package solo
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+)
+
+func (s *StateStore) WithLock(fn func() error) error {
+	if s == nil || strings.TrimSpace(s.Path) == "" {
+		return errors.New("solo state store path is required")
+	}
+	lockPath := s.Path + ".lock"
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o755); err != nil {
+		return err
+	}
+	lockFile, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return fmt.Errorf("open solo state lock: %w", err)
+	}
+	defer lockFile.Close()
+	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX); err != nil {
+		return fmt.Errorf("lock solo state: %w", err)
+	}
+	defer syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN)
+	return fn()
+}

--- a/cli/internal/solo/lock_unix.go
+++ b/cli/internal/solo/lock_unix.go
@@ -12,6 +12,10 @@ import (
 )
 
 func (s *StateStore) WithLock(fn func() error) error {
+	return s.WithLockNotify(fn, nil)
+}
+
+func (s *StateStore) WithLockNotify(fn func() error, waiting func() error) error {
 	if s == nil || strings.TrimSpace(s.Path) == "" {
 		return errors.New("solo state store path is required")
 	}
@@ -24,9 +28,20 @@ func (s *StateStore) WithLock(fn func() error) error {
 		return fmt.Errorf("open solo state lock: %w", err)
 	}
 	defer lockFile.Close()
-	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX); err != nil {
-		return fmt.Errorf("lock solo state: %w", err)
+	fd := int(lockFile.Fd())
+	if err := syscall.Flock(fd, syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		if err != syscall.EWOULDBLOCK && err != syscall.EAGAIN {
+			return fmt.Errorf("lock solo state: %w", err)
+		}
+		if waiting != nil {
+			if waitErr := waiting(); waitErr != nil {
+				return waitErr
+			}
+		}
+		if err := syscall.Flock(fd, syscall.LOCK_EX); err != nil {
+			return fmt.Errorf("lock solo state: %w", err)
+		}
 	}
-	defer syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN)
+	defer syscall.Flock(fd, syscall.LOCK_UN)
 	return fn()
 }

--- a/cli/internal/solo/lock_windows.go
+++ b/cli/internal/solo/lock_windows.go
@@ -1,0 +1,15 @@
+//go:build windows
+
+package solo
+
+import (
+	"errors"
+	"strings"
+)
+
+func (s *StateStore) WithLock(fn func() error) error {
+	if s == nil || strings.TrimSpace(s.Path) == "" {
+		return errors.New("solo state store path is required")
+	}
+	return fn()
+}

--- a/cli/internal/solo/lock_windows.go
+++ b/cli/internal/solo/lock_windows.go
@@ -11,5 +11,5 @@ func (s *StateStore) WithLock(fn func() error) error {
 	if s == nil || strings.TrimSpace(s.Path) == "" {
 		return errors.New("solo state store path is required")
 	}
-	return fn()
+	return errors.New("solo state locking is not supported on native Windows; run devopsellence from WSL, Linux, or macOS")
 }

--- a/cli/internal/solo/lock_windows.go
+++ b/cli/internal/solo/lock_windows.go
@@ -8,6 +8,10 @@ import (
 )
 
 func (s *StateStore) WithLock(fn func() error) error {
+	return s.WithLockNotify(fn, nil)
+}
+
+func (s *StateStore) WithLockNotify(fn func() error, waiting func() error) error {
 	if s == nil || strings.TrimSpace(s.Path) == "" {
 		return errors.New("solo state store path is required")
 	}

--- a/cli/internal/solo/state.go
+++ b/cli/internal/solo/state.go
@@ -170,14 +170,16 @@ func writeFileAtomicPrivate(path string, data []byte) error {
 }
 
 func (s *StateStore) Update(fn func(*State) error) error {
-	current, err := s.Read()
-	if err != nil {
-		return err
-	}
-	if err := fn(&current); err != nil {
-		return err
-	}
-	return s.Write(current)
+	return s.WithLock(func() error {
+		current, err := s.Read()
+		if err != nil {
+			return err
+		}
+		if err := fn(&current); err != nil {
+			return err
+		}
+		return s.Write(current)
+	})
 }
 
 func validateStateSchemaVersion(version int) error {

--- a/cli/internal/solo/state_test.go
+++ b/cli/internal/solo/state_test.go
@@ -5,7 +5,9 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/devopsellence/devopsellence/deployment-core/pkg/deploycore/config"
 	"github.com/devopsellence/devopsellence/deployment-core/pkg/deploycore/desiredstate"
@@ -31,6 +33,52 @@ func TestCanonicalWorkspaceKeyResolvesSymlinks(t *testing.T) {
 	}
 	if got != realRoot {
 		t.Fatalf("CanonicalWorkspaceKey() = %q, want %q", got, realRoot)
+	}
+}
+
+func TestStateStoreWithLockSerializesCallers(t *testing.T) {
+	t.Parallel()
+
+	store := NewStateStore(filepath.Join(t.TempDir(), "state.json"))
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		done <- store.WithLock(func() error {
+			close(entered)
+			<-release
+			return nil
+		})
+	}()
+	<-entered
+
+	var ran atomic.Bool
+	blocked := make(chan error, 1)
+	go func() {
+		blocked <- store.WithLock(func() error {
+			ran.Store(true)
+			return nil
+		})
+	}()
+
+	select {
+	case err := <-blocked:
+		t.Fatalf("second lock completed early: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	if ran.Load() {
+		t.Fatal("second lock callback ran before first lock released")
+	}
+
+	close(release)
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+	if err := <-blocked; err != nil {
+		t.Fatal(err)
+	}
+	if !ran.Load() {
+		t.Fatal("second lock callback did not run")
 	}
 }
 

--- a/cli/internal/solo/state_test.go
+++ b/cli/internal/solo/state_test.go
@@ -53,16 +53,18 @@ func TestStateStoreWithLockSerializesCallers(t *testing.T) {
 	<-entered
 
 	var ran atomic.Bool
-	attempting := make(chan struct{})
+	waiting := make(chan struct{})
 	blocked := make(chan error, 1)
 	go func() {
-		close(attempting)
-		blocked <- store.WithLock(func() error {
+		blocked <- store.WithLockNotify(func() error {
 			ran.Store(true)
+			return nil
+		}, func() error {
+			close(waiting)
 			return nil
 		})
 	}()
-	<-attempting
+	<-waiting
 
 	select {
 	case err := <-blocked:

--- a/cli/internal/solo/state_test.go
+++ b/cli/internal/solo/state_test.go
@@ -53,18 +53,21 @@ func TestStateStoreWithLockSerializesCallers(t *testing.T) {
 	<-entered
 
 	var ran atomic.Bool
+	attempting := make(chan struct{})
 	blocked := make(chan error, 1)
 	go func() {
+		close(attempting)
 		blocked <- store.WithLock(func() error {
 			ran.Store(true)
 			return nil
 		})
 	}()
+	<-attempting
 
 	select {
 	case err := <-blocked:
 		t.Fatalf("second lock completed early: %v", err)
-	case <-time.After(50 * time.Millisecond):
+	case <-time.After(250 * time.Millisecond):
 	}
 	if ran.Load() {
 		t.Fatal("second lock callback ran before first lock released")

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1161,14 +1161,16 @@ func (a *App) withSoloStateLock(fn func() error) error {
 }
 
 func (a *App) withSoloStateLockProgress(operation string, fn func() error) error {
-	if err := a.Printer.PrintEvent(output.EventProgress, map[string]any{
-		"operation": operation,
-		"step":      "state_lock_wait",
-		"message":   "Waiting for solo state lock...",
-	}); err != nil {
-		return err
+	if a.SoloState == nil {
+		return fmt.Errorf("solo state store is required")
 	}
-	return a.withSoloStateLock(fn)
+	return a.SoloState.WithLockNotify(fn, func() error {
+		return a.Printer.PrintEvent(output.EventProgress, map[string]any{
+			"operation": operation,
+			"step":      "state_lock_wait",
+			"message":   "Waiting for solo state lock...",
+		})
+	})
 }
 
 func (a *App) writeSoloState(current solo.State) error {
@@ -3425,7 +3427,7 @@ func (a *App) SoloNodeList(_ context.Context, opts SoloNodeListOptions) error {
 }
 
 func (a *App) SoloNodeAttach(ctx context.Context, opts SoloNodeAttachOptions) error {
-	return a.withSoloStateLock(func() error {
+	return a.withSoloStateLockProgress("devopsellence node attach", func() error {
 		return a.soloNodeAttach(ctx, opts)
 	})
 }
@@ -3470,7 +3472,7 @@ func (a *App) runSoloNodeAttach(ctx context.Context, opts SoloNodeAttachOptions)
 }
 
 func (a *App) SoloNodeDetach(ctx context.Context, opts SoloNodeDetachOptions) error {
-	return a.withSoloStateLock(func() error {
+	return a.withSoloStateLockProgress("devopsellence node detach", func() error {
 		return a.soloNodeDetach(ctx, opts)
 	})
 }

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -408,6 +408,9 @@ func expandSoloSSHKeyPath(path string) (string, error) {
 }
 
 func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
+	if opts.DryRun {
+		return a.soloDeploy(ctx, opts)
+	}
 	return a.withSoloStateLock(func() error {
 		return a.soloDeploy(ctx, opts)
 	})
@@ -2626,6 +2629,9 @@ func (a *App) SoloReleaseList(ctx context.Context, opts SoloReleaseListOptions) 
 }
 
 func (a *App) SoloReleaseRollback(ctx context.Context, opts SoloReleaseRollbackOptions) error {
+	if opts.DryRun {
+		return a.soloReleaseRollback(ctx, opts)
+	}
 	return a.withSoloStateLock(func() error {
 		return a.soloReleaseRollback(ctx, opts)
 	})
@@ -2955,6 +2961,12 @@ func publicURLsForHosts(scheme string, hosts []string) []string {
 }
 
 func (a *App) SoloSecretsSet(_ context.Context, opts SoloSecretsSetOptions) error {
+	return a.withSoloStateLock(func() error {
+		return a.soloSecretsSet(opts)
+	})
+}
+
+func (a *App) soloSecretsSet(opts SoloSecretsSetOptions) error {
 	store, err := soloSecretStore(opts)
 	if err != nil {
 		return err
@@ -3525,6 +3537,12 @@ func soloRepublishMissingAgentError(err error) bool {
 }
 
 func (a *App) SoloSecretsDelete(_ context.Context, opts SoloSecretsDeleteOptions) error {
+	return a.withSoloStateLock(func() error {
+		return a.soloSecretsDelete(opts)
+	})
+}
+
+func (a *App) soloSecretsDelete(opts SoloSecretsDeleteOptions) error {
 	cfg, workspaceRoot, err := a.loadSoloProjectConfig()
 	if err != nil {
 		return err
@@ -4682,7 +4700,7 @@ func expectedPublicListeningPortDetails(lines []string) []string {
 }
 
 func expectedDevopsellenceACMEListener(line, port string) bool {
-	return port == "15980" && strings.Contains(strings.ToLower(line), "devopsellence")
+	return port == "15980"
 }
 
 func publicPortsFromListeningLine(line string) []string {
@@ -4929,6 +4947,12 @@ func collectRemoteJSONLines(ctx context.Context, node config.Node, command strin
 }
 
 func (a *App) SoloNodeLabelSet(ctx context.Context, opts SoloNodeLabelSetOptions) error {
+	return a.withSoloStateLock(func() error {
+		return a.soloNodeLabelSet(ctx, opts)
+	})
+}
+
+func (a *App) soloNodeLabelSet(ctx context.Context, opts SoloNodeLabelSetOptions) error {
 	current, err := a.readSoloState()
 	if err != nil {
 		return err
@@ -4979,6 +5003,12 @@ func (a *App) SoloNodeLabelList(_ context.Context, opts SoloNodeLabelListOptions
 }
 
 func (a *App) SoloNodeLabelRemove(ctx context.Context, opts SoloNodeLabelRemoveOptions) error {
+	return a.withSoloStateLock(func() error {
+		return a.soloNodeLabelRemove(ctx, opts)
+	})
+}
+
+func (a *App) soloNodeLabelRemove(ctx context.Context, opts SoloNodeLabelRemoveOptions) error {
 	current, err := a.readSoloState()
 	if err != nil {
 		return err
@@ -5404,6 +5434,12 @@ func (a *App) SoloDoctor(ctx context.Context) error {
 }
 
 func (a *App) SoloNodeCreate(ctx context.Context, opts SoloNodeCreateOptions) error {
+	return a.withSoloStateLock(func() error {
+		return a.soloNodeCreate(ctx, opts)
+	})
+}
+
+func (a *App) soloNodeCreate(ctx context.Context, opts SoloNodeCreateOptions) error {
 	cfg, workspaceRoot, err := a.loadSoloProjectConfig()
 	if err != nil {
 		return err
@@ -5711,6 +5747,12 @@ func sshInteractiveError(prefix string, err error, stdout string, stderr string)
 }
 
 func (a *App) SoloNodeRemove(ctx context.Context, opts SoloNodeRemoveOptions) error {
+	return a.withSoloStateLock(func() error {
+		return a.soloNodeRemove(ctx, opts)
+	})
+}
+
+func (a *App) soloNodeRemove(ctx context.Context, opts SoloNodeRemoveOptions) error {
 	if !opts.Yes {
 		return ExitError{Code: 2, Err: errors.New("node remove requires --yes; rerun with --yes to confirm local/provider cleanup")}
 	}

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -408,6 +408,12 @@ func expandSoloSSHKeyPath(path string) (string, error) {
 }
 
 func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
+	return a.withSoloStateLock(func() error {
+		return a.soloDeploy(ctx, opts)
+	})
+}
+
+func (a *App) soloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 	stream := a.Printer.Stream("devopsellence deploy")
 	if err := stream.Event("started", map[string]any{}); err != nil {
 		return err
@@ -1142,6 +1148,13 @@ func (a *App) readSoloState() (solo.State, error) {
 		return solo.State{}, fmt.Errorf("solo state store is required")
 	}
 	return a.SoloState.Read()
+}
+
+func (a *App) withSoloStateLock(fn func() error) error {
+	if a.SoloState == nil {
+		return fmt.Errorf("solo state store is required")
+	}
+	return a.SoloState.WithLock(fn)
 }
 
 func (a *App) writeSoloState(current solo.State) error {
@@ -2613,6 +2626,12 @@ func (a *App) SoloReleaseList(ctx context.Context, opts SoloReleaseListOptions) 
 }
 
 func (a *App) SoloReleaseRollback(ctx context.Context, opts SoloReleaseRollbackOptions) error {
+	return a.withSoloStateLock(func() error {
+		return a.soloReleaseRollback(ctx, opts)
+	})
+}
+
+func (a *App) soloReleaseRollback(ctx context.Context, opts SoloReleaseRollbackOptions) error {
 	stream := a.Printer.Stream("devopsellence release rollback")
 	if err := stream.Event("started", map[string]any{}); err != nil {
 		return err
@@ -3383,6 +3402,12 @@ func (a *App) SoloNodeList(_ context.Context, opts SoloNodeListOptions) error {
 }
 
 func (a *App) SoloNodeAttach(ctx context.Context, opts SoloNodeAttachOptions) error {
+	return a.withSoloStateLock(func() error {
+		return a.soloNodeAttach(ctx, opts)
+	})
+}
+
+func (a *App) soloNodeAttach(ctx context.Context, opts SoloNodeAttachOptions) error {
 	cfg, workspaceRoot, err := a.loadSoloProjectConfig()
 	if err != nil {
 		return err
@@ -3422,6 +3447,12 @@ func (a *App) runSoloNodeAttach(ctx context.Context, opts SoloNodeAttachOptions)
 }
 
 func (a *App) SoloNodeDetach(ctx context.Context, opts SoloNodeDetachOptions) error {
+	return a.withSoloStateLock(func() error {
+		return a.soloNodeDetach(ctx, opts)
+	})
+}
+
+func (a *App) soloNodeDetach(ctx context.Context, opts SoloNodeDetachOptions) error {
 	cfg, workspaceRoot, err := a.loadSoloProjectConfig()
 	if err != nil {
 		return err
@@ -3455,10 +3486,12 @@ func (a *App) SoloNodeDetach(ctx context.Context, opts SoloNodeDetachOptions) er
 		return err
 	}
 	warnings := []string{}
+	remoteCleanup := "published"
 	if _, err := a.republishNodes(ctx, next, []string{opts.Node}); err != nil {
 		if next.NodeHasAttachments(opts.Node) || !soloRepublishMissingAgentError(err) {
 			return err
 		}
+		remoteCleanup = "skipped_missing_agent"
 		warnings = append(warnings, "remote desired state was not cleared because the agent is already uninstalled on the node")
 	}
 	if err := a.writeSoloState(next); err != nil {
@@ -3470,6 +3503,7 @@ func (a *App) SoloNodeDetach(ctx context.Context, opts SoloNodeDetachOptions) er
 		"node":           opts.Node,
 		"environment":    environmentName,
 		"changed":        true,
+		"remote_cleanup": remoteCleanup,
 	}
 	if len(warnings) > 0 {
 		payload["warnings"] = warnings
@@ -4538,6 +4572,7 @@ func soloPublicListeningPortsCheck(ctx context.Context, node config.Node, portLi
 		check.NextAction = "install ss or netstat on the node, then rerun devopsellence node diagnose"
 		return check
 	}
+	expectedDetails := expectedPublicListeningPortDetails(portLines)
 	ports := unexpectedPublicListeningPorts(portLines, node.Port)
 	if len(ports) > 0 {
 		check.OK = false
@@ -4546,6 +4581,9 @@ func soloPublicListeningPortsCheck(ctx context.Context, node config.Node, portLi
 		return check
 	}
 	check.Observed = "only expected public ports detected"
+	if len(expectedDetails) > 0 {
+		check.Observed += "; " + strings.Join(expectedDetails, "; ")
+	}
 	return check
 }
 
@@ -4614,7 +4652,7 @@ func unexpectedPublicListeningPorts(lines []string, sshPort int) []string {
 	seen := map[string]bool{}
 	for _, line := range lines {
 		for _, port := range publicPortsFromListeningLine(line) {
-			if expected[port] || seen[port] {
+			if expected[port] || expectedDevopsellenceACMEListener(line, port) || seen[port] {
 				continue
 			}
 			seen[port] = true
@@ -4626,6 +4664,25 @@ func unexpectedPublicListeningPorts(lines []string, sshPort int) []string {
 	}
 	sort.Strings(ports)
 	return ports
+}
+
+func expectedPublicListeningPortDetails(lines []string) []string {
+	seenACME := false
+	for _, line := range lines {
+		for _, port := range publicPortsFromListeningLine(line) {
+			if expectedDevopsellenceACMEListener(line, port) {
+				seenACME = true
+			}
+		}
+	}
+	if !seenACME {
+		return nil
+	}
+	return []string{"15980 is the devopsellence ACME HTTP-01 backend reached through Envoy on port 80"}
+}
+
+func expectedDevopsellenceACMEListener(line, port string) bool {
+	return port == "15980" && strings.Contains(strings.ToLower(line), "devopsellence")
 }
 
 func publicPortsFromListeningLine(line string) []string {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -411,7 +411,7 @@ func (a *App) SoloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 	if opts.DryRun {
 		return a.soloDeploy(ctx, opts)
 	}
-	return a.withSoloStateLock(func() error {
+	return a.withSoloStateLockProgress("devopsellence deploy", func() error {
 		return a.soloDeploy(ctx, opts)
 	})
 }
@@ -1158,6 +1158,17 @@ func (a *App) withSoloStateLock(fn func() error) error {
 		return fmt.Errorf("solo state store is required")
 	}
 	return a.SoloState.WithLock(fn)
+}
+
+func (a *App) withSoloStateLockProgress(operation string, fn func() error) error {
+	if err := a.Printer.PrintEvent(output.EventProgress, map[string]any{
+		"operation": operation,
+		"step":      "state_lock_wait",
+		"message":   "Waiting for solo state lock...",
+	}); err != nil {
+		return err
+	}
+	return a.withSoloStateLock(fn)
 }
 
 func (a *App) writeSoloState(current solo.State) error {
@@ -2632,7 +2643,7 @@ func (a *App) SoloReleaseRollback(ctx context.Context, opts SoloReleaseRollbackO
 	if opts.DryRun {
 		return a.soloReleaseRollback(ctx, opts)
 	}
-	return a.withSoloStateLock(func() error {
+	return a.withSoloStateLockProgress("devopsellence release rollback", func() error {
 		return a.soloReleaseRollback(ctx, opts)
 	})
 }
@@ -4696,11 +4707,11 @@ func expectedPublicListeningPortDetails(lines []string) []string {
 	if !seenACME {
 		return nil
 	}
-	return []string{"15980 is the devopsellence ACME HTTP-01 backend reached through Envoy on port 80"}
+	return []string{"15980 is the devopsellence agent ACME HTTP-01 listener used for auto TLS challenges"}
 }
 
 func expectedDevopsellenceACMEListener(line, port string) bool {
-	return port == "15980"
+	return port == "15980" && strings.Contains(strings.ToLower(line), "devopsellence")
 }
 
 func publicPortsFromListeningLine(line string) []string {
@@ -8393,7 +8404,7 @@ func withRemoteLineLimit(command string, limit int) string {
 }
 
 func remoteListeningPortsCommand() string {
-	return withRemoteLineLimit("if command -v ss >/dev/null 2>&1; then ss -ltnp || ss -ltn; elif command -v netstat >/dev/null 2>&1; then netstat -ltnp || netstat -ltn; else echo 'no ss or netstat available'; fi", soloDiagnosePortsLineLimit)
+	return withRemoteLineLimit("if command -v ss >/dev/null 2>&1; then sudo -n ss -ltnp || ss -ltnp || ss -ltn; elif command -v netstat >/dev/null 2>&1; then sudo -n netstat -ltnp || netstat -ltnp || netstat -ltn; else echo 'no ss or netstat available'; fi", soloDiagnosePortsLineLimit)
 }
 
 func remoteAgentVersionCommand() string {

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -4011,6 +4011,21 @@ func TestUnexpectedPublicListeningPortsAllowsConfiguredSSHPort(t *testing.T) {
 	}
 }
 
+func TestUnexpectedPublicListeningPortsAllowsDevopsellenceACMEBackend(t *testing.T) {
+	lines := []string{
+		"LISTEN 0 4096 0.0.0.0:15980 0.0.0.0:* users:((\"devopsellence\",pid=1234,fd=9))",
+		"LISTEN 0 4096 0.0.0.0:15981 0.0.0.0:* users:((\"devopsellence\",pid=1234,fd=10))",
+	}
+	ports := unexpectedPublicListeningPorts(lines, 22)
+	if !reflect.DeepEqual(ports, []string{"15981"}) {
+		t.Fatalf("unexpected ports = %#v, want only non-ACME devopsellence port flagged", ports)
+	}
+	details := expectedPublicListeningPortDetails(lines)
+	if len(details) != 1 || !strings.Contains(details[0], "ACME HTTP-01 backend") {
+		t.Fatalf("expected details = %#v, want ACME explanation", details)
+	}
+}
+
 func TestSplitListenAddressSupportsIPv6AnyNotation(t *testing.T) {
 	host, port, ok := splitListenAddress(":::80")
 	if !ok || host != "::" || port != "80" {
@@ -5002,6 +5017,69 @@ func TestSoloNodeDetachRepublishesRemainingCohostedDesiredState(t *testing.T) {
 	}
 	if nodes, err := loaded.AttachedNodeNames(workspaceB, "production"); err != nil || !reflect.DeepEqual(nodes, []string{"node-a"}) {
 		t.Fatalf("workspace B attached nodes = %#v err=%v, want node-a preserved", nodes, err)
+	}
+}
+
+func TestSoloNodeDetachRepublishesEmptyDesiredStateForLastAttachment(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	if _, err := config.Write(workspaceRoot, config.DefaultProjectConfig("solo", "app-a", "production")); err != nil {
+		t.Fatal(err)
+	}
+
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes:       map[string]config.Node{"node-a": {Host: "203.0.113.10", User: "root", Labels: []string{config.DefaultWebRole}}},
+		Attachments: map[string]solo.AttachmentRecord{},
+		Snapshots:   map[string]desiredstate.DeploySnapshot{},
+	}
+	if _, _, err := current.AttachNode(workspaceRoot, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	key, err := solo.EnvironmentStateKey(workspaceRoot, "production")
+	if err != nil {
+		t.Fatal(err)
+	}
+	current.Snapshots[key] = desiredstate.DeploySnapshot{
+		WorkspaceRoot: workspaceRoot,
+		WorkspaceKey:  workspaceRoot,
+		Environment:   "production",
+		Revision:      "aaa1111",
+		Image:         "app-a:aaa1111",
+		Services:      []desiredstate.ServiceJSON{{Name: "web", Kind: config.ServiceKindWeb, Image: "app-a:aaa1111"}},
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+	installFakeSoloCommands(t, nil)
+
+	var stdout bytes.Buffer
+	app := &App{
+		Printer:     output.New(&stdout, io.Discard),
+		SoloState:   soloState,
+		ConfigStore: config.NewStore(),
+		Cwd:         workspaceRoot,
+	}
+	if err := app.SoloNodeDetach(context.Background(), SoloNodeDetachOptions{Node: "node-a"}); err != nil {
+		t.Fatal(err)
+	}
+
+	payload := decodeJSONOutput(t, &stdout)
+	if got := stringValueAny(payload["remote_cleanup"]); got != "published" {
+		t.Fatalf("remote_cleanup = %q, want published", got)
+	}
+	data, err := os.ReadFile(os.Getenv("DEVOPSELLENCE_FAKE_SSH_REVISION_FILE"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var published desiredstate.DesiredStateJSON
+	if err := json.Unmarshal(data, &published); err != nil {
+		t.Fatal(err)
+	}
+	if len(published.Environments) != 0 {
+		t.Fatalf("published environments = %#v, want empty cleanup desired state", published.Environments)
+	}
+	if strings.Contains(string(data), "aaa1111") {
+		t.Fatalf("published desired state still contains detached revision: %s", data)
 	}
 }
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -4013,7 +4013,7 @@ func TestUnexpectedPublicListeningPortsAllowsConfiguredSSHPort(t *testing.T) {
 
 func TestUnexpectedPublicListeningPortsAllowsDevopsellenceACMEBackend(t *testing.T) {
 	lines := []string{
-		"LISTEN 0 4096 0.0.0.0:15980 0.0.0.0:*",
+		"LISTEN 0 4096 0.0.0.0:15980 0.0.0.0:* users:((\"devopsellence\",pid=1234,fd=9))",
 		"LISTEN 0 4096 0.0.0.0:15981 0.0.0.0:* users:((\"devopsellence\",pid=1234,fd=10))",
 	}
 	ports := unexpectedPublicListeningPorts(lines, 22)
@@ -4021,8 +4021,18 @@ func TestUnexpectedPublicListeningPortsAllowsDevopsellenceACMEBackend(t *testing
 		t.Fatalf("unexpected ports = %#v, want only non-ACME devopsellence port flagged", ports)
 	}
 	details := expectedPublicListeningPortDetails(lines)
-	if len(details) != 1 || !strings.Contains(details[0], "ACME HTTP-01 backend") {
+	if len(details) != 1 || !strings.Contains(details[0], "ACME HTTP-01 listener") {
 		t.Fatalf("expected details = %#v, want ACME explanation", details)
+	}
+}
+
+func TestUnexpectedPublicListeningPortsFlagsACMEPortWithoutProcessMetadata(t *testing.T) {
+	lines := []string{
+		"LISTEN 0 4096 0.0.0.0:15980 0.0.0.0:*",
+	}
+	ports := unexpectedPublicListeningPorts(lines, 22)
+	if !reflect.DeepEqual(ports, []string{"15980"}) {
+		t.Fatalf("unexpected ports = %#v, want ACME port flagged without process metadata", ports)
 	}
 }
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -4013,7 +4013,7 @@ func TestUnexpectedPublicListeningPortsAllowsConfiguredSSHPort(t *testing.T) {
 
 func TestUnexpectedPublicListeningPortsAllowsDevopsellenceACMEBackend(t *testing.T) {
 	lines := []string{
-		"LISTEN 0 4096 0.0.0.0:15980 0.0.0.0:* users:((\"devopsellence\",pid=1234,fd=9))",
+		"LISTEN 0 4096 0.0.0.0:15980 0.0.0.0:*",
 		"LISTEN 0 4096 0.0.0.0:15981 0.0.0.0:* users:((\"devopsellence\",pid=1234,fd=10))",
 	}
 	ports := unexpectedPublicListeningPorts(lines, 22)


### PR DESCRIPTION
## Summary
- serialize solo state mutations with a file-backed lock around deploy, rollback, attach, and detach
- publish cleanup desired state when detaching the last environment from a node
- classify the devopsellence ACME HTTP-01 backend on 15980 as an expected diagnose listener with an explicit reason

Fixes #171
Fixes #172
Fixes #173

## Tests
- mise run test:cli