### PR TITLE
[codex] Fix solo cohosted secret republish

### DIFF
--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1847,7 +1847,7 @@ func (a *App) resolveOnePasswordSecret(ctx context.Context, reference string) (s
 func (a *App) preparedNodeDesiredStateInputs(ctx context.Context, current solo.State, nodeName string, node config.Node, resolvedSnapshotCache map[string]desiredstate.DeploySnapshot, opts soloRepublishOptions) (preparedNodeState, error) {
 	storedSnapshots, releaseNodes, peers, _, err := soloNodeDesiredStateInputs(current, nodeName)
 	if err != nil {
-		return preparedNodeState{}, fmt.Errorf("build desired state inputs: %w", err)
+		return preparedNodeState{}, err
 	}
 	resolvedSnapshots := make([]desiredstate.DeploySnapshot, 0, len(storedSnapshots))
 	imageSet := map[string]bool{}

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -488,15 +488,6 @@ func (a *App) soloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 		return err
 	}
 
-	buildCtx := filepath.Join(workspaceRoot, cfg.Build.Context)
-	dockerfile := filepath.Join(workspaceRoot, cfg.Build.Dockerfile)
-	deployProgress := a.soloProgress("devopsellence deploy", map[string]any{"image": imageTag})
-	deployProgress("Building local Docker image...")
-	if err := dockerBuild(ctx, buildCtx, dockerfile, imageTag, cfg.Build.Platforms); err != nil {
-		return fmt.Errorf("docker build: %w", err)
-	}
-	deployProgress("Local Docker image built.")
-
 	secrets, err := a.resolveSoloSecretValues(ctx, current, workspaceRoot, environmentName, cfg)
 	if err != nil {
 		return fmt.Errorf("load secrets: %w", err)
@@ -510,6 +501,12 @@ func (a *App) soloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 	environmentID, err := solo.EnvironmentStateKey(workspaceRoot, environmentName)
 	if err != nil {
 		return err
+	}
+	legacySecretlessSnapshotKeys := map[string]bool{}
+	for key := range current.Current {
+		if key != environmentID {
+			legacySecretlessSnapshotKeys[key] = true
+		}
 	}
 	now := time.Now().UTC()
 	releaseID := soloReleaseID(shortSHA, now)
@@ -544,8 +541,21 @@ func (a *App) soloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 	if _, err := publishState.SaveRelease(release); err != nil {
 		return err
 	}
+	if err := a.validateRepublishPlan(ctx, publishState, attachedNodeNames, soloRepublishOptions{allowLegacySecretlessSnapshotKeys: legacySecretlessSnapshotKeys}); err != nil {
+		return err
+	}
+
+	buildCtx := filepath.Join(workspaceRoot, cfg.Build.Context)
+	dockerfile := filepath.Join(workspaceRoot, cfg.Build.Dockerfile)
+	deployProgress := a.soloProgress("devopsellence deploy", map[string]any{"image": imageTag})
+	deployProgress("Building local Docker image...")
+	if err := dockerBuild(ctx, buildCtx, dockerfile, imageTag, cfg.Build.Platforms); err != nil {
+		return fmt.Errorf("docker build: %w", err)
+	}
+	deployProgress("Local Docker image built.")
+
 	statusBaselines := a.soloNodeStatusTimes(ctx, nodes)
-	desiredStateRevisions, err := a.republishNodes(ctx, publishState, attachedNodeNames)
+	desiredStateRevisions, err := a.republishNodesWithOptions(ctx, publishState, attachedNodeNames, soloRepublishOptions{allowLegacySecretlessSnapshotKeys: legacySecretlessSnapshotKeys})
 	if err != nil {
 		return err
 	}
@@ -1372,6 +1382,14 @@ func appendSoloRepublishError(mu *sync.Mutex, errs *[]soloRepublishErrorEntry, n
 }
 
 func (a *App) republishNodes(ctx context.Context, current solo.State, nodeNames []string) (map[string]string, error) {
+	return a.republishNodesWithOptions(ctx, current, nodeNames, soloRepublishOptions{})
+}
+
+type soloRepublishOptions struct {
+	allowLegacySecretlessSnapshotKeys map[string]bool
+}
+
+func (a *App) republishNodesWithOptions(ctx context.Context, current solo.State, nodeNames []string, opts soloRepublishOptions) (map[string]string, error) {
 	if len(nodeNames) == 0 {
 		return map[string]string{}, nil
 	}
@@ -1398,7 +1416,7 @@ func (a *App) republishNodes(ctx context.Context, current solo.State, nodeNames 
 	prepared := make(map[string]preparedNodeState, len(sortedNames))
 	resolvedSnapshotCache := map[string]desiredstate.DeploySnapshot{}
 	for _, nodeName := range sortedNames {
-		inputs, err := a.preparedNodeDesiredStateInputs(ctx, current, nodeName, nodes[nodeName], resolvedSnapshotCache)
+		inputs, err := a.preparedNodeDesiredStateInputs(ctx, current, nodeName, nodes[nodeName], resolvedSnapshotCache, opts)
 		if err != nil {
 			return nil, err
 		}
@@ -1476,7 +1494,38 @@ func (a *App) republishNodes(ctx context.Context, current solo.State, nodeNames 
 	return revisions, nil
 }
 
+func (a *App) validateRepublishPlan(ctx context.Context, current solo.State, nodeNames []string, opts soloRepublishOptions) error {
+	if len(nodeNames) == 0 {
+		return nil
+	}
+	nodes, err := a.resolveNodes(current, nodeNames)
+	if err != nil {
+		return err
+	}
+	resolvedSnapshotCache := map[string]desiredstate.DeploySnapshot{}
+	for _, nodeName := range sortedNodeNames(nodes) {
+		inputs, err := a.preparedNodeDesiredStateInputs(ctx, current, nodeName, nodes[nodeName], resolvedSnapshotCache, opts)
+		if err != nil {
+			return err
+		}
+		if _, err := corerelease.PlanPublication(corerelease.PublicationPlanInput{
+			NodeName:     nodeName,
+			Node:         nodes[nodeName],
+			Releases:     publicationReleasesFromSnapshots(inputs.snapshots),
+			ReleaseNodes: inputs.releaseNodes,
+			NodePeers:    inputs.peers,
+		}); err != nil {
+			return fmt.Errorf("[%s] build desired state: %w", nodeName, err)
+		}
+	}
+	return nil
+}
+
 func (a *App) resolveStoredDeploySnapshot(ctx context.Context, current solo.State, snapshot desiredstate.DeploySnapshot) (desiredstate.DeploySnapshot, error) {
+	return a.resolveStoredDeploySnapshotWithOptions(ctx, current, snapshot, soloRepublishOptions{})
+}
+
+func (a *App) resolveStoredDeploySnapshotWithOptions(ctx context.Context, current solo.State, snapshot desiredstate.DeploySnapshot, opts soloRepublishOptions) (desiredstate.DeploySnapshot, error) {
 	snapshot = cloneDeploySnapshot(snapshot)
 	records, err := current.SecretRecords(snapshot.WorkspaceRoot, snapshot.Environment)
 	if err != nil {
@@ -1487,6 +1536,10 @@ func (a *App) resolveStoredDeploySnapshot(ctx context.Context, current solo.Stat
 		local[record.ServiceName+"\x00"+record.Name] = record
 	}
 	if len(local) > 0 && len(snapshot.SecretRefs) == 0 {
+		key, keyErr := solo.EnvironmentStateKey(snapshot.WorkspaceRoot, snapshot.Environment)
+		if keyErr == nil && opts.allowLegacySecretlessSnapshotKeys[key] {
+			return snapshot, nil
+		}
 		return desiredstate.DeploySnapshot{}, fmt.Errorf("stored release snapshot for %s (%s) was created before secret metadata was tracked; run `devopsellence deploy` to create a fresh release before rollback or republish", snapshot.WorkspaceRoot, snapshot.Environment)
 	}
 	cache := map[string]string{}
@@ -1773,7 +1826,7 @@ func (a *App) resolveOnePasswordSecret(ctx context.Context, reference string) (s
 	return value, nil
 }
 
-func (a *App) preparedNodeDesiredStateInputs(ctx context.Context, current solo.State, nodeName string, node config.Node, resolvedSnapshotCache map[string]desiredstate.DeploySnapshot) (struct {
+func (a *App) preparedNodeDesiredStateInputs(ctx context.Context, current solo.State, nodeName string, node config.Node, resolvedSnapshotCache map[string]desiredstate.DeploySnapshot, opts soloRepublishOptions) (struct {
 	snapshots    []desiredstate.DeploySnapshot
 	releaseNodes map[string]string
 	peers        []desiredstate.NodePeer
@@ -1794,7 +1847,7 @@ func (a *App) preparedNodeDesiredStateInputs(ctx context.Context, current solo.S
 		key := strings.TrimSpace(snapshot.WorkspaceKey) + "\n" + strings.TrimSpace(snapshot.Environment)
 		resolvedSnapshot, ok := resolvedSnapshotCache[key]
 		if !ok {
-			resolvedSnapshot, err = a.resolveStoredDeploySnapshot(ctx, current, snapshot)
+			resolvedSnapshot, err = a.resolveStoredDeploySnapshotWithOptions(ctx, current, snapshot, opts)
 			if err != nil {
 				return struct {
 					snapshots    []desiredstate.DeploySnapshot

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1432,10 +1432,12 @@ func (a *App) prepareRepublishPlans(ctx context.Context, current solo.State, nod
 	sortedNames := sortedNodeNames(nodes)
 	prepared := make(map[string]preparedNodePublication, len(sortedNames))
 	resolvedSnapshotCache := map[string]desiredstate.DeploySnapshot{}
+	var errs []soloRepublishErrorEntry
 	for _, nodeName := range sortedNames {
 		inputs, err := a.preparedNodeDesiredStateInputs(ctx, current, nodeName, nodes[nodeName], resolvedSnapshotCache, opts)
 		if err != nil {
-			return nil, err
+			errs = append(errs, soloRepublishErrorEntry{node: nodeName, operation: "build desired state inputs", err: err})
+			continue
 		}
 		publication, err := corerelease.PlanPublication(corerelease.PublicationPlanInput{
 			NodeName:     nodeName,
@@ -1445,13 +1447,17 @@ func (a *App) prepareRepublishPlans(ctx context.Context, current solo.State, nod
 			NodePeers:    inputs.peers,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("[%s] build desired state: %w", nodeName, err)
+			errs = append(errs, soloRepublishErrorEntry{node: nodeName, operation: "build desired state", err: err})
+			continue
 		}
 		prepared[nodeName] = preparedNodePublication{
 			node:        nodes[nodeName],
 			inputs:      inputs,
 			publication: publication,
 		}
+	}
+	if len(errs) > 0 {
+		return nil, &soloRepublishError{entries: errs}
 	}
 	return prepared, nil
 }

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -541,7 +541,8 @@ func (a *App) soloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 	if _, err := publishState.SaveRelease(release); err != nil {
 		return err
 	}
-	if err := a.validateRepublishPlan(ctx, publishState, attachedNodeNames, soloRepublishOptions{allowLegacySecretlessSnapshotKeys: legacySecretlessSnapshotKeys}); err != nil {
+	preparedRepublish, err := a.prepareRepublishPlans(ctx, publishState, attachedNodeNames, soloRepublishOptions{allowLegacySecretlessSnapshotKeys: legacySecretlessSnapshotKeys})
+	if err != nil {
 		return err
 	}
 
@@ -555,7 +556,7 @@ func (a *App) soloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 	deployProgress("Local Docker image built.")
 
 	statusBaselines := a.soloNodeStatusTimes(ctx, nodes)
-	desiredStateRevisions, err := a.republishNodesWithOptions(ctx, publishState, attachedNodeNames, soloRepublishOptions{allowLegacySecretlessSnapshotKeys: legacySecretlessSnapshotKeys})
+	desiredStateRevisions, err := a.republishPreparedNodes(ctx, preparedRepublish)
 	if err != nil {
 		return err
 	}
@@ -1390,15 +1391,62 @@ type soloRepublishOptions struct {
 }
 
 func (a *App) republishNodesWithOptions(ctx context.Context, current solo.State, nodeNames []string, opts soloRepublishOptions) (map[string]string, error) {
+	prepared, err := a.prepareRepublishPlans(ctx, current, nodeNames, opts)
+	if err != nil {
+		return nil, err
+	}
+	return a.republishPreparedNodes(ctx, prepared)
+}
+
+type preparedNodePublication struct {
+	node        config.Node
+	inputs      preparedNodeState
+	publication corerelease.PublicationPlan
+}
+
+type preparedNodeState struct {
+	snapshots    []desiredstate.DeploySnapshot
+	releaseNodes map[string]string
+	peers        []desiredstate.NodePeer
+	images       []string
+}
+
+func (a *App) prepareRepublishPlans(ctx context.Context, current solo.State, nodeNames []string, opts soloRepublishOptions) (map[string]preparedNodePublication, error) {
 	if len(nodeNames) == 0 {
-		return map[string]string{}, nil
+		return map[string]preparedNodePublication{}, nil
 	}
-	type preparedNodeState struct {
-		snapshots    []desiredstate.DeploySnapshot
-		releaseNodes map[string]string
-		peers        []desiredstate.NodePeer
-		images       []string
+	nodes, err := a.resolveNodes(current, nodeNames)
+	if err != nil {
+		return nil, err
 	}
+	sortedNames := sortedNodeNames(nodes)
+	prepared := make(map[string]preparedNodePublication, len(sortedNames))
+	resolvedSnapshotCache := map[string]desiredstate.DeploySnapshot{}
+	for _, nodeName := range sortedNames {
+		inputs, err := a.preparedNodeDesiredStateInputs(ctx, current, nodeName, nodes[nodeName], resolvedSnapshotCache, opts)
+		if err != nil {
+			return nil, err
+		}
+		publication, err := corerelease.PlanPublication(corerelease.PublicationPlanInput{
+			NodeName:     nodeName,
+			Node:         nodes[nodeName],
+			Releases:     publicationReleasesFromSnapshots(inputs.snapshots),
+			ReleaseNodes: inputs.releaseNodes,
+			NodePeers:    inputs.peers,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("[%s] build desired state: %w", nodeName, err)
+		}
+		prepared[nodeName] = preparedNodePublication{
+			node:        nodes[nodeName],
+			inputs:      inputs,
+			publication: publication,
+		}
+	}
+	return prepared, nil
+}
+
+func (a *App) republishPreparedNodes(ctx context.Context, prepared map[string]preparedNodePublication) (map[string]string, error) {
 	type localImageCheck struct {
 		once sync.Once
 		err  error
@@ -1408,27 +1456,19 @@ func (a *App) republishNodesWithOptions(ctx context.Context, current solo.State,
 	revisions := map[string]string{}
 	var wg sync.WaitGroup
 
-	nodes, err := a.resolveNodes(current, nodeNames)
-	if err != nil {
-		return nil, err
-	}
-	sortedNames := sortedNodeNames(nodes)
-	prepared := make(map[string]preparedNodeState, len(sortedNames))
-	resolvedSnapshotCache := map[string]desiredstate.DeploySnapshot{}
-	for _, nodeName := range sortedNames {
-		inputs, err := a.preparedNodeDesiredStateInputs(ctx, current, nodeName, nodes[nodeName], resolvedSnapshotCache, opts)
-		if err != nil {
-			return nil, err
-		}
-		prepared[nodeName] = inputs
-	}
 	var localImageChecksMu sync.Mutex
 	localImageChecks := map[string]*localImageCheck{}
-	for _, nodeName := range sortedNames {
-		node := nodes[nodeName]
-		inputs := prepared[nodeName]
+	nodeNames := make([]string, 0, len(prepared))
+	for nodeName := range prepared {
+		nodeNames = append(nodeNames, nodeName)
+	}
+	sort.Strings(nodeNames)
+	for _, nodeName := range nodeNames {
+		node := prepared[nodeName].node
+		inputs := prepared[nodeName].inputs
+		publication := prepared[nodeName].publication
 		wg.Add(1)
-		go func(name string, node config.Node, inputs preparedNodeState) {
+		go func(name string, node config.Node, inputs preparedNodeState, publication corerelease.PublicationPlan) {
 			defer wg.Done()
 			if len(inputs.images) > 0 {
 				if _, err := solo.RunSSH(ctx, node, remoteDockerCheckCommand(), nil); err != nil {
@@ -1464,17 +1504,6 @@ func (a *App) republishNodesWithOptions(ctx context.Context, current solo.State,
 					return
 				}
 			}
-			publication, err := corerelease.PlanPublication(corerelease.PublicationPlanInput{
-				NodeName:     name,
-				Node:         node,
-				Releases:     publicationReleasesFromSnapshots(inputs.snapshots),
-				ReleaseNodes: inputs.releaseNodes,
-				NodePeers:    inputs.peers,
-			})
-			if err != nil {
-				appendSoloRepublishError(&mu, &errs, name, "build desired state", err)
-				return
-			}
 			desiredStateJSON := publication.DesiredStateJSON
 			overridePath := desiredStateOverridePath(node)
 			cmd := remoteDesiredStateOverrideCommand(overridePath)
@@ -1485,40 +1514,13 @@ func (a *App) republishNodesWithOptions(ctx context.Context, current solo.State,
 			mu.Lock()
 			revisions[name] = publication.Revision
 			mu.Unlock()
-		}(nodeName, node, inputs)
+		}(nodeName, node, inputs, publication)
 	}
 	wg.Wait()
 	if len(errs) > 0 {
 		return nil, &soloRepublishError{entries: errs}
 	}
 	return revisions, nil
-}
-
-func (a *App) validateRepublishPlan(ctx context.Context, current solo.State, nodeNames []string, opts soloRepublishOptions) error {
-	if len(nodeNames) == 0 {
-		return nil
-	}
-	nodes, err := a.resolveNodes(current, nodeNames)
-	if err != nil {
-		return err
-	}
-	resolvedSnapshotCache := map[string]desiredstate.DeploySnapshot{}
-	for _, nodeName := range sortedNodeNames(nodes) {
-		inputs, err := a.preparedNodeDesiredStateInputs(ctx, current, nodeName, nodes[nodeName], resolvedSnapshotCache, opts)
-		if err != nil {
-			return err
-		}
-		if _, err := corerelease.PlanPublication(corerelease.PublicationPlanInput{
-			NodeName:     nodeName,
-			Node:         nodes[nodeName],
-			Releases:     publicationReleasesFromSnapshots(inputs.snapshots),
-			ReleaseNodes: inputs.releaseNodes,
-			NodePeers:    inputs.peers,
-		}); err != nil {
-			return fmt.Errorf("[%s] build desired state: %w", nodeName, err)
-		}
-	}
-	return nil
 }
 
 func (a *App) resolveStoredDeploySnapshot(ctx context.Context, current solo.State, snapshot desiredstate.DeploySnapshot) (desiredstate.DeploySnapshot, error) {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1838,20 +1838,10 @@ func (a *App) resolveOnePasswordSecret(ctx context.Context, reference string) (s
 	return value, nil
 }
 
-func (a *App) preparedNodeDesiredStateInputs(ctx context.Context, current solo.State, nodeName string, node config.Node, resolvedSnapshotCache map[string]desiredstate.DeploySnapshot, opts soloRepublishOptions) (struct {
-	snapshots    []desiredstate.DeploySnapshot
-	releaseNodes map[string]string
-	peers        []desiredstate.NodePeer
-	images       []string
-}, error) {
+func (a *App) preparedNodeDesiredStateInputs(ctx context.Context, current solo.State, nodeName string, node config.Node, resolvedSnapshotCache map[string]desiredstate.DeploySnapshot, opts soloRepublishOptions) (preparedNodeState, error) {
 	storedSnapshots, releaseNodes, peers, _, err := soloNodeDesiredStateInputs(current, nodeName)
 	if err != nil {
-		return struct {
-			snapshots    []desiredstate.DeploySnapshot
-			releaseNodes map[string]string
-			peers        []desiredstate.NodePeer
-			images       []string
-		}{}, fmt.Errorf("build desired state inputs: %w", err)
+		return preparedNodeState{}, fmt.Errorf("build desired state inputs: %w", err)
 	}
 	resolvedSnapshots := make([]desiredstate.DeploySnapshot, 0, len(storedSnapshots))
 	imageSet := map[string]bool{}
@@ -1861,24 +1851,14 @@ func (a *App) preparedNodeDesiredStateInputs(ctx context.Context, current solo.S
 		if !ok {
 			resolvedSnapshot, err = a.resolveStoredDeploySnapshotWithOptions(ctx, current, snapshot, opts)
 			if err != nil {
-				return struct {
-					snapshots    []desiredstate.DeploySnapshot
-					releaseNodes map[string]string
-					peers        []desiredstate.NodePeer
-					images       []string
-				}{}, fmt.Errorf("hydrate snapshot: %w", err)
+				return preparedNodeState{}, fmt.Errorf("hydrate snapshot: %w", err)
 			}
 			resolvedSnapshotCache[key] = resolvedSnapshot
 		}
 		if len(storedSnapshots) > 1 {
 			resolvedSnapshot, err = a.refreshSnapshotIngressIntent(resolvedSnapshot)
 			if err != nil {
-				return struct {
-					snapshots    []desiredstate.DeploySnapshot
-					releaseNodes map[string]string
-					peers        []desiredstate.NodePeer
-					images       []string
-				}{}, fmt.Errorf("refresh cohosted ingress intent: %w", err)
+				return preparedNodeState{}, fmt.Errorf("refresh cohosted ingress intent: %w", err)
 			}
 		}
 		resolvedSnapshots = append(resolvedSnapshots, resolvedSnapshot)
@@ -1893,12 +1873,7 @@ func (a *App) preparedNodeDesiredStateInputs(ctx context.Context, current solo.S
 		images = append(images, image)
 	}
 	sort.Strings(images)
-	return struct {
-		snapshots    []desiredstate.DeploySnapshot
-		releaseNodes map[string]string
-		peers        []desiredstate.NodePeer
-		images       []string
-	}{
+	return preparedNodeState{
 		snapshots:    resolvedSnapshots,
 		releaseNodes: releaseNodes,
 		peers:        peers,

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -502,12 +502,7 @@ func (a *App) soloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 	if err != nil {
 		return err
 	}
-	legacySecretlessSnapshotKeys := map[string]bool{}
-	for key := range current.Current {
-		if key != environmentID {
-			legacySecretlessSnapshotKeys[key] = true
-		}
-	}
+	legacySecretlessSnapshotKeys := deployLegacySecretlessSnapshotKeys(current, attachedNodeNames, environmentID)
 	now := time.Now().UTC()
 	releaseID := soloReleaseID(shortSHA, now)
 	release, err := corerelease.NewRelease(corerelease.ReleaseCreateInput{
@@ -1388,6 +1383,21 @@ func (a *App) republishNodes(ctx context.Context, current solo.State, nodeNames 
 
 type soloRepublishOptions struct {
 	allowLegacySecretlessSnapshotKeys map[string]bool
+}
+
+func deployLegacySecretlessSnapshotKeys(current solo.State, nodeNames []string, currentEnvironmentID string) map[string]bool {
+	keys := map[string]bool{}
+	currentEnvironmentID = strings.TrimSpace(currentEnvironmentID)
+	for _, nodeName := range normalizeSoloNames(nodeNames) {
+		for _, key := range current.AttachmentKeysForNode(nodeName) {
+			key = strings.TrimSpace(key)
+			if key == "" || key == currentEnvironmentID {
+				continue
+			}
+			keys[key] = true
+		}
+	}
+	return keys
 }
 
 func (a *App) republishNodesWithOptions(ctx context.Context, current solo.State, nodeNames []string, opts soloRepublishOptions) (map[string]string, error) {

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -252,6 +252,43 @@ func TestResolveStoredDeploySnapshotAllowsLegacySecretlessCohostedSnapshotForDep
 	}
 }
 
+func TestDeployLegacySecretlessSnapshotKeysIncludesSnapshotOnlyCohosts(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cohostRoot := t.TempDir()
+	current := solo.State{}
+	if err := current.SetNode("node-a", config.Node{Host: "203.0.113.10", User: "root", Labels: []string{config.DefaultWebRole}}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := current.AttachNode(workspaceRoot, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := current.AttachNode(cohostRoot, "staging", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	currentID, err := solo.EnvironmentStateKey(workspaceRoot, "production")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cohostID, err := solo.EnvironmentStateKey(cohostRoot, "staging")
+	if err != nil {
+		t.Fatal(err)
+	}
+	current.Snapshots[cohostID] = desiredstate.DeploySnapshot{
+		WorkspaceRoot: cohostRoot,
+		WorkspaceKey:  cohostRoot,
+		Environment:   "staging",
+		Revision:      "oldrev",
+	}
+
+	keys := deployLegacySecretlessSnapshotKeys(current, []string{"node-a"}, currentID)
+	if !keys[cohostID] {
+		t.Fatalf("keys = %#v, want snapshot-only cohost key %q", keys, cohostID)
+	}
+	if keys[currentID] {
+		t.Fatalf("keys = %#v, did not expect current environment key %q", keys, currentID)
+	}
+}
+
 func TestResolveStoredDeploySnapshotDoesNotMutateStoredSnapshotSecrets(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	storedSnapshot := desiredstate.DeploySnapshot{

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -11013,10 +11013,19 @@ func TestPrepareRepublishPlansReportsCohostedIngressSettingsBeforePublish(t *tes
 	if err := current.SetNode("node-a", config.Node{Host: "203.0.113.10", User: "root", Labels: []string{config.DefaultWebRole}}); err != nil {
 		t.Fatal(err)
 	}
+	if err := current.SetNode("node-b", config.Node{Host: "203.0.113.11", User: "root", Labels: []string{config.DefaultWebRole}}); err != nil {
+		t.Fatal(err)
+	}
 	if _, _, err := current.AttachNode(workspaceA, "production", "node-a"); err != nil {
 		t.Fatal(err)
 	}
 	if _, _, err := current.AttachNode(workspaceB, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := current.AttachNode(workspaceA, "production", "node-b"); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := current.AttachNode(workspaceB, "production", "node-b"); err != nil {
 		t.Fatal(err)
 	}
 	saveRelease := func(id, root string, cfg config.ProjectConfig, image, revision string) {
@@ -11043,12 +11052,17 @@ func TestPrepareRepublishPlansReportsCohostedIngressSettingsBeforePublish(t *tes
 	saveRelease("rel-a", workspaceA, cfgA, "app-a:aaa1111", "aaa1111")
 	saveRelease("rel-b", workspaceB, cfgB, "app-b:bbb2222", "bbb2222")
 
-	_, err := (&App{ConfigStore: config.NewStore()}).prepareRepublishPlans(context.Background(), current, []string{"node-a"}, soloRepublishOptions{})
+	_, err := (&App{ConfigStore: config.NewStore()}).prepareRepublishPlans(context.Background(), current, []string{"node-a", "node-b"}, soloRepublishOptions{})
 	if err == nil {
 		t.Fatal("prepareRepublishPlans() error = nil, want cohosted ingress mismatch")
 	}
 	if !strings.Contains(err.Error(), "cannot merge ingress for co-hosted environments with different settings") || !strings.Contains(err.Error(), "TLS") || !strings.Contains(err.Error(), "redirect_http") {
 		t.Fatalf("prepareRepublishPlans() error = %v, want TLS/redirect_http mismatch", err)
+	}
+	for _, nodeName := range []string{"node-a", "node-b"} {
+		if !strings.Contains(err.Error(), "["+nodeName+"] build desired state:") {
+			t.Fatalf("prepareRepublishPlans() error = %v, want %s planning error", err, nodeName)
+		}
 	}
 }
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -216,6 +216,42 @@ func TestResolveStoredDeploySnapshotRejectsLegacySnapshotWhenSecretsExist(t *tes
 	}
 }
 
+func TestResolveStoredDeploySnapshotAllowsLegacySecretlessCohostedSnapshotForDeployRepublish(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	storedSnapshot := desiredstate.DeploySnapshot{
+		WorkspaceRoot: workspaceRoot,
+		WorkspaceKey:  workspaceRoot,
+		Environment:   "staging",
+		Revision:      "oldrev",
+		Image:         "demo:old",
+		Services: []desiredstate.ServiceJSON{{
+			Name: "web",
+			Kind: config.ServiceKindWeb,
+			Env:  map[string]string{"APP_MODE": "old"},
+		}},
+	}
+	current := solo.State{}
+	if _, err := current.SetSecret(workspaceRoot, "staging", "web", "API_KEY", solo.SecretMaterial{Store: solo.SecretStorePlaintext, Value: "secret-value"}); err != nil {
+		t.Fatalf("set secret: %v", err)
+	}
+	key, err := solo.EnvironmentStateKey(workspaceRoot, "staging")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	app := &App{}
+	resolved, err := app.resolveStoredDeploySnapshotWithOptions(context.Background(), current, storedSnapshot, soloRepublishOptions{allowLegacySecretlessSnapshotKeys: map[string]bool{key: true}})
+	if err != nil {
+		t.Fatalf("resolve legacy cohosted snapshot: %v", err)
+	}
+	if _, ok := resolved.Services[0].Env["API_KEY"]; ok {
+		t.Fatalf("resolved env = %#v, did not expect secret injected into legacy snapshot", resolved.Services[0].Env)
+	}
+	if got := resolved.Services[0].Env["APP_MODE"]; got != "old" {
+		t.Fatalf("APP_MODE = %q, want historical value old", got)
+	}
+}
+
 func TestResolveStoredDeploySnapshotDoesNotMutateStoredSnapshotSecrets(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	storedSnapshot := desiredstate.DeploySnapshot{
@@ -10879,7 +10915,7 @@ func TestRepublishRefreshesCohostedIngressIntentFromCurrentConfigs(t *testing.T)
 	}
 
 	app := &App{ConfigStore: config.NewStore()}
-	inputs, err := app.preparedNodeDesiredStateInputs(context.Background(), current, "node-a", current.Nodes["node-a"], map[string]desiredstate.DeploySnapshot{})
+	inputs, err := app.preparedNodeDesiredStateInputs(context.Background(), current, "node-a", current.Nodes["node-a"], map[string]desiredstate.DeploySnapshot{}, soloRepublishOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -10904,6 +10940,78 @@ func TestRepublishRefreshesCohostedIngressIntentFromCurrentConfigs(t *testing.T)
 	}
 	if state.Ingress == nil || state.Ingress.TLS.Email != "ops@example.com" {
 		t.Fatalf("published ingress = %#v, want refreshed TLS email", state.Ingress)
+	}
+}
+
+func TestValidateRepublishPlanReportsCohostedIngressSettingsBeforePublish(t *testing.T) {
+	workspaceA := t.TempDir()
+	workspaceB := t.TempDir()
+	writeConfig := func(root, project, host, tlsMode string, redirect bool) config.ProjectConfig {
+		cfg := config.DefaultProjectConfig("solo", project, config.DefaultEnvironment)
+		cfg.Ingress = &config.IngressConfig{
+			Hosts: []string{host},
+			Rules: []config.IngressRuleConfig{{
+				Match:  config.IngressMatchConfig{Host: host, PathPrefix: "/"},
+				Target: config.IngressTargetConfig{Service: config.DefaultWebServiceName, Port: "http"},
+			}},
+			TLS:          config.IngressTLSConfig{Mode: tlsMode},
+			RedirectHTTP: configBoolPtr(redirect),
+		}
+		if _, err := config.Write(root, cfg); err != nil {
+			t.Fatal(err)
+		}
+		return cfg
+	}
+	cfgA := writeConfig(workspaceA, "app-a", "a.example.com", "off", false)
+	cfgB := writeConfig(workspaceB, "app-b", "b.example.com", "manual", true)
+	snapshotFor := func(root string, cfg config.ProjectConfig, image, revision string) desiredstate.DeploySnapshot {
+		snapshot, err := solo.BuildDeploySnapshot(&cfg, root, filepath.Join(root, config.FilePath), image, revision, map[string]string{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return snapshot
+	}
+
+	current := solo.State{}
+	if err := current.SetNode("node-a", config.Node{Host: "203.0.113.10", User: "root", Labels: []string{config.DefaultWebRole}}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := current.AttachNode(workspaceA, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := current.AttachNode(workspaceB, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	saveRelease := func(id, root string, cfg config.ProjectConfig, image, revision string) {
+		key, err := solo.EnvironmentStateKey(root, "production")
+		if err != nil {
+			t.Fatal(err)
+		}
+		release, err := corerelease.NewRelease(corerelease.ReleaseCreateInput{
+			ID:            id,
+			EnvironmentID: key,
+			Revision:      revision,
+			Snapshot:      snapshotFor(root, cfg, image, revision),
+			Image:         corerelease.ImageRef{Reference: image},
+			TargetNodeIDs: []string{"node-a"},
+			CreatedAt:     time.Now().UTC(),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := current.SaveRelease(release); err != nil {
+			t.Fatal(err)
+		}
+	}
+	saveRelease("rel-a", workspaceA, cfgA, "app-a:aaa1111", "aaa1111")
+	saveRelease("rel-b", workspaceB, cfgB, "app-b:bbb2222", "bbb2222")
+
+	err := (&App{ConfigStore: config.NewStore()}).validateRepublishPlan(context.Background(), current, []string{"node-a"}, soloRepublishOptions{})
+	if err == nil {
+		t.Fatal("validateRepublishPlan() error = nil, want cohosted ingress mismatch")
+	}
+	if !strings.Contains(err.Error(), "cannot merge ingress for co-hosted environments with different settings") || !strings.Contains(err.Error(), "TLS") || !strings.Contains(err.Error(), "redirect_http") {
+		t.Fatalf("validateRepublishPlan() error = %v, want TLS/redirect_http mismatch", err)
 	}
 }
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -10943,7 +10943,7 @@ func TestRepublishRefreshesCohostedIngressIntentFromCurrentConfigs(t *testing.T)
 	}
 }
 
-func TestValidateRepublishPlanReportsCohostedIngressSettingsBeforePublish(t *testing.T) {
+func TestPrepareRepublishPlansReportsCohostedIngressSettingsBeforePublish(t *testing.T) {
 	workspaceA := t.TempDir()
 	workspaceB := t.TempDir()
 	writeConfig := func(root, project, host, tlsMode string, redirect bool) config.ProjectConfig {
@@ -11006,12 +11006,12 @@ func TestValidateRepublishPlanReportsCohostedIngressSettingsBeforePublish(t *tes
 	saveRelease("rel-a", workspaceA, cfgA, "app-a:aaa1111", "aaa1111")
 	saveRelease("rel-b", workspaceB, cfgB, "app-b:bbb2222", "bbb2222")
 
-	err := (&App{ConfigStore: config.NewStore()}).validateRepublishPlan(context.Background(), current, []string{"node-a"}, soloRepublishOptions{})
+	_, err := (&App{ConfigStore: config.NewStore()}).prepareRepublishPlans(context.Background(), current, []string{"node-a"}, soloRepublishOptions{})
 	if err == nil {
-		t.Fatal("validateRepublishPlan() error = nil, want cohosted ingress mismatch")
+		t.Fatal("prepareRepublishPlans() error = nil, want cohosted ingress mismatch")
 	}
 	if !strings.Contains(err.Error(), "cannot merge ingress for co-hosted environments with different settings") || !strings.Contains(err.Error(), "TLS") || !strings.Contains(err.Error(), "redirect_http") {
-		t.Fatalf("validateRepublishPlan() error = %v, want TLS/redirect_http mismatch", err)
+		t.Fatalf("prepareRepublishPlans() error = %v, want TLS/redirect_http mismatch", err)
 	}
 }
 


### PR DESCRIPTION
Fixes two solo dogfood findings from the v0.2.0-preview run.

## Summary
- let deploy-only cohosted republish preserve legacy secretless snapshots without injecting newly added secrets
- validate the cohosted publication plan before Docker build/image transfer, so mixed ingress TLS/redirect settings fail early
- add regressions for cohosted legacy secret metadata and mixed ingress settings

## Validation
- `mise run test:cli -- ./internal/workflow -run 'TestResolveStoredDeploySnapshot|TestSoloDeployRepublishFailureDoesNotRecordCurrentRelease|TestRepublishRefreshesCohostedIngressIntentFromCurrentConfigs|TestValidateRepublishPlanReportsCohostedIngressSettingsBeforePublish'`
- `mise run test:cli`
- `mise run build:cli`
- `git diff --check`

Dogfood run artifact: `/tmp/devopsellence-dogfood-solo/20260507T001018779370Z-solo-v0-2-0-preview/report.md`
