### PR TITLE
[codex] Polish launch copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ logs, and a node agent that reconciles desired state.
 No PaaS. No Kubernetes-lite. No hidden scheduler pretending machines do not
 exist.
 
+Why care today: devopsellence gives an AI assistant a narrow deployment
+contract it can operate without guessing from prose logs or shell history:
+deploy a Dockerized app to a VM, verify status and HTTPS, inspect logs, manage
+secrets, and roll back.
+
 ## AI-operator-first
 
 The main operator is an AI coding or operations assistant acting for a human.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ No PaaS. No Kubernetes-lite. No hidden scheduler pretending machines do not
 exist.
 
 Why care today: devopsellence gives an AI assistant a narrow deployment
-contract it can operate without guessing from prose logs or shell history:
+contract it can follow without guessing from prose logs or shell history:
 deploy a Dockerized app to a VM, verify status and HTTPS, inspect logs, manage
 secrets, and roll back.
 

--- a/control-plane/app/views/marketing/index.html.erb
+++ b/control-plane/app/views/marketing/index.html.erb
@@ -3,7 +3,7 @@
 <main class="page">
   <section class="hero">
     <h1 class="hero-title">VMs are enough.</h1>
-    <p class="hero-sub">Deploy containerized apps to familiar VMs with commands an AI operator can safely run.<br>Plan, deploy, status, logs, secrets, rollback, and HTTPS checks.<br>No PaaS. No Kubernetes-lite. No hidden scheduler.</p>
+    <p class="hero-sub">Deploy containerized apps to familiar VMs with commands an AI operator can safely run.<br>Start in solo mode with dry-runs, deploys, status, logs, secrets, rollback, and HTTPS checks.<br>No PaaS. No Kubernetes-lite. No hidden scheduler.</p>
 
     <div class="install-pill">
       <code id="install-cmd"><%= @cli_install_command %></code>
@@ -17,7 +17,7 @@
   <section class="split-section">
     <div class="split-text">
       <h2>Keep the VM.<br>Lose the toil.</h2>
-      <p>devopsellence keeps the VM as the unit of execution. The CLI gives AI operators a narrow control surface for dry-runs, deploys, status, doctor, logs, exec, secrets, rollback, DNS checks, and HTTPS verification.</p>
+      <p>devopsellence keeps the VM as the unit of execution. In solo mode, the CLI gives AI operators a narrow control surface for dry-runs, deploys, status, doctor, logs, exec, secrets, rollback, DNS checks, and HTTPS verification.</p>
       <p>The node agent reconciles your app on familiar Linux VMs using ordinary primitives for images, state, and secrets.</p>
       <p>No dynos. No pods. No shared multi-tenant runtime. If the control plane goes down, your apps keep running.</p>
     </div>

--- a/control-plane/app/views/marketing/index.html.erb
+++ b/control-plane/app/views/marketing/index.html.erb
@@ -3,7 +3,7 @@
 <main class="page">
   <section class="hero">
     <h1 class="hero-title">VMs are enough.</h1>
-    <p class="hero-sub">devopsellence is a toolkit for deploying and running containerized apps.<br>No PaaS. No platform. No extra abstraction layer.<br>Start with SSH. Add a control plane when you need one.</p>
+    <p class="hero-sub">Deploy containerized apps to familiar VMs with commands an AI operator can safely run.<br>Plan, deploy, status, logs, secrets, rollback, and HTTPS checks.<br>No PaaS. No Kubernetes-lite. No hidden scheduler.</p>
 
     <div class="install-pill">
       <code id="install-cmd"><%= @cli_install_command %></code>
@@ -17,7 +17,8 @@
   <section class="split-section">
     <div class="split-text">
       <h2>Keep the VM.<br>Lose the toil.</h2>
-      <p>devopsellence keeps the VM as the unit of execution. The agent reconciles your app on machines you control using ordinary primitives for images, state, and secrets.</p>
+      <p>devopsellence keeps the VM as the unit of execution. The CLI gives AI operators a narrow control surface for dry-runs, deploys, status, doctor, logs, exec, secrets, rollback, DNS checks, and HTTPS verification.</p>
+      <p>The node agent reconciles your app on familiar Linux VMs using ordinary primitives for images, state, and secrets.</p>
       <p>No dynos. No pods. No shared multi-tenant runtime. If the control plane goes down, your apps keep running.</p>
     </div>
     <div class="split-visual">
@@ -46,13 +47,13 @@
     <div class="mode-compare" style="margin-top:32px;">
       <div class="mode-card">
         <h3>Solo</h3>
-        <p class="mode-tagline">SSH-first. No control plane. Deploy from your terminal to any Linux server.</p>
+        <p class="mode-tagline">SSH-first. No control plane. Deploy from your terminal or AI assistant to familiar Linux VMs.</p>
         <dl>
           <div class="mode-row"><dt>Transport</dt><dd>SSH</dd></div>
           <div class="mode-row"><dt>Auth</dt><dd>SSH keys</dd></div>
-          <div class="mode-row"><dt>Secrets</dt><dd>Local <code>.env</code> file</dd></div>
+          <div class="mode-row"><dt>Secrets</dt><dd>Local state or external refs</dd></div>
           <div class="mode-row"><dt>Images</dt><dd>Streamed over SSH</dd></div>
-          <div class="mode-row"><dt>HTTPS</dt><dd>Coming soon</dd></div>
+          <div class="mode-row"><dt>HTTPS</dt><dd>Auto TLS with Envoy + Let's Encrypt</dd></div>
           <div class="mode-row"><dt>Best for</dt><dd>Side projects, single-dev apps, staging</dd></div>
         </dl>
       </div>
@@ -73,7 +74,7 @@
 
   <section class="section section-center">
     <h2>Works with your stack</h2>
-    <p class="section-sub">Standard Dockerfiles. GitHub Actions. Any Linux server &mdash; Hetzner, DigitalOcean, GCP, or your home lab. Bring PlanetScale, RDS, Redis Cloud, S3, Datadog, Grafana Cloud, self-hosted Postgres, or your own services. devopsellence deploys your app; it does not replace the rest of your architecture.</p>
+    <p class="section-sub">Standard Dockerfiles. GitHub Actions. Familiar Linux VMs &mdash; Hetzner, DigitalOcean, GCP, or your home lab. Bring PlanetScale, RDS, Redis Cloud, S3, Datadog, Grafana Cloud, self-hosted Postgres, or your own services. devopsellence deploys your app; it does not replace the rest of your architecture.</p>
     <%= link_to "Read the docs", "https://docs.devopsellence.com", class: "btn btn-dark" %>
   </section>
 

--- a/docs-website/src/content/docs/getting-started/overview.md
+++ b/docs-website/src/content/docs/getting-started/overview.md
@@ -7,6 +7,10 @@ devopsellence deploys containerized applications to familiar VMs. It does not
 try to hide machines, containers, files, registries, or secret stores. It makes
 the ordinary primitives easier to use together.
 
+The immediate value is an operator-safe deployment loop: dry-run, deploy,
+status, doctor, logs, exec, secrets, rollback, DNS checks, and HTTPS verification
+with structured output an AI assistant can act on.
+
 The system has three product surfaces:
 
 - **Node agent**: runs on each node and reconciles containers, Envoy ingress,

--- a/docs-website/src/content/docs/getting-started/overview.md
+++ b/docs-website/src/content/docs/getting-started/overview.md
@@ -7,9 +7,9 @@ devopsellence deploys containerized applications to familiar VMs. It does not
 try to hide machines, containers, files, registries, or secret stores. It makes
 the ordinary primitives easier to use together.
 
-The immediate value is an operator-safe deployment loop: dry-run, deploy,
-status, doctor, logs, exec, secrets, rollback, DNS checks, and HTTPS verification
-with structured output an AI assistant can act on.
+The immediate solo-mode value is an operator-safe deployment loop: dry-run,
+deploy, status, doctor, logs, exec, secrets, rollback, DNS checks, and HTTPS
+verification with structured output an AI assistant can act on.
 
 The system has three product surfaces:
 

--- a/docs-website/src/content/docs/getting-started/solo-quickstart.md
+++ b/docs-website/src/content/docs/getting-started/solo-quickstart.md
@@ -58,3 +58,18 @@ devopsellence node logs prod-1 --lines 100
 `deploy --dry-run` prints a structured plan and does not build images, connect to
 nodes, publish desired state, or write solo state. Review that plan before
 mutating production.
+
+<ol class="command-sequence" start="5">
+  <li>Add a hostname and HTTPS when the app is ready for public traffic.</li>
+</ol>
+
+```bash
+devopsellence ingress set --service web --host app.example.com --tls-email ops@example.com
+devopsellence ingress check --wait 5m
+devopsellence deploy
+devopsellence status
+curl https://app.example.com/
+```
+
+Treat HTTPS as ready only after the DNS/TLS check, `status`, and a direct HTTPS
+request all agree. See [Ingress and TLS](/guides/ingress-tls/) for details.

--- a/docs-website/src/content/docs/getting-started/solo-quickstart.md
+++ b/docs-website/src/content/docs/getting-started/solo-quickstart.md
@@ -65,11 +65,13 @@ mutating production.
 
 ```bash
 devopsellence ingress set --service web --host app.example.com --tls-email ops@example.com
-devopsellence ingress check --wait 5m
 devopsellence deploy
+devopsellence ingress check --wait 5m
 devopsellence status
 curl https://app.example.com/
 ```
 
-Treat HTTPS as ready only after the DNS/TLS check, `status`, and a direct HTTPS
-request all agree. See [Ingress and TLS](/guides/ingress-tls/) for details.
+`ingress check` verifies DNS and TLS after deploy publishes the ingress desired
+state. Treat HTTPS as ready only after the DNS/TLS check, `status`, and a direct
+HTTPS request all agree. See [Ingress and TLS](/guides/ingress-tls/) for
+details.

--- a/docs-website/src/content/docs/getting-started/solo-quickstart.md
+++ b/docs-website/src/content/docs/getting-started/solo-quickstart.md
@@ -65,13 +65,15 @@ mutating production.
 
 ```bash
 devopsellence ingress set --service web --host app.example.com --tls-email ops@example.com
+# update DNS so app.example.com points at the attached web node IP before deploy
 devopsellence deploy
 devopsellence ingress check --wait 5m
 devopsellence status
 curl https://app.example.com/
 ```
 
-`ingress check` verifies DNS and TLS after deploy publishes the ingress desired
-state. Treat HTTPS as ready only after the DNS/TLS check, `status`, and a direct
-HTTPS request all agree. See [Ingress and TLS](/guides/ingress-tls/) for
-details.
+With auto TLS, `deploy` runs a DNS preflight and expects the hostname to resolve
+to the attached web node IPs. `ingress check` verifies DNS and TLS after deploy
+publishes the ingress desired state. Treat HTTPS as ready only after the DNS/TLS
+check, `status`, and a direct HTTPS request all agree. See [Ingress and
+TLS](/guides/ingress-tls/) for details.

--- a/docs-website/src/content/docs/guides/ingress-tls.md
+++ b/docs-website/src/content/docs/guides/ingress-tls.md
@@ -10,16 +10,17 @@ For solo HTTPS, point DNS at each web node, then configure ingress:
 
 ```bash
 devopsellence ingress set --service web --host app.example.com --tls-email ops@example.com
-devopsellence ingress check --wait 5m
 devopsellence deploy
+devopsellence ingress check --wait 5m
 devopsellence status
 curl https://app.example.com/
 ```
 
 Pass `--service` when the target web service is not obvious.
 
-`ingress check --wait` checks DNS readiness. After deploy, use
-`devopsellence status` and `curl` to confirm TLS reachability.
+`ingress check --wait` verifies DNS and TLS after deploy publishes the ingress
+desired state and the agent has reconciled Envoy. Use `devopsellence status` and
+`curl` as direct runtime proof before treating HTTPS as ready.
 
 ## Auto TLS On Multiple Nodes
 

--- a/docs-website/src/content/docs/guides/ingress-tls.md
+++ b/docs-website/src/content/docs/guides/ingress-tls.md
@@ -10,6 +10,7 @@ For solo HTTPS, point DNS at each web node, then configure ingress:
 
 ```bash
 devopsellence ingress set --service web --host app.example.com --tls-email ops@example.com
+# update DNS so app.example.com points at the attached web node IP before deploy
 devopsellence deploy
 devopsellence ingress check --wait 5m
 devopsellence status
@@ -18,9 +19,11 @@ curl https://app.example.com/
 
 Pass `--service` when the target web service is not obvious.
 
-`ingress check --wait` verifies DNS and TLS after deploy publishes the ingress
-desired state and the agent has reconciled Envoy. Use `devopsellence status` and
-`curl` as direct runtime proof before treating HTTPS as ready.
+With auto TLS, `deploy` runs a DNS preflight and expects the hostname to resolve
+to the attached web node IPs. `ingress check --wait` verifies DNS and TLS after
+deploy publishes the ingress desired state and the agent has reconciled Envoy.
+Use `devopsellence status` and `curl` as direct runtime proof before treating
+HTTPS as ready.
 
 ## Auto TLS On Multiple Nodes
 

--- a/docs-website/src/content/docs/index.md
+++ b/docs-website/src/content/docs/index.md
@@ -13,7 +13,12 @@ hero:
 devopsellence helps AI coding and operations assistants deploy containerized
 apps without inventing production shell choreography.
 
-The contract is narrow: inspect, plan, apply desired state, observe
+Why care today: it gives Codex, Claude, or a human operator a narrow deployment
+contract for Dockerized apps on VMs. Plan a change, deploy it, verify status and
+HTTPS, inspect logs, manage secrets, and roll back with structured evidence
+instead of guesses.
+
+The contract stays narrow: inspect, plan, apply desired state, observe
 reconciliation, and recover with ordinary tools when needed. Humans stay in the
 approval loop; the node agent stays deterministic.
 
@@ -30,6 +35,8 @@ not require npm or `npx`.
 
 - [Solo quickstart](/getting-started/solo-quickstart/) for the shortest path to
   one VM.
+- [Ingress and TLS](/guides/ingress-tls/) for hostnames, DNS checks, and HTTPS
+  verification.
 - [Basecamp Fizzy on Rails](/examples/fizzy-rails-solo/) for a real Rails app
   example that maps a Kamal-style deployment to devopsellence solo.
 - [Flue agents on Node.js](/examples/flue-node-solo/) for deploying an


### PR DESCRIPTION
## Summary

- add a short "why care today" value prop to the repo README
- tighten the marketing homepage around AI-safe VM deploys and remove stale solo HTTPS copy
- make the docs entry pages more concrete, including HTTPS verification from the solo quickstart

## Why

Product Hunt readers need to understand what devopsellence gives them today, not just the product thesis. The copy now leads with the concrete loop: dry-run, deploy, status, logs, secrets, rollback, DNS checks, and HTTPS verification on familiar VMs.

## Validation

- `cd docs-website && npm run build`
- `ruby -rerb -e 'src = ERB.new(File.read(ARGV[0])).src; puts src' control-plane/app/views/marketing/index.html.erb | ruby -c`
- `git diff --check`
