### PR TITLE
[codex] Simplify solo republish planning

### DIFF
--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -502,7 +502,6 @@ func (a *App) soloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 	if err != nil {
 		return err
 	}
-	legacySecretlessSnapshotKeys := deployLegacySecretlessSnapshotKeys(current, attachedNodeNames, environmentID)
 	now := time.Now().UTC()
 	releaseID := soloReleaseID(shortSHA, now)
 	release, err := corerelease.NewRelease(corerelease.ReleaseCreateInput{
@@ -536,7 +535,7 @@ func (a *App) soloDeploy(ctx context.Context, opts SoloDeployOptions) error {
 	if _, err := publishState.SaveRelease(release); err != nil {
 		return err
 	}
-	preparedRepublish, err := a.prepareRepublishPlans(ctx, publishState, attachedNodeNames, soloRepublishOptions{allowLegacySecretlessSnapshotKeys: legacySecretlessSnapshotKeys})
+	preparedRepublish, err := a.prepareRepublishPlans(ctx, publishState, attachedNodeNames)
 	if err != nil {
 		return err
 	}
@@ -1378,30 +1377,7 @@ func appendSoloRepublishError(mu *sync.Mutex, errs *[]soloRepublishErrorEntry, n
 }
 
 func (a *App) republishNodes(ctx context.Context, current solo.State, nodeNames []string) (map[string]string, error) {
-	return a.republishNodesWithOptions(ctx, current, nodeNames, soloRepublishOptions{})
-}
-
-type soloRepublishOptions struct {
-	allowLegacySecretlessSnapshotKeys map[string]bool
-}
-
-func deployLegacySecretlessSnapshotKeys(current solo.State, nodeNames []string, currentEnvironmentID string) map[string]bool {
-	keys := map[string]bool{}
-	currentEnvironmentID = strings.TrimSpace(currentEnvironmentID)
-	for _, nodeName := range normalizeSoloNames(nodeNames) {
-		for _, key := range current.AttachmentKeysForNode(nodeName) {
-			key = strings.TrimSpace(key)
-			if key == "" || key == currentEnvironmentID {
-				continue
-			}
-			keys[key] = true
-		}
-	}
-	return keys
-}
-
-func (a *App) republishNodesWithOptions(ctx context.Context, current solo.State, nodeNames []string, opts soloRepublishOptions) (map[string]string, error) {
-	prepared, err := a.prepareRepublishPlans(ctx, current, nodeNames, opts)
+	prepared, err := a.prepareRepublishPlans(ctx, current, nodeNames)
 	if err != nil {
 		return nil, err
 	}
@@ -1421,7 +1397,7 @@ type preparedNodeState struct {
 	images       []string
 }
 
-func (a *App) prepareRepublishPlans(ctx context.Context, current solo.State, nodeNames []string, opts soloRepublishOptions) (map[string]preparedNodePublication, error) {
+func (a *App) prepareRepublishPlans(ctx context.Context, current solo.State, nodeNames []string) (map[string]preparedNodePublication, error) {
 	if len(nodeNames) == 0 {
 		return map[string]preparedNodePublication{}, nil
 	}
@@ -1434,7 +1410,7 @@ func (a *App) prepareRepublishPlans(ctx context.Context, current solo.State, nod
 	resolvedSnapshotCache := map[string]desiredstate.DeploySnapshot{}
 	var errs []soloRepublishErrorEntry
 	for _, nodeName := range sortedNames {
-		inputs, err := a.preparedNodeDesiredStateInputs(ctx, current, nodeName, nodes[nodeName], resolvedSnapshotCache, opts)
+		inputs, err := a.preparedNodeDesiredStateInputs(ctx, current, nodeName, nodes[nodeName], resolvedSnapshotCache)
 		if err != nil {
 			errs = append(errs, soloRepublishErrorEntry{node: nodeName, operation: "build desired state inputs", err: err})
 			continue
@@ -1540,10 +1516,6 @@ func (a *App) republishPreparedNodes(ctx context.Context, prepared map[string]pr
 }
 
 func (a *App) resolveStoredDeploySnapshot(ctx context.Context, current solo.State, snapshot desiredstate.DeploySnapshot) (desiredstate.DeploySnapshot, error) {
-	return a.resolveStoredDeploySnapshotWithOptions(ctx, current, snapshot, soloRepublishOptions{})
-}
-
-func (a *App) resolveStoredDeploySnapshotWithOptions(ctx context.Context, current solo.State, snapshot desiredstate.DeploySnapshot, opts soloRepublishOptions) (desiredstate.DeploySnapshot, error) {
 	snapshot = cloneDeploySnapshot(snapshot)
 	records, err := current.SecretRecords(snapshot.WorkspaceRoot, snapshot.Environment)
 	if err != nil {
@@ -1554,10 +1526,6 @@ func (a *App) resolveStoredDeploySnapshotWithOptions(ctx context.Context, curren
 		local[record.ServiceName+"\x00"+record.Name] = record
 	}
 	if len(local) > 0 && len(snapshot.SecretRefs) == 0 {
-		key, keyErr := solo.EnvironmentStateKey(snapshot.WorkspaceRoot, snapshot.Environment)
-		if keyErr == nil && opts.allowLegacySecretlessSnapshotKeys[key] {
-			return snapshot, nil
-		}
 		return desiredstate.DeploySnapshot{}, fmt.Errorf("stored release snapshot for %s (%s) was created before secret metadata was tracked; run `devopsellence deploy` to create a fresh release before rollback or republish", snapshot.WorkspaceRoot, snapshot.Environment)
 	}
 	cache := map[string]string{}
@@ -1844,7 +1812,7 @@ func (a *App) resolveOnePasswordSecret(ctx context.Context, reference string) (s
 	return value, nil
 }
 
-func (a *App) preparedNodeDesiredStateInputs(ctx context.Context, current solo.State, nodeName string, node config.Node, resolvedSnapshotCache map[string]desiredstate.DeploySnapshot, opts soloRepublishOptions) (preparedNodeState, error) {
+func (a *App) preparedNodeDesiredStateInputs(ctx context.Context, current solo.State, nodeName string, node config.Node, resolvedSnapshotCache map[string]desiredstate.DeploySnapshot) (preparedNodeState, error) {
 	storedSnapshots, releaseNodes, peers, _, err := soloNodeDesiredStateInputs(current, nodeName)
 	if err != nil {
 		return preparedNodeState{}, err
@@ -1855,7 +1823,7 @@ func (a *App) preparedNodeDesiredStateInputs(ctx context.Context, current solo.S
 		key := strings.TrimSpace(snapshot.WorkspaceKey) + "\n" + strings.TrimSpace(snapshot.Environment)
 		resolvedSnapshot, ok := resolvedSnapshotCache[key]
 		if !ok {
-			resolvedSnapshot, err = a.resolveStoredDeploySnapshotWithOptions(ctx, current, snapshot, opts)
+			resolvedSnapshot, err = a.resolveStoredDeploySnapshot(ctx, current, snapshot)
 			if err != nil {
 				return preparedNodeState{}, fmt.Errorf("hydrate snapshot: %w", err)
 			}

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -216,79 +216,6 @@ func TestResolveStoredDeploySnapshotRejectsLegacySnapshotWhenSecretsExist(t *tes
 	}
 }
 
-func TestResolveStoredDeploySnapshotAllowsLegacySecretlessCohostedSnapshotForDeployRepublish(t *testing.T) {
-	workspaceRoot := t.TempDir()
-	storedSnapshot := desiredstate.DeploySnapshot{
-		WorkspaceRoot: workspaceRoot,
-		WorkspaceKey:  workspaceRoot,
-		Environment:   "staging",
-		Revision:      "oldrev",
-		Image:         "demo:old",
-		Services: []desiredstate.ServiceJSON{{
-			Name: "web",
-			Kind: config.ServiceKindWeb,
-			Env:  map[string]string{"APP_MODE": "old"},
-		}},
-	}
-	current := solo.State{}
-	if _, err := current.SetSecret(workspaceRoot, "staging", "web", "API_KEY", solo.SecretMaterial{Store: solo.SecretStorePlaintext, Value: "secret-value"}); err != nil {
-		t.Fatalf("set secret: %v", err)
-	}
-	key, err := solo.EnvironmentStateKey(workspaceRoot, "staging")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	app := &App{}
-	resolved, err := app.resolveStoredDeploySnapshotWithOptions(context.Background(), current, storedSnapshot, soloRepublishOptions{allowLegacySecretlessSnapshotKeys: map[string]bool{key: true}})
-	if err != nil {
-		t.Fatalf("resolve legacy cohosted snapshot: %v", err)
-	}
-	if _, ok := resolved.Services[0].Env["API_KEY"]; ok {
-		t.Fatalf("resolved env = %#v, did not expect secret injected into legacy snapshot", resolved.Services[0].Env)
-	}
-	if got := resolved.Services[0].Env["APP_MODE"]; got != "old" {
-		t.Fatalf("APP_MODE = %q, want historical value old", got)
-	}
-}
-
-func TestDeployLegacySecretlessSnapshotKeysIncludesSnapshotOnlyCohosts(t *testing.T) {
-	workspaceRoot := t.TempDir()
-	cohostRoot := t.TempDir()
-	current := solo.State{}
-	if err := current.SetNode("node-a", config.Node{Host: "203.0.113.10", User: "root", Labels: []string{config.DefaultWebRole}}); err != nil {
-		t.Fatal(err)
-	}
-	if _, _, err := current.AttachNode(workspaceRoot, "production", "node-a"); err != nil {
-		t.Fatal(err)
-	}
-	if _, _, err := current.AttachNode(cohostRoot, "staging", "node-a"); err != nil {
-		t.Fatal(err)
-	}
-	currentID, err := solo.EnvironmentStateKey(workspaceRoot, "production")
-	if err != nil {
-		t.Fatal(err)
-	}
-	cohostID, err := solo.EnvironmentStateKey(cohostRoot, "staging")
-	if err != nil {
-		t.Fatal(err)
-	}
-	current.Snapshots[cohostID] = desiredstate.DeploySnapshot{
-		WorkspaceRoot: cohostRoot,
-		WorkspaceKey:  cohostRoot,
-		Environment:   "staging",
-		Revision:      "oldrev",
-	}
-
-	keys := deployLegacySecretlessSnapshotKeys(current, []string{"node-a"}, currentID)
-	if !keys[cohostID] {
-		t.Fatalf("keys = %#v, want snapshot-only cohost key %q", keys, cohostID)
-	}
-	if keys[currentID] {
-		t.Fatalf("keys = %#v, did not expect current environment key %q", keys, currentID)
-	}
-}
-
 func TestResolveStoredDeploySnapshotDoesNotMutateStoredSnapshotSecrets(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	storedSnapshot := desiredstate.DeploySnapshot{
@@ -10952,7 +10879,7 @@ func TestRepublishRefreshesCohostedIngressIntentFromCurrentConfigs(t *testing.T)
 	}
 
 	app := &App{ConfigStore: config.NewStore()}
-	inputs, err := app.preparedNodeDesiredStateInputs(context.Background(), current, "node-a", current.Nodes["node-a"], map[string]desiredstate.DeploySnapshot{}, soloRepublishOptions{})
+	inputs, err := app.preparedNodeDesiredStateInputs(context.Background(), current, "node-a", current.Nodes["node-a"], map[string]desiredstate.DeploySnapshot{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -11052,7 +10979,7 @@ func TestPrepareRepublishPlansReportsCohostedIngressSettingsBeforePublish(t *tes
 	saveRelease("rel-a", workspaceA, cfgA, "app-a:aaa1111", "aaa1111")
 	saveRelease("rel-b", workspaceB, cfgB, "app-b:bbb2222", "bbb2222")
 
-	_, err := (&App{ConfigStore: config.NewStore()}).prepareRepublishPlans(context.Background(), current, []string{"node-a", "node-b"}, soloRepublishOptions{})
+	_, err := (&App{ConfigStore: config.NewStore()}).prepareRepublishPlans(context.Background(), current, []string{"node-a", "node-b"})
 	if err == nil {
 		t.Fatal("prepareRepublishPlans() error = nil, want cohosted ingress mismatch")
 	}


### PR DESCRIPTION
## Summary

Simplifies the solo republish path after PR #179 now that we do not need no-user compatibility for old secretless snapshots.

- removes the legacy secretless cohost allow-list and option plumbing
- keeps early desired-state publication planning before Docker build/image transfer
- keeps reuse of the prepared publication plans and per-node planning errors
- removes the compatibility-only tests

## Why

The previous PR fixed the right operational issue, but carried extra compatibility code for old solo state. We do not have users yet, so the simpler rule is better: if local secrets exist and a stored snapshot lacks secret metadata, fail plainly and require a fresh clean deploy/state.

## Validation

- `mise run test:cli -- ./internal/workflow -run 'TestResolveStoredDeploySnapshot|TestPrepareRepublishPlansReportsCohostedIngressSettingsBeforePublish|TestRepublishRefreshesCohostedIngressIntentFromCurrentConfigs|TestSoloDeployRepublishFailureDoesNotRecordCurrentRelease'`
- `mise run test:cli`
- `mise run build:cli`
- `git diff --check`
