### PR TITLE
[codex] Fix shared ingress TLS readiness reporting

### DIFF
--- a/agent/internal/acme/manager.go
+++ b/agent/internal/acme/manager.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/devopsellence/devopsellence/agent/internal/desiredstatepb"
+	"github.com/devopsellence/devopsellence/agent/internal/report"
 	"github.com/go-acme/lego/v4/certcrypto"
 	"github.com/go-acme/lego/v4/certificate"
 	"github.com/go-acme/lego/v4/lego"
@@ -52,6 +53,8 @@ type Manager struct {
 	provider *HTTP01Provider
 	once     sync.Once
 	startErr error
+	statusMu sync.Mutex
+	lastErr  string
 }
 
 func New(cfg Config) *Manager {
@@ -76,6 +79,36 @@ func New(cfg Config) *Manager {
 }
 
 func (m *Manager) Ensure(ctx context.Context, ingress *desiredstatepb.Ingress, nodePeers []*desiredstatepb.NodePeer) error {
+	err := m.ensure(ctx, ingress, nodePeers)
+	m.recordEnsureResult(err)
+	return err
+}
+
+func (m *Manager) Status(ingress *desiredstatepb.Ingress) *report.IngressStatus {
+	if !wantsTLS(ingress) {
+		m.recordEnsureResult(nil)
+		return nil
+	}
+
+	hosts := ingressHosts(ingress)
+	if len(hosts) == 0 {
+		return &report.IngressStatus{TLSStatus: "failed", TLSError: "ingress hosts required"}
+	}
+
+	cert, err := certificateForHosts(m.cfg.CertPath, hosts)
+	if err == nil && time.Now().Before(cert.NotAfter) {
+		notAfter := cert.NotAfter.UTC()
+		return &report.IngressStatus{TLSStatus: "ready", TLSNotAfter: &notAfter}
+	}
+
+	if lastErr := m.lastError(); lastErr != "" {
+		return &report.IngressStatus{TLSStatus: "failed", TLSError: lastErr}
+	}
+
+	return &report.IngressStatus{TLSStatus: "pending"}
+}
+
+func (m *Manager) ensure(ctx context.Context, ingress *desiredstatepb.Ingress, nodePeers []*desiredstatepb.NodePeer) error {
 	if !needsAutoTLS(ingress) {
 		return nil
 	}
@@ -133,6 +166,22 @@ func (m *Manager) Ensure(ctx context.Context, ingress *desiredstatepb.Ingress, n
 	}
 	m.logger.Info("acme certificate ready", "hosts", strings.Join(hosts, ","))
 	return nil
+}
+
+func (m *Manager) recordEnsureResult(err error) {
+	m.statusMu.Lock()
+	defer m.statusMu.Unlock()
+	if err == nil {
+		m.lastErr = ""
+		return
+	}
+	m.lastErr = err.Error()
+}
+
+func (m *Manager) lastError() string {
+	m.statusMu.Lock()
+	defer m.statusMu.Unlock()
+	return m.lastErr
 }
 
 func (m *Manager) startHTTP01Server() error {
@@ -348,6 +397,25 @@ func needsAutoTLS(ingress *desiredstatepb.Ingress) bool {
 	return mode == "" || mode == "auto"
 }
 
+func wantsTLS(ingress *desiredstatepb.Ingress) bool {
+	if ingress == nil {
+		return false
+	}
+	mode := strings.TrimSpace(ingress.Mode)
+	if mode == "" {
+		mode = "public"
+	}
+	if mode != "public" {
+		return false
+	}
+	tls := ingress.GetTls()
+	if tls == nil {
+		return true
+	}
+	mode = strings.TrimSpace(tls.Mode)
+	return mode == "" || mode == "auto" || mode == "manual"
+}
+
 func ingressTLSEmail(ingress *desiredstatepb.Ingress) string {
 	if ingress == nil || ingress.GetTls() == nil {
 		return ""
@@ -413,20 +481,25 @@ func ingressHosts(ingress *desiredstatepb.Ingress) []string {
 }
 
 func certCurrent(path string, hosts []string, renewBefore time.Duration) bool {
-	data, err := os.ReadFile(path)
+	cert, err := certificateForHosts(path, hosts)
 	if err != nil {
 		return false
+	}
+	return time.Until(cert.NotAfter) > renewBefore
+}
+
+func certificateForHosts(path string, hosts []string) (*x509.Certificate, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
 	}
 	block, _ := pem.Decode(data)
 	if block == nil || block.Type != "CERTIFICATE" {
-		return false
+		return nil, fmt.Errorf("acme: certificate PEM missing")
 	}
 	cert, err := x509.ParseCertificate(block.Bytes)
 	if err != nil {
-		return false
-	}
-	if time.Until(cert.NotAfter) <= renewBefore {
-		return false
+		return nil, err
 	}
 	names := map[string]bool{}
 	for _, name := range cert.DNSNames {
@@ -437,10 +510,10 @@ func certCurrent(path string, hosts []string, renewBefore time.Duration) bool {
 	}
 	for _, host := range hosts {
 		if !names[host] {
-			return false
+			return nil, fmt.Errorf("acme: certificate missing host %s", host)
 		}
 	}
-	return true
+	return cert, nil
 }
 
 func parseECPrivateKey(data []byte) (*ecdsa.PrivateKey, error) {

--- a/agent/internal/acme/manager.go
+++ b/agent/internal/acme/manager.go
@@ -100,6 +100,9 @@ func (m *Manager) Status(ingress *desiredstatepb.Ingress) *report.IngressStatus 
 		notAfter := cert.NotAfter.UTC()
 		return &report.IngressStatus{TLSStatus: "ready", TLSNotAfter: &notAfter}
 	}
+	if err != nil && !os.IsNotExist(err) {
+		return &report.IngressStatus{TLSStatus: "failed", TLSError: err.Error()}
+	}
 
 	if lastErr := m.lastError(); lastErr != "" {
 		return &report.IngressStatus{TLSStatus: "failed", TLSError: lastErr}

--- a/agent/internal/acme/manager_test.go
+++ b/agent/internal/acme/manager_test.go
@@ -1,9 +1,19 @@
 package acme
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/devopsellence/devopsellence/agent/internal/desiredstatepb"
 )
@@ -73,5 +83,78 @@ func TestNeedsAutoTLSTreatsBlankModeAsPublic(t *testing.T) {
 	ingress := &desiredstatepb.Ingress{Hosts: []string{"app.example.com"}}
 	if !needsAutoTLS(ingress) {
 		t.Fatal("expected blank mode ingress to need auto TLS")
+	}
+}
+
+func TestStatusReportsPendingUntilCertificateExists(t *testing.T) {
+	manager := New(Config{CertPath: filepath.Join(t.TempDir(), "cert.pem")})
+
+	status := manager.Status(&desiredstatepb.Ingress{
+		Mode:  "public",
+		Hosts: []string{"app.example.com"},
+		Tls:   &desiredstatepb.IngressTLS{Mode: "auto"},
+	})
+
+	if status == nil || status.TLSStatus != "pending" {
+		t.Fatalf("status = %#v, want pending", status)
+	}
+}
+
+func TestStatusReportsReadyForMatchingCertificate(t *testing.T) {
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "cert.pem")
+	notAfter := time.Now().Add(24 * time.Hour).UTC().Truncate(time.Second)
+	writeTestCertificate(t, certPath, []string{"app.example.com"}, notAfter)
+
+	manager := New(Config{CertPath: certPath})
+	status := manager.Status(&desiredstatepb.Ingress{
+		Mode:  "public",
+		Hosts: []string{"app.example.com"},
+		Tls:   &desiredstatepb.IngressTLS{Mode: "auto"},
+	})
+
+	if status == nil || status.TLSStatus != "ready" {
+		t.Fatalf("status = %#v, want ready", status)
+	}
+	if status.TLSNotAfter == nil || !status.TLSNotAfter.Equal(notAfter) {
+		t.Fatalf("not_after = %#v, want %s", status.TLSNotAfter, notAfter)
+	}
+}
+
+func TestStatusReportsLastAutoTLSErrorWhenCertificateMissing(t *testing.T) {
+	manager := New(Config{CertPath: filepath.Join(t.TempDir(), "cert.pem")})
+	manager.recordEnsureResult(os.ErrPermission)
+
+	status := manager.Status(&desiredstatepb.Ingress{
+		Mode:  "public",
+		Hosts: []string{"app.example.com"},
+		Tls:   &desiredstatepb.IngressTLS{Mode: "auto"},
+	})
+
+	if status == nil || status.TLSStatus != "failed" || status.TLSError == "" {
+		t.Fatalf("status = %#v, want failed with error", status)
+	}
+}
+
+func writeTestCertificate(t *testing.T, path string, hosts []string, notAfter time.Time) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: hosts[0]},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     notAfter,
+		DNSNames:     hosts,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create certificate: %v", err)
+	}
+	if err := os.WriteFile(path, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), 0o644); err != nil {
+		t.Fatalf("write cert: %v", err)
 	}
 }

--- a/agent/internal/acme/manager_test.go
+++ b/agent/internal/acme/manager_test.go
@@ -136,6 +136,25 @@ func TestStatusReportsLastAutoTLSErrorWhenCertificateMissing(t *testing.T) {
 	}
 }
 
+func TestStatusReportsCertificateParseError(t *testing.T) {
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "cert.pem")
+	if err := os.WriteFile(certPath, []byte("not a certificate"), 0o644); err != nil {
+		t.Fatalf("write cert: %v", err)
+	}
+
+	manager := New(Config{CertPath: certPath})
+	status := manager.Status(&desiredstatepb.Ingress{
+		Mode:  "public",
+		Hosts: []string{"app.example.com"},
+		Tls:   &desiredstatepb.IngressTLS{Mode: "auto"},
+	})
+
+	if status == nil || status.TLSStatus != "failed" || status.TLSError == "" {
+		t.Fatalf("status = %#v, want failed with certificate error", status)
+	}
+}
+
 func writeTestCertificate(t *testing.T, path string, hosts []string, notAfter time.Time) {
 	t.Helper()
 

--- a/agent/internal/agent/agent.go
+++ b/agent/internal/agent/agent.go
@@ -171,6 +171,7 @@ func (a *Agent) reconcileOnce(ctx context.Context) error {
 		Revision:     desired.Revision,
 		Message:      fmt.Sprintf("created=%d updated=%d removed=%d unchanged=%d", result.Created, result.Updated, result.Removed, result.Unchanged),
 		Summary:      summary,
+		Ingress:      a.reconciler.IngressStatus(desired),
 		DiskCare:     diskCareStatus,
 		Environments: environments,
 	}, fetched.Sequence)
@@ -318,6 +319,7 @@ type reportFingerprint struct {
 	err              string
 	taskHash         string
 	diskCareHash     string
+	ingressHash      string
 	environmentsHash string
 }
 
@@ -330,6 +332,7 @@ func newReportFingerprint(sequence int64, status report.Status) *reportFingerpri
 		err:              status.Error,
 		taskHash:         fingerprintTask(status.Task),
 		diskCareHash:     fingerprintDiskCare(status.DiskCare),
+		ingressHash:      fingerprintIngress(status.Ingress),
 		environmentsHash: fingerprintEnvironments(status.Environments),
 	}
 }
@@ -343,6 +346,7 @@ func (f *reportFingerprint) suppresses(other *reportFingerprint) bool {
 	}
 	if f.phase == report.PhaseSettled {
 		return f.diskCareHash == other.diskCareHash &&
+			f.ingressHash == other.ingressHash &&
 			f.environmentsHash == other.environmentsHash
 	}
 	return f.revision == other.revision &&
@@ -350,6 +354,7 @@ func (f *reportFingerprint) suppresses(other *reportFingerprint) bool {
 		f.err == other.err &&
 		f.taskHash == other.taskHash &&
 		f.diskCareHash == other.diskCareHash &&
+		f.ingressHash == other.ingressHash &&
 		f.environmentsHash == other.environmentsHash
 }
 
@@ -406,6 +411,22 @@ func fingerprintDiskCare(status *report.DiskCareStatus) string {
 		builder.WriteString(fmt.Sprintf("%d", artifact.Bytes))
 		builder.WriteByte(0)
 	}
+	return builder.String()
+}
+
+func fingerprintIngress(status *report.IngressStatus) string {
+	if status == nil {
+		return ""
+	}
+
+	var builder strings.Builder
+	builder.WriteString(status.TLSStatus)
+	builder.WriteByte(0)
+	if status.TLSNotAfter != nil && !status.TLSNotAfter.IsZero() {
+		builder.WriteString(status.TLSNotAfter.UTC().Format(time.RFC3339))
+	}
+	builder.WriteByte(0)
+	builder.WriteString(status.TLSError)
 	return builder.String()
 }
 

--- a/agent/internal/agent/agent_test.go
+++ b/agent/internal/agent/agent_test.go
@@ -215,6 +215,18 @@ func (f *fakeEnvoy) WaitForRoute(ctx context.Context, path string) error {
 	return nil
 }
 
+type fakeIngressCert struct {
+	status *report.IngressStatus
+}
+
+func (f *fakeIngressCert) Ensure(ctx context.Context, ingress *desiredstatepb.Ingress, nodePeers []*desiredstatepb.NodePeer) error {
+	return nil
+}
+
+func (f *fakeIngressCert) Status(ingress *desiredstatepb.Ingress) *report.IngressStatus {
+	return f.status
+}
+
 type staticHTTPProber struct{}
 
 func (staticHTTPProber) Get(ctx context.Context, target string, timeout time.Duration) (int, error) {
@@ -274,6 +286,42 @@ func TestAgentReconcileE2E(t *testing.T) {
 	}
 	if !envoyManager.updated {
 		t.Fatal("expected envoy EDS update")
+	}
+}
+
+func TestAgentReportsIngressTLSStatus(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+
+	desired := desiredWithWeb("rev-1")
+	desired.Ingress = &desiredstatepb.Ingress{
+		Mode:  "public",
+		Hosts: []string{"app.example.com"},
+		Tls:   &desiredstatepb.IngressTLS{Mode: "auto"},
+	}
+
+	eng := newFakeEngine()
+	eng.images["busybox"] = true
+	certStatus := &report.IngressStatus{TLSStatus: "ready"}
+	reconciler := reconcile.New(eng, reconcile.Options{
+		Network:     "devopsellence",
+		WebPort:     3000,
+		Envoy:       &fakeEnvoy{},
+		IngressCert: &fakeIngressCert{status: certStatus},
+		HTTPProber:  staticHTTPProber{},
+	})
+	reporter := &captureReporter{}
+	metrics := observability.NewMetrics(prometheus.NewRegistry())
+	ag := New(&fakeAuthority{desired: desired, sequence: 7}, reconciler, reporter, time.Minute, logger, metrics, nil)
+
+	if err := ag.reconcileOnce(context.Background()); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	if len(reporter.calls) != 1 {
+		t.Fatalf("reports = %d, want 1", len(reporter.calls))
+	}
+	if reporter.calls[0].Ingress == nil || reporter.calls[0].Ingress.TLSStatus != "ready" {
+		t.Fatalf("ingress = %#v, want ready TLS status", reporter.calls[0].Ingress)
 	}
 }
 
@@ -354,6 +402,25 @@ func TestSettledFingerprintDoesNotSuppressEnvironmentChangesForSameSequence(t *t
 
 	if first.suppresses(changed) {
 		t.Fatal("settled report suppression must not hide changed environment/service status")
+	}
+}
+
+func TestSettledFingerprintDoesNotSuppressIngressTLSChangesForSameSequence(t *testing.T) {
+	first := newReportFingerprint(7, report.Status{
+		Revision: "desired-rev",
+		Phase:    report.PhaseSettled,
+		Message:  "created=0 updated=0 removed=0 unchanged=1",
+		Ingress:  &report.IngressStatus{TLSStatus: "pending"},
+	})
+	changed := newReportFingerprint(7, report.Status{
+		Revision: "desired-rev",
+		Phase:    report.PhaseSettled,
+		Message:  "created=0 updated=0 removed=0 unchanged=1",
+		Ingress:  &report.IngressStatus{TLSStatus: "ready"},
+	})
+
+	if first.suppresses(changed) {
+		t.Fatal("settled report suppression must not hide changed ingress TLS status")
 	}
 }
 

--- a/agent/internal/reconcile/ingress_status.go
+++ b/agent/internal/reconcile/ingress_status.go
@@ -1,0 +1,21 @@
+package reconcile
+
+import (
+	"github.com/devopsellence/devopsellence/agent/internal/desiredstatepb"
+	"github.com/devopsellence/devopsellence/agent/internal/report"
+)
+
+type IngressStatusReporter interface {
+	Status(ingress *desiredstatepb.Ingress) *report.IngressStatus
+}
+
+func (r *Reconciler) IngressStatus(desired *desiredstatepb.DesiredState) *report.IngressStatus {
+	if desired == nil || desired.Ingress == nil || r.opts.IngressCert == nil {
+		return nil
+	}
+	reporter, ok := r.opts.IngressCert.(IngressStatusReporter)
+	if !ok {
+		return nil
+	}
+	return reporter.Status(desired.Ingress)
+}

--- a/agent/internal/report/status.go
+++ b/agent/internal/report/status.go
@@ -18,6 +18,7 @@ type Status struct {
 	Error        string              `json:"error,omitempty"`
 	Summary      *Summary            `json:"summary,omitempty"`
 	Task         *TaskStatus         `json:"task,omitempty"`
+	Ingress      *IngressStatus      `json:"ingress,omitempty"`
 	DiskCare     *DiskCareStatus     `json:"disk_care,omitempty"`
 	Environments []EnvironmentStatus `json:"environments,omitempty"`
 }
@@ -51,6 +52,12 @@ type TaskStatus struct {
 	Message  string `json:"message,omitempty"`
 	Error    string `json:"error,omitempty"`
 	ExitCode int64  `json:"exit_code,omitempty"`
+}
+
+type IngressStatus struct {
+	TLSStatus   string     `json:"tls_status,omitempty"`
+	TLSNotAfter *time.Time `json:"tls_not_after,omitempty"`
+	TLSError    string     `json:"tls_error,omitempty"`
 }
 
 // DiskCareStatus reports node-local cleanup and retention state for

--- a/cli/internal/api/client.go
+++ b/cli/internal/api/client.go
@@ -167,11 +167,15 @@ type DeploymentProgressNode struct {
 }
 
 type DeploymentProgressIngress struct {
-	Hostname   string   `json:"hostname"`
-	Hosts      []string `json:"hosts,omitempty"`
-	PublicURL  string   `json:"public_url"`
-	PublicURLs []string `json:"public_urls,omitempty"`
-	Status     string   `json:"status"`
+	Hostname             string   `json:"hostname"`
+	Hosts                []string `json:"hosts,omitempty"`
+	PublicURL            string   `json:"public_url"`
+	PublicURLs           []string `json:"public_urls,omitempty"`
+	ConfiguredPublicURLs []string `json:"configured_public_urls,omitempty"`
+	PublicURLStatus      string   `json:"public_url_status,omitempty"`
+	Status               string   `json:"status"`
+	TLSStatus            string   `json:"tls_status,omitempty"`
+	TLSError             string   `json:"tls_error,omitempty"`
 }
 
 type DeploymentProgress struct {

--- a/cli/internal/workflow/app.go
+++ b/cli/internal/workflow/app.go
@@ -778,6 +778,12 @@ func (a *App) Deploy(ctx context.Context, opts DeployOptions) error {
 			"public_url":       publicURL(publish),
 			"trial_expires_at": stringFromMap(publish, "trial_expires_at"),
 		}
+		if status := stringFromMap(publish, "public_url_status"); status != "" {
+			result["public_url_status"] = status
+		}
+		if urls := stringSlice(publish["configured_public_urls"]); len(urls) > 0 {
+			result["configured_public_urls"] = urls
+		}
 		accessToken = session.AccessToken()
 		return nil
 	}
@@ -2470,7 +2476,7 @@ func isTransientServerError(err error) bool {
 }
 
 func deploymentProgressMap(progress api.DeploymentProgress) map[string]any {
-	return map[string]any{
+	result := map[string]any{
 		"id":             progress.ID,
 		"sequence":       progress.Sequence,
 		"status":         progress.Status,
@@ -2495,6 +2501,31 @@ func deploymentProgressMap(progress api.DeploymentProgress) map[string]any {
 		},
 		"nodes": progress.Nodes,
 	}
+	if progress.Ingress != nil {
+		ingress := map[string]any{
+			"hostname":    progress.Ingress.Hostname,
+			"hosts":       progress.Ingress.Hosts,
+			"public_urls": progress.Ingress.PublicURLs,
+			"status":      progress.Ingress.Status,
+		}
+		if progress.Ingress.PublicURL != "" {
+			ingress["public_url"] = progress.Ingress.PublicURL
+		}
+		if len(progress.Ingress.ConfiguredPublicURLs) > 0 {
+			ingress["configured_public_urls"] = progress.Ingress.ConfiguredPublicURLs
+		}
+		if progress.Ingress.PublicURLStatus != "" {
+			ingress["public_url_status"] = progress.Ingress.PublicURLStatus
+		}
+		if progress.Ingress.TLSStatus != "" {
+			ingress["tls_status"] = progress.Ingress.TLSStatus
+		}
+		if progress.Ingress.TLSError != "" {
+			ingress["tls_error"] = progress.Ingress.TLSError
+		}
+		result["ingress"] = ingress
+	}
+	return result
 }
 
 func rolloutOutcome(progress api.DeploymentProgress) error {

--- a/control-plane/app/controllers/api/v1/cli/deployments_controller.rb
+++ b/control-plane/app/controllers/api/v1/cli/deployments_controller.rb
@@ -86,20 +86,16 @@ module Api
               environments: row.environments
             }
           end,
-            ingress: serialize_ingress(environment.environment_ingress)
+            ingress: serialize_ingress(environment, release)
           }
         end
 
-        def serialize_ingress(ingress)
-          return nil unless ingress
-
-          {
-            hostname: ingress.primary_hostname,
-            hosts: ingress.hosts,
-            public_url: ingress.public_url,
-            public_urls: ingress.public_urls,
-            status: ingress.status
-          }
+        def serialize_ingress(environment, release)
+          ::Cli::IngressStatusSerializer.new(
+            environment: environment,
+            ingress: environment.environment_ingress,
+            release: release
+          ).as_json
         end
 
         def serialize_release_task(deployment)

--- a/control-plane/app/controllers/api/v1/cli/environment_statuses_controller.rb
+++ b/control-plane/app/controllers/api/v1/cli/environment_statuses_controller.rb
@@ -30,7 +30,7 @@ module Api
               runtime_kind: environment.runtime_kind,
               ingress_strategy: environment.ingress_strategy
             },
-            ingress: serialize_ingress(environment.environment_ingress),
+            ingress: serialize_ingress(environment),
             current_release: serialize_release(current_release, organization),
             latest_deployment: serialize_deployment(latest_deployment),
             assigned_nodes: assigned_nodes,
@@ -80,17 +80,12 @@ module Api
           }
         end
 
-        def serialize_ingress(ingress)
-          return nil unless ingress
-
-          {
-            hostname: ingress.primary_hostname,
-            hosts: ingress.hosts,
-            public_url: ingress.public_url,
-            public_urls: ingress.public_urls,
-            status: ingress.status,
-            last_error: ingress.last_error
-          }
+        def serialize_ingress(environment)
+          ::Cli::IngressStatusSerializer.new(
+            environment: environment,
+            ingress: environment.environment_ingress,
+            release: environment.current_release
+          ).as_json
         end
 
         def assignment_warning_for(environment, assigned_nodes)

--- a/control-plane/app/controllers/api/v1/cli/releases_controller.rb
+++ b/control-plane/app/controllers/api/v1/cli/releases_controller.rb
@@ -49,6 +49,7 @@ module Api
           ).call
           deployment = result.deployment
           assigned_nodes = environment.nodes.count
+          ingress = serialize_ingress(environment, release)
 
           render json: {
             deployment_id: deployment.id,
@@ -61,12 +62,14 @@ module Api
             warning: assignment_warning_for(environment, assigned_nodes),
             trial_expires_at: environment.nodes.maximum(:lease_expires_at)&.utc&.iso8601,
             ingress_strategy: environment.ingress_strategy,
-            hostname: environment.environment_ingress&.primary_hostname,
-            hosts: environment.environment_ingress&.hosts || [],
-            public_url: environment.environment_ingress&.public_url,
-            public_urls: environment.environment_ingress&.public_urls || [],
-            ingress_status: environment.environment_ingress&.status,
-            ingress: serialize_ingress(environment.environment_ingress)
+            hostname: ingress&.fetch(:hostname, nil),
+            hosts: ingress&.fetch(:hosts, []) || [],
+            public_url: ingress&.fetch(:public_url, nil),
+            public_urls: ingress&.fetch(:public_urls, []) || [],
+            configured_public_urls: ingress&.fetch(:configured_public_urls, []) || [],
+            public_url_status: ingress&.fetch(:public_url_status, nil),
+            ingress_status: ingress&.fetch(:status, nil),
+            ingress: ingress
           }, status: :created
         end
 
@@ -120,17 +123,12 @@ module Api
           ).to_h
         end
 
-        def serialize_ingress(ingress)
-          return nil unless ingress
-
-          {
-            hostname: ingress.primary_hostname,
-            hosts: ingress.hosts,
-            public_url: ingress.public_url,
-            public_urls: ingress.public_urls,
-            status: ingress.status,
-            last_error: ingress.last_error
-          }
+        def serialize_ingress(environment, release)
+          ::Cli::IngressStatusSerializer.new(
+            environment: environment,
+            ingress: environment.environment_ingress,
+            release: release
+          ).as_json
         end
 
         def publish_request_token

--- a/control-plane/app/services/cli/ingress_status_serializer.rb
+++ b/control-plane/app/services/cli/ingress_status_serializer.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+module Cli
+  class IngressStatusSerializer
+    def initialize(environment:, ingress:, release: nil)
+      @environment = environment
+      @ingress = ingress
+      @release = release || environment.current_release
+    end
+
+    def as_json
+      return nil unless ingress
+
+      payload = {
+        hostname: ingress.primary_hostname,
+        hosts: ingress.hosts,
+        public_urls: verified_public_urls,
+        configured_public_urls: configured_public_urls,
+        status: ingress.status,
+        last_error: ingress.last_error
+      }.compact
+      payload[:public_url] = verified_public_urls.first if verified_public_urls.any?
+      payload[:public_url_status] = public_url_status if verified_public_urls.empty? && configured_public_urls.any?
+      payload[:tls_status] = tls_status if tls_required? && tls_status.present?
+      payload[:tls_error] = tls_error if tls_required? && tls_error.present?
+      payload
+    end
+
+    private
+
+      attr_reader :environment, :ingress, :release
+
+      def verified_public_urls
+        @verified_public_urls ||= begin
+          if ingress.ready? && (!tls_required? || tls_ready?)
+            configured_public_urls
+          else
+            []
+          end
+        end
+      end
+
+      def configured_public_urls
+        @configured_public_urls ||= ingress.hosts.map { |host| public_url_for(host) }.compact
+      end
+
+      def public_url_status
+        return "configured_tls_failed" if tls_required? && tls_status == Node::INGRESS_TLS_FAILED
+        return "configured_tls_pending" if tls_required?
+
+        "configured_pending"
+      end
+
+      def public_url_for(host)
+        return Devopsellence::IngressConfig.public_url(host) if Devopsellence::IngressConfig.local?
+        return nil if host.blank?
+
+        "#{url_scheme}://#{host}"
+      end
+
+      def url_scheme
+        tls_required? ? "https" : "http"
+      end
+
+      def tls_required?
+        return false if Devopsellence::IngressConfig.local?
+
+        mode = release&.ingress_config&.dig("tls", "mode").to_s.strip
+        mode = "auto" if mode.blank?
+        mode == "auto" || mode == "manual"
+      end
+
+      def tls_ready?
+        tls_status == Node::INGRESS_TLS_READY
+      end
+
+      def tls_status
+        @tls_status ||= begin
+          nodes = eligible_ingress_nodes
+          if nodes.empty?
+            nil
+          elsif nodes.any? { |node| node.ingress_tls_status == Node::INGRESS_TLS_FAILED }
+            Node::INGRESS_TLS_FAILED
+          elsif nodes.all?(&:ingress_tls_ready?)
+            Node::INGRESS_TLS_READY
+          else
+            Node::INGRESS_TLS_PENDING
+          end
+        end
+      end
+
+      def tls_error
+        eligible_ingress_nodes.filter_map(&:ingress_tls_last_error).first
+      end
+
+      def eligible_ingress_nodes
+        @eligible_ingress_nodes ||= EnvironmentIngresses::EligibleNodes.new(environment:).call
+      end
+  end
+end

--- a/control-plane/app/services/cli/ingress_status_serializer.rb
+++ b/control-plane/app/services/cli/ingress_status_serializer.rb
@@ -28,73 +28,73 @@ module Cli
 
     private
 
-      attr_reader :environment, :ingress, :release
+    attr_reader :environment, :ingress, :release
 
-      def verified_public_urls
-        @verified_public_urls ||= begin
-          if ingress.ready? && (!tls_required? || tls_ready?)
-            configured_public_urls
-          else
-            []
-          end
+    def verified_public_urls
+      @verified_public_urls ||= begin
+        if ingress.ready? && (!tls_required? || tls_ready?)
+          configured_public_urls
+        else
+          []
         end
       end
+    end
 
-      def configured_public_urls
-        @configured_public_urls ||= ingress.hosts.map { |host| public_url_for(host) }.compact
-      end
+    def configured_public_urls
+      @configured_public_urls ||= ingress.hosts.map { |host| public_url_for(host) }.compact
+    end
 
-      def public_url_status
-        return "configured_tls_failed" if tls_required? && tls_status == Node::INGRESS_TLS_FAILED
-        return "configured_tls_pending" if tls_required?
+    def public_url_status
+      return "configured_tls_failed" if tls_required? && tls_status == Node::INGRESS_TLS_FAILED
+      return "configured_tls_pending" if tls_required?
 
-        "configured_pending"
-      end
+      "configured_pending"
+    end
 
-      def public_url_for(host)
-        return Devopsellence::IngressConfig.public_url(host) if Devopsellence::IngressConfig.local?
-        return nil if host.blank?
+    def public_url_for(host)
+      return Devopsellence::IngressConfig.public_url(host) if Devopsellence::IngressConfig.local?
+      return nil if host.blank?
 
-        "#{url_scheme}://#{host}"
-      end
+      "#{url_scheme}://#{host}"
+    end
 
-      def url_scheme
-        tls_required? ? "https" : "http"
-      end
+    def url_scheme
+      tls_required? ? "https" : "http"
+    end
 
-      def tls_required?
-        return false if Devopsellence::IngressConfig.local?
+    def tls_required?
+      return false if Devopsellence::IngressConfig.local?
 
-        mode = release&.ingress_config&.dig("tls", "mode").to_s.strip
-        mode = "auto" if mode.blank?
-        mode == "auto" || mode == "manual"
-      end
+      mode = release&.ingress_config&.dig("tls", "mode").to_s.strip
+      mode = "auto" if mode.blank?
+      mode == "auto" || mode == "manual"
+    end
 
-      def tls_ready?
-        tls_status == Node::INGRESS_TLS_READY
-      end
+    def tls_ready?
+      tls_status == Node::INGRESS_TLS_READY
+    end
 
-      def tls_status
-        @tls_status ||= begin
-          nodes = eligible_ingress_nodes
-          if nodes.empty?
-            nil
-          elsif nodes.any? { |node| node.ingress_tls_status == Node::INGRESS_TLS_FAILED }
-            Node::INGRESS_TLS_FAILED
-          elsif nodes.all?(&:ingress_tls_ready?)
-            Node::INGRESS_TLS_READY
-          else
-            Node::INGRESS_TLS_PENDING
-          end
+    def tls_status
+      @tls_status ||= begin
+        nodes = eligible_ingress_nodes
+        if nodes.empty?
+          nil
+        elsif nodes.any? { |node| node.ingress_tls_status == Node::INGRESS_TLS_FAILED }
+          Node::INGRESS_TLS_FAILED
+        elsif nodes.all?(&:ingress_tls_ready?)
+          Node::INGRESS_TLS_READY
+        else
+          Node::INGRESS_TLS_PENDING
         end
       end
+    end
 
-      def tls_error
-        eligible_ingress_nodes.filter_map(&:ingress_tls_last_error).first
-      end
+    def tls_error
+      eligible_ingress_nodes.filter_map(&:ingress_tls_last_error).first
+    end
 
-      def eligible_ingress_nodes
-        @eligible_ingress_nodes ||= EnvironmentIngresses::EligibleNodes.new(environment:).call
-      end
+    def eligible_ingress_nodes
+      @eligible_ingress_nodes ||= EnvironmentIngresses::EligibleNodes.new(environment:).call
+    end
   end
 end

--- a/control-plane/app/services/environment_ingresses/eligible_nodes.rb
+++ b/control-plane/app/services/environment_ingresses/eligible_nodes.rb
@@ -45,13 +45,20 @@ module EnvironmentIngresses
     def latest_deployment_node_statuses_by_node_id(node_ids, release:)
       return {} if node_ids.empty?
 
-      DeploymentNodeStatus
+      ranked_statuses = DeploymentNodeStatus
         .joins(:deployment)
         .where(node_id: node_ids, deployments: { environment_id: environment.id, release_id: release.id })
-        .order("deployment_node_statuses.node_id ASC, deployments.sequence DESC, deployment_node_statuses.reported_at DESC, deployment_node_statuses.id DESC")
-        .each_with_object({}) do |status, statuses_by_node_id|
-          statuses_by_node_id[status.node_id] ||= status
-        end
+        .select(
+          "deployment_node_statuses.*",
+          "ROW_NUMBER() OVER (PARTITION BY deployment_node_statuses.node_id " \
+            "ORDER BY deployments.sequence DESC, deployment_node_statuses.reported_at DESC, " \
+            "deployment_node_statuses.id DESC) AS latest_rank"
+        )
+
+      DeploymentNodeStatus
+        .from(ranked_statuses, :deployment_node_statuses)
+        .where(latest_rank: 1)
+        .index_by(&:node_id)
     end
   end
 end

--- a/control-plane/app/services/environment_ingresses/eligible_nodes.rb
+++ b/control-plane/app/services/environment_ingresses/eligible_nodes.rb
@@ -9,10 +9,16 @@ module EnvironmentIngresses
     end
 
     def call
-      return [] unless environment.current_release
+      release = environment.current_release
+      return [] unless release
 
-      environment.nodes.order(:created_at).select do |node|
-        eligible_node?(node)
+      candidates = environment.nodes.order(:created_at).select do |node|
+        candidate_node?(node, release:)
+      end
+      latest_statuses = latest_deployment_node_statuses_by_node_id(candidates.map(&:id), release:)
+
+      candidates.select do |node|
+        latest_statuses[node.id]&.phase == DeploymentNodeStatus::PHASE_SETTLED
       end
     end
 
@@ -20,15 +26,14 @@ module EnvironmentIngresses
 
     attr_reader :environment, :stale_node_after, :clock
 
-    def eligible_node?(node)
-      release = environment.current_release
-      return false unless release&.ingress_scheduled_on?(node)
+    def candidate_node?(node, release:)
+      return false unless release.ingress_scheduled_on?(node)
       return false if node.public_ip.to_s.strip.blank?
       return false if node.provisioning_status != Node::PROVISIONING_READY
       return false unless node.supports_capability?(Node::CAPABILITY_DIRECT_DNS_INGRESS)
       return false unless fresh?(node)
 
-      latest_deployment_node_status_for(node)&.phase == DeploymentNodeStatus::PHASE_SETTLED
+      true
     end
 
     def fresh?(node)
@@ -37,16 +42,16 @@ module EnvironmentIngresses
       node.last_seen_at >= clock.call - stale_node_after
     end
 
-    def latest_deployment_node_status_for(node)
-      @latest_deployment_node_statuses ||= {}
-      return @latest_deployment_node_statuses[node.id] if @latest_deployment_node_statuses.key?(node.id)
+    def latest_deployment_node_statuses_by_node_id(node_ids, release:)
+      return {} if node_ids.empty?
 
-      status = DeploymentNodeStatus
+      DeploymentNodeStatus
         .joins(:deployment)
-        .where(node_id: node.id, deployments: { environment_id: environment.id, release_id: environment.current_release_id })
-        .order("deployments.sequence DESC, deployment_node_statuses.reported_at DESC, deployment_node_statuses.id DESC")
-        .first
-      @latest_deployment_node_statuses[node.id] = status
+        .where(node_id: node_ids, deployments: { environment_id: environment.id, release_id: release.id })
+        .order("deployment_node_statuses.node_id ASC, deployments.sequence DESC, deployment_node_statuses.reported_at DESC, deployment_node_statuses.id DESC")
+        .each_with_object({}) do |status, statuses_by_node_id|
+          statuses_by_node_id[status.node_id] ||= status
+        end
     end
   end
 end

--- a/control-plane/test/integration/api_cli_ingress_status_test.rb
+++ b/control-plane/test/integration/api_cli_ingress_status_test.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require "securerandom"
+require "test_helper"
+
+class ApiCliIngressStatusTest < ActionDispatch::IntegrationTest
+  test "environment status does not advertise ready HTTPS before direct DNS TLS is ready" do
+    user, environment, node, hostname = build_ready_direct_dns_environment
+    node.update!(ingress_tls_status: Node::INGRESS_TLS_PENDING)
+
+    get "/api/v1/cli/environments/#{environment.id}/status", headers: auth_headers_for(user), as: :json
+
+    assert_response :success
+    assert_equal EnvironmentIngress::STATUS_READY, json_body.dig("ingress", "status")
+    assert_nil json_body.dig("ingress", "public_url")
+    assert_equal [], json_body.dig("ingress", "public_urls")
+    assert_equal [ "https://#{hostname}" ], json_body.dig("ingress", "configured_public_urls")
+    assert_equal "configured_tls_pending", json_body.dig("ingress", "public_url_status")
+    assert_equal Node::INGRESS_TLS_PENDING, json_body.dig("ingress", "tls_status")
+  end
+
+  test "environment status advertises HTTPS after direct DNS TLS is ready" do
+    user, environment, node, hostname = build_ready_direct_dns_environment
+    node.update!(ingress_tls_status: Node::INGRESS_TLS_READY)
+
+    get "/api/v1/cli/environments/#{environment.id}/status", headers: auth_headers_for(user), as: :json
+
+    assert_response :success
+    assert_equal EnvironmentIngress::STATUS_READY, json_body.dig("ingress", "status")
+    assert_equal "https://#{hostname}", json_body.dig("ingress", "public_url")
+    assert_equal [ "https://#{hostname}" ], json_body.dig("ingress", "public_urls")
+    assert_equal Node::INGRESS_TLS_READY, json_body.dig("ingress", "tls_status")
+    assert_nil json_body.dig("ingress", "public_url_status")
+  end
+
+  private
+
+  def build_ready_direct_dns_environment
+    user = User.create!(email: "owner-#{SecureRandom.hex(4)}@example.com", confirmed_at: Time.current)
+    organization = Organization.create!(name: "org-#{SecureRandom.hex(3)}")
+    OrganizationMembership.create!(organization: organization, user: user, role: OrganizationMembership::ROLE_OWNER)
+    ensure_test_organization_runtime!(organization)
+
+    project = organization.projects.create!(name: "ShopApp")
+    environment = project.environments.create!(
+      name: "qa",
+      gcp_project_id: organization.gcp_project_id,
+      gcp_project_number: organization.gcp_project_number,
+      workload_identity_pool: organization.workload_identity_pool,
+      workload_identity_provider: organization.workload_identity_provider,
+      service_account_email: "env@#{organization.gcp_project_id}.iam.gserviceaccount.com",
+      ingress_strategy: Environment::INGRESS_STRATEGY_DIRECT_DNS
+    )
+    release = project.releases.create!(
+      git_sha: "a" * 40,
+      revision: "rel-1",
+      image_repository: "shop-app",
+      image_digest: "sha256:#{"b" * 64}",
+      runtime_json: release_runtime_json
+    )
+    environment.update!(current_release: release)
+
+    node, = issue_test_node!(
+      organization: organization,
+      name: "node-a",
+      public_ip: "198.51.100.10"
+    )
+    node.update!(environment: environment)
+    environment.deployments.create!(
+      release: release,
+      sequence: 1,
+      request_token: SecureRandom.hex(8),
+      status: Deployment::STATUS_PUBLISHED,
+      status_message: "rollout settled",
+      published_at: Time.current,
+      finished_at: Time.current
+    ).deployment_node_statuses.create!(
+      node: node,
+      phase: DeploymentNodeStatus::PHASE_SETTLED,
+      message: "ok",
+      reported_at: Time.current
+    )
+    hostname = random_ingress_hostname
+    environment.create_environment_ingress!(
+      hostname: hostname,
+      status: EnvironmentIngress::STATUS_READY,
+      provisioned_at: Time.current
+    )
+
+    [ user, environment, node, hostname ]
+  end
+
+  def auth_headers_for(user)
+    _record, access_token, _refresh_token = ApiToken.issue!(user: user)
+    { "Authorization" => "Bearer #{access_token}" }
+  end
+
+  def json_body
+    JSON.parse(response.body)
+  end
+end

--- a/control-plane/test/integration/api_cli_mvp_test.rb
+++ b/control-plane/test/integration/api_cli_mvp_test.rb
@@ -515,7 +515,7 @@ class ApiCliMvpTest < ActionDispatch::IntegrationTest
       service_account_email: "env@runtime-proj.iam.gserviceaccount.com",
       current_release: release
     )
-    environment.deployments.create!(
+    deployment = environment.deployments.create!(
       release: release,
       sequence: 1,
       request_token: SecureRandom.hex(8),
@@ -529,8 +529,14 @@ class ApiCliMvpTest < ActionDispatch::IntegrationTest
       status: EnvironmentIngress::STATUS_READY,
       provisioned_at: Time.current
     )
-    node, _access, _refresh = issue_test_node!(organization: organization, name: "node-a")
-    node.update!(environment: environment, desired_state_sequence: 1)
+    node, _access, _refresh = issue_test_node!(organization: organization, name: "node-a", public_ip: "198.51.100.10")
+    node.update!(environment: environment, desired_state_sequence: 1, ingress_tls_status: Node::INGRESS_TLS_READY)
+    deployment.deployment_node_statuses.create!(
+      node: node,
+      phase: DeploymentNodeStatus::PHASE_SETTLED,
+      message: "ok",
+      reported_at: Time.current
+    )
 
     get "/api/v1/cli/environments/#{environment.id}/status", headers: auth_headers_for(user), as: :json
 
@@ -545,6 +551,7 @@ class ApiCliMvpTest < ActionDispatch::IntegrationTest
     assert_nil json_body["warning"]
     assert_equal hostname, json_body.dig("ingress", "hostname")
     assert_equal "https://#{hostname}", json_body.dig("ingress", "public_url")
+    assert_equal Node::INGRESS_TLS_READY, json_body.dig("ingress", "tls_status")
   end
 
   test "environment status warns when customer-managed environment has no assigned nodes" do
@@ -615,10 +622,14 @@ class ApiCliMvpTest < ActionDispatch::IntegrationTest
     assert_equal 1, json_body.fetch("assigned_nodes")
     assert_nil json_body["warning"]
     assert_equal hostname, json_body.dig("ingress", "hostname")
-    assert_equal "https://#{hostname}", json_body.dig("ingress", "public_url")
+    assert_nil json_body.dig("ingress", "public_url")
+    assert_equal [ "https://#{hostname}" ], json_body.dig("ingress", "configured_public_urls")
+    assert_equal "configured_tls_pending", json_body.dig("ingress", "public_url_status")
     assert_equal EnvironmentIngress::STATUS_READY, json_body.dig("ingress", "status")
     assert_equal hostname, json_body.fetch("hostname")
-    assert_equal "https://#{hostname}", json_body.fetch("public_url")
+    assert_nil json_body.fetch("public_url")
+    assert_equal [ "https://#{hostname}" ], json_body.fetch("configured_public_urls")
+    assert_equal "configured_tls_pending", json_body.fetch("public_url_status")
     assert_equal EnvironmentIngress::STATUS_READY, json_body.fetch("ingress_status")
   end
 

--- a/control-plane/test/integration/api_deployment_progress_test.rb
+++ b/control-plane/test/integration/api_deployment_progress_test.rb
@@ -28,7 +28,7 @@ class ApiDeploymentProgressTest < ActionDispatch::IntegrationTest
       image_digest: "sha256:#{'b' * 64}",
       runtime_json: release_runtime_json
     )
-    node, access_token, _refresh = issue_test_node!(organization: organization, name: "node-a")
+    node, access_token, _refresh = issue_test_node!(organization: organization, name: "node-a", public_ip: "198.51.100.10")
     node.update!(environment: environment)
     hostname = random_ingress_hostname
     environment.create_environment_ingress!(
@@ -65,7 +65,7 @@ class ApiDeploymentProgressTest < ActionDispatch::IntegrationTest
           }
         ]
       },
-      headers: { "Authorization" => "Bearer #{access_token}" },
+      headers: agent_headers_for(access_token),
       as: :json
 
     assert_response :accepted
@@ -89,7 +89,9 @@ class ApiDeploymentProgressTest < ActionDispatch::IntegrationTest
     assert_equal "node-a", body.dig("nodes", 0, "name")
     assert_equal "starting", body.dig("nodes", 0, "environments", 0, "services", 0, "state")
     assert_equal hostname, body.dig("ingress", "hostname")
-    assert_equal "https://#{hostname}", body.dig("ingress", "public_url")
+    assert_nil body.dig("ingress", "public_url")
+    assert_equal [ "https://#{hostname}" ], body.dig("ingress", "configured_public_urls")
+    assert_equal "configured_tls_pending", body.dig("ingress", "public_url_status")
     assert_equal EnvironmentIngress::STATUS_READY, body.dig("ingress", "status")
 
     post "/api/v1/agent/status",
@@ -98,6 +100,10 @@ class ApiDeploymentProgressTest < ActionDispatch::IntegrationTest
         revision: release.revision,
         phase: "settled",
         message: "revision healthy",
+        ingress: {
+          tls_status: Node::INGRESS_TLS_READY,
+          tls_not_after: "2026-06-01T12:00:00Z"
+        },
         summary: {
           environments: 1,
           services: 1,
@@ -114,10 +120,11 @@ class ApiDeploymentProgressTest < ActionDispatch::IntegrationTest
           }
         ]
       },
-      headers: { "Authorization" => "Bearer #{access_token}" },
+      headers: agent_headers_for(access_token),
       as: :json
 
     assert_response :accepted
+    assert_equal Node::INGRESS_TLS_READY, node.reload.ingress_tls_status
 
     get "/api/v1/cli/deployments/#{deployment.id}",
       headers: auth_headers_for(user),
@@ -385,6 +392,13 @@ class ApiDeploymentProgressTest < ActionDispatch::IntegrationTest
   def auth_headers_for(user)
     _record, access_token, _refresh_token = ApiToken.issue!(user: user)
     { "Authorization" => "Bearer #{access_token}" }
+  end
+
+  def agent_headers_for(access_token)
+    {
+      "Authorization" => "Bearer #{access_token}",
+      "devopsellence-agent-capabilities" => Node::CAPABILITY_DIRECT_DNS_INGRESS
+    }
   end
 
   def json_body

--- a/control-plane/test/services/deployments/progress_recorder_test.rb
+++ b/control-plane/test/services/deployments/progress_recorder_test.rb
@@ -6,6 +6,49 @@ module Deployments
   class ProgressRecorderTest < ActiveSupport::TestCase
     include ActiveJob::TestHelper
 
+    test "records node ingress TLS status from agent report" do
+      organization = Organization.create!(name: "org-#{SecureRandom.hex(3)}")
+      ensure_test_organization_runtime!(organization)
+      project = organization.projects.create!(name: "Project A")
+      environment = project.environments.create!(
+        name: "Production",
+        gcp_project_id: organization.gcp_project_id,
+        gcp_project_number: organization.gcp_project_number,
+        workload_identity_pool: organization.workload_identity_pool,
+        workload_identity_provider: organization.workload_identity_provider,
+        service_account_email: "env@#{organization.gcp_project_id}.iam.gserviceaccount.com",
+        runtime_kind: Environment::RUNTIME_CUSTOMER_NODES
+      )
+      release = project.releases.create!(
+        git_sha: "abcd1234",
+        image_digest: "sha256:abc",
+        image_repository: "api",
+        runtime_json: release_runtime_json,
+        revision: "rel-1"
+      )
+      environment.update!(current_release: release)
+      node, = issue_test_node!(organization: organization, name: "node-a")
+      node.update!(environment: environment)
+
+      ProgressRecorder.new(
+        node: node,
+        status: {
+          revision: release.revision,
+          phase: DeploymentNodeStatus::PHASE_SETTLED,
+          ingress: {
+            tls_status: Node::INGRESS_TLS_READY,
+            tls_not_after: "2026-06-01T12:00:00Z",
+            tls_error: ""
+          }
+        }
+      ).call
+
+      node.reload
+      assert_equal Node::INGRESS_TLS_READY, node.ingress_tls_status
+      assert_equal Time.zone.parse("2026-06-01T12:00:00Z"), node.ingress_tls_not_after
+      assert_nil node.ingress_tls_last_error
+    end
+
     test "release task success marks deployment succeeded and enqueues publish" do
       organization = Organization.create!(name: "org-#{SecureRandom.hex(3)}")
       ensure_test_organization_runtime!(organization)

--- a/control-plane/test/services/environment_ingresses/eligible_nodes_test.rb
+++ b/control-plane/test/services/environment_ingresses/eligible_nodes_test.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class EnvironmentIngresses::EligibleNodesTest < ActiveSupport::TestCase
+  test "uses one bulk deployment status query for candidate nodes" do
+    organization = Organization.create!(name: "org-#{SecureRandom.hex(3)}")
+    ensure_test_organization_runtime!(organization)
+    project = organization.projects.create!(name: "Project A")
+    environment = project.environments.create!(
+      name: "Production",
+      gcp_project_id: organization.gcp_project_id,
+      gcp_project_number: organization.gcp_project_number,
+      service_account_email: "env@#{organization.gcp_project_id}.iam.gserviceaccount.com",
+      workload_identity_pool: organization.workload_identity_pool,
+      workload_identity_provider: organization.workload_identity_provider,
+      runtime_kind: Environment::RUNTIME_CUSTOMER_NODES,
+      ingress_strategy: Environment::INGRESS_STRATEGY_DIRECT_DNS
+    )
+    release = project.releases.create!(
+      git_sha: "a" * 40,
+      image_digest: "sha256:#{"b" * 64}",
+      image_repository: "api",
+      runtime_json: release_runtime_json,
+      revision: "rel-1"
+    )
+    environment.update!(current_release: release)
+
+    settled_node = create_ingress_node!(organization:, environment:, name: "node-a", public_ip: "198.51.100.10")
+    failed_node = create_ingress_node!(organization:, environment:, name: "node-b", public_ip: "198.51.100.11")
+    create_ingress_node!(organization:, environment:, name: "node-c", public_ip: "198.51.100.12")
+    old_deployment = create_deployment!(environment:, release:, sequence: 1)
+    current_deployment = create_deployment!(environment:, release:, sequence: 2)
+    create_node_status!(deployment: old_deployment, node: settled_node, phase: DeploymentNodeStatus::PHASE_ERROR)
+    create_node_status!(deployment: old_deployment, node: failed_node, phase: DeploymentNodeStatus::PHASE_SETTLED)
+    create_node_status!(deployment: current_deployment, node: settled_node, phase: DeploymentNodeStatus::PHASE_SETTLED)
+    create_node_status!(deployment: current_deployment, node: failed_node, phase: DeploymentNodeStatus::PHASE_ERROR)
+
+    result = nil
+    status_queries = count_deployment_node_status_queries do
+      result = EnvironmentIngresses::EligibleNodes.new(environment: environment.reload).call
+    end
+
+    assert_equal [ settled_node ], result
+    assert_equal 1, status_queries
+  end
+
+  private
+
+  def create_ingress_node!(organization:, environment:, name:, public_ip:)
+    node, = issue_test_node!(organization:, name:, public_ip:)
+    node.update!(environment:)
+    node
+  end
+
+  def create_deployment!(environment:, release:, sequence:)
+    environment.deployments.create!(
+      release:,
+      sequence:,
+      request_token: SecureRandom.hex(8),
+      status: Deployment::STATUS_PUBLISHED,
+      status_message: "rollout settled",
+      published_at: Time.current,
+      finished_at: Time.current
+    )
+  end
+
+  def create_node_status!(deployment:, node:, phase:)
+    deployment.deployment_node_statuses.create!(
+      node:,
+      phase:,
+      message: phase,
+      reported_at: Time.current
+    )
+  end
+
+  def count_deployment_node_status_queries(&block)
+    count = 0
+    subscriber = lambda do |_name, _started, _finished, _id, payload|
+      sql = payload[:sql].to_s
+      count += 1 if payload[:name] != "SCHEMA" && !payload[:cached] && sql.match?(/\bdeployment_node_statuses\b/i)
+    end
+
+    ActiveSupport::Notifications.subscribed(subscriber, "sql.active_record", &block)
+    count
+  end
+end

--- a/control-plane/test/services/environment_ingresses/eligible_nodes_test.rb
+++ b/control-plane/test/services/environment_ingresses/eligible_nodes_test.rb
@@ -37,12 +37,13 @@ class EnvironmentIngresses::EligibleNodesTest < ActiveSupport::TestCase
     create_node_status!(deployment: current_deployment, node: failed_node, phase: DeploymentNodeStatus::PHASE_ERROR)
 
     result = nil
-    status_queries = count_deployment_node_status_queries do
+    metrics = capture_deployment_node_status_work do
       result = EnvironmentIngresses::EligibleNodes.new(environment: environment.reload).call
     end
 
     assert_equal [ settled_node ], result
-    assert_equal 1, status_queries
+    assert_equal 1, metrics.fetch(:queries)
+    assert_equal 2, metrics.fetch(:rows)
   end
 
   private
@@ -74,14 +75,22 @@ class EnvironmentIngresses::EligibleNodesTest < ActiveSupport::TestCase
     )
   end
 
-  def count_deployment_node_status_queries(&block)
-    count = 0
-    subscriber = lambda do |_name, _started, _finished, _id, payload|
+  def capture_deployment_node_status_work(&block)
+    metrics = { queries: 0, rows: 0 }
+    sql_subscriber = lambda do |_name, _started, _finished, _id, payload|
       sql = payload[:sql].to_s
-      count += 1 if payload[:name] != "SCHEMA" && !payload[:cached] && sql.match?(/\bdeployment_node_statuses\b/i)
+      if payload[:name] != "SCHEMA" && !payload[:cached] && sql.match?(/\bdeployment_node_statuses\b/i)
+        metrics[:queries] += 1
+      end
+    end
+    instantiation_subscriber = lambda do |_name, _started, _finished, _id, payload|
+      metrics[:rows] += payload[:record_count] if payload[:class_name] == "DeploymentNodeStatus"
     end
 
-    ActiveSupport::Notifications.subscribed(subscriber, "sql.active_record", &block)
-    count
+    ActiveSupport::Notifications.subscribed(sql_subscriber, "sql.active_record") do
+      ActiveSupport::Notifications.subscribed(instantiation_subscriber, "instantiation.active_record", &block)
+    end
+
+    metrics
   end
 end


### PR DESCRIPTION
## Summary
- add agent ingress TLS readiness reporting from node-local ACME certificate state
- make shared CLI ingress serialization distinguish configured HTTPS from verified HTTPS
- add regression coverage for ready DNS with pending TLS and promotion after TLS is ready

## Root Cause
Shared direct DNS ingress marked the DNS/provisioning side as ready and serialized the canonical hostname as `https://...` immediately. The agent did not report node-local TLS readiness through normal status reports, so the control plane could not avoid advertising HTTPS before Envoy had a certificate and 443 published.

## Validation
- `mise run test:cp`
- `mise run test:agent`
- `mise run test:cli`
