### PR TITLE
[codex] document supporting services

### DIFF
--- a/agent/internal/desiredstate/names.go
+++ b/agent/internal/desiredstate/names.go
@@ -54,6 +54,14 @@ func ServiceContainerName(environmentName, serviceName, revision, hash string) (
 	return name, nil
 }
 
+func ServiceNetworkAlias(serviceName string) (string, error) {
+	alias := sanitize(serviceName)
+	if alias == "" {
+		return "", fmt.Errorf("service name sanitizes to empty")
+	}
+	return alias, nil
+}
+
 func EnvironmentNetworkPrefix(baseNetworkName string) string {
 	base := sanitize(baseNetworkName)
 	if base == "" {

--- a/agent/internal/desiredstate/names_test.go
+++ b/agent/internal/desiredstate/names_test.go
@@ -33,3 +33,19 @@ func TestEnvironmentNetworkNameSanitizeEmpty(t *testing.T) {
 		t.Fatal("expected error")
 	}
 }
+
+func TestServiceNetworkAliasSanitizesServiceName(t *testing.T) {
+	alias, err := ServiceNetworkAlias("Mail Queue")
+	if err != nil {
+		t.Fatalf("alias error: %v", err)
+	}
+	if alias != "mail-queue" {
+		t.Fatalf("unexpected alias: %s", alias)
+	}
+}
+
+func TestServiceNetworkAliasSanitizeEmpty(t *testing.T) {
+	if _, err := ServiceNetworkAlias("!!!"); err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/agent/internal/engine/docker/docker.go
+++ b/agent/internal/engine/docker/docker.go
@@ -145,7 +145,7 @@ func buildContainerCreateConfig(spec engine.ContainerSpec) (*container.Config, *
 	if spec.Network != "" {
 		networkingConfig = &network.NetworkingConfig{
 			EndpointsConfig: map[string]*network.EndpointSettings{
-				spec.Network: {},
+				spec.Network: {Aliases: spec.Aliases},
 			},
 		}
 	}

--- a/agent/internal/engine/docker/docker_test.go
+++ b/agent/internal/engine/docker/docker_test.go
@@ -9,9 +9,10 @@ import (
 
 func TestBuildContainerCreateConfigSetsNetworkModeForManagedNetwork(t *testing.T) {
 	spec := engine.ContainerSpec{
-		Name:    "devopsellence-envoy",
-		Image:   "envoyproxy/envoy:latest",
+		Name:    "web",
+		Image:   "example/web:rev1",
 		Network: "devopsellence",
+		Aliases: []string{"web"},
 		Ports: []engine.PortBinding{{
 			ContainerPort: 8443,
 			HostPort:      8443,
@@ -31,6 +32,9 @@ func TestBuildContainerCreateConfigSetsNetworkModeForManagedNetwork(t *testing.T
 	}
 	if _, ok := networkingConfig.EndpointsConfig["devopsellence"]; !ok {
 		t.Fatalf("expected endpoint config for managed network")
+	}
+	if got := networkingConfig.EndpointsConfig["devopsellence"].Aliases; len(got) != 1 || got[0] != "web" {
+		t.Fatalf("network aliases = %#v, want web", got)
 	}
 }
 

--- a/agent/internal/engine/engine.go
+++ b/agent/internal/engine/engine.go
@@ -54,6 +54,7 @@ type ContainerSpec struct {
 	Restart    *RestartPolicy
 	Log        *LogConfig
 	Network    string
+	Aliases    []string
 	Binds      []string
 	Ports      []PortBinding
 	ExtraHosts []string // e.g. ["host.docker.internal:host-gateway"]

--- a/agent/internal/reconcile/reconcile.go
+++ b/agent/internal/reconcile/reconcile.go
@@ -727,11 +727,14 @@ func (r *Reconciler) specForService(runtime desiredstate.RuntimeService) (string
 		return "", "", engine.ContainerSpec{}, fmt.Errorf("hash service %s/%s: %w", runtime.EnvironmentName, runtime.ServiceName, err)
 	}
 
-	alias, err := desiredstate.ServiceNetworkAlias(runtime.ServiceName)
-	if err != nil {
-		return "", "", engine.ContainerSpec{}, err
+	aliases := []string(nil)
+	if strings.TrimSpace(network) != "" {
+		alias, err := desiredstate.ServiceNetworkAlias(runtime.ServiceName)
+		if err != nil {
+			return "", "", engine.ContainerSpec{}, err
+		}
+		aliases = []string{alias}
 	}
-	aliases := []string{alias}
 	hash = runtimeContainerHash(hash, r.opts.LogConfig, network, aliases)
 	name, err := desiredstate.ServiceContainerName(runtime.EnvironmentName, runtime.ServiceName, runtime.EnvironmentRevision, hash)
 	if err != nil {

--- a/agent/internal/reconcile/reconcile.go
+++ b/agent/internal/reconcile/reconcile.go
@@ -712,6 +712,10 @@ func (r *Reconciler) specForService(runtime desiredstate.RuntimeService) (string
 	if err != nil {
 		return "", "", engine.ContainerSpec{}, err
 	}
+	alias, err := desiredstate.ServiceNetworkAlias(runtime.ServiceName)
+	if err != nil {
+		return "", "", engine.ContainerSpec{}, err
+	}
 
 	env := make(map[string]string, len(service.Env))
 	for k, v := range service.Env {
@@ -737,7 +741,7 @@ func (r *Reconciler) specForService(runtime desiredstate.RuntimeService) (string
 		Labels:     labels,
 		Log:        engine.CloneLogConfig(r.opts.LogConfig),
 		Network:    network,
-		Aliases:    []string{runtime.ServiceName},
+		Aliases:    []string{alias},
 	}
 
 	return name, hash, spec, nil

--- a/agent/internal/reconcile/reconcile.go
+++ b/agent/internal/reconcile/reconcile.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -501,13 +502,32 @@ func (r *Reconciler) environmentNetwork(environmentName string) (string, error) 
 	return desiredstate.EnvironmentNetworkName(r.opts.Network, environmentName)
 }
 
-func runtimeContainerHash(baseHash string, logConfig *engine.LogConfig, network string) string {
+func runtimeContainerHash(baseHash string, logConfig *engine.LogConfig, network string, aliases []string) string {
 	logHash := engine.LogConfigHash(logConfig)
-	if logHash == "" && network == "" {
+	aliasHash := runtimeAliasHash(aliases)
+	if logHash == "" && network == "" && aliasHash == "" {
 		return baseHash
 	}
-	sum := sha256.Sum256([]byte(baseHash + "\x00" + logHash + "\x00" + strings.TrimSpace(network)))
+	hashInput := baseHash + "\x00" + logHash + "\x00" + strings.TrimSpace(network)
+	if aliasHash != "" {
+		hashInput += "\x00" + aliasHash
+	}
+	sum := sha256.Sum256([]byte(hashInput))
 	return hex.EncodeToString(sum[:])
+}
+
+func runtimeAliasHash(aliases []string) string {
+	normalized := make([]string, 0, len(aliases))
+	for _, alias := range aliases {
+		if alias = strings.TrimSpace(alias); alias != "" {
+			normalized = append(normalized, alias)
+		}
+	}
+	if len(normalized) == 0 {
+		return ""
+	}
+	sort.Strings(normalized)
+	return strings.Join(normalized, "\x00")
 }
 
 func isPersistentEnvoyContainer(c engine.ContainerState, protectedNames []string) bool {
@@ -707,12 +727,13 @@ func (r *Reconciler) specForService(runtime desiredstate.RuntimeService) (string
 		return "", "", engine.ContainerSpec{}, fmt.Errorf("hash service %s/%s: %w", runtime.EnvironmentName, runtime.ServiceName, err)
 	}
 
-	hash = runtimeContainerHash(hash, r.opts.LogConfig, network)
-	name, err := desiredstate.ServiceContainerName(runtime.EnvironmentName, runtime.ServiceName, runtime.EnvironmentRevision, hash)
+	alias, err := desiredstate.ServiceNetworkAlias(runtime.ServiceName)
 	if err != nil {
 		return "", "", engine.ContainerSpec{}, err
 	}
-	alias, err := desiredstate.ServiceNetworkAlias(runtime.ServiceName)
+	aliases := []string{alias}
+	hash = runtimeContainerHash(hash, r.opts.LogConfig, network, aliases)
+	name, err := desiredstate.ServiceContainerName(runtime.EnvironmentName, runtime.ServiceName, runtime.EnvironmentRevision, hash)
 	if err != nil {
 		return "", "", engine.ContainerSpec{}, err
 	}
@@ -741,7 +762,7 @@ func (r *Reconciler) specForService(runtime desiredstate.RuntimeService) (string
 		Labels:     labels,
 		Log:        engine.CloneLogConfig(r.opts.LogConfig),
 		Network:    network,
-		Aliases:    []string{alias},
+		Aliases:    aliases,
 	}
 
 	return name, hash, spec, nil

--- a/agent/internal/reconcile/reconcile.go
+++ b/agent/internal/reconcile/reconcile.go
@@ -737,6 +737,7 @@ func (r *Reconciler) specForService(runtime desiredstate.RuntimeService) (string
 		Labels:     labels,
 		Log:        engine.CloneLogConfig(r.opts.LogConfig),
 		Network:    network,
+		Aliases:    []string{runtime.ServiceName},
 	}
 
 	return name, hash, spec, nil

--- a/agent/internal/reconcile/reconcile_test.go
+++ b/agent/internal/reconcile/reconcile_test.go
@@ -577,7 +577,7 @@ func TestReconcileRestart(t *testing.T) {
 	if err != nil {
 		t.Fatalf("hash: %v", err)
 	}
-	hash = runtimeContainerHash(hash, nil, "devopsellence-env-production")
+	hash = runtimeContainerHash(hash, nil, "devopsellence-env-production", []string{"worker"})
 	name, err := desiredstate.ServiceContainerName("production", "worker", "rev-1", hash)
 	if err != nil {
 		t.Fatalf("name: %v", err)
@@ -753,7 +753,7 @@ func TestReconcileContinuesHealthyCohostedServiceWhenPeerServiceFails(t *testing
 	if err != nil {
 		t.Fatalf("healthy network: %v", err)
 	}
-	healthyHash = runtimeContainerHash(healthyHash, nil, healthyNetwork)
+	healthyHash = runtimeContainerHash(healthyHash, nil, healthyNetwork, []string{"web"})
 	healthyName, err := desiredstate.ServiceContainerName("app-b-production", "web", "rev-b", healthyHash)
 	if err != nil {
 		t.Fatalf("healthy container name: %v", err)
@@ -952,6 +952,43 @@ func TestReconcileRecreatesRuntimeContainerWhenNetworkChanges(t *testing.T) {
 	}
 	if len(eng.created) != 1 || eng.created[0].Name == oldName || eng.created[0].Network != "devopsellence-env-production" {
 		t.Fatalf("expected replacement container on environment network, created=%#v", eng.created)
+	}
+}
+
+func TestReconcileRecreatesRuntimeContainerWhenAliasIsMissingFromHash(t *testing.T) {
+	eng := newFakeEngine()
+	eng.images["busybox"] = true
+	service := workerService("worker", nil)
+	oldHash, err := desiredstate.HashService(service)
+	if err != nil {
+		t.Fatalf("hash service: %v", err)
+	}
+	oldHash = runtimeContainerHash(oldHash, nil, "devopsellence-env-production", nil)
+	oldName, err := desiredstate.ServiceContainerName("production", "worker", "rev-1", oldHash)
+	if err != nil {
+		t.Fatalf("container name: %v", err)
+	}
+	eng.containers[oldName] = engine.ContainerState{
+		Name:        oldName,
+		Image:       "busybox",
+		Running:     true,
+		Managed:     true,
+		Hash:        oldHash,
+		Environment: "production",
+		Service:     "worker",
+		ServiceKind: "worker",
+	}
+
+	rec := New(eng, Options{Network: "devopsellence"})
+	result, err := rec.Reconcile(context.Background(), desiredState(service))
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if result.Updated != 1 || result.Removed != 1 {
+		t.Fatalf("result = %#v, want updated=1 removed=1", result)
+	}
+	if len(eng.created) != 1 || eng.created[0].Name == oldName || len(eng.created[0].Aliases) != 1 || eng.created[0].Aliases[0] != "worker" {
+		t.Fatalf("expected replacement container with worker alias, created=%#v", eng.created)
 	}
 }
 

--- a/agent/internal/reconcile/reconcile_test.go
+++ b/agent/internal/reconcile/reconcile_test.go
@@ -916,6 +916,31 @@ func TestReconcileAppliesLogConfigToRuntimeContainers(t *testing.T) {
 	}
 }
 
+func TestReconcileOmitsAliasesWithoutRuntimeNetwork(t *testing.T) {
+	eng := newFakeEngine()
+	eng.images["busybox"] = true
+	service := workerService("worker", nil)
+	baseHash, err := desiredstate.HashService(service)
+	if err != nil {
+		t.Fatalf("hash service: %v", err)
+	}
+
+	rec := New(eng, Options{})
+	result, err := rec.Reconcile(context.Background(), desiredState(service))
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if result.Created != 1 || len(eng.created) != 1 {
+		t.Fatalf("result=%#v created=%#v, want one created container", result, eng.created)
+	}
+	if eng.created[0].Network != "" || len(eng.created[0].Aliases) != 0 {
+		t.Fatalf("network=%q aliases=%#v, want no network aliases without runtime network", eng.created[0].Network, eng.created[0].Aliases)
+	}
+	if eng.created[0].Labels[engine.LabelHash] != baseHash {
+		t.Fatalf("hash = %q, want base hash %q", eng.created[0].Labels[engine.LabelHash], baseHash)
+	}
+}
+
 func TestReconcileRecreatesRuntimeContainerWhenNetworkChanges(t *testing.T) {
 	eng := newFakeEngine()
 	eng.images["busybox"] = true

--- a/agent/internal/reconcile/reconcile_test.go
+++ b/agent/internal/reconcile/reconcile_test.go
@@ -275,6 +275,9 @@ func TestReconcileCreatesMultipleWorkersInOneEnvironment(t *testing.T) {
 		if spec.Labels[engine.LabelService] == "" {
 			t.Fatalf("missing service label: %#v", spec.Labels)
 		}
+		if len(spec.Aliases) != 1 || spec.Aliases[0] != spec.Labels[engine.LabelService] {
+			t.Fatalf("unexpected service alias: aliases=%#v labels=%#v", spec.Aliases, spec.Labels)
+		}
 	}
 }
 

--- a/agent/internal/reconcile/reconcile_test.go
+++ b/agent/internal/reconcile/reconcile_test.go
@@ -257,7 +257,7 @@ func TestReconcileCreatesMultipleWorkersInOneEnvironment(t *testing.T) {
 
 	result, err := rec.Reconcile(context.Background(), desiredState(
 		workerService("default", map[string]string{"QUEUE": "default"}),
-		workerService("mailers", map[string]string{"QUEUE": "mailers"}),
+		workerService("Mail Queue", map[string]string{"QUEUE": "mailers"}),
 	))
 	if err != nil {
 		t.Fatalf("reconcile: %v", err)
@@ -275,9 +275,16 @@ func TestReconcileCreatesMultipleWorkersInOneEnvironment(t *testing.T) {
 		if spec.Labels[engine.LabelService] == "" {
 			t.Fatalf("missing service label: %#v", spec.Labels)
 		}
-		if len(spec.Aliases) != 1 || spec.Aliases[0] != spec.Labels[engine.LabelService] {
+		if len(spec.Aliases) != 1 {
 			t.Fatalf("unexpected service alias: aliases=%#v labels=%#v", spec.Aliases, spec.Labels)
 		}
+	}
+	aliases := map[string]bool{}
+	for _, spec := range eng.created {
+		aliases[spec.Aliases[0]] = true
+	}
+	if !aliases["default"] || !aliases["mail-queue"] {
+		t.Fatalf("unexpected service aliases: %#v", aliases)
 	}
 }
 

--- a/docs-website/astro.config.mjs
+++ b/docs-website/astro.config.mjs
@@ -45,6 +45,7 @@ export default defineConfig({
             { label: "CloudStack VMs", link: "/guides/cloudstack-vms/" },
             { label: "GitHub Actions", link: "/guides/github-actions/" },
             { label: "Secrets", link: "/guides/secrets/" },
+            { label: "Supporting services", link: "/guides/supporting-services/" },
             { label: "Ingress and TLS", link: "/guides/ingress-tls/" },
             { label: "Rollback", link: "/guides/rollback/" },
             { label: "Backup and restore", link: "/guides/backup-restore/" },

--- a/docs-website/src/content/docs/guides/solo-deploy.md
+++ b/docs-website/src/content/docs/guides/solo-deploy.md
@@ -34,6 +34,9 @@ For app data, use an ordinary backup service with restic and the existing
 `secret`, `deploy`, `logs`, and `exec` commands. See
 [Backup and restore](/guides/backup-restore/).
 
+For Redis, Memcached, and other companion containers, add another service with
+a custom `image`. See [Supporting services](/guides/supporting-services/).
+
 To create a Hetzner-backed solo node:
 
 ```bash

--- a/docs-website/src/content/docs/guides/supporting-services.md
+++ b/docs-website/src/content/docs/guides/supporting-services.md
@@ -68,10 +68,12 @@ Memcached is usually disposable, so this example does not mount a volume.
 
 ## Scheduling
 
-Non-HTTP services are scheduled as worker services. Solo nodes created with the
-default labels only run `web` services, so add `worker` to any node that should
-host Redis, Memcached, background workers, backup services, or other private
-runtime units:
+Services with a port named `http`, a healthcheck, or the exact service name
+`web` are scheduled as `web`. Other services are scheduled as `worker`.
+
+Solo nodes created with the default labels only run `web` services, so add
+`worker` to any node that should host Redis, Memcached, background workers,
+backup services, or other private runtime units:
 
 ```bash
 devopsellence node label set prod-1 --labels web,worker

--- a/docs-website/src/content/docs/guides/supporting-services.md
+++ b/docs-website/src/content/docs/guides/supporting-services.md
@@ -1,0 +1,108 @@
+---
+title: Supporting services
+description: Run Redis, Memcached, and other companion containers beside an app.
+---
+
+Use another `services` entry when a dependency should run on the same VM as
+your app. Set `image` for services that come from an upstream or separately
+built container image. If `image` is omitted, the service uses the app image
+built from `build.context` and `build.dockerfile`.
+
+Supporting services are still ordinary workload services. They are reconciled
+by the node agent, show up in status, and work with `logs`, `exec`, secrets,
+and volumes. They do not get public ingress unless an ingress rule targets
+them.
+
+## Redis
+
+```yaml
+services:
+  web:
+    env:
+      REDIS_URL: redis://redis:6379/0
+    ports:
+      - name: http
+        port: 3000
+    healthcheck:
+      path: /up
+      port: 3000
+
+  redis:
+    image: redis:7-alpine
+    args:
+      - redis-server
+      - --appendonly
+      - "yes"
+    volumes:
+      - source: redis_data
+        target: /data
+```
+
+`redis` has no `ports`, `healthcheck`, or ingress rule because it is private to
+the app environment. Services in the same environment can reach it by service
+name on the environment Docker network.
+
+## Memcached
+
+```yaml
+services:
+  web:
+    env:
+      MEMCACHE_SERVERS: memcached:11211
+    ports:
+      - name: http
+        port: 3000
+    healthcheck:
+      path: /up
+      port: 3000
+
+  memcached:
+    image: memcached:1.6-alpine
+    args:
+      - memcached
+      - -m
+      - "128"
+```
+
+Memcached is usually disposable, so this example does not mount a volume.
+
+## Scheduling
+
+Non-HTTP services are scheduled as worker services. Solo nodes created with the
+default labels only run `web` services, so add `worker` to any node that should
+host Redis, Memcached, background workers, backup services, or other private
+runtime units:
+
+```bash
+devopsellence node label set prod-1 --labels web,worker
+devopsellence deploy
+```
+
+In shared mode, use the same config shape. The control plane and node agent use
+the same desired-state model; only image publication and secret storage differ.
+
+## Operational notes
+
+Use named volumes for state you expect to keep across deploys. For Redis, that
+means mounting `/data` when persistence is enabled. For services that are only
+caches, prefer disposable configuration and keep the durable system of record
+outside the cache.
+
+Use service-scoped secrets when the supporting service needs credentials:
+
+```yaml
+services:
+  web:
+    env:
+      SEARCH_URL: http://search:9200
+
+  search:
+    image: registry.example.com/search:<version>
+    secret_refs:
+      - name: SEARCH_PASSWORD
+        secret: SEARCH_PASSWORD
+```
+
+```bash
+devopsellence secret set SEARCH_PASSWORD --service search --stdin
+```

--- a/docs-website/src/content/docs/reference/devopsellence-yml.md
+++ b/docs-website/src/content/docs/reference/devopsellence-yml.md
@@ -68,3 +68,30 @@ environments:
 
 Services are explicit. Do not rely on fixed concepts such as one `web` and one
 `worker`; name the runtime units your app actually needs.
+
+Services can use the app image or a custom image. Leave `image` empty when the
+service should run the image built from this workspace. Set `image` for
+supporting services such as Redis, Memcached, backup agents, or separately
+built workers:
+
+```yaml
+services:
+  web:
+    env:
+      REDIS_URL: redis://redis:6379/0
+    ports:
+      - name: http
+        port: 3000
+    healthcheck:
+      path: /up
+      port: 3000
+
+  redis:
+    image: redis:7-alpine
+    volumes:
+      - source: redis_data
+        target: /data
+```
+
+See [Supporting services](/guides/supporting-services/) for Redis, Memcached,
+and node-label details.


### PR DESCRIPTION
## Summary

- Add stable Docker network aliases for reconciled workload services so service-name URLs like `redis://redis:6379/0` work inside an environment network.
- Add a Supporting services docs guide with Redis and Memcached examples, node-label guidance, and operational notes.
- Link the guide from the sidebar, solo deploy guide, and `devopsellence.yml` reference.

## Validation

- `mise run test:agent`
- `npm run check` in `docs-website/`
- `npm run build` in `docs-website/`
- `git diff --check`