### PR TITLE
fix: proxy shared canonical DNS records

### DIFF
--- a/control-plane/app/services/cloudflare/rest_client.rb
+++ b/control-plane/app/services/cloudflare/rest_client.rb
@@ -26,8 +26,8 @@ module Cloudflare
       @api_base = api_base.to_s.strip.presence || DEFAULT_API_BASE
     end
 
-    def replace_dns_a_records(hostname:, addresses:, ttl: 60)
-      replace_dns_records(hostname:, type: "A", values: Array(addresses).map { |entry| entry.to_s.strip }.reject(&:blank?), ttl:, proxied: false)
+    def replace_dns_a_records(hostname:, addresses:, ttl: 60, proxied: false)
+      replace_dns_records(hostname:, type: "A", values: Array(addresses).map { |entry| entry.to_s.strip }.reject(&:blank?), ttl:, proxied:)
     end
 
     def replace_dns_txt_records(hostname:, values:, ttl: 60)

--- a/control-plane/app/services/environment_ingresses/direct_dns_strategy.rb
+++ b/control-plane/app/services/environment_ingresses/direct_dns_strategy.rb
@@ -52,7 +52,7 @@ module EnvironmentIngresses
       end
       ingress.hosts.each do |host|
         client.delete_dns_records(hostname: host, type: "CNAME")
-        client.replace_dns_a_records(hostname: host, addresses:)
+        client.replace_dns_a_records(hostname: host, addresses:, proxied: true)
       end
     rescue StandardError
       restore_dns_snapshots(snapshots)

--- a/control-plane/test/services/environment_ingresses/direct_dns_strategy_test.rb
+++ b/control-plane/test/services/environment_ingresses/direct_dns_strategy_test.rb
@@ -17,8 +17,8 @@ module EnvironmentIngresses
         operations << [ :delete, hostname, type ]
       end
 
-      def replace_dns_a_records(hostname:, addresses:, ttl: 60)
-        operations << [ :replace_a, hostname, addresses, ttl ]
+      def replace_dns_a_records(hostname:, addresses:, ttl: 60, proxied: false)
+        operations << [ :replace_a, hostname, addresses, ttl, proxied ]
         raise "boom" if @fail_replace
       end
 
@@ -80,7 +80,7 @@ module EnvironmentIngresses
         [ :records, ingress.hostname, "CNAME" ],
         [ :records, ingress.hostname, "A" ],
         [ :delete, ingress.hostname, "CNAME" ],
-        [ :replace_a, ingress.hostname, [ "198.51.100.10" ], 60 ]
+        [ :replace_a, ingress.hostname, [ "198.51.100.10" ], 60, true ]
       ], client.operations
     end
 
@@ -136,7 +136,7 @@ module EnvironmentIngresses
         [ :records, ingress.hostname, "CNAME" ],
         [ :records, ingress.hostname, "A" ],
         [ :delete, ingress.hostname, "CNAME" ],
-        [ :replace_a, ingress.hostname, [ "198.51.100.10" ], 60 ],
+        [ :replace_a, ingress.hostname, [ "198.51.100.10" ], 60, true ],
         [ :delete, ingress.hostname, "A" ],
         [ :delete, ingress.hostname, "CNAME" ],
         [ :restore, [{ "name" => ingress.hostname, "type" => "CNAME", "content" => "old.example.test", "proxied" => false, "ttl" => 60 }] ]


### PR DESCRIPTION
## Summary
- make control-plane managed canonical A records Cloudflare-proxied instead of DNS-only
- keep `public_url` as HTTPS for canonical `devopsellence.io` hosts while making port 443 terminate at Cloudflare
- extend the direct DNS strategy regression to assert proxied A-record cutover and rollback behavior

## Test Plan
- `cd control-plane && mise run test -- test/services/environment_ingresses/direct_dns_strategy_test.rb -n '/replaces canonical DNS with eligible node IP addresses|marks ingress failed when direct dns cutover fails/'`
- `cd control-plane && mise run test -- test/services/environment_ingresses/direct_dns_strategy_test.rb test/integration/api_cli_mvp_test.rb`

Closes #186
