### PR TITLE
[codex] add Rails app template vibe flow

### DIFF
--- a/cli/internal/agentskill/agentskill.go
+++ b/cli/internal/agentskill/agentskill.go
@@ -10,6 +10,7 @@ import (
 )
 
 const Name = "devopsellence"
+const RailsAppID = "rails-app"
 const RailsAppName = "devopsellence-rails-app"
 
 type Skill struct {
@@ -25,7 +26,7 @@ var skills = []Skill{
 		Description: "Operate devopsellence deployments, nodes, secrets, logs, diagnostics, and rollback.",
 	},
 	{
-		ID:          "rails-app",
+		ID:          RailsAppID,
 		Name:        RailsAppName,
 		Description: "Build, test, run, deploy, and scale the blessed devopsellence Rails app baseline.",
 	},

--- a/cli/internal/agentskill/agentskill.go
+++ b/cli/internal/agentskill/agentskill.go
@@ -6,14 +6,36 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 )
 
 const Name = "devopsellence"
+const RailsAppName = "devopsellence-rails-app"
 
-//go:embed all:devopsellence
+type Skill struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+var skills = []Skill{
+	{
+		ID:          "devopsellence",
+		Name:        Name,
+		Description: "Operate devopsellence deployments, nodes, secrets, logs, diagnostics, and rollback.",
+	},
+	{
+		ID:          "rails-app",
+		Name:        RailsAppName,
+		Description: "Build, test, run, deploy, and scale the blessed devopsellence Rails app baseline.",
+	},
+}
+
+//go:embed all:devopsellence all:devopsellence-rails-app
 var bundled embed.FS
 
 type InstallResult struct {
+	ID      string
 	Name    string
 	Path    string
 	Paths   []InstalledPath
@@ -31,6 +53,7 @@ type InstallOptions struct {
 	SkillsDir     string
 	WorkspaceRoot string
 	Global        bool
+	Skill         string
 }
 
 type installTarget struct {
@@ -51,7 +74,31 @@ func ProjectSkillsDir(workspaceRoot string) string {
 	return filepath.Join(workspaceRoot, ".agents", "skills")
 }
 
+func Available() []Skill {
+	result := append([]Skill(nil), skills...)
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].ID < result[j].ID
+	})
+	return result
+}
+
+func Resolve(idOrName string) (Skill, error) {
+	if idOrName == "" {
+		idOrName = Name
+	}
+	for _, skill := range skills {
+		if idOrName == skill.ID || idOrName == skill.Name {
+			return skill, nil
+		}
+	}
+	return Skill{}, fmt.Errorf("unknown skill %q", idOrName)
+}
+
 func Install(opts InstallOptions, version string) (InstallResult, error) {
+	skill, err := Resolve(opts.Skill)
+	if err != nil {
+		return InstallResult{}, err
+	}
 	targets, err := installTargets(opts)
 	if err != nil {
 		return InstallResult{}, err
@@ -59,8 +106,8 @@ func Install(opts InstallOptions, version string) (InstallResult, error) {
 
 	installed := make([]InstalledPath, 0, len(targets))
 	for _, target := range targets {
-		dest := filepath.Join(target.SkillsDir, Name)
-		if err := installTo(dest); err != nil {
+		dest := filepath.Join(target.SkillsDir, skill.Name)
+		if err := installTo(dest, skill.Name); err != nil {
 			return InstallResult{}, err
 		}
 		installed = append(installed, InstalledPath{
@@ -69,7 +116,7 @@ func Install(opts InstallOptions, version string) (InstallResult, error) {
 			Path:  dest,
 		})
 	}
-	return InstallResult{Name: Name, Path: installed[0].Path, Paths: installed, Version: version, Source: "embedded"}, nil
+	return InstallResult{ID: skill.ID, Name: skill.Name, Path: installed[0].Path, Paths: installed, Version: version, Source: "embedded"}, nil
 }
 
 func installTargets(opts InstallOptions) ([]installTarget, error) {
@@ -117,18 +164,18 @@ func installTargets(opts InstallOptions) ([]installTarget, error) {
 	return targets, nil
 }
 
-func installTo(dest string) error {
+func installTo(dest, skillName string) error {
 	if err := os.RemoveAll(dest); err != nil {
 		return fmt.Errorf("remove existing skill: %w", err)
 	}
 	if err := os.MkdirAll(dest, 0o755); err != nil {
 		return fmt.Errorf("create skill dir: %w", err)
 	}
-	if err := fs.WalkDir(bundled, Name, func(path string, entry fs.DirEntry, walkErr error) error {
+	if err := fs.WalkDir(bundled, skillName, func(path string, entry fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
 		}
-		rel, err := filepath.Rel(Name, path)
+		rel, err := filepath.Rel(skillName, path)
 		if err != nil {
 			return err
 		}

--- a/cli/internal/agentskill/agentskill_test.go
+++ b/cli/internal/agentskill/agentskill_test.go
@@ -26,6 +26,38 @@ func TestInstallWritesBundledSkill(t *testing.T) {
 	}
 }
 
+func TestInstallWritesRailsAppSkillByID(t *testing.T) {
+	dir := t.TempDir()
+	result, err := Install(InstallOptions{SkillsDir: dir, Skill: "rails-app"}, "v1-test")
+	if err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+	if result.ID != "rails-app" || result.Name != "devopsellence-rails-app" || result.Source != "embedded" {
+		t.Fatalf("result = %#v, want rails app skill", result)
+	}
+	path := filepath.Join(dir, "devopsellence-rails-app", "SKILL.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", path, err)
+	}
+	if !strings.Contains(string(data), "Rails") {
+		t.Fatalf("%s does not look like the Rails skill", path)
+	}
+}
+
+func TestAvailableIncludesRailsAppSkill(t *testing.T) {
+	got := Available()
+	var ids []string
+	for _, skill := range got {
+		ids = append(ids, skill.ID)
+	}
+	for _, want := range []string{"devopsellence", "rails-app"} {
+		if !containsString(ids, want) {
+			t.Fatalf("Available() ids = %v, missing %q", ids, want)
+		}
+	}
+}
+
 func TestInstallDefaultsToProjectAgentSkillDirs(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	if err := os.Mkdir(filepath.Join(workspaceRoot, ".claude"), 0o755); err != nil {
@@ -96,15 +128,28 @@ func TestInstallRequiresTarget(t *testing.T) {
 }
 
 func TestBundledSkillMatchesPublicSkill(t *testing.T) {
-	bundled, err := os.ReadFile(filepath.Join("devopsellence", "SKILL.md"))
-	if err != nil {
-		t.Fatal(err)
+	for _, skill := range Available() {
+		t.Run(skill.Name, func(t *testing.T) {
+			bundled, err := os.ReadFile(filepath.Join(skill.Name, "SKILL.md"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			public, err := os.ReadFile(filepath.Join("..", "..", "..", "skills", skill.Name, "SKILL.md"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(bundled) != string(public) {
+				t.Fatalf("bundled %s skill differs from skills/%s/SKILL.md", skill.Name, skill.Name)
+			}
+		})
 	}
-	public, err := os.ReadFile(filepath.Join("..", "..", "..", "skills", "devopsellence", "SKILL.md"))
-	if err != nil {
-		t.Fatal(err)
+}
+
+func containsString(items []string, needle string) bool {
+	for _, item := range items {
+		if item == needle {
+			return true
+		}
 	}
-	if string(bundled) != string(public) {
-		t.Fatal("bundled devopsellence skill differs from skills/devopsellence/SKILL.md")
-	}
+	return false
 }

--- a/cli/internal/agentskill/devopsellence-rails-app/SKILL.md
+++ b/cli/internal/agentskill/devopsellence-rails-app/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: devopsellence-rails-app
+description: Use when building, modifying, testing, deploying, or scaling the blessed devopsellence Rails application baseline. Covers Rails 8.1, PostgreSQL, Hotwire, Tailwind, Solid Queue/Cache/Cable, Active Storage, Sentry, OpenTelemetry, security checks, Docker, mise, and devopsellence solo on Linux servers.
+---
+
+# devopsellence Rails App
+
+Use this skill inside apps generated from the devopsellence Rails template.
+
+## Defaults
+
+- Rails 8.1, Ruby 3.4+, PostgreSQL, Puma, Thruster, Hotwire, Turbo, Stimulus, ERB, importmap, Propshaft, and Tailwind.
+- Solid Queue, Solid Cache, and Solid Cable before Redis or Sidekiq.
+- Active Storage with S3-compatible object storage for durable uploads.
+- Built-in Rails authentication with `bcrypt`; use Pundit for authorization.
+- ViewComponent, Pagy, lucide icons, Sentry, OpenTelemetry, Brakeman, bundler-audit, and rubocop-rails-omakase.
+- Minitest, fixtures, Capybara system tests, and focused integration tests.
+- `mise` owns language/tool versions. Do not replace it with ad hoc local setup docs.
+
+## Do Not Add By Default
+
+- Devise, Sidekiq, Redis, React, Next.js, Vite, GraphQL, Elasticsearch, Meilisearch, Kubernetes, or an admin framework.
+- Extra gems before the app has a real product need.
+- A second deployment system. Use devopsellence for deploy, secrets, logs, status, rollback, and node operations.
+
+## Build Loop
+
+1. Inspect the app and the user's request.
+2. Keep changes idiomatic Rails and close to the behavior.
+3. Add or update focused tests.
+4. Run the narrowest useful command first, then broader checks before handoff:
+   - `mise install`
+   - `bin/rails db:prepare`
+   - `bin/rails test`
+   - `bin/rails test:system` when UI behavior changed
+   - `bin/brakeman`
+   - `bundle exec bundler-audit check --update`
+5. Keep production concerns wired while building features: health checks, background jobs, uploads, secrets, logs, and deploy config.
+
+## Production Shape
+
+- Start with one Rails web process, PostgreSQL, Solid tables, object storage, Sentry, OpenTelemetry, JSON logs, and devopsellence deploy.
+- Scale to medium-company shape by adding web nodes, splitting workers, moving PostgreSQL to managed or dedicated infrastructure, and separating Solid Queue/Cache/Cable databases or pools when pressure appears.
+- Keep ordinary-tool escape hatches visible: SSH, Docker, logs, files, SQL, JSON, and cloud CLIs.
+
+## devopsellence Loop
+
+1. Configure `devopsellence.yml` with explicit services, ports, health checks, and worker processes.
+2. Store production secrets with `devopsellence secret set --stdin`; never commit secret values.
+3. Run `devopsellence deploy --dry-run` before production mutations.
+4. After deploy, collect `devopsellence status`, app logs, node logs, and HTTPS evidence when ingress is configured.

--- a/cli/internal/workflow/root.go
+++ b/cli/internal/workflow/root.go
@@ -516,17 +516,34 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 
 	var skillInstallDir string
 	var skillInstallGlobal bool
-	skillCommand := &cobra.Command{Use: "skill", Short: "Manage bundled AI agent skill"}
-	skillInstallCommand := &cobra.Command{
-		Use:   "install",
-		Short: "Install the bundled devopsellence agent skill",
+	skillCommand := &cobra.Command{Use: "skill", Short: "Manage bundled AI agent skills"}
+	skillListCommand := &cobra.Command{
+		Use:   "list",
+		Short: "List bundled AI agent skills",
 		RunE: func(_ *cobra.Command, _ []string) error {
+			return app.Printer.PrintJSON(map[string]any{
+				"schema_version": outputSchemaVersion,
+				"skills":         agentskill.Available(),
+				"source":         "embedded",
+			})
+		},
+	}
+	skillInstallCommand := &cobra.Command{
+		Use:   "install [skill]",
+		Short: "Install a bundled devopsellence agent skill",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
 			if skillInstallDir != "" && skillInstallGlobal {
 				return ExitError{Code: 2, Err: errors.New("cannot use --dir with --global")}
+			}
+			skillID := agentskill.Name
+			if len(args) > 0 {
+				skillID = args[0]
 			}
 			installOpts := agentskill.InstallOptions{
 				SkillsDir: skillInstallDir,
 				Global:    skillInstallGlobal,
+				Skill:     skillID,
 			}
 			if skillInstallDir == "" && !skillInstallGlobal {
 				discovered, discoverErr := discovery.Discover(app.Cwd)
@@ -556,6 +573,7 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 			return app.Printer.PrintJSON(map[string]any{
 				"schema_version": outputSchemaVersion,
 				"action":         "installed",
+				"id":             result.ID,
 				"skill":          result.Name,
 				"path":           result.Path,
 				"paths":          paths,
@@ -566,8 +584,31 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 	}
 	skillInstallCommand.Flags().StringVar(&skillInstallDir, "dir", "", "Parent skills directory (default <project>/.agents/skills)")
 	skillInstallCommand.Flags().BoolVar(&skillInstallGlobal, "global", false, "Install to user-level agent skill directories")
-	skillCommand.AddCommand(skillInstallCommand)
+	skillCommand.AddCommand(skillListCommand, skillInstallCommand)
 	root.AddCommand(skillCommand)
+
+	var vibeOpts VibeOptions
+	var vibeNoLaunch bool
+	vibeOpts.Launch = true
+	vibeCommand := &cobra.Command{
+		Use:   "vibe [directory]",
+		Short: "Generate a blessed Rails app and start an AI-agent build loop",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				vibeOpts.Directory = args[0]
+			}
+			vibeOpts.Launch = !vibeNoLaunch
+			return app.Vibe(cmd.Context(), vibeOpts)
+		},
+	}
+	vibeCommand.Flags().StringVar(&vibeOpts.AIAgent, "ai-agent", "", "AI agent to seed: codex, claude, pi, or generic")
+	vibeCommand.Flags().StringVar(&vibeOpts.Idea, "idea", "", "App idea to seed into the AI agent prompt")
+	vibeCommand.Flags().StringVar(&vibeOpts.TemplateVersion, "template-version", defaultVibeTemplateVersion, "devopsellence Rails template version")
+	vibeCommand.Flags().BoolVar(&vibeNoLaunch, "no-launch", false, "Prepare the Rails app without starting the AI agent")
+	vibeCommand.Flags().BoolVar(&vibeOpts.NoAgent, "no-agent", false, "Prepare the Rails app and prompt without selecting or starting an AI agent")
+	vibeCommand.Flags().BoolVar(&vibeOpts.Force, "force", false, "Allow initializing a non-empty directory")
+	root.AddCommand(vibeCommand)
 
 	var initSharedOpts InitOptions
 	var initMode string

--- a/cli/internal/workflow/root.go
+++ b/cli/internal/workflow/root.go
@@ -540,6 +540,9 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 			if len(args) > 0 {
 				skillID = args[0]
 			}
+			if _, resolveErr := agentskill.Resolve(skillID); resolveErr != nil {
+				return ExitError{Code: 2, Err: resolveErr}
+			}
 			installOpts := agentskill.InstallOptions{
 				SkillsDir: skillInstallDir,
 				Global:    skillInstallGlobal,

--- a/cli/internal/workflow/root_test.go
+++ b/cli/internal/workflow/root_test.go
@@ -39,6 +39,43 @@ printf '%s\n' 'coverage/' > "$target/.gitignore"
 printf '%s\n' 'FROM ruby:3.4' > "$target/Dockerfile"
 printf '%s\n' 'name: fake' > "$target/devopsellence.yml"
 `)
+	writeExecutable(t, filepath.Join(binDir, "git"), `#!/usr/bin/env bash
+set -euo pipefail
+cwd="$PWD"
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -C)
+      cwd="$2"
+      shift 2
+      ;;
+    -c)
+      shift 2
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+case "${1:-}" in
+  init)
+    mkdir -p "$cwd/.git"
+    ;;
+  rev-parse)
+    test -f "$cwd/.git/fake-head"
+    ;;
+  add)
+    exit 0
+    ;;
+  commit)
+    mkdir -p "$cwd/.git"
+    touch "$cwd/.git/fake-head"
+    ;;
+  *)
+    echo "unexpected git command: $*" >&2
+    exit 1
+    ;;
+esac
+`)
 	for _, agent := range agents {
 		writeExecutable(t, filepath.Join(binDir, agent), "#!/usr/bin/env bash\nexit 0\n")
 	}
@@ -317,6 +354,9 @@ func TestRootVibePreparesRailsAppWorkspace(t *testing.T) {
 	if payload["template_version"] != defaultVibeTemplateVersion || payload["template_url"] != vibeTemplateURL(defaultVibeTemplateVersion) || payload["initial_commit"] != true {
 		t.Fatalf("payload = %#v, want pinned template and initial commit", payload)
 	}
+	if payload["skill_id"] != "rails-app" || payload["skill_name"] != "devopsellence-rails-app" || payload["launched"] != false {
+		t.Fatalf("payload = %#v, want stable skill metadata and no launched agent", payload)
+	}
 	for _, path := range []string{
 		filepath.Join(appDir, ".git"),
 		filepath.Join(appDir, ".mise.toml"),
@@ -440,6 +480,28 @@ func TestRootVibeNoAgentUsesGeneric(t *testing.T) {
 	path := filepath.Join(cwd, "rails-app", ".agents", "skills", "devopsellence-rails-app", "SKILL.md")
 	if _, err := os.Stat(path); err != nil {
 		t.Fatalf("expected rails app skill at %s: %v", path, err)
+	}
+}
+
+func TestRootVibeLaunchReportsSuccess(t *testing.T) {
+	cwd := t.TempDir()
+	installFakeVibeTools(t, "codex")
+	var stdout bytes.Buffer
+	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, cwd)
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{
+		"vibe", "launched-app",
+		"--ai-agent", "codex",
+		"--idea", "Launch this app",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	if payload["launch_requested"] != true || payload["launched"] != true {
+		t.Fatalf("payload = %#v, want successful launch reported", payload)
 	}
 }
 

--- a/cli/internal/workflow/root_test.go
+++ b/cli/internal/workflow/root_test.go
@@ -15,6 +15,36 @@ import (
 	"github.com/devopsellence/devopsellence/deployment-core/pkg/deploycore/config"
 )
 
+func installFakeVibeTools(t *testing.T, agents ...string) {
+	t.Helper()
+	binDir := t.TempDir()
+	writeExecutable(t, filepath.Join(binDir, "mise"), "#!/usr/bin/env bash\nexit 0\n")
+	writeExecutable(t, filepath.Join(binDir, "rails"), `#!/usr/bin/env bash
+set -euo pipefail
+if [ "${1:-}" != "new" ]; then
+  echo "unexpected rails command: $*" >&2
+  exit 1
+fi
+target="$2"
+mkdir -p "$target/.agents/skills/devopsellence-rails-app" "$target/app/controllers" "$target/config"
+printf '%s\n' '---
+name: devopsellence-rails-app
+description: Fake test skill.
+---
+
+# Fake Rails App Skill
+' > "$target/.agents/skills/devopsellence-rails-app/SKILL.md"
+printf '%s\n' '[tools]' 'ruby = "3.4"' 'node = "24"' > "$target/.mise.toml"
+printf '%s\n' 'coverage/' > "$target/.gitignore"
+printf '%s\n' 'FROM ruby:3.4' > "$target/Dockerfile"
+printf '%s\n' 'name: fake' > "$target/devopsellence.yml"
+`)
+	for _, agent := range agents {
+		writeExecutable(t, filepath.Join(binDir, agent), "#!/usr/bin/env bash\nexit 0\n")
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
 func TestRootVersionCommand(t *testing.T) {
 	for _, args := range [][]string{{"version"}, {"--version"}} {
 		args := args
@@ -126,6 +156,57 @@ func TestRootSkillInstallWritesBundledSkill(t *testing.T) {
 	}
 }
 
+func TestRootSkillListIncludesRailsAppSkill(t *testing.T) {
+	var stdout bytes.Buffer
+	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, t.TempDir())
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{"skill", "list"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	skills, ok := payload["skills"].([]any)
+	if !ok {
+		t.Fatalf("skills = %#v, want array", payload["skills"])
+	}
+	var ids []string
+	for _, raw := range skills {
+		skill, ok := raw.(map[string]any)
+		if !ok {
+			t.Fatalf("skill = %#v, want object", raw)
+		}
+		ids = append(ids, skill["id"].(string))
+	}
+	for _, want := range []string{"devopsellence", "rails-app"} {
+		if !stringSliceContains(ids, want) {
+			t.Fatalf("skill ids = %v, missing %q", ids, want)
+		}
+	}
+}
+
+func TestRootSkillInstallWritesRailsAppSkill(t *testing.T) {
+	skillsDir := t.TempDir()
+	var stdout bytes.Buffer
+	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, t.TempDir())
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{"skill", "install", "rails-app", "--dir", skillsDir})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	if payload["id"] != "rails-app" || payload["skill"] != "devopsellence-rails-app" || payload["source"] != "embedded" {
+		t.Fatalf("payload = %#v, want rails-app install result", payload)
+	}
+	path := filepath.Join(skillsDir, "devopsellence-rails-app", "SKILL.md")
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected bundled skill at %s: %v", path, err)
+	}
+}
+
 func TestRootSkillInstallDefaultsToProjectSkillDirs(t *testing.T) {
 	cwd := t.TempDir()
 	if err := os.WriteFile(filepath.Join(cwd, "devopsellence.yml"), []byte("schema_version: 1\n"), 0o644); err != nil {
@@ -176,13 +257,23 @@ func TestRootSkillInstallRejectsDirWithGlobalAsUsageError(t *testing.T) {
 }
 
 func TestRootSkillInstallRequiresWorkspaceForDefaultProjectInstall(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cwd, err := os.MkdirTemp(home, "devopsellence-no-workspace-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(cwd) })
+
 	var stdout bytes.Buffer
-	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, t.TempDir())
+	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, cwd)
 	cmd.SetOut(&stdout)
 	cmd.SetErr(&stdout)
 	cmd.SetArgs([]string{"skill", "install"})
 
-	err := cmd.Execute()
+	err = cmd.Execute()
 	var exitErr ExitError
 	if !errors.As(err, &exitErr) || exitErr.Code != 2 {
 		t.Fatalf("error = %#v, want ExitError code 2", err)
@@ -190,6 +281,190 @@ func TestRootSkillInstallRequiresWorkspaceForDefaultProjectInstall(t *testing.T)
 	if !strings.Contains(err.Error(), "devopsellence.yml") || !strings.Contains(err.Error(), "--global") || !strings.Contains(err.Error(), "--dir <path>") {
 		t.Fatalf("error = %v, want workspace/global/dir guidance", err)
 	}
+}
+
+func TestRootVibePreparesRailsAppWorkspace(t *testing.T) {
+	cwd := t.TempDir()
+	installFakeVibeTools(t)
+	var stdout bytes.Buffer
+	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, cwd)
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{
+		"vibe", "my-app",
+		"--ai-agent", "Codex",
+		"--idea", "A tiny CRM for solo consultants",
+		"--no-launch",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	appDir := filepath.Join(cwd, "my-app")
+	if payload["directory"] != appDir || payload["ai_agent"] != "codex" || payload["app_stack"] != "rails-app" || payload["launch_requested"] != false {
+		t.Fatalf("payload = %#v, want prepared codex rails workspace", payload)
+	}
+	if payload["template_version"] != defaultVibeTemplateVersion || payload["template_url"] != vibeTemplateURL(defaultVibeTemplateVersion) || payload["initial_commit"] != true {
+		t.Fatalf("payload = %#v, want pinned template and initial commit", payload)
+	}
+	for _, path := range []string{
+		filepath.Join(appDir, ".git"),
+		filepath.Join(appDir, ".mise.toml"),
+		filepath.Join(appDir, ".agents", "skills", "devopsellence", "SKILL.md"),
+		filepath.Join(appDir, ".agents", "skills", "devopsellence-rails-app", "SKILL.md"),
+		filepath.Join(appDir, ".agents", "devopsellence-vibe.json"),
+	} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("expected %s: %v", path, err)
+		}
+	}
+	promptPath := filepath.Join(appDir, ".agents", "prompts", "devopsellence-vibe.md")
+	prompt, err := os.ReadFile(promptPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(prompt), "/goal") || !strings.Contains(string(prompt), "A tiny CRM") || !strings.Contains(string(prompt), "Rails 8.1") {
+		t.Fatalf("prompt = %q, want seeded codex prompt", prompt)
+	}
+	nextCommands := jsonArrayFromMap(t, payload, "next_commands")
+	if !jsonArrayContains(nextCommands, `codex "$(cat .agents/prompts/devopsellence-vibe.md)"`) {
+		t.Fatalf("next_commands = %#v, want prompt-file command", nextCommands)
+	}
+	manifestData, err := os.ReadFile(filepath.Join(appDir, ".agents", "devopsellence-vibe.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var manifest vibeManifest
+	if err := json.Unmarshal(manifestData, &manifest); err != nil {
+		t.Fatal(err)
+	}
+	if filepath.IsAbs(manifest.SkillDir) || filepath.IsAbs(manifest.PromptPath) || manifest.AppStack != "rails-app" || manifest.TemplateVersion != defaultVibeTemplateVersion {
+		t.Fatalf("manifest = %#v, want repo-relative paths", manifest)
+	}
+}
+
+func TestRootVibeAppendsSecretPatternsToExistingGitignore(t *testing.T) {
+	cwd := t.TempDir()
+	installFakeVibeTools(t)
+	appDir := filepath.Join(cwd, "existing-app")
+	if err := os.MkdirAll(appDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(appDir, ".gitignore"), []byte("coverage/\n!.env.example\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var stdout bytes.Buffer
+	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, cwd)
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{
+		"vibe", "existing-app",
+		"--ai-agent", "generic",
+		"--idea", "A tiny uptime API",
+		"--no-launch",
+		"--force",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(appDir, ".gitignore"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	gitignore := string(data)
+	for _, want := range []string{"coverage/", ".env", ".env.*", "!.env.example"} {
+		if !strings.Contains(gitignore, want) {
+			t.Fatalf(".gitignore = %q, missing %q", gitignore, want)
+		}
+	}
+	if strings.Index(gitignore, ".env.*") > strings.Index(gitignore, "!.env.example") {
+		t.Fatalf(".gitignore = %q, want .env.* before !.env.example", gitignore)
+	}
+
+	stdout.Reset()
+	cmd = NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, cwd)
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{
+		"vibe", "existing-app",
+		"--ai-agent", "generic",
+		"--idea", "A tiny uptime API",
+		"--no-launch",
+		"--force",
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() second run error = %v", err)
+	}
+	data, err = os.ReadFile(filepath.Join(appDir, ".gitignore"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != gitignore {
+		t.Fatalf(".gitignore changed on second run:\nfirst=%q\nsecond=%q", gitignore, data)
+	}
+}
+
+func TestRootVibeNoAgentUsesGeneric(t *testing.T) {
+	cwd := t.TempDir()
+	installFakeVibeTools(t)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	input := bytes.NewBuffer(nil)
+	cmd := NewRootCommand(input, &stdout, &stderr, cwd)
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{
+		"vibe", "rails-app",
+		"--idea", "A tiny uptime page",
+		"--no-agent",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	if payload["ai_agent"] != "generic" || payload["app_stack"] != "rails-app" || payload["launch_requested"] != false {
+		t.Fatalf("payload = %#v, want generic rails app workspace", payload)
+	}
+	path := filepath.Join(cwd, "rails-app", ".agents", "skills", "devopsellence-rails-app", "SKILL.md")
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected rails app skill at %s: %v", path, err)
+	}
+}
+
+func TestRootVibeRejectsBlankPromptedAgent(t *testing.T) {
+	cwd := t.TempDir()
+	installFakeVibeTools(t, "codex", "claude")
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	input := bytes.NewBufferString("\n")
+	cmd := NewRootCommand(input, &stdout, &stderr, cwd)
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{
+		"vibe", "blank-agent",
+		"--idea", "A tiny uptime page",
+		"--no-launch",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() error = nil, want missing ai agent")
+	}
+	if !strings.Contains(err.Error(), "missing ai agent") {
+		t.Fatalf("error = %v, want missing ai agent", err)
+	}
+}
+
+func stringSliceContains(items []string, needle string) bool {
+	for _, item := range items {
+		if item == needle {
+			return true
+		}
+	}
+	return false
 }
 
 func TestRootModeFlagIsNotGlobal(t *testing.T) {

--- a/cli/internal/workflow/root_test.go
+++ b/cli/internal/workflow/root_test.go
@@ -377,8 +377,8 @@ func TestRootVibePreparesRailsAppWorkspace(t *testing.T) {
 		t.Fatalf("prompt = %q, want seeded codex prompt", prompt)
 	}
 	nextCommands := jsonArrayFromMap(t, payload, "next_commands")
-	if !jsonArrayContains(nextCommands, "cat .agents/prompts/devopsellence-vibe.md") {
-		t.Fatalf("next_commands = %#v, want prompt inspection command", nextCommands)
+	if !jsonArrayContains(nextCommands, "codex 'Read .agents/prompts/devopsellence-vibe.md and follow it.'") {
+		t.Fatalf("next_commands = %#v, want prompt-file agent command", nextCommands)
 	}
 	manifestData, err := os.ReadFile(filepath.Join(appDir, ".agents", "devopsellence-vibe.json"))
 	if err != nil {

--- a/cli/internal/workflow/root_test.go
+++ b/cli/internal/workflow/root_test.go
@@ -207,6 +207,23 @@ func TestRootSkillInstallWritesRailsAppSkill(t *testing.T) {
 	}
 }
 
+func TestRootSkillInstallUnknownSkillIsUsageError(t *testing.T) {
+	var stdout bytes.Buffer
+	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, t.TempDir())
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{"skill", "install", "unknown-pack"})
+
+	err := cmd.Execute()
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("Execute() error = %T %[1]v, want ExitError", err)
+	}
+	if exitErr.Code != 2 {
+		t.Fatalf("ExitError.Code = %d, want 2", exitErr.Code)
+	}
+}
+
 func TestRootSkillInstallDefaultsToProjectSkillDirs(t *testing.T) {
 	cwd := t.TempDir()
 	if err := os.WriteFile(filepath.Join(cwd, "devopsellence.yml"), []byte("schema_version: 1\n"), 0o644); err != nil {

--- a/cli/internal/workflow/root_test.go
+++ b/cli/internal/workflow/root_test.go
@@ -274,15 +274,7 @@ func TestRootSkillInstallRejectsDirWithGlobalAsUsageError(t *testing.T) {
 }
 
 func TestRootSkillInstallRequiresWorkspaceForDefaultProjectInstall(t *testing.T) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		t.Fatal(err)
-	}
-	cwd, err := os.MkdirTemp(home, "devopsellence-no-workspace-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = os.RemoveAll(cwd) })
+	cwd := filepath.Join(string(os.PathSeparator), "devopsellence-no-workspace-"+strings.ReplaceAll(t.Name(), "/", "-"))
 
 	var stdout bytes.Buffer
 	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, cwd)
@@ -290,7 +282,7 @@ func TestRootSkillInstallRequiresWorkspaceForDefaultProjectInstall(t *testing.T)
 	cmd.SetErr(&stdout)
 	cmd.SetArgs([]string{"skill", "install"})
 
-	err = cmd.Execute()
+	err := cmd.Execute()
 	var exitErr ExitError
 	if !errors.As(err, &exitErr) || exitErr.Code != 2 {
 		t.Fatalf("error = %#v, want ExitError code 2", err)

--- a/cli/internal/workflow/root_test.go
+++ b/cli/internal/workflow/root_test.go
@@ -79,7 +79,7 @@ esac
 	for _, agent := range agents {
 		writeExecutable(t, filepath.Join(binDir, agent), "#!/usr/bin/env bash\nexit 0\n")
 	}
-	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+"/usr/bin:/bin")
 }
 
 func TestRootVersionCommand(t *testing.T) {
@@ -377,8 +377,8 @@ func TestRootVibePreparesRailsAppWorkspace(t *testing.T) {
 		t.Fatalf("prompt = %q, want seeded codex prompt", prompt)
 	}
 	nextCommands := jsonArrayFromMap(t, payload, "next_commands")
-	if !jsonArrayContains(nextCommands, `codex "$(cat .agents/prompts/devopsellence-vibe.md)"`) {
-		t.Fatalf("next_commands = %#v, want prompt-file command", nextCommands)
+	if !jsonArrayContains(nextCommands, "cat .agents/prompts/devopsellence-vibe.md") {
+		t.Fatalf("next_commands = %#v, want prompt inspection command", nextCommands)
 	}
 	manifestData, err := os.ReadFile(filepath.Join(appDir, ".agents", "devopsellence-vibe.json"))
 	if err != nil {
@@ -502,6 +502,42 @@ func TestRootVibeLaunchReportsSuccess(t *testing.T) {
 	payload := decodeJSONOutput(t, &stdout)
 	if payload["launch_requested"] != true || payload["launched"] != true {
 		t.Fatalf("payload = %#v, want successful launch reported", payload)
+	}
+}
+
+func TestRootVibeRejectsMissingLaunchAgentBeforeScaffold(t *testing.T) {
+	cwd := t.TempDir()
+	installFakeVibeTools(t)
+	var stdout bytes.Buffer
+	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, cwd)
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{
+		"vibe", "missing-agent",
+		"--ai-agent", "codex",
+		"--idea", "Launch this app",
+	})
+
+	err := cmd.Execute()
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 2 {
+		t.Fatalf("error = %#v, want ExitError code 2", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(cwd, "missing-agent")); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("generated app exists after missing agent preflight: %v", statErr)
+	}
+}
+
+func TestPrepareVibeDirectoryRejectsFileAsUsageError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(path, []byte("nope"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := prepareVibeDirectory(path, false)
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 2 {
+		t.Fatalf("error = %#v, want ExitError code 2", err)
 	}
 }
 

--- a/cli/internal/workflow/vibe.go
+++ b/cli/internal/workflow/vibe.go
@@ -409,7 +409,11 @@ func (a *App) launchVibeAgent(ctx context.Context, agent, cwd string) error {
 	if _, err := a.LookPath(binary); err != nil {
 		return ExitError{Code: 2, Err: fmt.Errorf("%s not found; rerun with --no-launch and start it manually from .agents/prompts/devopsellence-vibe.md", binary)}
 	}
-	cmd := exec.CommandContext(ctx, "sh", "-lc", vibeAgentCommand(agent))
+	prompt, err := os.ReadFile(filepath.Join(cwd, ".agents", "prompts", "devopsellence-vibe.md"))
+	if err != nil {
+		return fmt.Errorf("read vibe prompt: %w", err)
+	}
+	cmd := exec.CommandContext(ctx, binary, string(prompt))
 	cmd.Dir = cwd
 	cmd.Stdin = a.In
 	cmd.Stdout = a.Printer.Err

--- a/cli/internal/workflow/vibe.go
+++ b/cli/internal/workflow/vibe.go
@@ -77,6 +77,11 @@ func (a *App) Vibe(ctx context.Context, opts VibeOptions) error {
 	if opts.AIAgent == "generic" {
 		opts.Launch = false
 	}
+	if opts.Launch {
+		if _, err := a.LookPath(opts.AIAgent); err != nil {
+			return ExitError{Code: 2, Err: fmt.Errorf("%s not found; rerun with --no-launch and start it manually from .agents/prompts/devopsellence-vibe.md", opts.AIAgent)}
+		}
+	}
 	if strings.TrimSpace(opts.Idea) == "" {
 		idea, err := a.askVibeQuestion(reader, "App idea")
 		if err != nil {
@@ -243,7 +248,7 @@ func prepareVibeDirectory(path string, force bool) error {
 		return nil
 	}
 	if !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("inspect directory: %w", err)
+		return ExitError{Code: 2, Err: fmt.Errorf("%s is not an inspectable directory: %w", path, err)}
 	}
 	parent := filepath.Dir(path)
 	if parent == "." || parent == path {
@@ -397,16 +402,7 @@ func vibePrompt(agent, templateURL, idea string) string {
 }
 
 func vibeAgentCommand(agent string) string {
-	switch agent {
-	case "codex":
-		return `codex "$(cat .agents/prompts/devopsellence-vibe.md)"`
-	case "claude":
-		return `claude "$(cat .agents/prompts/devopsellence-vibe.md)"`
-	case "pi":
-		return `pi "$(cat .agents/prompts/devopsellence-vibe.md)"`
-	default:
-		return "cat .agents/prompts/devopsellence-vibe.md"
-	}
+	return "cat .agents/prompts/devopsellence-vibe.md"
 }
 
 func (a *App) launchVibeAgent(ctx context.Context, agent, cwd string) error {

--- a/cli/internal/workflow/vibe.go
+++ b/cli/internal/workflow/vibe.go
@@ -237,7 +237,11 @@ func prepareVibeDirectory(path string, force bool) error {
 	if !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("inspect directory: %w", err)
 	}
-	return os.MkdirAll(path, 0o755)
+	parent := filepath.Dir(path)
+	if parent == "." || parent == path {
+		return nil
+	}
+	return os.MkdirAll(parent, 0o755)
 }
 
 func ensureGitRepository(ctx context.Context, path string) error {
@@ -254,10 +258,13 @@ func ensureGitRepository(ctx context.Context, path string) error {
 }
 
 func ensureInitialVibeCommit(ctx context.Context, path string) (bool, error) {
-	if output, err := exec.CommandContext(ctx, "git", "-C", path, "rev-parse", "--verify", "HEAD").CombinedOutput(); err == nil {
+	if err := exec.CommandContext(ctx, "git", "-C", path, "rev-parse", "--quiet", "--verify", "HEAD").Run(); err == nil {
 		return false, nil
-	} else if strings.TrimSpace(string(output)) != "" && !strings.Contains(string(output), "Needed a single revision") && !strings.Contains(string(output), "unknown revision") && !strings.Contains(string(output), "ambiguous argument") {
-		return false, fmt.Errorf("inspect git HEAD: %w: %s", err, strings.TrimSpace(string(output)))
+	} else {
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) || (exitErr.ExitCode() != 1 && exitErr.ExitCode() != 128) {
+			return false, fmt.Errorf("inspect git HEAD: %w", err)
+		}
 	}
 	if output, err := exec.CommandContext(ctx, "git", "-C", path, "add", ".").CombinedOutput(); err != nil {
 		return false, fmt.Errorf("git add: %w: %s", err, strings.TrimSpace(string(output)))

--- a/cli/internal/workflow/vibe.go
+++ b/cli/internal/workflow/vibe.go
@@ -42,6 +42,7 @@ type vibeManifest struct {
 const (
 	vibeAppStack               = "rails-app"
 	defaultVibeTemplateVersion = "v0.1.3"
+	vibePromptInstruction      = "Read .agents/prompts/devopsellence-vibe.md and follow it."
 )
 
 var vibeSlugPattern = regexp.MustCompile(`[^a-z0-9]+`)
@@ -402,7 +403,10 @@ func vibePrompt(agent, templateURL, idea string) string {
 }
 
 func vibeAgentCommand(agent string) string {
-	return "cat .agents/prompts/devopsellence-vibe.md"
+	if agent == "generic" {
+		return "cat .agents/prompts/devopsellence-vibe.md"
+	}
+	return agent + " '" + vibePromptInstruction + "'"
 }
 
 func (a *App) launchVibeAgent(ctx context.Context, agent, cwd string) error {
@@ -413,11 +417,7 @@ func (a *App) launchVibeAgent(ctx context.Context, agent, cwd string) error {
 	if _, err := a.LookPath(binary); err != nil {
 		return ExitError{Code: 2, Err: fmt.Errorf("%s not found; rerun with --no-launch and start it manually from .agents/prompts/devopsellence-vibe.md", binary)}
 	}
-	prompt, err := os.ReadFile(filepath.Join(cwd, ".agents", "prompts", "devopsellence-vibe.md"))
-	if err != nil {
-		return fmt.Errorf("read vibe prompt: %w", err)
-	}
-	cmd := exec.CommandContext(ctx, binary, string(prompt))
+	cmd := exec.CommandContext(ctx, binary, vibePromptInstruction)
 	cmd.Dir = cwd
 	cmd.Stdin = a.In
 	cmd.Stdout = a.Printer.Err

--- a/cli/internal/workflow/vibe.go
+++ b/cli/internal/workflow/vibe.go
@@ -175,21 +175,29 @@ func (a *App) Vibe(ctx context.Context, opts VibeOptions) error {
 		"app_stack":        vibeAppStack,
 		"template_url":     templateURL,
 		"template_version": opts.TemplateVersion,
+		"skill_id":         agentskill.RailsAppID,
+		"skill_name":       agentskill.RailsAppName,
 		"skill":            agentskill.RailsAppName,
 		"skill_dir":        skillsDir,
 		"prompt_path":      promptPath,
 		"manifest_path":    manifestPath,
 		"initial_commit":   initialCommit,
 		"launch_requested": opts.Launch,
+		"launched":         false,
 		"next_commands":    nextCommands,
+	}
+	var launchErr error
+	if opts.Launch {
+		launchErr = a.launchVibeAgent(ctx, opts.AIAgent, target)
+		payload["launched"] = launchErr == nil
+		if launchErr != nil {
+			payload["launch_error"] = launchErr.Error()
+		}
 	}
 	if err := a.Printer.PrintJSON(payload); err != nil {
 		return err
 	}
-	if opts.Launch {
-		return a.launchVibeAgent(ctx, opts.AIAgent, target)
-	}
-	return nil
+	return launchErr
 }
 
 func (a *App) askVibeQuestion(reader *bufio.Reader, label string) (string, error) {

--- a/cli/internal/workflow/vibe.go
+++ b/cli/internal/workflow/vibe.go
@@ -1,0 +1,421 @@
+package workflow
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/devopsellence/cli/internal/agentskill"
+	"github.com/devopsellence/cli/internal/version"
+)
+
+type VibeOptions struct {
+	Directory       string
+	AIAgent         string
+	Idea            string
+	TemplateVersion string
+	Launch          bool
+	NoAgent         bool
+	Force           bool
+}
+
+type vibeManifest struct {
+	SchemaVersion   int      `json:"schema_version"`
+	AIAgent         string   `json:"ai_agent"`
+	DetectedAgents  []string `json:"detected_agents"`
+	AppStack        string   `json:"app_stack"`
+	TemplateURL     string   `json:"template_url"`
+	TemplateVersion string   `json:"template_version"`
+	SkillDir        string   `json:"skill_dir"`
+	PromptPath      string   `json:"prompt_path"`
+	Idea            string   `json:"idea"`
+	NextCommands    []string `json:"next_commands"`
+}
+
+const (
+	vibeAppStack               = "rails-app"
+	defaultVibeTemplateVersion = "v0.1.0"
+)
+
+var vibeSlugPattern = regexp.MustCompile(`[^a-z0-9]+`)
+
+func (a *App) Vibe(ctx context.Context, opts VibeOptions) error {
+	opts.AIAgent = strings.ToLower(strings.TrimSpace(opts.AIAgent))
+	reader := bufio.NewReader(a.In)
+	detectedAgents := a.detectVibeAgents()
+	if opts.NoAgent {
+		opts.AIAgent = "generic"
+		opts.Launch = false
+	}
+	if opts.AIAgent == "" && len(detectedAgents) == 1 {
+		opts.AIAgent = detectedAgents[0]
+	}
+	if opts.AIAgent == "" && len(detectedAgents) == 0 {
+		opts.AIAgent = "generic"
+		opts.Launch = false
+	}
+	if opts.AIAgent == "" {
+		agent, err := a.askVibeQuestion(reader, "AI agent "+vibeAgentChoiceHint(detectedAgents))
+		if err != nil {
+			return err
+		}
+		opts.AIAgent = strings.ToLower(strings.TrimSpace(agent))
+	}
+	if opts.AIAgent == "" {
+		return ExitError{Code: 2, Err: errors.New("missing ai agent; choose codex, claude, pi, or generic")}
+	}
+	if !supportedVibeAgent(opts.AIAgent) {
+		return ExitError{Code: 2, Err: fmt.Errorf("unsupported ai agent %q; use codex, claude, pi, or generic", opts.AIAgent)}
+	}
+	if opts.AIAgent == "generic" {
+		opts.Launch = false
+	}
+	if strings.TrimSpace(opts.Idea) == "" {
+		idea, err := a.askVibeQuestion(reader, "App idea")
+		if err != nil {
+			return err
+		}
+		opts.Idea = idea
+	}
+	if strings.TrimSpace(opts.Idea) == "" {
+		return ExitError{Code: 2, Err: errors.New("missing app idea")}
+	}
+	if len(opts.Idea) > 4096 {
+		return ExitError{Code: 2, Err: errors.New("app idea is too long; keep it under 4096 characters")}
+	}
+	opts.TemplateVersion = strings.TrimSpace(opts.TemplateVersion)
+	if opts.TemplateVersion == "" {
+		opts.TemplateVersion = defaultVibeTemplateVersion
+	}
+	templateURL := vibeTemplateURL(opts.TemplateVersion)
+	if err := a.ensureVibeTools(); err != nil {
+		return err
+	}
+
+	target := strings.TrimSpace(opts.Directory)
+	if target == "" {
+		target = vibeSlug(opts.Idea)
+	}
+	if !filepath.IsAbs(target) {
+		target = filepath.Join(a.Cwd, target)
+	}
+	if err := prepareVibeDirectory(target, opts.Force); err != nil {
+		return err
+	}
+	if err := a.generateVibeRailsApp(ctx, target, templateURL, opts.Force); err != nil {
+		return err
+	}
+
+	agentsDir := filepath.Join(target, ".agents")
+	skillsDir := filepath.Join(agentsDir, "skills")
+	promptsDir := filepath.Join(agentsDir, "prompts")
+	if err := os.MkdirAll(promptsDir, 0o755); err != nil {
+		return fmt.Errorf("create prompts dir: %w", err)
+	}
+	if _, err := agentskill.Install(agentskill.InstallOptions{SkillsDir: skillsDir, Skill: agentskill.Name}, version.String()); err != nil {
+		return err
+	}
+	if err := ensureVibeRailsAppSkill(target); err != nil {
+		return err
+	}
+	if err := ensureVibeGitignore(target); err != nil {
+		return err
+	}
+
+	prompt := vibePrompt(opts.AIAgent, templateURL, opts.Idea)
+	promptPath := filepath.Join(promptsDir, "devopsellence-vibe.md")
+	if err := os.WriteFile(promptPath, []byte(prompt), 0o644); err != nil {
+		return fmt.Errorf("write prompt: %w", err)
+	}
+
+	agentCommand := vibeAgentCommand(opts.AIAgent)
+	manifestNextCommands := []string{agentCommand}
+	manifest := vibeManifest{
+		SchemaVersion:   outputSchemaVersion,
+		AIAgent:         opts.AIAgent,
+		DetectedAgents:  detectedAgents,
+		AppStack:        vibeAppStack,
+		TemplateURL:     templateURL,
+		TemplateVersion: opts.TemplateVersion,
+		SkillDir:        filepath.Join(".agents", "skills"),
+		PromptPath:      filepath.Join(".agents", "prompts", "devopsellence-vibe.md"),
+		Idea:            opts.Idea,
+		NextCommands:    manifestNextCommands,
+	}
+	nextCommands := []string{"cd " + shellQuote(target), agentCommand}
+	manifestPath := filepath.Join(agentsDir, "devopsellence-vibe.json")
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(manifestPath, append(data, '\n'), 0o644); err != nil {
+		return fmt.Errorf("write vibe manifest: %w", err)
+	}
+	if err := ensureGitRepository(ctx, target); err != nil {
+		return err
+	}
+	initialCommit, err := ensureInitialVibeCommit(ctx, target)
+	if err != nil {
+		return err
+	}
+
+	payload := map[string]any{
+		"schema_version":   outputSchemaVersion,
+		"action":           "initialized",
+		"directory":        target,
+		"ai_agent":         opts.AIAgent,
+		"detected_agents":  detectedAgents,
+		"app_stack":        vibeAppStack,
+		"template_url":     templateURL,
+		"template_version": opts.TemplateVersion,
+		"skill":            agentskill.RailsAppName,
+		"skill_dir":        skillsDir,
+		"prompt_path":      promptPath,
+		"manifest_path":    manifestPath,
+		"initial_commit":   initialCommit,
+		"launch_requested": opts.Launch,
+		"next_commands":    nextCommands,
+	}
+	if err := a.Printer.PrintJSON(payload); err != nil {
+		return err
+	}
+	if opts.Launch {
+		return a.launchVibeAgent(ctx, opts.AIAgent, target)
+	}
+	return nil
+}
+
+func (a *App) askVibeQuestion(reader *bufio.Reader, label string) (string, error) {
+	_, _ = fmt.Fprintf(a.Printer.Err, "%s: ", label)
+	answer, err := reader.ReadString('\n')
+	if err != nil && strings.TrimSpace(answer) == "" {
+		return "", ExitError{Code: 2, Err: fmt.Errorf("missing %s; pass it with a flag for non-interactive use", strings.ToLower(label))}
+	}
+	return strings.TrimSpace(answer), nil
+}
+
+func supportedVibeAgent(agent string) bool {
+	switch agent {
+	case "codex", "claude", "pi", "generic":
+		return true
+	default:
+		return false
+	}
+}
+
+func (a *App) detectVibeAgents() []string {
+	var agents []string
+	for _, name := range []string{"codex", "claude", "pi"} {
+		if _, err := a.LookPath(name); err == nil {
+			agents = append(agents, name)
+		}
+	}
+	return agents
+}
+
+func vibeAgentChoiceHint(agents []string) string {
+	choices := append([]string(nil), agents...)
+	choices = append(choices, "generic")
+	return "(" + strings.Join(choices, ", ") + ")"
+}
+
+func prepareVibeDirectory(path string, force bool) error {
+	entries, err := os.ReadDir(path)
+	if err == nil {
+		if len(entries) > 0 && !force {
+			return ExitError{Code: 2, Err: fmt.Errorf("%s is not empty; choose another directory or pass --force", path)}
+		}
+		return nil
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("inspect directory: %w", err)
+	}
+	return os.MkdirAll(path, 0o755)
+}
+
+func ensureGitRepository(ctx context.Context, path string) error {
+	if _, err := os.Stat(filepath.Join(path, ".git")); err == nil {
+		return nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("stat .git: %w", err)
+	}
+	cmd := exec.CommandContext(ctx, "git", "-C", path, "init")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("git init: %w: %s", err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+func ensureInitialVibeCommit(ctx context.Context, path string) (bool, error) {
+	if output, err := exec.CommandContext(ctx, "git", "-C", path, "rev-parse", "--verify", "HEAD").CombinedOutput(); err == nil {
+		return false, nil
+	} else if strings.TrimSpace(string(output)) != "" && !strings.Contains(string(output), "Needed a single revision") && !strings.Contains(string(output), "unknown revision") && !strings.Contains(string(output), "ambiguous argument") {
+		return false, fmt.Errorf("inspect git HEAD: %w: %s", err, strings.TrimSpace(string(output)))
+	}
+	if output, err := exec.CommandContext(ctx, "git", "-C", path, "add", ".").CombinedOutput(); err != nil {
+		return false, fmt.Errorf("git add: %w: %s", err, strings.TrimSpace(string(output)))
+	}
+	cmd := exec.CommandContext(ctx, "git", "-C", path, "-c", "user.name=devopsellence", "-c", "user.email=devopsellence@example.invalid", "commit", "-m", "Initial devopsellence Rails app")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return false, fmt.Errorf("git commit: %w: %s", err, strings.TrimSpace(string(output)))
+	}
+	return true, nil
+}
+
+func ensureVibeGitignore(path string) error {
+	gitignore := filepath.Join(path, ".gitignore")
+	required := []string{".env", ".env.*", "!.env.example", "node_modules/", "dist/", "tmp/", "log/"}
+	if data, err := os.ReadFile(gitignore); err == nil {
+		requiredSet := map[string]bool{}
+		for _, line := range required {
+			requiredSet[line] = true
+		}
+
+		var next []string
+		content := strings.TrimRight(string(data), "\n")
+		if content != "" {
+			for _, line := range strings.Split(content, "\n") {
+				if requiredSet[strings.TrimSpace(line)] {
+					continue
+				}
+				next = append(next, line)
+			}
+		}
+		for len(next) > 0 && strings.TrimSpace(next[len(next)-1]) == "" {
+			next = next[:len(next)-1]
+		}
+		if len(next) > 0 {
+			next = append(next, "")
+		}
+		next = append(next, required...)
+
+		updated := strings.Join(next, "\n") + "\n"
+		if updated == string(data) {
+			return nil
+		}
+		return os.WriteFile(gitignore, []byte(updated), 0o644)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("read .gitignore: %w", err)
+	}
+	return os.WriteFile(gitignore, []byte(strings.Join(required, "\n")+"\n"), 0o644)
+}
+
+func (a *App) ensureVibeTools() error {
+	if _, err := a.LookPath("mise"); err != nil {
+		return ExitError{Code: 2, Err: errors.New("mise not found; install mise before running devopsellence vibe")}
+	}
+	if _, err := a.LookPath("rails"); err != nil {
+		return ExitError{Code: 2, Err: errors.New("rails not found; install Rails with mise-managed Ruby before running devopsellence vibe")}
+	}
+	return nil
+}
+
+func (a *App) generateVibeRailsApp(ctx context.Context, target, templateURL string, force bool) error {
+	args := []string{"new", target, "-d", "postgresql", "-m", templateURL}
+	if force {
+		args = append(args, "--force")
+	}
+	cmd := exec.CommandContext(ctx, "rails", args...)
+	cmd.Dir = a.Cwd
+	cmd.Stdin = a.In
+	cmd.Stdout = a.Printer.Err
+	cmd.Stderr = a.Printer.Err
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("rails new: %w", err)
+	}
+	return nil
+}
+
+func ensureVibeRailsAppSkill(target string) error {
+	path := filepath.Join(target, ".agents", "skills", agentskill.RailsAppName, "SKILL.md")
+	if _, err := os.Stat(path); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("rails template did not install %s at %s", agentskill.RailsAppName, path)
+		}
+		return fmt.Errorf("inspect rails app skill: %w", err)
+	}
+	return nil
+}
+
+func vibeTemplateURL(version string) string {
+	return "https://raw.githubusercontent.com/devopsellence/rails-app-template/" + version + "/template.rb"
+}
+
+func vibePrompt(agent, templateURL, idea string) string {
+	var firstLine string
+	switch agent {
+	case "codex":
+		firstLine = "/goal Build this app idea into a deployable Rails product using the installed devopsellence Rails app skill."
+	case "claude":
+		firstLine = "Run a tight build-test-deploy loop for this Rails app idea using the installed devopsellence Rails app skill."
+	case "pi":
+		firstLine = "Use the installed devopsellence Rails app skill as the operating instructions for this app build."
+	default:
+		firstLine = "Build this Rails app idea using the installed devopsellence Rails app skill."
+	}
+	return strings.Join([]string{
+		firstLine,
+		"",
+		"App idea:",
+		idea,
+		"",
+		"Rails template: " + templateURL,
+		"",
+		"Use .agents/skills/devopsellence-rails-app for app-building guidance.",
+		"Use .agents/skills/devopsellence for deploy, secrets, logs, status, rollback, and node operations.",
+		"Stay inside the blessed Rails baseline: Rails 8.1, PostgreSQL, Hotwire, Tailwind, Solid Queue/Cache/Cable, Active Storage, Sentry, OpenTelemetry, Minitest, Docker, and mise.",
+		"Do not add Redis, Sidekiq, React, GraphQL, Elasticsearch, Kubernetes, or an admin framework unless the product need is explicit.",
+		"Before any production mutation, run devopsellence deploy --dry-run.",
+		"After deploy, report devopsellence status, app logs, node logs, and HTTPS evidence when ingress is configured.",
+		"",
+	}, "\n")
+}
+
+func vibeAgentCommand(agent string) string {
+	switch agent {
+	case "codex":
+		return `codex "$(cat .agents/prompts/devopsellence-vibe.md)"`
+	case "claude":
+		return `claude "$(cat .agents/prompts/devopsellence-vibe.md)"`
+	case "pi":
+		return `pi "$(cat .agents/prompts/devopsellence-vibe.md)"`
+	default:
+		return "cat .agents/prompts/devopsellence-vibe.md"
+	}
+}
+
+func (a *App) launchVibeAgent(ctx context.Context, agent, cwd string) error {
+	if agent == "generic" {
+		return nil
+	}
+	binary := agent
+	if _, err := a.LookPath(binary); err != nil {
+		return ExitError{Code: 2, Err: fmt.Errorf("%s not found; rerun with --no-launch and start it manually from .agents/prompts/devopsellence-vibe.md", binary)}
+	}
+	cmd := exec.CommandContext(ctx, "sh", "-lc", vibeAgentCommand(agent))
+	cmd.Dir = cwd
+	cmd.Stdin = a.In
+	cmd.Stdout = a.Printer.Err
+	cmd.Stderr = a.Printer.Err
+	return cmd.Run()
+}
+
+func vibeSlug(input string) string {
+	slug := strings.ToLower(strings.TrimSpace(input))
+	slug = vibeSlugPattern.ReplaceAllString(slug, "-")
+	slug = strings.Trim(slug, "-")
+	if slug == "" {
+		return "vibe-app"
+	}
+	if len(slug) > 48 {
+		slug = strings.Trim(slug[:48], "-")
+	}
+	return slug
+}

--- a/cli/internal/workflow/vibe.go
+++ b/cli/internal/workflow/vibe.go
@@ -321,6 +321,9 @@ func (a *App) ensureVibeTools() error {
 	if _, err := a.LookPath("rails"); err != nil {
 		return ExitError{Code: 2, Err: errors.New("rails not found; install Rails with mise-managed Ruby before running devopsellence vibe")}
 	}
+	if _, err := a.LookPath("git"); err != nil {
+		return ExitError{Code: 2, Err: errors.New("git not found; install git before running devopsellence vibe")}
+	}
 	return nil
 }
 

--- a/cli/internal/workflow/vibe.go
+++ b/cli/internal/workflow/vibe.go
@@ -41,7 +41,7 @@ type vibeManifest struct {
 
 const (
 	vibeAppStack               = "rails-app"
-	defaultVibeTemplateVersion = "v0.1.0"
+	defaultVibeTemplateVersion = "v0.1.3"
 )
 
 var vibeSlugPattern = regexp.MustCompile(`[^a-z0-9]+`)

--- a/docs-website/astro.config.mjs
+++ b/docs-website/astro.config.mjs
@@ -42,6 +42,7 @@ export default defineConfig({
           items: [
             { label: "Deploy with solo", link: "/guides/solo-deploy/" },
             { label: "Deploy with shared", link: "/guides/shared-deploy/" },
+            { label: "Rails app template", link: "/guides/rails-app-template/" },
             { label: "CloudStack VMs", link: "/guides/cloudstack-vms/" },
             { label: "GitHub Actions", link: "/guides/github-actions/" },
             { label: "Secrets", link: "/guides/secrets/" },

--- a/docs-website/src/content/docs/getting-started/solo-quickstart.md
+++ b/docs-website/src/content/docs/getting-started/solo-quickstart.md
@@ -14,8 +14,17 @@ and the `devopsellence` CLI.
 devopsellence init --mode solo
 ```
 
-Start from an app that already has a Dockerfile. devopsellence does not install
-language toolchains or generate Rails, Node, or Go apps for you.
+Start from an app that already has a Dockerfile, or let devopsellence generate
+the blessed Rails baseline first.
+
+If you want Codex, Claude Code, Pi, or another AI coding agent to create or
+prepare the app first, start from the [Rails app template](/guides/rails-app-template/):
+
+```bash
+devopsellence vibe my-app --ai-agent=codex --idea="A tiny CRM"
+```
+
+Use `--no-agent` to generate the app and prompt without starting an AI agent.
 
 <ol class="command-sequence" start="2">
   <li>Commit the app before the first deploy.</li>

--- a/docs-website/src/content/docs/guides/rails-app-template.md
+++ b/docs-website/src/content/docs/guides/rails-app-template.md
@@ -23,7 +23,7 @@ devopsellence vibe my-crm --idea="A tiny CRM for solo consultants" --no-agent
 Pin a template release when reproducing a scaffold:
 
 ```bash
-devopsellence vibe my-crm --template-version=v0.1.0 --no-launch
+devopsellence vibe my-crm --template-version=v0.1.0 --no-agent
 ```
 
 The command runs Rails with the pinned template:

--- a/docs-website/src/content/docs/guides/rails-app-template.md
+++ b/docs-website/src/content/docs/guides/rails-app-template.md
@@ -1,0 +1,79 @@
+---
+title: Rails app template
+description: Start a production-minded Rails app with devopsellence, mise, and a local AI-agent skill.
+---
+
+`devopsellence vibe` creates one blessed Rails app shape instead of asking you
+to choose a stack. It uses the devopsellence Rails template, writes a local
+agent skill, seeds a prompt, initializes git, and can launch Codex, Claude Code,
+Pi, or another agent.
+
+```bash
+devopsellence vibe my-crm \
+  --ai-agent=codex \
+  --idea="A tiny CRM for solo consultants"
+```
+
+Prepare the app and prompt without starting an agent:
+
+```bash
+devopsellence vibe my-crm --idea="A tiny CRM for solo consultants" --no-agent
+```
+
+Pin a template release when reproducing a scaffold:
+
+```bash
+devopsellence vibe my-crm --template-version=v0.1.0 --no-launch
+```
+
+The command runs Rails with the pinned template:
+
+```bash
+rails new my-crm \
+  -d postgresql \
+  -m https://raw.githubusercontent.com/devopsellence/rails-app-template/v0.1.0/template.rb
+```
+
+## Included Baseline
+
+- Rails 8.1, Ruby 3.4+, PostgreSQL, Puma, Thruster, Hotwire, Turbo, Stimulus,
+  ERB, importmap, Propshaft, and Tailwind.
+- Solid Queue, Solid Cache, and Solid Cable.
+- Active Storage ready for S3-compatible object storage.
+- Rails authentication with `bcrypt`, Pundit authorization, ViewComponent,
+  Pagy, lucide icons, Sentry, and OpenTelemetry.
+- Minitest, Capybara system tests, Brakeman, bundler-audit, and
+  rubocop-rails-omakase.
+- Dockerfile, health check, `devopsellence.yml`, `.mise.toml`, and
+  `.agents/skills/devopsellence-rails-app`.
+
+The generated app uses `mise` for tool versions. The template owns the app's
+Ruby and Node versions so local development, CI, and agent work start from the
+same baseline.
+
+## Agent Loop
+
+Codex prompts start with `/goal`. Other agents get the same build-test-deploy
+loop in plain prompt form. The prompt tells the agent to use:
+
+- `.agents/skills/devopsellence-rails-app` for Rails product work;
+- `.agents/skills/devopsellence` for deploys, secrets, logs, status, rollback,
+  and node operations.
+
+Use the same app shape from 0 to 1 and from 1 to a medium-company scale: add web
+nodes, split workers, move PostgreSQL to managed or dedicated infrastructure,
+and separate Solid Queue/Cache/Cable databases or pools when pressure appears.
+
+## Existing Rails Apps
+
+Install the Rails app skill into an existing repo:
+
+```bash
+devopsellence skill install rails-app --dir .agents/skills
+```
+
+Install the base devopsellence operations skill:
+
+```bash
+devopsellence skill install --dir .agents/skills
+```

--- a/docs-website/src/content/docs/guides/rails-app-template.md
+++ b/docs-website/src/content/docs/guides/rails-app-template.md
@@ -23,7 +23,7 @@ devopsellence vibe my-crm --idea="A tiny CRM for solo consultants" --no-agent
 Pin a template release when reproducing a scaffold:
 
 ```bash
-devopsellence vibe my-crm --template-version=v0.1.0 --no-agent
+devopsellence vibe my-crm --template-version=v0.1.3 --no-agent
 ```
 
 The command runs Rails with the pinned template:
@@ -31,7 +31,7 @@ The command runs Rails with the pinned template:
 ```bash
 rails new my-crm \
   -d postgresql \
-  -m https://raw.githubusercontent.com/devopsellence/rails-app-template/v0.1.0/template.rb
+  -m https://raw.githubusercontent.com/devopsellence/rails-app-template/v0.1.3/template.rb
 ```
 
 ## Included Baseline

--- a/docs-website/src/content/docs/reference/cli.md
+++ b/docs-website/src/content/docs/reference/cli.md
@@ -56,3 +56,16 @@ devopsellence secret list
 devopsellence ingress set --service web --host app.example.com --tls-email ops@example.com
 devopsellence ingress check --wait 5m
 ```
+
+## Agent skills
+
+```bash
+devopsellence vibe my-app --ai-agent=codex --idea="A tiny CRM"
+devopsellence vibe my-app --idea="A tiny CRM" --no-agent
+devopsellence vibe my-app --ai-agent=claude --no-launch
+devopsellence skill list
+devopsellence skill install
+devopsellence skill install --global
+devopsellence skill install --dir .agents/skills
+devopsellence skill install rails-app --dir .agents/skills
+```

--- a/docs-website/src/content/docs/reference/cli.md
+++ b/docs-website/src/content/docs/reference/cli.md
@@ -62,7 +62,7 @@ devopsellence ingress check --wait 5m
 ```bash
 devopsellence vibe my-app --ai-agent=codex --idea="A tiny CRM"
 devopsellence vibe my-app --idea="A tiny CRM" --no-agent
-devopsellence vibe my-app --ai-agent=claude --no-launch
+devopsellence vibe my-app --ai-agent=claude --idea="A tiny CRM" --no-launch
 devopsellence skill list
 devopsellence skill install
 devopsellence skill install --global

--- a/skills/devopsellence-rails-app/SKILL.md
+++ b/skills/devopsellence-rails-app/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: devopsellence-rails-app
+description: Use when building, modifying, testing, deploying, or scaling the blessed devopsellence Rails application baseline. Covers Rails 8.1, PostgreSQL, Hotwire, Tailwind, Solid Queue/Cache/Cable, Active Storage, Sentry, OpenTelemetry, security checks, Docker, mise, and devopsellence solo on Linux servers.
+---
+
+# devopsellence Rails App
+
+Use this skill inside apps generated from the devopsellence Rails template.
+
+## Defaults
+
+- Rails 8.1, Ruby 3.4+, PostgreSQL, Puma, Thruster, Hotwire, Turbo, Stimulus, ERB, importmap, Propshaft, and Tailwind.
+- Solid Queue, Solid Cache, and Solid Cable before Redis or Sidekiq.
+- Active Storage with S3-compatible object storage for durable uploads.
+- Built-in Rails authentication with `bcrypt`; use Pundit for authorization.
+- ViewComponent, Pagy, lucide icons, Sentry, OpenTelemetry, Brakeman, bundler-audit, and rubocop-rails-omakase.
+- Minitest, fixtures, Capybara system tests, and focused integration tests.
+- `mise` owns language/tool versions. Do not replace it with ad hoc local setup docs.
+
+## Do Not Add By Default
+
+- Devise, Sidekiq, Redis, React, Next.js, Vite, GraphQL, Elasticsearch, Meilisearch, Kubernetes, or an admin framework.
+- Extra gems before the app has a real product need.
+- A second deployment system. Use devopsellence for deploy, secrets, logs, status, rollback, and node operations.
+
+## Build Loop
+
+1. Inspect the app and the user's request.
+2. Keep changes idiomatic Rails and close to the behavior.
+3. Add or update focused tests.
+4. Run the narrowest useful command first, then broader checks before handoff:
+   - `mise install`
+   - `bin/rails db:prepare`
+   - `bin/rails test`
+   - `bin/rails test:system` when UI behavior changed
+   - `bin/brakeman`
+   - `bundle exec bundler-audit check --update`
+5. Keep production concerns wired while building features: health checks, background jobs, uploads, secrets, logs, and deploy config.
+
+## Production Shape
+
+- Start with one Rails web process, PostgreSQL, Solid tables, object storage, Sentry, OpenTelemetry, JSON logs, and devopsellence deploy.
+- Scale to medium-company shape by adding web nodes, splitting workers, moving PostgreSQL to managed or dedicated infrastructure, and separating Solid Queue/Cache/Cable databases or pools when pressure appears.
+- Keep ordinary-tool escape hatches visible: SSH, Docker, logs, files, SQL, JSON, and cloud CLIs.
+
+## devopsellence Loop
+
+1. Configure `devopsellence.yml` with explicit services, ports, health checks, and worker processes.
+2. Store production secrets with `devopsellence secret set --stdin`; never commit secret values.
+3. Run `devopsellence deploy --dry-run` before production mutations.
+4. After deploy, collect `devopsellence status`, app logs, node logs, and HTTPS evidence when ingress is configured.


### PR DESCRIPTION
## Summary
- add bundled devopsellence Rails app skill alongside the base operations skill
- add `devopsellence vibe <directory>` to generate a Rails app from `devopsellence/rails-app-template`, seed a prompt, initialize git, and optionally launch codex/claude/pi
- document the Rails app template flow in the public docs site

## Validation
- `go test ./internal/agentskill ./internal/workflow -run 'Test(Install|Available|Bundled|RootSkill|RootVibe)'` (cli)
- `npm run check` (docs-website)
- `ruby test/template_smoke_test.rb` (`devopsellence/rails-app-template`)
- dogfood run: `/tmp/devopsellence-dogfood/20260509T231905802541Z-vibe-rails-app-scaffold`
  - found and fixed `.ruby-version`/mise mismatch
  - found and fixed missing bundle under the mise Ruby
  - final scaffold used template `v0.1.3`; `mise exec -- bundle check` passed; Rails runner printed `8.1.3`; generated git tree was clean
