### PR TITLE
Improve solo dogfood status diagnostics

### DIFF
--- a/.agents/skills/dogfood-solo/SKILL.md
+++ b/.agents/skills/dogfood-solo/SKILL.md
@@ -22,6 +22,7 @@ Terminology: "AI agent" means the coding/operator agent doing the dogfood run. "
 - For release/RC validation, use **official CLI and agent artifacts from the exact commit/version**. A local CLI build does not prove the deployed node agent is current.
 - Keep secrets out of terminal history, command logs, reports, PR bodies, and chat. Use stdin and redact values as `[REDACTED]`.
 - Reuse existing dogfood nodes when the user approves and that better matches the scenario; otherwise prefer run-scoped disposable resources.
+- Treat zirk as the preferred run-scoped disposable VM path when it is available and approved. Do not block on public-provider quota if zirk can provide a clean VM for the scenario.
 - Record every meaningful command and outcome in `commands.log` as the run proceeds.
 - Every material finding must ratchet into at least one durable artifact: regression test, product issue, docs update, skill update, or follow-up PR.
 
@@ -76,6 +77,7 @@ Use when a user reports a solo-mode bug. Reproduce with evidence, isolate root c
    - Check `devopsellence --version` and, for live nodes, `/usr/local/bin/devopsellence-agent --version` or equivalent.
    - Identify the node strategy: existing approved node, zirk VM, provider-created VM, or user-provided SSH host.
    - Record resource names, expected cost/blast radius, approval state, and cleanup command before provisioning or destructive cleanup.
+   - For GitHub release workflow dispatch, prefer a branch name or full commit SHA as `source_ref`; short SHAs can be interpreted as missing branch/tag names by checkout.
 
 3. Prepare solo apps/environments.
    - At minimum use one app in `production`.
@@ -87,6 +89,14 @@ Use when a user reports a solo-mode bug. Reproduce with evidence, isolate root c
    - Use `references/checklist.md` as the scenario checklist.
    - Prefer structured CLI output when available.
    - Verify runtime truth with curls, SSH/Docker observations, status/logs, and node-agent logs when appropriate.
+   - If deploy/status appears hung or times out, immediately collect the timeout trap before changing code or restarting:
+     - `devopsellence status`
+     - `devopsellence node diagnose <node>`
+     - `devopsellence node logs <node> --lines 200`
+     - `devopsellence node exec <node> -- systemctl cat devopsellence-agent`
+     - `devopsellence node exec <node> -- find /var/lib/devopsellence -maxdepth 3 -printf '%m %u %g %p\n'`
+     - `devopsellence node exec <node> -- docker ps --format '{{.Names}} {{.Status}} {{.Ports}}'`
+     - Compare the CLI-expected status path, usually `/var/lib/devopsellence/status.json`, with any private status path such as `/var/lib/devopsellence/private/status.json`.
 
 5. Expert pass and fixes.
    - Only after blind/operator evidence is captured, inspect implementation, tests, state files, desired-state payloads, and node logs.
@@ -114,6 +124,8 @@ Treat these as the core solo readiness surfaces:
 - **Dry-run boundary:** deploy/rollback dry-run must not build, publish, SSH, mutate release state, or write local state.
 - **DNS honesty:** bad hostnames should produce clear structured missing-IP evidence rather than false readiness.
 - **Diagnostics:** `status`, `logs`, `exec`, `node logs`, `node diagnose`, and `release list` should target the selected logical environment even when runtime environment names are project-scoped.
+- **Status-path honesty:** `doctor` and `node diagnose` must fail loudly if the agent is active but the CLI cannot read a fresh status report from the expected root status path. A green doctor is not enough unless `status` also works.
+- **State permission split:** verify the solo state parent is traversable for Envoy/status access while sensitive agent state stays private: parent `0711`, private child `0700`, root `status.json` present, auth/disk-care under private.
 - **Cleanup/recovery:** detach/remove one co-hosted project without breaking others; restart agent; reboot node; verify all expected endpoints after recovery.
 
 ## Release Blockers

--- a/.agents/skills/dogfood-solo/references/checklist.md
+++ b/.agents/skills/dogfood-solo/references/checklist.md
@@ -8,8 +8,10 @@ Use this checklist as a menu, not a bureaucracy. For PR-focused probes, run only
 - [ ] Record branch, SHA, PR, target version, and validation mode.
 - [ ] Confirm whether this is local-build validation or official-artifact validation.
 - [ ] Record node strategy: existing approved node, zirk VM, provider VM, or user-provided SSH host.
+- [ ] Prefer a run-scoped zirk VM when available; do not treat Hetzner/provider quota as a blocker if zirk satisfies the disposable-node requirement.
 - [ ] Record cleanup plan before creating/deleting resources.
 - [ ] Confirm no secrets will be printed or persisted in reports.
+- [ ] For GitHub release dispatch, use a branch name or full commit SHA for `source_ref`; short SHAs can fail checkout as missing branch/tag names.
 
 Useful commands:
 
@@ -20,6 +22,20 @@ gh pr view <number> --json number,url,headRefOid,reviewDecision,statusCheckRollu
 devopsellence --version || true
 devopsellence mode show || true
 devopsellence context show || true
+```
+
+Useful zirk disposable-node flow:
+
+```sh
+zirk create --flavor small <node>
+zirk show <node>
+zirk exec <node> "mkdir -p /root/.ssh"
+zirk exec <node> "echo '<public-key>' >> /root/.ssh/authorized_keys"
+zirk exec <node> "chmod 700 /root/.ssh && chmod 600 /root/.ssh/authorized_keys"
+ssh -i <key> -o StrictHostKeyChecking=accept-new root@<ip> true
+# cleanup proof
+zirk delete --force <node>
+zirk show <node>; echo $?
 ```
 
 ## 1. Official Artifact Reality
@@ -41,6 +57,7 @@ Do not treat `cli/scripts/release-local.sh` as proof of node-agent behavior; it 
 - [ ] Run `doctor` before deploy.
 - [ ] Deploy a fresh revision.
 - [ ] Verify CLI-reported status and runtime endpoint health.
+- [ ] Verify `doctor` includes a passing `agent_status_report` runtime check.
 - [ ] Verify logs and exec for the deployed service.
 
 Useful commands:
@@ -53,6 +70,22 @@ devopsellence status
 devopsellence logs --node <node> --lines 100
 devopsellence exec <service> -- <command>
 curl -fsS <url>/up
+```
+
+Status/permission evidence to capture on solo nodes:
+
+```sh
+devopsellence node exec <node> -- sh -lc 'stat -c "%a %U %G %n" /var/lib/devopsellence /var/lib/devopsellence/private /var/lib/devopsellence/status.json /var/lib/devopsellence/private/disk-care-state.json /var/lib/devopsellence/desired-state-override.json'
+```
+
+Expected shape:
+
+```text
+711 root root /var/lib/devopsellence
+700 root root /var/lib/devopsellence/private
+640 root root /var/lib/devopsellence/status.json
+600 root root /var/lib/devopsellence/private/disk-care-state.json
+600 root root /var/lib/devopsellence/desired-state-override.json
 ```
 
 ## 3. TLS Auto / ACME
@@ -210,6 +243,19 @@ devopsellence node diagnose <node>
 devopsellence release list --limit 5
 devopsellence exec <service> -- <command>
 ```
+
+Timeout trap for deploy/status hangs:
+
+```sh
+devopsellence status
+devopsellence node diagnose <node>
+devopsellence node logs <node> --lines 200
+devopsellence node exec <node> -- systemctl cat devopsellence-agent
+devopsellence node exec <node> -- find /var/lib/devopsellence -maxdepth 3 -printf '%m %u %g %p\n'
+devopsellence node exec <node> -- docker ps --format '{{.Names}} {{.Status}} {{.Ports}}'
+```
+
+Interpretation: compare the CLI-expected root `status.json` with the agent's effective `--auth-state-path` and any private status file. A green `doctor` with broken `status` is a product bug, not a passing preflight.
 
 ## 13. Report and Ratchet
 

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -925,6 +925,7 @@ func soloRolloutNextSteps(environment string, nodes []string, healthchecks []map
 	for _, node := range nodes {
 		steps = append(steps, "devopsellence logs"+envFlag+" --node "+shellQuote(node)+" --lines 100")
 		steps = append(steps, "devopsellence node logs "+shellQuote(node)+" --lines 100")
+		steps = append(steps, "devopsellence node diagnose "+shellQuote(node))
 	}
 	return steps
 }
@@ -4216,6 +4217,9 @@ func (a *App) SoloNodeDiagnose(ctx context.Context, opts SoloNodeDiagnoseOptions
 		payload["ok"] = false
 	} else if statusResult.Missing {
 		payload["status_missing"] = true
+		payload["status_path"] = path.Join(firstNonEmpty(node.AgentStateDir, "/var/lib/devopsellence"), "status.json")
+		diagnoseOK = false
+		payload["ok"] = false
 	} else {
 		var statusPayload any
 		if err := json.Unmarshal(statusResult.Raw, &statusPayload); err == nil {
@@ -4371,6 +4375,46 @@ func soloAgentVersionCheck(ctx context.Context, node config.Node) soloRuntimeChe
 		check.OK = false
 		check.NextAction = "run devopsellence node diagnose <node>"
 	}
+	return check
+}
+
+func soloAgentStatusReportCheck(ctx context.Context, node config.Node) soloRuntimeCheck {
+	statusPath := path.Join(firstNonEmpty(node.AgentStateDir, "/var/lib/devopsellence"), "status.json")
+	result, err := readNodeStatus(ctx, node)
+	check := soloRuntimeCheck{OK: true}
+	if err != nil {
+		check.OK = false
+		check.Observed = "unknown: read " + statusPath + ": " + err.Error()
+		check.NextAction = "run devopsellence node diagnose <node> and inspect the agent status path"
+		return check
+	}
+	if result.Missing {
+		check.OK = false
+		check.Observed = "missing expected status report at " + statusPath
+		check.NextAction = "reinstall or restart the agent, then rerun devopsellence doctor"
+		return check
+	}
+	if strings.TrimSpace(result.Status.Time) == "" {
+		check.OK = false
+		check.Observed = "status report at " + statusPath + " is missing time"
+		check.NextAction = "run devopsellence node diagnose <node> and inspect the agent status writer"
+		return check
+	}
+	statusTime, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(result.Status.Time))
+	if err != nil {
+		check.OK = false
+		check.Observed = "status report at " + statusPath + " has invalid time " + shellQuote(result.Status.Time)
+		check.NextAction = "run devopsellence node diagnose <node> and inspect the agent status writer"
+		return check
+	}
+	age := time.Since(statusTime)
+	if age > 5*time.Minute {
+		check.OK = false
+		check.Observed = fmt.Sprintf("status report at %s is stale: time=%s", statusPath, result.Status.Time)
+		check.NextAction = "restart devopsellence-agent and rerun devopsellence doctor"
+		return check
+	}
+	check.Observed = fmt.Sprintf("fresh status report at %s: phase=%s time=%s", statusPath, firstNonEmpty(result.Status.Phase, "unknown"), result.Status.Time)
 	return check
 }
 
@@ -5315,6 +5359,7 @@ func (a *App) soloRuntimeDoctorChecks(ctx context.Context, opts SoloDoctorOption
 		}
 		if !sshOK {
 			results = append(results, soloRuntimeAgentVersionCheckResult(name, soloRuntimeCheck{OK: false, Observed: "skipped: ssh check failed", NextAction: "fix SSH connectivity, then rerun devopsellence doctor"}))
+			results = append(results, soloRuntimeStatusReportCheckResult(name, soloRuntimeCheck{OK: false, Observed: "skipped: ssh check failed", NextAction: "fix SSH connectivity, then rerun devopsellence doctor"}))
 			for _, check := range soloSkippedSecurityChecksAfterSSHFailure() {
 				results = append(results, soloRuntimeSecurityCheckResult(name, check))
 			}
@@ -5326,6 +5371,11 @@ func (a *App) soloRuntimeDoctorChecks(ctx context.Context, opts SoloDoctorOption
 			failed = true
 		}
 		results = append(results, versionResult)
+		statusReportCheck := soloAgentStatusReportCheck(ctx, node)
+		if !statusReportCheck.OK {
+			failed = true
+		}
+		results = append(results, soloRuntimeStatusReportCheckResult(name, statusReportCheck))
 		for _, check := range soloNodeSecurityChecks(ctx, node, nil, false, nil) {
 			result := soloRuntimeSecurityCheckResult(name, check)
 			if !check.OK {
@@ -5341,6 +5391,19 @@ func soloRuntimeAgentVersionCheckResult(nodeName string, check soloRuntimeCheck)
 	result := map[string]any{
 		"node":   nodeName,
 		"check":  "agent_version",
+		"ok":     check.OK,
+		"detail": check.Observed,
+	}
+	if check.NextAction != "" {
+		result["next_action"] = check.NextAction
+	}
+	return result
+}
+
+func soloRuntimeStatusReportCheckResult(nodeName string, check soloRuntimeCheck) map[string]any {
+	result := map[string]any{
+		"node":   nodeName,
+		"check":  "agent_status_report",
 		"ok":     check.OK,
 		"detail": check.Observed,
 	}

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -4414,13 +4414,7 @@ func soloAgentStatusReportCheck(ctx context.Context, node config.Node) soloRunti
 		check.NextAction = "check node clock skew, then rerun devopsellence doctor"
 		return check
 	}
-	if age > 5*time.Minute {
-		check.OK = false
-		check.Observed = fmt.Sprintf("status report at %s is stale: time=%s", statusPath, result.Status.Time)
-		check.NextAction = "restart devopsellence-agent and rerun devopsellence doctor"
-		return check
-	}
-	check.Observed = fmt.Sprintf("fresh status report at %s: phase=%s time=%s", statusPath, firstNonEmpty(result.Status.Phase, "unknown"), result.Status.Time)
+	check.Observed = fmt.Sprintf("status report at %s: phase=%s time=%s age=%s", statusPath, firstNonEmpty(result.Status.Phase, "unknown"), result.Status.Time, age.Round(time.Second))
 	return check
 }
 

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -4408,6 +4408,12 @@ func soloAgentStatusReportCheck(ctx context.Context, node config.Node) soloRunti
 		return check
 	}
 	age := time.Since(statusTime)
+	if age < -2*time.Minute {
+		check.OK = false
+		check.Observed = fmt.Sprintf("status report at %s is from the future: time=%s", statusPath, result.Status.Time)
+		check.NextAction = "check node clock skew, then rerun devopsellence doctor"
+		return check
+	}
 	if age > 5*time.Minute {
 		check.OK = false
 		check.Observed = fmt.Sprintf("status report at %s is stale: time=%s", statusPath, result.Status.Time)

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -2398,6 +2398,54 @@ func TestSoloDoctorFailsWhenAgentStatusReportMissingAtExpectedPath(t *testing.T)
 	t.Fatalf("runtime_checks = %#v, want agent_status_report", checks)
 }
 
+func TestSoloDoctorFailsWhenAgentStatusReportTimeIsInFuture(t *testing.T) {
+	installFakeSoloCommands(t, []fakeSSHResponse{{stdout: `{"time":"2099-01-01T00:00:00Z","revision":"abc","phase":"settled"}` + "\n"}})
+
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	commitTestRepo(t, workspaceRoot)
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.Node{
+			"node-a": {Host: "203.0.113.10", User: "root"},
+		},
+	}
+	if _, _, err := current.AttachNode(workspaceRoot, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{
+		Printer:     output.New(&stdout, io.Discard),
+		Docker:      &fakeDocker{},
+		SoloState:   soloState,
+		ConfigStore: config.NewStore(),
+		Cwd:         workspaceRoot,
+	}
+	err := app.SoloDoctor(context.Background())
+	if err == nil {
+		t.Fatal("SoloDoctor() error = nil, want future status report failure")
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	checks := jsonArrayFromMap(t, payload, "runtime_checks")
+	for _, item := range checks {
+		check := jsonMapFromAny(t, item)
+		if check["check"] == "agent_status_report" {
+			if check["ok"] != false || !strings.Contains(stringValueAny(check["detail"]), "future") || !strings.Contains(stringValueAny(check["next_action"]), "clock skew") {
+				t.Fatalf("agent_status_report = %#v, want future timestamp failure", check)
+			}
+			return
+		}
+	}
+	t.Fatalf("runtime_checks = %#v, want agent_status_report", checks)
+}
+
 func TestSoloDoctorReportsSecurityFindings(t *testing.T) {
 	installFakeSoloCommands(t, nil)
 	t.Setenv("DEVOPSELLENCE_FAKE_SSH_PASSWORD_AUTH", "yes")
@@ -10471,7 +10519,7 @@ if [[ "$command" == *"status.json"* ]]; then
       cat "$base.stdout"
     fi
   elif [[ ! -f "$base.stderr" && ! -f "$base.code" ]]; then
-    printf '{"time":"2099-01-01T00:00:00Z","revision":"fake-revision","phase":"settled","environments":[{"name":"production","revision":"fake-revision","phase":"settled","services":[{"name":"web","state":"running"}]}]}\n'
+    printf '{"time":"%s","revision":"fake-revision","phase":"settled","environments":[{"name":"production","revision":"fake-revision","phase":"settled","services":[{"name":"web","state":"running"}]}]}\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   fi
   if [[ -f "$base.stderr" ]]; then
     cat "$base.stderr" >&2

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -2446,6 +2446,53 @@ func TestSoloDoctorFailsWhenAgentStatusReportTimeIsInFuture(t *testing.T) {
 	t.Fatalf("runtime_checks = %#v, want agent_status_report", checks)
 }
 
+func TestSoloDoctorAllowsOldSettledStatusReport(t *testing.T) {
+	installFakeSoloCommands(t, []fakeSSHResponse{{stdout: `{"time":"2000-01-01T00:00:00Z","revision":"abc","phase":"settled"}` + "\n"}})
+
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	commitTestRepo(t, workspaceRoot)
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.Node{
+			"node-a": {Host: "203.0.113.10", User: "root"},
+		},
+	}
+	if _, _, err := current.AttachNode(workspaceRoot, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{
+		Printer:     output.New(&stdout, io.Discard),
+		Docker:      &fakeDocker{},
+		SoloState:   soloState,
+		ConfigStore: config.NewStore(),
+		Cwd:         workspaceRoot,
+	}
+	if err := app.SoloDoctor(context.Background()); err != nil {
+		t.Fatalf("SoloDoctor() error = %v, want old settled status accepted", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	checks := jsonArrayFromMap(t, payload, "runtime_checks")
+	for _, item := range checks {
+		check := jsonMapFromAny(t, item)
+		if check["check"] == "agent_status_report" {
+			if check["ok"] != true || !strings.Contains(stringValueAny(check["detail"]), "age=") {
+				t.Fatalf("agent_status_report = %#v, want non-fatal age detail", check)
+			}
+			return
+		}
+	}
+	t.Fatalf("runtime_checks = %#v, want agent_status_report", checks)
+}
+
 func TestSoloDoctorReportsSecurityFindings(t *testing.T) {
 	installFakeSoloCommands(t, nil)
 	t.Setenv("DEVOPSELLENCE_FAKE_SSH_PASSWORD_AUTH", "yes")

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -2347,6 +2347,57 @@ func TestSoloDoctorScopesRuntimeChecksToCurrentEnvironment(t *testing.T) {
 	}
 }
 
+func TestSoloDoctorFailsWhenAgentStatusReportMissingAtExpectedPath(t *testing.T) {
+	installFakeSoloCommands(t, []fakeSSHResponse{{stdout: soloStatusMissingSentinel + "\n"}})
+
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	commitTestRepo(t, workspaceRoot)
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.Node{
+			"node-a": {Host: "203.0.113.10", User: "root"},
+		},
+	}
+	if _, _, err := current.AttachNode(workspaceRoot, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{
+		Printer:     output.New(&stdout, io.Discard),
+		Docker:      &fakeDocker{},
+		SoloState:   soloState,
+		ConfigStore: config.NewStore(),
+		Cwd:         workspaceRoot,
+	}
+	err := app.SoloDoctor(context.Background())
+	if err == nil {
+		t.Fatal("SoloDoctor() error = nil, want missing status report failure")
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	if payload["ok"] != false {
+		t.Fatalf("payload ok = %#v, want false", payload["ok"])
+	}
+	checks := jsonArrayFromMap(t, payload, "runtime_checks")
+	for _, item := range checks {
+		check := jsonMapFromAny(t, item)
+		if check["check"] == "agent_status_report" {
+			if check["ok"] != false || !strings.Contains(stringValueAny(check["detail"]), "/var/lib/devopsellence/status.json") {
+				t.Fatalf("agent_status_report = %#v, want expected status path failure", check)
+			}
+			return
+		}
+	}
+	t.Fatalf("runtime_checks = %#v, want agent_status_report", checks)
+}
+
 func TestSoloDoctorReportsSecurityFindings(t *testing.T) {
 	installFakeSoloCommands(t, nil)
 	t.Setenv("DEVOPSELLENCE_FAKE_SSH_PASSWORD_AUTH", "yes")
@@ -8680,7 +8731,7 @@ func TestSoloReleaseRollbackRolloutFailurePreservesCurrentRelease(t *testing.T) 
 		t.Fatalf("healthchecks = %#v, want selected release snapshot healthcheck", healthchecks)
 	}
 	steps := fields["next_steps"].([]string)
-	if len(steps) != 4 || steps[0] != "devopsellence status --env 'production'" || steps[2] != "devopsellence logs --env 'production' --node 'node-a' --lines 100" || !strings.Contains(steps[1], "returns HTTP 2xx") {
+	if len(steps) != 5 || steps[0] != "devopsellence status --env 'production'" || steps[2] != "devopsellence logs --env 'production' --node 'node-a' --lines 100" || steps[4] != "devopsellence node diagnose 'node-a'" || !strings.Contains(steps[1], "returns HTTP 2xx") {
 		t.Fatalf("next_steps = %#v, want env-scoped healthcheck remediation", steps)
 	}
 }
@@ -8721,7 +8772,7 @@ func TestSoloReleaseRollbackTimeoutPreservesCurrentRelease(t *testing.T) {
 	}
 	fields := timeoutErr.ErrorFields()
 	steps := fields["next_steps"].([]string)
-	if fields["environment"] != "production" || len(steps) != 3 || steps[0] != "devopsellence status --env 'production'" || steps[1] != "devopsellence logs --env 'production' --node 'node-a' --lines 100" {
+	if fields["environment"] != "production" || len(steps) != 4 || steps[0] != "devopsellence status --env 'production'" || steps[1] != "devopsellence logs --env 'production' --node 'node-a' --lines 100" || steps[3] != "devopsellence node diagnose 'node-a'" {
 		t.Fatalf("fields = %#v, want env-scoped timeout guidance", fields)
 	}
 	updatedState, readErr := soloState.Read()
@@ -8874,7 +8925,7 @@ func TestSoloDeployRolloutFailureIncludesHealthcheckContext(t *testing.T) {
 		t.Fatalf("healthchecks = %#v, want web healthcheck context", healthchecks)
 	}
 	steps := fields["next_steps"].([]string)
-	if len(steps) != 4 || steps[0] != "devopsellence status --env 'production'" || steps[2] != "devopsellence logs --env 'production' --node 'node-a' --lines 100" || !strings.Contains(steps[1], "returns HTTP 2xx on healthcheck path '/up' port 3000") {
+	if len(steps) != 5 || steps[0] != "devopsellence status --env 'production'" || steps[2] != "devopsellence logs --env 'production' --node 'node-a' --lines 100" || steps[4] != "devopsellence node diagnose 'node-a'" || !strings.Contains(steps[1], "returns HTTP 2xx on healthcheck path '/up' port 3000") {
 		t.Fatalf("next_steps = %#v, want healthcheck remediation before logs", steps)
 	}
 	loaded, err := soloState.Read()
@@ -8954,7 +9005,7 @@ func TestSoloDeployRolloutFailureDoesNotPrescribeHealthcheckForImagePull(t *test
 		t.Fatalf("fields = %#v, want healthcheck context", fields)
 	}
 	steps := fields["next_steps"].([]string)
-	if len(steps) != 3 || strings.Contains(strings.Join(steps, "\n"), "returns HTTP 2xx") {
+	if len(steps) != 4 || strings.Contains(strings.Join(steps, "\n"), "returns HTTP 2xx") {
 		t.Fatalf("next_steps = %#v, want log diagnostics without healthcheck remediation", steps)
 	}
 }
@@ -9042,8 +9093,8 @@ func TestWaitForSoloRolloutFailsOnExpectedRevisionErrorPhase(t *testing.T) {
 	}
 	fields := rolloutErr.ErrorFields()
 	steps := fields["next_steps"].([]string)
-	if len(steps) != 3 || steps[1] != "devopsellence logs --node 'node-a' --lines 100" || steps[2] != "devopsellence node logs 'node-a' --lines 100" {
-		t.Fatalf("next_steps = %#v, want status, workload logs, and node logs commands", steps)
+	if len(steps) != 4 || steps[1] != "devopsellence logs --node 'node-a' --lines 100" || steps[2] != "devopsellence node logs 'node-a' --lines 100" || steps[3] != "devopsellence node diagnose 'node-a'" {
+		t.Fatalf("next_steps = %#v, want status, workload logs, node logs, and diagnose commands", steps)
 	}
 }
 
@@ -9137,8 +9188,8 @@ func TestWaitForSoloRolloutTimesOutWhenExpectedRevisionNeverSettles(t *testing.T
 	}
 	fields := timeoutErr.ErrorFields()
 	steps := fields["next_steps"].([]string)
-	if len(steps) != 3 || steps[1] != "devopsellence logs --node 'node-a' --lines 100" || steps[2] != "devopsellence node logs 'node-a' --lines 100" {
-		t.Fatalf("next_steps = %#v, want status, workload logs, and node logs commands", steps)
+	if len(steps) != 4 || steps[1] != "devopsellence logs --node 'node-a' --lines 100" || steps[2] != "devopsellence node logs 'node-a' --lines 100" || steps[3] != "devopsellence node diagnose 'node-a'" {
+		t.Fatalf("next_steps = %#v, want status, workload logs, node logs, and diagnose commands", steps)
 	}
 }
 
@@ -10419,6 +10470,8 @@ if [[ "$command" == *"status.json"* ]]; then
     else
       cat "$base.stdout"
     fi
+  elif [[ ! -f "$base.stderr" && ! -f "$base.code" ]]; then
+    printf '{"time":"2099-01-01T00:00:00Z","revision":"fake-revision","phase":"settled","environments":[{"name":"production","revision":"fake-revision","phase":"settled","services":[{"name":"web","state":"running"}]}]}\n'
   fi
   if [[ -f "$base.stderr" ]]; then
     cat "$base.stderr" >&2


### PR DESCRIPTION
## Summary
- make solo doctor verify the agent writes a fresh status report at the CLI-expected root status path
- make node diagnose fail when that expected status report is missing and include the status path
- add node diagnose to rollout failure/timeout next steps
- update dogfood-solo guidance with zirk, release dispatch, status-permission evidence, and timeout trap notes

## Tests
- `cd cli && mise exec -- go test ./...`
