### PR TITLE
Guard solo detach for duplicate host records

### DIFF
--- a/agent/internal/config/config.go
+++ b/agent/internal/config/config.go
@@ -249,8 +249,10 @@ func Load(args []string) (*Config, error) {
 		return nil, errors.New("--auth-state-path is required")
 	}
 
-	// Derive paths from AuthStatePath directory.
-	stateDir := filepath.Dir(cfg.AuthStatePath)
+	// Derive sibling state paths from the agent state root. Solo installs
+	// keep auth under a private child directory while status/TLS artifacts
+	// remain in the root so the CLI and Envoy can read them.
+	stateDir := derivedStateDir(cfg.AuthStatePath)
 	cfg.StatusPath = filepath.Join(stateDir, "status.json")
 	cfg.LifecycleStatePath = filepath.Join(stateDir, "lifecycle-state.json")
 	if cfg.DesiredStateCachePath == "" {
@@ -307,6 +309,14 @@ func Load(args []string) (*Config, error) {
 	}
 
 	return cfg, nil
+}
+
+func derivedStateDir(authStatePath string) string {
+	stateDir := filepath.Dir(authStatePath)
+	if filepath.Base(stateDir) == "private" {
+		return filepath.Dir(stateDir)
+	}
+	return stateDir
 }
 
 func parseLevel(level string) (slog.Level, error) {

--- a/agent/internal/config/config.go
+++ b/agent/internal/config/config.go
@@ -253,6 +253,7 @@ func Load(args []string) (*Config, error) {
 	// keep auth under a private child directory while status/TLS artifacts
 	// remain in the root so the CLI and Envoy can read them.
 	stateDir := derivedStateDir(cfg.AuthStatePath)
+	privateStateDir := filepath.Dir(cfg.AuthStatePath)
 	cfg.StatusPath = filepath.Join(stateDir, "status.json")
 	cfg.LifecycleStatePath = filepath.Join(stateDir, "lifecycle-state.json")
 	if cfg.DesiredStateCachePath == "" {
@@ -262,7 +263,7 @@ func Load(args []string) (*Config, error) {
 		cfg.DesiredStateOverridePath = filepath.Join(stateDir, "desired-state-override.json")
 	}
 	if cfg.DiskCareStatePath == "" {
-		cfg.DiskCareStatePath = filepath.Join(stateDir, "disk-care-state.json")
+		cfg.DiskCareStatePath = filepath.Join(privateStateDir, "disk-care-state.json")
 	}
 	if cfg.EnvoyTLSCertPath == "" {
 		cfg.EnvoyTLSCertPath = filepath.Join(stateDir, "ingress-cert.pem")

--- a/agent/internal/config/config_test.go
+++ b/agent/internal/config/config_test.go
@@ -108,7 +108,7 @@ func TestLoadDerivesStateRootOutsidePrivateAuthDir(t *testing.T) {
 	if cfg.DesiredStateCachePath != "/var/lib/devopsellence/desired-state-cache.json" {
 		t.Fatalf("unexpected desired state cache path: %s", cfg.DesiredStateCachePath)
 	}
-	if cfg.DiskCareStatePath != "/var/lib/devopsellence/disk-care-state.json" {
+	if cfg.DiskCareStatePath != "/var/lib/devopsellence/private/disk-care-state.json" {
 		t.Fatalf("unexpected disk care path: %s", cfg.DiskCareStatePath)
 	}
 	if cfg.EnvoyTLSCertPath != "/var/lib/devopsellence/ingress-cert.pem" || cfg.EnvoyTLSKeyPath != "/var/lib/devopsellence/ingress-key.pem" {

--- a/agent/internal/config/config_test.go
+++ b/agent/internal/config/config_test.go
@@ -88,6 +88,34 @@ func TestLoadDefaults(t *testing.T) {
 	}
 }
 
+func TestLoadDerivesStateRootOutsidePrivateAuthDir(t *testing.T) {
+	cfg, err := Load([]string{
+		"--control-plane-base-url=https://cp.example.com",
+		"--auth-state-path=/var/lib/devopsellence/private/auth.json",
+	})
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if cfg.AuthStatePath != "/var/lib/devopsellence/private/auth.json" {
+		t.Fatalf("unexpected auth path: %s", cfg.AuthStatePath)
+	}
+	if cfg.StatusPath != "/var/lib/devopsellence/status.json" {
+		t.Fatalf("unexpected status path: %s", cfg.StatusPath)
+	}
+	if cfg.LifecycleStatePath != "/var/lib/devopsellence/lifecycle-state.json" {
+		t.Fatalf("unexpected lifecycle path: %s", cfg.LifecycleStatePath)
+	}
+	if cfg.DesiredStateCachePath != "/var/lib/devopsellence/desired-state-cache.json" {
+		t.Fatalf("unexpected desired state cache path: %s", cfg.DesiredStateCachePath)
+	}
+	if cfg.DiskCareStatePath != "/var/lib/devopsellence/disk-care-state.json" {
+		t.Fatalf("unexpected disk care path: %s", cfg.DiskCareStatePath)
+	}
+	if cfg.EnvoyTLSCertPath != "/var/lib/devopsellence/ingress-cert.pem" || cfg.EnvoyTLSKeyPath != "/var/lib/devopsellence/ingress-key.pem" {
+		t.Fatalf("unexpected ingress tls paths: cert=%s key=%s", cfg.EnvoyTLSCertPath, cfg.EnvoyTLSKeyPath)
+	}
+}
+
 func TestLoadRejectsOutOfRangeEnvoyPublicPorts(t *testing.T) {
 	_, err := Load([]string{
 		"--control-plane-base-url=https://cp.example.com",

--- a/agent/internal/fileaccess/permissions.go
+++ b/agent/internal/fileaccess/permissions.go
@@ -12,6 +12,22 @@ func EnsureDirMode(path string, mode os.FileMode) error {
 	return ensureMode(path, mode)
 }
 
+func EnsureDirMaxMode(path string, mode os.FileMode) error {
+	if err := os.MkdirAll(path, mode); err != nil {
+		return err
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	current := info.Mode().Perm()
+	next := current & mode
+	if next == current {
+		return nil
+	}
+	return os.Chmod(path, next)
+}
+
 func EnsureDirOwnershipAndMode(path string, mode os.FileMode, uid int, gid int) error {
 	if err := os.MkdirAll(path, mode); err != nil {
 		return err

--- a/agent/internal/lifecycle/store.go
+++ b/agent/internal/lifecycle/store.go
@@ -71,7 +71,7 @@ func (s *Store) save(state *fileState) error {
 	if s == nil || s.path == "" {
 		return nil
 	}
-	if err := fileaccess.EnsureDirMode(filepath.Dir(s.path), 0o711); err != nil {
+	if err := fileaccess.EnsureDirMaxMode(filepath.Dir(s.path), 0o711); err != nil {
 		return err
 	}
 	data, err := json.Marshal(state)

--- a/agent/internal/lifecycle/store.go
+++ b/agent/internal/lifecycle/store.go
@@ -71,7 +71,7 @@ func (s *Store) save(state *fileState) error {
 	if s == nil || s.path == "" {
 		return nil
 	}
-	if err := fileaccess.EnsureDirMode(filepath.Dir(s.path), 0o751); err != nil {
+	if err := fileaccess.EnsureDirMode(filepath.Dir(s.path), 0o700); err != nil {
 		return err
 	}
 	data, err := json.Marshal(state)

--- a/agent/internal/lifecycle/store.go
+++ b/agent/internal/lifecycle/store.go
@@ -71,7 +71,7 @@ func (s *Store) save(state *fileState) error {
 	if s == nil || s.path == "" {
 		return nil
 	}
-	if err := fileaccess.EnsureDirMode(filepath.Dir(s.path), 0o700); err != nil {
+	if err := fileaccess.EnsureDirMode(filepath.Dir(s.path), 0o751); err != nil {
 		return err
 	}
 	data, err := json.Marshal(state)

--- a/agent/internal/lifecycle/store.go
+++ b/agent/internal/lifecycle/store.go
@@ -71,7 +71,7 @@ func (s *Store) save(state *fileState) error {
 	if s == nil || s.path == "" {
 		return nil
 	}
-	if err := fileaccess.EnsureDirMode(filepath.Dir(s.path), 0o751); err != nil {
+	if err := fileaccess.EnsureDirMode(filepath.Dir(s.path), 0o711); err != nil {
 		return err
 	}
 	data, err := json.Marshal(state)

--- a/agent/internal/lifecycle/store_test.go
+++ b/agent/internal/lifecycle/store_test.go
@@ -28,3 +28,23 @@ func TestMarkSatisfiedTightensExistingDirectoryPermissions(t *testing.T) {
 		t.Fatalf("unexpected dir permissions: %v", info.Mode().Perm())
 	}
 }
+
+func TestMarkSatisfiedPreservesPrivateDirectoryPermissions(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "state")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	store := NewStore(filepath.Join(dir, "lifecycle-state.json"))
+	if err := store.MarkSatisfied("web", 7, "abc"); err != nil {
+		t.Fatalf("mark satisfied: %v", err)
+	}
+
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat dir: %v", err)
+	}
+	if info.Mode().Perm() != 0o700 {
+		t.Fatalf("unexpected dir permissions: %v", info.Mode().Perm())
+	}
+}

--- a/agent/internal/lifecycle/store_test.go
+++ b/agent/internal/lifecycle/store_test.go
@@ -24,7 +24,7 @@ func TestMarkSatisfiedTightensExistingDirectoryPermissions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("stat dir: %v", err)
 	}
-	if info.Mode().Perm() != 0o751 {
+	if info.Mode().Perm() != 0o711 {
 		t.Fatalf("unexpected dir permissions: %v", info.Mode().Perm())
 	}
 }

--- a/agent/internal/lifecycle/store_test.go
+++ b/agent/internal/lifecycle/store_test.go
@@ -24,7 +24,7 @@ func TestMarkSatisfiedTightensExistingDirectoryPermissions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("stat dir: %v", err)
 	}
-	if info.Mode().Perm() != 0o751 {
+	if info.Mode().Perm() != 0o700 {
 		t.Fatalf("unexpected dir permissions: %v", info.Mode().Perm())
 	}
 }

--- a/agent/internal/lifecycle/store_test.go
+++ b/agent/internal/lifecycle/store_test.go
@@ -24,7 +24,7 @@ func TestMarkSatisfiedTightensExistingDirectoryPermissions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("stat dir: %v", err)
 	}
-	if info.Mode().Perm() != 0o700 {
+	if info.Mode().Perm() != 0o751 {
 		t.Fatalf("unexpected dir permissions: %v", info.Mode().Perm())
 	}
 }

--- a/agent/internal/report/file/file.go
+++ b/agent/internal/report/file/file.go
@@ -35,7 +35,7 @@ func (r *Reporter) Report(ctx context.Context, status report.Status) error {
 	}
 
 	dir := filepath.Dir(r.path)
-	if err := fileaccess.EnsureDirMode(dir, 0o751); err != nil {
+	if err := fileaccess.EnsureDirMode(dir, 0o711); err != nil {
 		return fmt.Errorf("mkdir status dir: %w", err)
 	}
 

--- a/agent/internal/report/file/file.go
+++ b/agent/internal/report/file/file.go
@@ -35,7 +35,7 @@ func (r *Reporter) Report(ctx context.Context, status report.Status) error {
 	}
 
 	dir := filepath.Dir(r.path)
-	if err := fileaccess.EnsureDirMode(dir, 0o711); err != nil {
+	if err := fileaccess.EnsureDirMaxMode(dir, 0o711); err != nil {
 		return fmt.Errorf("mkdir status dir: %w", err)
 	}
 

--- a/agent/internal/report/file/file.go
+++ b/agent/internal/report/file/file.go
@@ -35,7 +35,7 @@ func (r *Reporter) Report(ctx context.Context, status report.Status) error {
 	}
 
 	dir := filepath.Dir(r.path)
-	if err := fileaccess.EnsureDirMode(dir, 0o751); err != nil {
+	if err := fileaccess.EnsureDirMode(dir, 0o700); err != nil {
 		return fmt.Errorf("mkdir status dir: %w", err)
 	}
 

--- a/agent/internal/report/file/file.go
+++ b/agent/internal/report/file/file.go
@@ -35,7 +35,7 @@ func (r *Reporter) Report(ctx context.Context, status report.Status) error {
 	}
 
 	dir := filepath.Dir(r.path)
-	if err := fileaccess.EnsureDirMode(dir, 0o700); err != nil {
+	if err := fileaccess.EnsureDirMode(dir, 0o751); err != nil {
 		return fmt.Errorf("mkdir status dir: %w", err)
 	}
 

--- a/agent/internal/report/file/file_test.go
+++ b/agent/internal/report/file/file_test.go
@@ -71,7 +71,7 @@ func TestReportTightensExistingDirectoryPermissions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("stat dir: %v", err)
 	}
-	if info.Mode().Perm() != 0o700 {
+	if info.Mode().Perm() != 0o751 {
 		t.Fatalf("unexpected dir permissions: %v", info.Mode().Perm())
 	}
 }

--- a/agent/internal/report/file/file_test.go
+++ b/agent/internal/report/file/file_test.go
@@ -71,7 +71,7 @@ func TestReportTightensExistingDirectoryPermissions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("stat dir: %v", err)
 	}
-	if info.Mode().Perm() != 0o751 {
+	if info.Mode().Perm() != 0o700 {
 		t.Fatalf("unexpected dir permissions: %v", info.Mode().Perm())
 	}
 }

--- a/agent/internal/report/file/file_test.go
+++ b/agent/internal/report/file/file_test.go
@@ -71,7 +71,7 @@ func TestReportTightensExistingDirectoryPermissions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("stat dir: %v", err)
 	}
-	if info.Mode().Perm() != 0o751 {
+	if info.Mode().Perm() != 0o711 {
 		t.Fatalf("unexpected dir permissions: %v", info.Mode().Perm())
 	}
 }

--- a/agent/internal/report/file/file_test.go
+++ b/agent/internal/report/file/file_test.go
@@ -75,3 +75,24 @@ func TestReportTightensExistingDirectoryPermissions(t *testing.T) {
 		t.Fatalf("unexpected dir permissions: %v", info.Mode().Perm())
 	}
 }
+
+func TestReportPreservesPrivateDirectoryPermissions(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "state")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	logger := slog.New(slog.NewJSONHandler(io.Discard, &slog.HandlerOptions{}))
+	reporter := New(filepath.Join(dir, "status.json"), logger)
+	if err := reporter.Report(context.Background(), report.Status{Time: time.Now().UTC()}); err != nil {
+		t.Fatalf("report: %v", err)
+	}
+
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat dir: %v", err)
+	}
+	if info.Mode().Perm() != 0o700 {
+		t.Fatalf("unexpected dir permissions: %v", info.Mode().Perm())
+	}
+}

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -7633,6 +7633,7 @@ func installSoloAgent(ctx context.Context, node config.Node, opts SoloAgentInsta
 		return runSoloAgentInstallScript(ctx, node, soloAgentInstallScript(soloAgentInstallScriptOptions{
 			StateDir:        firstNonEmpty(node.AgentStateDir, "/var/lib/devopsellence"),
 			LocalBinaryPath: remotePath,
+			HardenSSH:       soloAgentInstallShouldHardenSSH(node),
 		}), reporter)
 	}
 
@@ -7642,7 +7643,12 @@ func installSoloAgent(ctx context.Context, node config.Node, opts SoloAgentInsta
 		StateDir:     firstNonEmpty(node.AgentStateDir, "/var/lib/devopsellence"),
 		BaseURL:      baseURL,
 		AgentVersion: releasedAgentVersionForInstall(),
+		HardenSSH:    soloAgentInstallShouldHardenSSH(node),
 	}), reporter)
+}
+
+func soloAgentInstallShouldHardenSSH(node config.Node) bool {
+	return strings.TrimSpace(node.Provider) != ""
 }
 
 func runSoloAgentInstallScript(ctx context.Context, node config.Node, script string, reporter soloInstallReporter) error {
@@ -7658,6 +7664,7 @@ type soloAgentInstallScriptOptions struct {
 	BaseURL         string
 	AgentVersion    string
 	LocalBinaryPath string
+	HardenSSH       bool
 }
 
 // Accept stable tags, semver-style prereleases, and workflow-generated
@@ -7676,6 +7683,10 @@ func soloAgentInstallScript(opts soloAgentInstallScriptOptions) string {
 	agentVersion := strings.TrimSpace(opts.AgentVersion)
 	localBinary := strings.TrimSpace(opts.LocalBinaryPath)
 	baseURL := strings.TrimRight(strings.TrimSpace(opts.BaseURL), "/")
+	hardenSSH := "false"
+	if opts.HardenSSH {
+		hardenSSH = "true"
+	}
 	return fmt.Sprintf(`set -euo pipefail
 
 STATE_DIR=%s
@@ -7684,6 +7695,7 @@ SERVICE_FILE=/etc/systemd/system/devopsellence-agent.service
 BASE_URL=%s
 AGENT_VERSION=%s
 LOCAL_BINARY=%s
+HARDEN_SSH=%s
 
 if [ "$(id -u)" -ne 0 ]; then
   SUDO=sudo
@@ -7697,6 +7709,20 @@ run_root() {
   else
     "$@"
   fi
+}
+
+harden_sshd_password_auth() {
+  [ "$HARDEN_SSH" = "true" ] || return 0
+  command -v sshd >/dev/null 2>&1 || return 0
+  [ -d /etc/ssh ] || return 0
+  echo "progress: hardening SSH password authentication"
+  run_root mkdir -p /etc/ssh/sshd_config.d
+  run_root tee /etc/ssh/sshd_config.d/60-devopsellence-hardening.conf >/dev/null <<'EOF_SSHD'
+PasswordAuthentication no
+KbdInteractiveAuthentication no
+EOF_SSHD
+  run_root sshd -t
+  run_root systemctl reload ssh || run_root systemctl reload sshd || run_root systemctl restart ssh || run_root systemctl restart sshd
 }
 
 docker_ready() {
@@ -7743,6 +7769,7 @@ if ! docker_ready; then
   echo "Docker Engine is unavailable after install/start" >&2
   exit 1
 fi
+harden_sshd_password_auth
 
 run_root mkdir -p "$STATE_DIR" "$STATE_DIR/envoy"
 TMP_BIN="$(mktemp)"
@@ -7807,7 +7834,7 @@ run_root systemctl stop devopsellence-agent || true
 run_root systemctl enable --now devopsellence-agent
 echo "progress: checking devopsellence-agent service"
 run_root systemctl is-active --quiet devopsellence-agent
-`, shellQuote(stateDir), shellQuote(baseURL), shellQuote(agentVersion), shellQuote(localBinary), systemdQuoteArg(authStatePath), systemdQuoteArg(overridePath), systemdQuoteArg(envoyBootstrapPath))
+`, shellQuote(stateDir), shellQuote(baseURL), shellQuote(agentVersion), shellQuote(localBinary), shellQuote(hardenSSH), systemdQuoteArg(authStatePath), systemdQuoteArg(overridePath), systemdQuoteArg(envoyBootstrapPath))
 }
 
 type soloAgentUninstallScriptOptions struct {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -7800,6 +7800,7 @@ fi
 harden_sshd_password_auth
 
 run_root mkdir -p "$STATE_DIR" "$STATE_DIR/envoy"
+run_root chmod 700 "$STATE_DIR"
 TMP_BIN="$(mktemp)"
 TMP_SUMS="$(mktemp)"
 cleanup() {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -3501,7 +3501,7 @@ func (a *App) soloNodeDetach(ctx context.Context, opts SoloNodeDetachOptions) er
 		return fmt.Errorf("node %q is not attached to %s", opts.Node, environmentName)
 	}
 	if conflicts := soloNodeRemoteCleanupConflicts(next, opts.Node); len(conflicts) > 0 {
-		return ExitError{Code: 1, Err: fmt.Errorf("remote cleanup for node %q refused: %s. These node records point at the same host; use the attached node record or remove the stale duplicate before detaching so cleanup cannot remove unrelated workloads", opts.Node, strings.Join(conflicts, "; "))}
+		return ExitError{Code: 1, Err: fmt.Errorf("remote cleanup for node %q refused: %s. These node records point at the same provider target or SSH endpoint; use the attached node record or remove the stale duplicate before detaching so cleanup cannot remove unrelated workloads", opts.Node, strings.Join(conflicts, "; "))}
 	}
 	remainingNodeNames := make([]string, 0, len(nodeNamesBefore))
 	for _, name := range nodeNamesBefore {
@@ -3573,7 +3573,14 @@ func soloNodesShareRemoteCleanupTarget(a, b config.Node) bool {
 	}
 	aHost := strings.TrimSpace(strings.ToLower(a.Host))
 	bHost := strings.TrimSpace(strings.ToLower(b.Host))
-	return aHost != "" && aHost == bHost
+	return aHost != "" && aHost == bHost && normalizedSoloNodePort(a.Port) == normalizedSoloNodePort(b.Port)
+}
+
+func normalizedSoloNodePort(port int) int {
+	if port == 0 {
+		return 22
+	}
+	return port
 }
 
 func soloRepublishMissingAgentError(err error) bool {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -7740,7 +7740,11 @@ EOF_SSHD
     run_root mv "$tmp_sshd_config" /etc/ssh/sshd_config
   fi
   run_root "$SSHD_BIN" -t
-  if ! run_root "$SSHD_BIN" -T | awk 'tolower($1) == "passwordauthentication" && tolower($2) == "no" { found = 1 } END { exit(found ? 0 : 1) }'; then
+  if ! run_root "$SSHD_BIN" -T | awk '
+    tolower($1) == "passwordauthentication" { password = tolower($2) }
+    tolower($1) == "kbdinteractiveauthentication" { keyboard = tolower($2) }
+    END { exit(password == "no" && keyboard == "no" ? 0 : 1) }
+  '; then
     echo "SSH password hardening was written but is not effective according to sshd -T" >&2
     return 1
   fi

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -4522,9 +4522,9 @@ func soloAgentStatePermissionsCheck(ctx context.Context, node config.Node) soloS
 		check.NextAction = "restore root group ownership on the agent state directory, for example chown root:root " + shellQuote(stateDir)
 		return check
 	}
-	if mode&0o026 != 0 {
+	if mode&0o077 != 0 {
 		check.OK = false
-		check.NextAction = "remove group write and other read/write access from the agent state directory, for example chmod g-w,o-rw " + shellQuote(stateDir)
+		check.NextAction = "remove group and other access from the agent state directory, for example chmod 700 " + shellQuote(stateDir)
 	}
 	return check
 }

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -7731,7 +7731,13 @@ PasswordAuthentication no
 KbdInteractiveAuthentication no
 EOF_SSHD
   if [ -f /etc/ssh/sshd_config ] && ! run_root grep -Eq '^[[:space:]]*Include[[:space:]]+/etc/ssh/sshd_config\.d/\*\.conf' /etc/ssh/sshd_config; then
-    printf '\nInclude /etc/ssh/sshd_config.d/*.conf\n' | run_root tee -a /etc/ssh/sshd_config >/dev/null
+    tmp_sshd_config="$(mktemp)"
+    {
+      printf 'Include /etc/ssh/sshd_config.d/*.conf\n'
+      run_root cat /etc/ssh/sshd_config
+    } >"$tmp_sshd_config"
+    run_root cp "$tmp_sshd_config" /etc/ssh/sshd_config
+    rm -f "$tmp_sshd_config"
   fi
   run_root "$SSHD_BIN" -t
   if ! run_root "$SSHD_BIN" -T | grep -qi '^passwordauthentication no$'; then

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -4522,9 +4522,9 @@ func soloAgentStatePermissionsCheck(ctx context.Context, node config.Node) soloS
 		check.NextAction = "restore root group ownership on the agent state directory, for example chown root:root " + shellQuote(stateDir)
 		return check
 	}
-	if mode&0o077 != 0 {
+	if mode&0o026 != 0 {
 		check.OK = false
-		check.NextAction = "remove group and other access from the agent state directory, for example chmod 700 " + shellQuote(stateDir)
+		check.NextAction = "remove group write and other read/write access from the agent state directory, for example chmod g-w,o-rw " + shellQuote(stateDir)
 	}
 	return check
 }
@@ -7819,7 +7819,7 @@ fi
 harden_sshd_password_auth
 
 run_root mkdir -p "$STATE_DIR" "$STATE_DIR/envoy"
-run_root chmod 700 "$STATE_DIR"
+run_root chmod 751 "$STATE_DIR"
 TMP_BIN="$(mktemp)"
 TMP_SUMS="$(mktemp)"
 cleanup() {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1025,6 +1025,11 @@ func (a *App) waitForSoloRolloutForRuntime(ctx context.Context, nodes map[string
 					details = append(details, name+"="+runtime.Detail)
 					continue
 				case "error":
+					if soloRolloutErrorRetryable(runtime.Message) {
+						reconcilingCount++
+						details = append(details, fmt.Sprintf("%s=retryable_error:%s", name, runtime.Message))
+						continue
+					}
 					return ExitError{Code: 1, Err: &soloRolloutError{Node: name, Message: runtime.Message, HealthcheckFailure: runtime.HealthcheckFailure}}
 				case "settled":
 					settledCount++
@@ -1035,6 +1040,11 @@ func (a *App) waitForSoloRolloutForRuntime(ctx context.Context, nodes map[string
 					settledCount++
 				case "error":
 					message := firstNonEmpty(strings.TrimSpace(result.Status.Error), "node reported phase=error")
+					if soloRolloutErrorRetryable(message) {
+						reconcilingCount++
+						details = append(details, fmt.Sprintf("%s=retryable_error:%s", name, message))
+						continue
+					}
 					return ExitError{Code: 1, Err: &soloRolloutError{Node: name, Message: message, HealthcheckFailure: soloRolloutMessageLooksLikeHealthcheck(message)}}
 				default:
 					reconcilingCount++
@@ -1063,6 +1073,15 @@ func (a *App) waitForSoloRolloutForRuntime(ctx context.Context, nodes map[string
 		case <-timer.C:
 		}
 	}
+}
+
+func soloRolloutErrorRetryable(message string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(message))
+	if normalized == "" {
+		return false
+	}
+	return strings.Contains(normalized, "network sandbox for container") ||
+		strings.Contains(normalized, "envoy unhealthy")
 }
 
 type soloRuntimeStatusResult struct {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -7721,7 +7721,7 @@ run_root() {
 
 harden_sshd_password_auth() {
   [ "$HARDEN_SSH" = "true" ] || return 0
-  command -v sshd >/dev/null 2>&1 || return 0
+  run_root sh -c 'command -v sshd >/dev/null 2>&1 || [ -x /usr/sbin/sshd ] || [ -x /usr/bin/sshd ]' || return 0
   [ -d /etc/ssh ] || return 0
   echo "progress: hardening SSH password authentication"
   run_root mkdir -p /etc/ssh/sshd_config.d
@@ -7740,8 +7740,8 @@ EOF_SSHD
   fi
   run_root sshd -t
   if ! run_root sshd -T | grep -qi '^passwordauthentication no$'; then
-    echo "warning: SSH password hardening was written but is not effective according to sshd -T" >&2
-    return 0
+    echo "SSH password hardening was written but is not effective according to sshd -T" >&2
+    return 1
   fi
   if ! run_root systemctl reload ssh && ! run_root systemctl reload sshd; then
     echo "warning: SSH password hardening was written but sshd reload failed; reload sshd or reboot to apply it" >&2

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -3502,7 +3502,7 @@ func (a *App) soloNodeDetach(ctx context.Context, opts SoloNodeDetachOptions) er
 		return fmt.Errorf("node %q is not attached to %s", nodeName, environmentName)
 	}
 	if conflicts := soloNodeRemoteCleanupConflicts(next, nodeName); len(conflicts) > 0 {
-		return ExitError{Code: 1, Err: fmt.Errorf("remote cleanup for node %q refused: %s. These node records point at the same provider target or SSH endpoint; use the attached node record or remove the stale duplicate before detaching so cleanup cannot remove unrelated workloads", nodeName, strings.Join(conflicts, "; "))}
+		return ExitError{Code: 1, Err: fmt.Errorf("remote cleanup for node %q refused: %s. These node records point at the same provider target or SSH endpoint; keep the duplicate records attached until they can be consolidated so cleanup cannot remove unrelated workloads", nodeName, strings.Join(conflicts, "; "))}
 	}
 	remainingNodeNames := make([]string, 0, len(nodeNamesBefore))
 	for _, name := range nodeNamesBefore {
@@ -7721,7 +7721,7 @@ run_root() {
 
 harden_sshd_password_auth() {
   [ "$HARDEN_SSH" = "true" ] || return 0
-  SSHD_BIN="$(run_root sh -c 'command -v sshd || { [ -x /usr/sbin/sshd ] && printf %%s /usr/sbin/sshd; } || { [ -x /usr/bin/sshd ] && printf %%s /usr/bin/sshd; }')"
+  SSHD_BIN="$(run_root sh -c 'command -v sshd || { [ -x /usr/sbin/sshd ] && printf %%s /usr/sbin/sshd; } || { [ -x /usr/bin/sshd ] && printf %%s /usr/bin/sshd; } || true')"
   [ -n "$SSHD_BIN" ] || return 0
   [ -d /etc/ssh ] || return 0
   echo "progress: hardening SSH password authentication"
@@ -7731,13 +7731,13 @@ PasswordAuthentication no
 KbdInteractiveAuthentication no
 EOF_SSHD
   if [ -f /etc/ssh/sshd_config ] && ! run_root grep -Eq '^[[:space:]]*Include[[:space:]]+/etc/ssh/sshd_config\.d/\*\.conf' /etc/ssh/sshd_config; then
-    tmp_sshd_config="$(mktemp)"
-    {
-      printf 'Include /etc/ssh/sshd_config.d/*.conf\n'
-      run_root cat /etc/ssh/sshd_config
-    } >"$tmp_sshd_config"
-    run_root cp "$tmp_sshd_config" /etc/ssh/sshd_config
-    rm -f "$tmp_sshd_config"
+    tmp_sshd_config="$(run_root mktemp /etc/ssh/sshd_config.devopsellence.XXXXXX)"
+    run_root cp -p /etc/ssh/sshd_config "$tmp_sshd_config"
+    run_root sh -c '{
+      echo "Include /etc/ssh/sshd_config.d/*.conf"
+      cat /etc/ssh/sshd_config
+    } >"$1"' sh "$tmp_sshd_config"
+    run_root mv "$tmp_sshd_config" /etc/ssh/sshd_config
   fi
   run_root "$SSHD_BIN" -t
   if ! run_root "$SSHD_BIN" -T | awk 'tolower($1) == "passwordauthentication" && tolower($2) == "no" { found = 1 } END { exit(found ? 0 : 1) }'; then

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -7740,7 +7740,7 @@ EOF_SSHD
     rm -f "$tmp_sshd_config"
   fi
   run_root "$SSHD_BIN" -t
-  if ! run_root "$SSHD_BIN" -T | grep -qi '^passwordauthentication no$'; then
+  if ! run_root "$SSHD_BIN" -T | awk 'tolower($1) == "passwordauthentication" && tolower($2) == "no" { found = 1 } END { exit(found ? 0 : 1) }'; then
     echo "SSH password hardening was written but is not effective according to sshd -T" >&2
     return 1
   fi

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -3498,6 +3498,9 @@ func (a *App) SoloNodeDetach(ctx context.Context, opts SoloNodeDetachOptions) er
 
 func (a *App) soloNodeDetach(ctx context.Context, opts SoloNodeDetachOptions) error {
 	nodeName := strings.TrimSpace(opts.Node)
+	if nodeName == "" {
+		return ExitError{Code: 2, Err: errors.New("missing required option: --node")}
+	}
 	cfg, workspaceRoot, err := a.loadSoloProjectConfig()
 	if err != nil {
 		return err
@@ -7814,9 +7817,9 @@ fi
 harden_sshd_password_auth
 
 run_root mkdir -p "$STATE_DIR" "$STATE_DIR/envoy"
-# The parent must remain traversable so Envoy can open the bind-mounted
+# The parent must remain executable so Envoy can open the bind-mounted
 # bootstrap/socket directory; sensitive state files are written 0600/0640.
-run_root chmod 751 "$STATE_DIR"
+run_root chmod 711 "$STATE_DIR"
 TMP_BIN="$(mktemp)"
 TMP_SUMS="$(mktemp)"
 cleanup() {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -3593,14 +3593,9 @@ func soloNodesShareRemoteCleanupTarget(a, b config.Node) bool {
 	}
 	aHost := strings.TrimSpace(strings.ToLower(a.Host))
 	bHost := strings.TrimSpace(strings.ToLower(b.Host))
-	return aHost != "" && aHost == bHost && normalizedSoloNodePort(a.Port) == normalizedSoloNodePort(b.Port)
-}
-
-func normalizedSoloNodePort(port int) int {
-	if port == 0 {
-		return 22
-	}
-	return port
+	aPort := solo.NormalizeNode(a).Port
+	bPort := solo.NormalizeNode(b).Port
+	return aHost != "" && aHost == bHost && aPort == bPort
 }
 
 func soloRepublishMissingAgentError(err error) bool {
@@ -7819,6 +7814,8 @@ fi
 harden_sshd_password_auth
 
 run_root mkdir -p "$STATE_DIR" "$STATE_DIR/envoy"
+# The parent must remain traversable so Envoy can open the bind-mounted
+# bootstrap/socket directory; sensitive state files are written 0600/0640.
 run_root chmod 751 "$STATE_DIR"
 TMP_BIN="$(mktemp)"
 TMP_SUMS="$(mktemp)"

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -3500,6 +3500,9 @@ func (a *App) soloNodeDetach(ctx context.Context, opts SoloNodeDetachOptions) er
 	} else if !changed {
 		return fmt.Errorf("node %q is not attached to %s", opts.Node, environmentName)
 	}
+	if conflicts := soloNodeRemoteCleanupConflicts(next, opts.Node); len(conflicts) > 0 {
+		return ExitError{Code: 1, Err: fmt.Errorf("remote cleanup for node %q refused: %s. These node records point at the same host; use the attached node record or remove the stale duplicate before detaching so cleanup cannot remove unrelated workloads", opts.Node, strings.Join(conflicts, "; "))}
+	}
 	remainingNodeNames := make([]string, 0, len(nodeNamesBefore))
 	for _, name := range nodeNamesBefore {
 		if name != opts.Node {
@@ -3535,6 +3538,42 @@ func (a *App) soloNodeDetach(ctx context.Context, opts SoloNodeDetachOptions) er
 	}
 	return a.Printer.PrintJSON(payload)
 
+}
+
+func soloNodeRemoteCleanupConflicts(current solo.State, nodeName string) []string {
+	nodeName = strings.TrimSpace(nodeName)
+	node, ok := current.Nodes[nodeName]
+	if !ok {
+		return nil
+	}
+	conflicts := []string{}
+	for otherName, otherNode := range current.Nodes {
+		if otherName == nodeName || !soloNodesShareRemoteCleanupTarget(node, otherNode) || !current.NodeHasAttachments(otherName) {
+			continue
+		}
+		attachments := current.AttachmentsForNode(otherName)
+		descriptions := make([]string, 0, len(attachments))
+		for _, attachment := range attachments {
+			descriptions = append(descriptions, fmt.Sprintf("%s:%s", attachment.WorkspaceKey, attachment.Environment))
+		}
+		sort.Strings(descriptions)
+		conflicts = append(conflicts, fmt.Sprintf("%s has attached environments [%s]", otherName, strings.Join(descriptions, ", ")))
+	}
+	sort.Strings(conflicts)
+	return conflicts
+}
+
+func soloNodesShareRemoteCleanupTarget(a, b config.Node) bool {
+	aProvider := strings.TrimSpace(strings.ToLower(a.Provider))
+	bProvider := strings.TrimSpace(strings.ToLower(b.Provider))
+	aProviderID := strings.TrimSpace(a.ProviderServerID)
+	bProviderID := strings.TrimSpace(b.ProviderServerID)
+	if aProvider != "" && aProviderID != "" && aProvider == bProvider && aProviderID == bProviderID {
+		return true
+	}
+	aHost := strings.TrimSpace(strings.ToLower(a.Host))
+	bHost := strings.TrimSpace(strings.ToLower(b.Host))
+	return aHost != "" && aHost == bHost
 }
 
 func soloRepublishMissingAgentError(err error) bool {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -7702,7 +7702,7 @@ func soloAgentInstallScript(opts soloAgentInstallScriptOptions) string {
 	if stateDir == "" {
 		stateDir = "/var/lib/devopsellence"
 	}
-	authStatePath := stateDir + "/auth.json"
+	authStatePath := stateDir + "/private/auth.json"
 	overridePath := stateDir + "/desired-state-override.json"
 	envoyBootstrapPath := stateDir + "/envoy/envoy.yaml"
 	agentVersion := strings.TrimSpace(opts.AgentVersion)
@@ -7816,10 +7816,11 @@ if ! docker_ready; then
 fi
 harden_sshd_password_auth
 
-run_root mkdir -p "$STATE_DIR" "$STATE_DIR/envoy"
+run_root mkdir -p "$STATE_DIR" "$STATE_DIR/envoy" "$STATE_DIR/private"
 # The parent must remain executable so Envoy can open the bind-mounted
 # bootstrap/socket directory; sensitive state files are written 0600/0640.
 run_root chmod 711 "$STATE_DIR"
+run_root chmod 700 "$STATE_DIR/private"
 TMP_BIN="$(mktemp)"
 TMP_SUMS="$(mktemp)"
 cleanup() {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -7656,7 +7656,7 @@ func installSoloAgent(ctx context.Context, node config.Node, opts SoloAgentInsta
 }
 
 func soloAgentInstallShouldHardenSSH(node config.Node) bool {
-	return strings.TrimSpace(node.Provider) != ""
+	return strings.TrimSpace(node.Provider) != "" && strings.TrimSpace(node.ProviderServerID) != ""
 }
 
 func runSoloAgentInstallScript(ctx context.Context, node config.Node, script string, reporter soloInstallReporter) error {
@@ -7729,8 +7729,23 @@ harden_sshd_password_auth() {
 PasswordAuthentication no
 KbdInteractiveAuthentication no
 EOF_SSHD
+  if [ -f /etc/ssh/sshd_config ] && ! run_root grep -Eq '^[[:space:]]*Include[[:space:]]+/etc/ssh/sshd_config\.d/\*\.conf' /etc/ssh/sshd_config; then
+    tmp_sshd_config="$(mktemp)"
+    {
+      printf 'Include /etc/ssh/sshd_config.d/*.conf\n'
+      run_root cat /etc/ssh/sshd_config
+    } >"$tmp_sshd_config"
+    run_root cp "$tmp_sshd_config" /etc/ssh/sshd_config
+    rm -f "$tmp_sshd_config"
+  fi
   run_root sshd -t
-  run_root systemctl reload ssh || run_root systemctl reload sshd || run_root systemctl restart ssh || run_root systemctl restart sshd
+  if ! run_root sshd -T | grep -qi '^passwordauthentication no$'; then
+    echo "warning: SSH password hardening was written but is not effective according to sshd -T" >&2
+    return 0
+  fi
+  if ! run_root systemctl reload ssh && ! run_root systemctl reload sshd; then
+    echo "warning: SSH password hardening was written but sshd reload failed; reload sshd or reboot to apply it" >&2
+  fi
 }
 
 docker_ready() {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -3478,6 +3478,7 @@ func (a *App) SoloNodeDetach(ctx context.Context, opts SoloNodeDetachOptions) er
 }
 
 func (a *App) soloNodeDetach(ctx context.Context, opts SoloNodeDetachOptions) error {
+	nodeName := strings.TrimSpace(opts.Node)
 	cfg, workspaceRoot, err := a.loadSoloProjectConfig()
 	if err != nil {
 		return err
@@ -3495,17 +3496,17 @@ func (a *App) soloNodeDetach(ctx context.Context, opts SoloNodeDetachOptions) er
 		return fmt.Errorf("environment %s has no attached nodes", environmentName)
 	}
 	next := cloneSoloState(current)
-	if _, changed, err := next.DetachNode(workspaceRoot, environmentName, opts.Node); err != nil {
+	if _, changed, err := next.DetachNode(workspaceRoot, environmentName, nodeName); err != nil {
 		return err
 	} else if !changed {
-		return fmt.Errorf("node %q is not attached to %s", opts.Node, environmentName)
+		return fmt.Errorf("node %q is not attached to %s", nodeName, environmentName)
 	}
-	if conflicts := soloNodeRemoteCleanupConflicts(next, opts.Node); len(conflicts) > 0 {
-		return ExitError{Code: 1, Err: fmt.Errorf("remote cleanup for node %q refused: %s. These node records point at the same provider target or SSH endpoint; use the attached node record or remove the stale duplicate before detaching so cleanup cannot remove unrelated workloads", opts.Node, strings.Join(conflicts, "; "))}
+	if conflicts := soloNodeRemoteCleanupConflicts(next, nodeName); len(conflicts) > 0 {
+		return ExitError{Code: 1, Err: fmt.Errorf("remote cleanup for node %q refused: %s. These node records point at the same provider target or SSH endpoint; use the attached node record or remove the stale duplicate before detaching so cleanup cannot remove unrelated workloads", nodeName, strings.Join(conflicts, "; "))}
 	}
 	remainingNodeNames := make([]string, 0, len(nodeNamesBefore))
 	for _, name := range nodeNamesBefore {
-		if name != opts.Node {
+		if name != nodeName {
 			remainingNodeNames = append(remainingNodeNames, name)
 		}
 	}
@@ -3515,8 +3516,8 @@ func (a *App) soloNodeDetach(ctx context.Context, opts SoloNodeDetachOptions) er
 	}
 	warnings := []string{}
 	remoteCleanup := "published"
-	if _, err := a.republishNodes(ctx, next, []string{opts.Node}); err != nil {
-		if next.NodeHasAttachments(opts.Node) || !soloRepublishMissingAgentError(err) {
+	if _, err := a.republishNodes(ctx, next, []string{nodeName}); err != nil {
+		if next.NodeHasAttachments(nodeName) || !soloRepublishMissingAgentError(err) {
 			return err
 		}
 		remoteCleanup = "skipped_missing_agent"
@@ -3528,7 +3529,7 @@ func (a *App) soloNodeDetach(ctx context.Context, opts SoloNodeDetachOptions) er
 
 	payload := map[string]any{
 		"schema_version": outputSchemaVersion,
-		"node":           opts.Node,
+		"node":           nodeName,
 		"environment":    environmentName,
 		"changed":        true,
 		"remote_cleanup": remoteCleanup,

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -7721,7 +7721,8 @@ run_root() {
 
 harden_sshd_password_auth() {
   [ "$HARDEN_SSH" = "true" ] || return 0
-  run_root sh -c 'command -v sshd >/dev/null 2>&1 || [ -x /usr/sbin/sshd ] || [ -x /usr/bin/sshd ]' || return 0
+  SSHD_BIN="$(run_root sh -c 'command -v sshd || { [ -x /usr/sbin/sshd ] && printf %%s /usr/sbin/sshd; } || { [ -x /usr/bin/sshd ] && printf %%s /usr/bin/sshd; }')"
+  [ -n "$SSHD_BIN" ] || return 0
   [ -d /etc/ssh ] || return 0
   echo "progress: hardening SSH password authentication"
   run_root mkdir -p /etc/ssh/sshd_config.d
@@ -7730,16 +7731,10 @@ PasswordAuthentication no
 KbdInteractiveAuthentication no
 EOF_SSHD
   if [ -f /etc/ssh/sshd_config ] && ! run_root grep -Eq '^[[:space:]]*Include[[:space:]]+/etc/ssh/sshd_config\.d/\*\.conf' /etc/ssh/sshd_config; then
-    tmp_sshd_config="$(mktemp)"
-    {
-      printf 'Include /etc/ssh/sshd_config.d/*.conf\n'
-      run_root cat /etc/ssh/sshd_config
-    } >"$tmp_sshd_config"
-    run_root cp "$tmp_sshd_config" /etc/ssh/sshd_config
-    rm -f "$tmp_sshd_config"
+    printf '\nInclude /etc/ssh/sshd_config.d/*.conf\n' | run_root tee -a /etc/ssh/sshd_config >/dev/null
   fi
-  run_root sshd -t
-  if ! run_root sshd -T | grep -qi '^passwordauthentication no$'; then
+  run_root "$SSHD_BIN" -t
+  if ! run_root "$SSHD_BIN" -T | grep -qi '^passwordauthentication no$'; then
     echo "SSH password hardening was written but is not effective according to sshd -T" >&2
     return 1
   fi

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -4413,8 +4413,10 @@ func TestSoloAgentUpgradeHardensProviderNodeSSH(t *testing.T) {
 		"KbdInteractiveAuthentication no",
 		"/etc/ssh/sshd_config.d/60-devopsellence-hardening.conf",
 		"Include /etc/ssh/sshd_config.d/*.conf",
+		"run_root sh -c 'command -v sshd",
 		"sshd -t",
 		"sshd -T",
+		"not effective according to sshd -T",
 		"systemctl reload ssh",
 	} {
 		if !strings.Contains(script, want) {

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -4413,9 +4413,11 @@ func TestSoloAgentUpgradeHardensProviderNodeSSH(t *testing.T) {
 		"KbdInteractiveAuthentication no",
 		"/etc/ssh/sshd_config.d/60-devopsellence-hardening.conf",
 		"Include /etc/ssh/sshd_config.d/*.conf",
-		"run_root sh -c 'command -v sshd",
-		"sshd -t",
-		"sshd -T",
+		"SSHD_BIN=",
+		"/usr/sbin/sshd",
+		`run_root "$SSHD_BIN" -t`,
+		`run_root "$SSHD_BIN" -T`,
+		"tee -a /etc/ssh/sshd_config",
 		"not effective according to sshd -T",
 		"systemctl reload ssh",
 	} {
@@ -9188,7 +9190,8 @@ func TestSoloAgentInstallScriptCanHardenSSHPasswordAuthentication(t *testing.T) 
 		"/etc/ssh/sshd_config.d/60-devopsellence-hardening.conf",
 		"PasswordAuthentication no",
 		"KbdInteractiveAuthentication no",
-		"sshd -t",
+		`run_root "$SSHD_BIN" -t`,
+		`run_root "$SSHD_BIN" -T`,
 		"systemctl reload ssh",
 	} {
 		if !strings.Contains(script, want) {

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -5183,7 +5183,7 @@ func TestSoloNodeDetachRefusesRemoteCleanupWhenDuplicateHostHasAttachments(t *te
 	if !errors.As(err, &exitErr) || exitErr.Code != 1 {
 		t.Fatalf("error = %#v, want ExitError code 1", err)
 	}
-	for _, want := range []string{"remote cleanup", "docs-1", "same host", "unrelated workloads"} {
+	for _, want := range []string{"remote cleanup", "docs-1", "same provider target or SSH endpoint", "unrelated workloads"} {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("error = %q, want substring %q", err.Error(), want)
 		}
@@ -5200,6 +5200,50 @@ func TestSoloNodeDetachRefusesRemoteCleanupWhenDuplicateHostHasAttachments(t *te
 	}
 	if !loaded.NodeHasAttachments("docs-1") {
 		t.Fatalf("docs-1 attachment was removed after refused detach: %#v", loaded.Attachments)
+	}
+}
+
+func TestSoloNodesShareRemoteCleanupTarget(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		a    config.Node
+		b    config.Node
+		want bool
+	}{
+		{
+			name: "same provider target",
+			a:    config.Node{Provider: "hetzner", ProviderServerID: "srv-1", Host: "203.0.113.10", Port: 22},
+			b:    config.Node{Provider: " HETZNER ", ProviderServerID: "srv-1", Host: "203.0.113.11", Port: 2222},
+			want: true,
+		},
+		{
+			name: "same ssh endpoint",
+			a:    config.Node{Host: "203.0.113.10", Port: 22},
+			b:    config.Node{Host: " 203.0.113.10 ", Port: 0},
+			want: true,
+		},
+		{
+			name: "same host different ssh port",
+			a:    config.Node{Host: "203.0.113.10", Port: 22},
+			b:    config.Node{Host: "203.0.113.10", Port: 2222},
+			want: false,
+		},
+		{
+			name: "different provider target same stale host",
+			a:    config.Node{Provider: "hetzner", ProviderServerID: "srv-1", Host: "203.0.113.10", Port: 22},
+			b:    config.Node{Provider: "hetzner", ProviderServerID: "srv-2", Host: "203.0.113.10", Port: 2222},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := soloNodesShareRemoteCleanupTarget(tt.a, tt.b); got != tt.want {
+				t.Fatalf("soloNodesShareRemoteCleanupTarget() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -4412,11 +4412,49 @@ func TestSoloAgentUpgradeHardensProviderNodeSSH(t *testing.T) {
 		"PasswordAuthentication no",
 		"KbdInteractiveAuthentication no",
 		"/etc/ssh/sshd_config.d/60-devopsellence-hardening.conf",
+		"Include /etc/ssh/sshd_config.d/*.conf",
 		"sshd -t",
+		"sshd -T",
+		"systemctl reload ssh",
 	} {
 		if !strings.Contains(script, want) {
 			t.Fatalf("install script missing %q:\n%s", want, script)
 		}
+	}
+	if strings.Contains(script, "systemctl restart ssh") || strings.Contains(script, "systemctl restart sshd") {
+		t.Fatalf("install script should not restart sshd over the active SSH session:\n%s", script)
+	}
+}
+
+func TestSoloAgentInstallShouldHardenSSHRequiresCompleteProviderMetadata(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		node config.Node
+		want bool
+	}{
+		{
+			name: "manual node",
+			node: config.Node{Host: "203.0.113.10", User: "root"},
+		},
+		{
+			name: "provider without server id",
+			node: config.Node{Host: "203.0.113.10", User: "root", Provider: "hetzner"},
+		},
+		{
+			name: "complete provider metadata",
+			node: config.Node{Host: "203.0.113.10", User: "root", Provider: "hetzner", ProviderServerID: "123"},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := soloAgentInstallShouldHardenSSH(tt.node); got != tt.want {
+				t.Fatalf("soloAgentInstallShouldHardenSSH() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -4146,8 +4146,17 @@ func TestSoloAgentStatePermissionsRejectsOtherRead(t *testing.T) {
 	installFakeSoloCommands(t, nil)
 	t.Setenv("DEVOPSELLENCE_FAKE_SSH_AGENT_STATE_STAT", "755 root root /var/lib/devopsellence")
 	check := soloAgentStatePermissionsCheck(context.Background(), config.Node{Host: "203.0.113.10", User: "root"})
-	if check.OK || !strings.Contains(check.NextAction, "other read/write") {
+	if check.OK || !strings.Contains(check.NextAction, "chmod 700") {
 		t.Fatalf("agent state check = %#v, want other-read finding", check)
+	}
+}
+
+func TestSoloAgentStatePermissionsRejectsOtherExecute(t *testing.T) {
+	installFakeSoloCommands(t, nil)
+	t.Setenv("DEVOPSELLENCE_FAKE_SSH_AGENT_STATE_STAT", "751 root root /var/lib/devopsellence")
+	check := soloAgentStatePermissionsCheck(context.Background(), config.Node{Host: "203.0.113.10", User: "root"})
+	if check.OK || !strings.Contains(check.NextAction, "chmod 700") {
+		t.Fatalf("agent state check = %#v, want other-execute finding", check)
 	}
 }
 
@@ -10272,7 +10281,7 @@ if [[ "$command" == *"__DEVOPSELLENCE_EXIT_CODE__"* && "$command" == *"stat -c"*
 fi
 
 if [[ "$command" == *"__DEVOPSELLENCE_EXIT_CODE__"* && "$command" == *"stat -c"* && "$command" == *"/var/lib/devopsellence"* ]]; then
-  state_stat="${DEVOPSELLENCE_FAKE_SSH_AGENT_STATE_STAT:-751 root root /var/lib/devopsellence}"
+  state_stat="${DEVOPSELLENCE_FAKE_SSH_AGENT_STATE_STAT:-700 root root /var/lib/devopsellence}"
   printf '__DEVOPSELLENCE_EXIT_CODE__0\n__DEVOPSELLENCE_STDOUT__\n%s\n__DEVOPSELLENCE_STDERR__\n' "$state_stat"
   exit 0
 fi

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -5093,6 +5093,70 @@ func TestSoloNodeDetachRepublishesEmptyDesiredStateForLastAttachment(t *testing.
 	}
 }
 
+func TestSoloNodeDetachRefusesRemoteCleanupWhenDuplicateHostHasAttachments(t *testing.T) {
+	workspaceDocs := t.TempDir()
+	workspaceDogfood := t.TempDir()
+	if _, err := config.Write(workspaceDocs, config.DefaultProjectConfig("solo", "docs", "production")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := config.Write(workspaceDogfood, config.DefaultProjectConfig("solo", "dogfood", "production")); err != nil {
+		t.Fatal(err)
+	}
+
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.Node{
+			"docs-1":           {Host: "203.0.113.10", User: "root", Labels: []string{config.DefaultWebRole}},
+			"docs-df-existing": {Host: "203.0.113.10", User: "root", Labels: []string{config.DefaultWebRole}},
+		},
+		Attachments: map[string]solo.AttachmentRecord{},
+	}
+	if _, _, err := current.AttachNode(workspaceDocs, "production", "docs-1"); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := current.AttachNode(workspaceDogfood, "production", "docs-df-existing"); err != nil {
+		t.Fatal(err)
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+	revisionPath := installFakeSoloCommands(t, nil)
+
+	var stdout bytes.Buffer
+	app := &App{
+		Printer:     output.New(&stdout, io.Discard),
+		SoloState:   soloState,
+		ConfigStore: config.NewStore(),
+		Cwd:         workspaceDogfood,
+	}
+	err := app.SoloNodeDetach(context.Background(), SoloNodeDetachOptions{Node: "docs-df-existing"})
+	if err == nil {
+		t.Fatal("expected duplicate-host detach refusal")
+	}
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 1 {
+		t.Fatalf("error = %#v, want ExitError code 1", err)
+	}
+	for _, want := range []string{"remote cleanup", "docs-1", "same host", "unrelated workloads"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error = %q, want substring %q", err.Error(), want)
+		}
+	}
+	if _, err := os.Stat(revisionPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("desired state file stat err = %v, want not exist", err)
+	}
+	loaded, err := soloState.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !loaded.NodeHasAttachments("docs-df-existing") {
+		t.Fatalf("docs-df-existing attachment was removed after refused detach: %#v", loaded.Attachments)
+	}
+	if !loaded.NodeHasAttachments("docs-1") {
+		t.Fatalf("docs-1 attachment was removed after refused detach: %#v", loaded.Attachments)
+	}
+}
+
 func TestNodeRemoveForManualNodeForgetsLocalState(t *testing.T) {
 	t.Parallel()
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -9208,7 +9208,7 @@ func TestSoloAgentInstallScriptConfiguresSoloMode(t *testing.T) {
 	script := soloAgentInstallScript(soloAgentInstallScriptOptions{BaseURL: "https://example.test"})
 	for _, want := range []string{
 		"--mode=solo",
-		`--auth-state-path="/var/lib/devopsellence/auth.json"`,
+		`--auth-state-path="/var/lib/devopsellence/private/auth.json"`,
 		`--desired-state-override-path="/var/lib/devopsellence/desired-state-override.json"`,
 		"AGENT_BIN=/usr/local/bin/devopsellence-agent",
 		`ARTIFACT_NAME="agent-$OS-$ARCH"`,
@@ -9216,6 +9216,7 @@ func TestSoloAgentInstallScriptConfiguresSoloMode(t *testing.T) {
 		"$BASE_URL/agent/download",
 		"$BASE_URL/agent/checksums",
 		`run_root chmod 711 "$STATE_DIR"`,
+		`run_root chmod 700 "$STATE_DIR/private"`,
 		"HARDEN_SSH='false'",
 	} {
 		if !strings.Contains(script, want) {
@@ -9252,7 +9253,7 @@ func TestSoloAgentInstallScriptUsesConfiguredStateDir(t *testing.T) {
 
 	for _, want := range []string{
 		"STATE_DIR='/tmp/devopsellence-test-state'",
-		`--auth-state-path="/tmp/devopsellence-test-state/auth.json"`,
+		`--auth-state-path="/tmp/devopsellence-test-state/private/auth.json"`,
 		`--desired-state-override-path="/tmp/devopsellence-test-state/desired-state-override.json"`,
 		`--envoy-bootstrap-path="/tmp/devopsellence-test-state/envoy/envoy.yaml"`,
 	} {
@@ -9269,7 +9270,7 @@ func TestSoloAgentInstallScriptQuotesSystemdExecStartPaths(t *testing.T) {
 	})
 
 	for _, want := range []string{
-		`--auth-state-path="/tmp/devopsellence state/\"quoted\"%%value/auth.json"`,
+		`--auth-state-path="/tmp/devopsellence state/\"quoted\"%%value/private/auth.json"`,
 		`--desired-state-override-path="/tmp/devopsellence state/\"quoted\"%%value/desired-state-override.json"`,
 		`--envoy-bootstrap-path="/tmp/devopsellence state/\"quoted\"%%value/envoy/envoy.yaml"`,
 	} {

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -4372,6 +4372,52 @@ func TestSoloAgentUpgradeReinstallsAgent(t *testing.T) {
 	if !strings.Contains(string(scriptBytes), "AGENT_VERSION='v2.0.0'") {
 		t.Fatalf("install script missing pinned version:\n%s", string(scriptBytes))
 	}
+	if strings.Contains(string(scriptBytes), "HARDEN_SSH='true'") {
+		t.Fatalf("manual node install script unexpectedly enables SSH hardening:\n%s", string(scriptBytes))
+	}
+}
+
+func TestSoloAgentUpgradeHardensProviderNodeSSH(t *testing.T) {
+	originalVersion := cliversion.Version
+	t.Cleanup(func() { cliversion.Version = originalVersion })
+	cliversion.Version = "v2.0.0"
+	scriptPath := filepath.Join(t.TempDir(), "install.sh")
+	installFakeSoloCommands(t, nil)
+	t.Setenv("DEVOPSELLENCE_FAKE_AGENT_VERSION", "devopsellence v2.0.0 (commit new, built now)")
+	t.Setenv("DEVOPSELLENCE_FAKE_SSH_SCRIPT", scriptPath)
+
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.Node{
+			"node-a": {Host: "203.0.113.10", User: "root", Provider: "hetzner", ProviderServerID: "123"},
+		},
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState}
+	if err := app.SoloAgentUpgrade(context.Background(), SoloAgentUpgradeOptions{Node: "node-a", BaseURL: "https://example.test"}); err != nil {
+		t.Fatalf("SoloAgentUpgrade() error = %v", err)
+	}
+	scriptBytes, err := os.ReadFile(scriptPath)
+	if err != nil {
+		t.Fatalf("read install script: %v", err)
+	}
+	script := string(scriptBytes)
+	for _, want := range []string{
+		"HARDEN_SSH='true'",
+		"harden_sshd_password_auth",
+		"PasswordAuthentication no",
+		"KbdInteractiveAuthentication no",
+		"/etc/ssh/sshd_config.d/60-devopsellence-hardening.conf",
+		"sshd -t",
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("install script missing %q:\n%s", want, script)
+		}
+	}
 }
 
 func TestSoloAgentInstallReportsVerification(t *testing.T) {
@@ -8999,6 +9045,24 @@ func TestSoloAgentInstallScriptConfiguresSoloMode(t *testing.T) {
 		"BASE_URL='https://example.test'",
 		"$BASE_URL/agent/download",
 		"$BASE_URL/agent/checksums",
+		"HARDEN_SSH='false'",
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("install script missing %q", want)
+		}
+	}
+}
+
+func TestSoloAgentInstallScriptCanHardenSSHPasswordAuthentication(t *testing.T) {
+	script := soloAgentInstallScript(soloAgentInstallScriptOptions{BaseURL: "https://example.test", HardenSSH: true})
+	for _, want := range []string{
+		"HARDEN_SSH='true'",
+		"progress: hardening SSH password authentication",
+		"/etc/ssh/sshd_config.d/60-devopsellence-hardening.conf",
+		"PasswordAuthentication no",
+		"KbdInteractiveAuthentication no",
+		"sshd -t",
+		"systemctl reload ssh",
 	} {
 		if !strings.Contains(script, want) {
 			t.Fatalf("install script missing %q", want)

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -5139,6 +5139,49 @@ func TestSoloNodeDetachRepublishesEmptyDesiredStateForLastAttachment(t *testing.
 	}
 }
 
+func TestSoloNodeDetachTrimsNodeNameBeforeRepublish(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	if _, err := config.Write(workspaceRoot, config.DefaultProjectConfig("solo", "app-a", "production")); err != nil {
+		t.Fatal(err)
+	}
+
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes:       map[string]config.Node{"node-a": {Host: "203.0.113.10", User: "root", Labels: []string{config.DefaultWebRole}}},
+		Attachments: map[string]solo.AttachmentRecord{},
+	}
+	if _, _, err := current.AttachNode(workspaceRoot, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+	installFakeSoloCommands(t, nil)
+
+	var stdout bytes.Buffer
+	app := &App{
+		Printer:     output.New(&stdout, io.Discard),
+		SoloState:   soloState,
+		ConfigStore: config.NewStore(),
+		Cwd:         workspaceRoot,
+	}
+	if err := app.SoloNodeDetach(context.Background(), SoloNodeDetachOptions{Node: " node-a "}); err != nil {
+		t.Fatal(err)
+	}
+
+	payload := decodeJSONOutput(t, &stdout)
+	if got := stringValueAny(payload["node"]); got != "node-a" {
+		t.Fatalf("node = %q, want trimmed node-a", got)
+	}
+	loaded, err := soloState.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.NodeHasAttachments("node-a") {
+		t.Fatalf("node-a attachment remains after detach: %#v", loaded.Attachments)
+	}
+}
+
 func TestSoloNodeDetachRefusesRemoteCleanupWhenDuplicateHostHasAttachments(t *testing.T) {
 	workspaceDocs := t.TempDir()
 	workspaceDogfood := t.TempDir()

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -4418,7 +4418,9 @@ func TestSoloAgentUpgradeHardensProviderNodeSSH(t *testing.T) {
 		`run_root "$SSHD_BIN" -t`,
 		`run_root "$SSHD_BIN" -T`,
 		`awk 'tolower($1) == "passwordauthentication"`,
-		"run_root cp \"$tmp_sshd_config\" /etc/ssh/sshd_config",
+		"mktemp /etc/ssh/sshd_config.devopsellence.",
+		"run_root cp -p /etc/ssh/sshd_config \"$tmp_sshd_config\"",
+		"run_root mv \"$tmp_sshd_config\" /etc/ssh/sshd_config",
 		"not effective according to sshd -T",
 		"systemctl reload ssh",
 	} {

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -4417,7 +4417,7 @@ func TestSoloAgentUpgradeHardensProviderNodeSSH(t *testing.T) {
 		"/usr/sbin/sshd",
 		`run_root "$SSHD_BIN" -t`,
 		`run_root "$SSHD_BIN" -T`,
-		"tee -a /etc/ssh/sshd_config",
+		"run_root cp \"$tmp_sshd_config\" /etc/ssh/sshd_config",
 		"not effective according to sshd -T",
 		"systemctl reload ssh",
 	} {

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -9038,6 +9038,31 @@ func TestWaitForSoloRolloutFailsOnExpectedRevisionErrorPhase(t *testing.T) {
 	}
 }
 
+func TestWaitForSoloRolloutRetriesTransientExpectedRevisionErrorPhase(t *testing.T) {
+	statusCountPath := installFakeSoloCommands(t, []fakeSSHResponse{
+		{stdout: `{"revision":"expected-revision","phase":"error","error":"ensure envoy: connect envoy to workload network app-net: Error response from daemon: network sandbox for container abc not found"}` + "\n"},
+		{stdout: `{"revision":"expected-revision","phase":"settled","environments":[{"name":"production","revision":"workload-revision","phase":"settled","services":[{"name":"web","phase":"settled","state":"running"}]}]}` + "\n"},
+	})
+
+	app := &App{
+		Printer:            output.New(io.Discard, io.Discard),
+		DeployPollInterval: 5 * time.Millisecond,
+		DeployTimeout:      time.Second,
+	}
+
+	err := app.waitForSoloRolloutForRuntime(context.Background(), map[string]config.Node{
+		"node-a": {Host: "203.0.113.10", User: "root", Port: 22, AgentStateDir: "/var/lib/devopsellence"},
+	}, map[string]string{
+		"node-a": "expected-revision",
+	}, "production", "workload-revision")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := readFakeSSHStatusCount(t, statusCountPath); got != 2 {
+		t.Fatalf("status poll count = %d, want retry then settled", got)
+	}
+}
+
 func TestWaitForSoloRolloutFailsOnUnhealthyRuntimeEnvironmentDespiteTopLevelSettled(t *testing.T) {
 	installFakeSoloCommands(t, []fakeSSHResponse{
 		{stdout: `{"revision":"expected-revision","phase":"settled","environments":[{"name":"production","revision":"workload-revision","phase":"settled","services":[{"name":"web","phase":"settled","state":"unhealthy"}]}]}` + "\n"},

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -4417,6 +4417,7 @@ func TestSoloAgentUpgradeHardensProviderNodeSSH(t *testing.T) {
 		"/usr/sbin/sshd",
 		`run_root "$SSHD_BIN" -t`,
 		`run_root "$SSHD_BIN" -T`,
+		`awk 'tolower($1) == "passwordauthentication"`,
 		"run_root cp \"$tmp_sshd_config\" /etc/ssh/sshd_config",
 		"not effective according to sshd -T",
 		"systemctl reload ssh",
@@ -4427,6 +4428,9 @@ func TestSoloAgentUpgradeHardensProviderNodeSSH(t *testing.T) {
 	}
 	if strings.Contains(script, "systemctl restart ssh") || strings.Contains(script, "systemctl restart sshd") {
 		t.Fatalf("install script should not restart sshd over the active SSH session:\n%s", script)
+	}
+	if strings.Contains(script, "grep -qi '^passwordauthentication no$'") {
+		t.Fatalf("install script should not use grep -q with sshd -T under pipefail:\n%s", script)
 	}
 }
 
@@ -9192,6 +9196,7 @@ func TestSoloAgentInstallScriptCanHardenSSHPasswordAuthentication(t *testing.T) 
 		"KbdInteractiveAuthentication no",
 		`run_root "$SSHD_BIN" -t`,
 		`run_root "$SSHD_BIN" -T`,
+		`awk 'tolower($1) == "passwordauthentication"`,
 		"systemctl reload ssh",
 	} {
 		if !strings.Contains(script, want) {

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -4146,17 +4146,8 @@ func TestSoloAgentStatePermissionsRejectsOtherRead(t *testing.T) {
 	installFakeSoloCommands(t, nil)
 	t.Setenv("DEVOPSELLENCE_FAKE_SSH_AGENT_STATE_STAT", "755 root root /var/lib/devopsellence")
 	check := soloAgentStatePermissionsCheck(context.Background(), config.Node{Host: "203.0.113.10", User: "root"})
-	if check.OK || !strings.Contains(check.NextAction, "chmod 700") {
+	if check.OK || !strings.Contains(check.NextAction, "other read/write") {
 		t.Fatalf("agent state check = %#v, want other-read finding", check)
-	}
-}
-
-func TestSoloAgentStatePermissionsRejectsOtherExecute(t *testing.T) {
-	installFakeSoloCommands(t, nil)
-	t.Setenv("DEVOPSELLENCE_FAKE_SSH_AGENT_STATE_STAT", "751 root root /var/lib/devopsellence")
-	check := soloAgentStatePermissionsCheck(context.Background(), config.Node{Host: "203.0.113.10", User: "root"})
-	if check.OK || !strings.Contains(check.NextAction, "chmod 700") {
-		t.Fatalf("agent state check = %#v, want other-execute finding", check)
 	}
 }
 
@@ -9215,7 +9206,7 @@ func TestSoloAgentInstallScriptConfiguresSoloMode(t *testing.T) {
 		"BASE_URL='https://example.test'",
 		"$BASE_URL/agent/download",
 		"$BASE_URL/agent/checksums",
-		`run_root chmod 700 "$STATE_DIR"`,
+		`run_root chmod 751 "$STATE_DIR"`,
 		"HARDEN_SSH='false'",
 	} {
 		if !strings.Contains(script, want) {
@@ -10281,7 +10272,7 @@ if [[ "$command" == *"__DEVOPSELLENCE_EXIT_CODE__"* && "$command" == *"stat -c"*
 fi
 
 if [[ "$command" == *"__DEVOPSELLENCE_EXIT_CODE__"* && "$command" == *"stat -c"* && "$command" == *"/var/lib/devopsellence"* ]]; then
-  state_stat="${DEVOPSELLENCE_FAKE_SSH_AGENT_STATE_STAT:-700 root root /var/lib/devopsellence}"
+  state_stat="${DEVOPSELLENCE_FAKE_SSH_AGENT_STATE_STAT:-751 root root /var/lib/devopsellence}"
   printf '__DEVOPSELLENCE_EXIT_CODE__0\n__DEVOPSELLENCE_STDOUT__\n%s\n__DEVOPSELLENCE_STDERR__\n' "$state_stat"
   exit 0
 fi

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -4417,7 +4417,8 @@ func TestSoloAgentUpgradeHardensProviderNodeSSH(t *testing.T) {
 		"/usr/sbin/sshd",
 		`run_root "$SSHD_BIN" -t`,
 		`run_root "$SSHD_BIN" -T`,
-		`awk 'tolower($1) == "passwordauthentication"`,
+		`password = tolower($2)`,
+		`keyboard = tolower($2)`,
 		"mktemp /etc/ssh/sshd_config.devopsellence.",
 		"run_root cp -p /etc/ssh/sshd_config \"$tmp_sshd_config\"",
 		"run_root mv \"$tmp_sshd_config\" /etc/ssh/sshd_config",
@@ -9198,7 +9199,8 @@ func TestSoloAgentInstallScriptCanHardenSSHPasswordAuthentication(t *testing.T) 
 		"KbdInteractiveAuthentication no",
 		`run_root "$SSHD_BIN" -t`,
 		`run_root "$SSHD_BIN" -T`,
-		`awk 'tolower($1) == "passwordauthentication"`,
+		`password = tolower($2)`,
+		`keyboard = tolower($2)`,
 		"systemctl reload ssh",
 	} {
 		if !strings.Contains(script, want) {

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -4981,6 +4981,15 @@ exit 1
 	}
 }
 
+func TestSoloNodeDetachRejectsBlankNodeName(t *testing.T) {
+	app := &App{Printer: output.New(io.Discard, io.Discard)}
+	err := app.soloNodeDetach(context.Background(), SoloNodeDetachOptions{Node: " \t "})
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 2 || !strings.Contains(exitErr.Error(), "--node") {
+		t.Fatalf("error = %#v, want missing --node ExitError", err)
+	}
+}
+
 func TestSoloNodeDetachPreservesLocalAttachmentWhenRemoteCleanupFails(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")
@@ -9206,7 +9215,7 @@ func TestSoloAgentInstallScriptConfiguresSoloMode(t *testing.T) {
 		"BASE_URL='https://example.test'",
 		"$BASE_URL/agent/download",
 		"$BASE_URL/agent/checksums",
-		`run_root chmod 751 "$STATE_DIR"`,
+		`run_root chmod 711 "$STATE_DIR"`,
 		"HARDEN_SSH='false'",
 	} {
 		if !strings.Contains(script, want) {
@@ -10272,7 +10281,7 @@ if [[ "$command" == *"__DEVOPSELLENCE_EXIT_CODE__"* && "$command" == *"stat -c"*
 fi
 
 if [[ "$command" == *"__DEVOPSELLENCE_EXIT_CODE__"* && "$command" == *"stat -c"* && "$command" == *"/var/lib/devopsellence"* ]]; then
-  state_stat="${DEVOPSELLENCE_FAKE_SSH_AGENT_STATE_STAT:-751 root root /var/lib/devopsellence}"
+  state_stat="${DEVOPSELLENCE_FAKE_SSH_AGENT_STATE_STAT:-711 root root /var/lib/devopsellence}"
   printf '__DEVOPSELLENCE_EXIT_CODE__0\n__DEVOPSELLENCE_STDOUT__\n%s\n__DEVOPSELLENCE_STDERR__\n' "$state_stat"
   exit 0
 fi

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -9181,6 +9181,7 @@ func TestSoloAgentInstallScriptConfiguresSoloMode(t *testing.T) {
 		"BASE_URL='https://example.test'",
 		"$BASE_URL/agent/download",
 		"$BASE_URL/agent/checksums",
+		`run_root chmod 700 "$STATE_DIR"`,
 		"HARDEN_SSH='false'",
 	} {
 		if !strings.Contains(script, want) {


### PR DESCRIPTION
## Summary
- refuse solo detach remote cleanup when another node record points at the same provider target or SSH endpoint and still has attachments
- keep local attachment state unchanged when cleanup is refused
- normalize solo detach node names before republish/state checks
- harden provider-managed solo node installs/upgrades by disabling SSH password authentication when provider metadata is complete; manual/partial-provider nodes keep their current SSH policy
- verify sshd hardening with `sshd -T`, ensure sshd drop-in inclusion when needed, and reload without restarting the active SSH service
- add regression coverage for duplicate-host cleanup, detach node-name normalization, and SSH-hardening install paths

## Tests
- go test ./internal/workflow -run 'TestSoloNodeDetach(RepublishesRemainingCohostedDesiredState|RepublishesEmptyDesiredStateForLastAttachment|RefusesRemoteCleanupWhenDuplicateHostHasAttachments|PreservesLocalAttachmentWhenRemoteCleanupFails|SucceedsWhenAgentAlreadyUninstalled)'
- go test ./internal/workflow -run 'TestSoloAgent(UpgradeReinstallsAgent|UpgradeHardensProviderNodeSSH|InstallShouldHardenSSHRequiresCompleteProviderMetadata|InstallScriptConfiguresSoloMode|InstallScriptCanHardenSSHPasswordAuthentication|InstallScriptUsesConfiguredStateDir)'
- go test ./internal/workflow -run 'TestSoloNodeDetach(TrimsNodeNameBeforeRepublish|RepublishesEmptyDesiredStateForLastAttachment|RefusesRemoteCleanupWhenDuplicateHostHasAttachments)|TestSoloNodesShareRemoteCleanupTarget'
- go test ./...
- mise run test:cli
- mise run e2e-solo

Fixes #175
Refs #177


## Dogfood / release validation

Latest preview validated from official artifacts: `v0.2.0-preview` at `2c3f547802ac9dd45302c007ae99f69187294848`. This PR also hardens provider-managed solo node installs/upgrades by disabling SSH password and keyboard-interactive authentication only when provider metadata is complete (`provider` + `provider_server_id`). Manual SSH nodes are left unchanged.
