### PR TITLE
[codex] Improve agent skill install targets

### DIFF
--- a/cli/internal/agentskill/agentskill.go
+++ b/cli/internal/agentskill/agentskill.go
@@ -84,10 +84,10 @@ func installTargets(opts InstallOptions) ([]installTarget, error) {
 		modes++
 	}
 	if modes == 0 {
-		return nil, fmt.Errorf("missing install target: set exactly one of WorkspaceRoot for project install, Global for user install, or SkillsDir for an explicit parent skills directory")
+		return nil, fmt.Errorf("missing install target: run from a devopsellence workspace, use --global, or pass --dir <path>")
 	}
 	if modes > 1 {
-		return nil, fmt.Errorf("conflicting install targets: set exactly one of WorkspaceRoot, Global, or SkillsDir")
+		return nil, fmt.Errorf("conflicting install targets: use only one of a devopsellence workspace, --global, or --dir <path>")
 	}
 
 	if opts.SkillsDir != "" {

--- a/cli/internal/agentskill/agentskill.go
+++ b/cli/internal/agentskill/agentskill.go
@@ -16,8 +16,21 @@ var bundled embed.FS
 type InstallResult struct {
 	Name    string
 	Path    string
+	Paths   []InstallTarget
 	Version string
 	Source  string
+}
+
+type InstallTarget struct {
+	Agent string
+	Scope string
+	Path  string
+}
+
+type InstallOptions struct {
+	SkillsDir     string
+	WorkspaceRoot string
+	Global        bool
 }
 
 func DefaultSkillsDir() (string, error) {
@@ -28,20 +41,71 @@ func DefaultSkillsDir() (string, error) {
 	return filepath.Join(home, ".agents", "skills"), nil
 }
 
-func Install(skillsDir string, version string) (InstallResult, error) {
-	if skillsDir == "" {
-		defaultDir, err := DefaultSkillsDir()
-		if err != nil {
+func ProjectSkillsDir(workspaceRoot string) string {
+	return filepath.Join(workspaceRoot, ".agents", "skills")
+}
+
+func Install(opts InstallOptions, version string) (InstallResult, error) {
+	targets, err := installTargets(opts)
+	if err != nil {
+		return InstallResult{}, err
+	}
+
+	installed := make([]InstallTarget, 0, len(targets))
+	for _, target := range targets {
+		dest := filepath.Join(target.Path, Name)
+		if err := installTo(dest); err != nil {
 			return InstallResult{}, err
 		}
-		skillsDir = defaultDir
+		installed = append(installed, InstallTarget{
+			Agent: target.Agent,
+			Scope: target.Scope,
+			Path:  dest,
+		})
 	}
-	dest := filepath.Join(skillsDir, Name)
+	return InstallResult{Name: Name, Path: installed[0].Path, Paths: installed, Version: version, Source: "embedded"}, nil
+}
+
+func installTargets(opts InstallOptions) ([]InstallTarget, error) {
+	if opts.SkillsDir != "" {
+		if opts.Global {
+			return nil, fmt.Errorf("cannot use --dir with --global")
+		}
+		return []InstallTarget{{Agent: "agents", Scope: "custom", Path: opts.SkillsDir}}, nil
+	}
+
+	if opts.Global {
+		defaultDir, err := DefaultSkillsDir()
+		if err != nil {
+			return nil, err
+		}
+		targets := []InstallTarget{{Agent: "agents", Scope: "global", Path: defaultDir}}
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil, err
+		}
+		if isDir(filepath.Join(home, ".claude")) {
+			targets = append(targets, InstallTarget{Agent: "claude", Scope: "global", Path: filepath.Join(home, ".claude", "skills")})
+		}
+		return targets, nil
+	}
+
+	if opts.WorkspaceRoot == "" {
+		return nil, fmt.Errorf("missing workspace root")
+	}
+	targets := []InstallTarget{{Agent: "agents", Scope: "project", Path: ProjectSkillsDir(opts.WorkspaceRoot)}}
+	if isDir(filepath.Join(opts.WorkspaceRoot, ".claude")) {
+		targets = append(targets, InstallTarget{Agent: "claude", Scope: "project", Path: filepath.Join(opts.WorkspaceRoot, ".claude", "skills")})
+	}
+	return targets, nil
+}
+
+func installTo(dest string) error {
 	if err := os.RemoveAll(dest); err != nil {
-		return InstallResult{}, fmt.Errorf("remove existing skill: %w", err)
+		return fmt.Errorf("remove existing skill: %w", err)
 	}
 	if err := os.MkdirAll(dest, 0o755); err != nil {
-		return InstallResult{}, fmt.Errorf("create skill dir: %w", err)
+		return fmt.Errorf("create skill dir: %w", err)
 	}
 	if err := fs.WalkDir(bundled, Name, func(path string, entry fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
@@ -64,7 +128,12 @@ func Install(skillsDir string, version string) (InstallResult, error) {
 		}
 		return os.WriteFile(target, data, 0o644)
 	}); err != nil {
-		return InstallResult{}, fmt.Errorf("write bundled skill: %w", err)
+		return fmt.Errorf("write bundled skill: %w", err)
 	}
-	return InstallResult{Name: Name, Path: dest, Version: version, Source: "embedded"}, nil
+	return nil
+}
+
+func isDir(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
 }

--- a/cli/internal/agentskill/agentskill.go
+++ b/cli/internal/agentskill/agentskill.go
@@ -16,12 +16,12 @@ var bundled embed.FS
 type InstallResult struct {
 	Name    string
 	Path    string
-	Paths   []InstallTarget
+	Paths   []InstalledPath
 	Version string
 	Source  string
 }
 
-type InstallTarget struct {
+type InstalledPath struct {
 	Agent string
 	Scope string
 	Path  string
@@ -31,6 +31,12 @@ type InstallOptions struct {
 	SkillsDir     string
 	WorkspaceRoot string
 	Global        bool
+}
+
+type installTarget struct {
+	Agent     string
+	Scope     string
+	SkillsDir string
 }
 
 func DefaultSkillsDir() (string, error) {
@@ -51,13 +57,13 @@ func Install(opts InstallOptions, version string) (InstallResult, error) {
 		return InstallResult{}, err
 	}
 
-	installed := make([]InstallTarget, 0, len(targets))
+	installed := make([]InstalledPath, 0, len(targets))
 	for _, target := range targets {
-		dest := filepath.Join(target.Path, Name)
+		dest := filepath.Join(target.SkillsDir, Name)
 		if err := installTo(dest); err != nil {
 			return InstallResult{}, err
 		}
-		installed = append(installed, InstallTarget{
+		installed = append(installed, InstalledPath{
 			Agent: target.Agent,
 			Scope: target.Scope,
 			Path:  dest,
@@ -66,12 +72,26 @@ func Install(opts InstallOptions, version string) (InstallResult, error) {
 	return InstallResult{Name: Name, Path: installed[0].Path, Paths: installed, Version: version, Source: "embedded"}, nil
 }
 
-func installTargets(opts InstallOptions) ([]InstallTarget, error) {
+func installTargets(opts InstallOptions) ([]installTarget, error) {
+	modes := 0
 	if opts.SkillsDir != "" {
-		if opts.Global {
-			return nil, fmt.Errorf("cannot use --dir with --global")
-		}
-		return []InstallTarget{{Agent: "agents", Scope: "custom", Path: opts.SkillsDir}}, nil
+		modes++
+	}
+	if opts.WorkspaceRoot != "" {
+		modes++
+	}
+	if opts.Global {
+		modes++
+	}
+	if modes == 0 {
+		return nil, fmt.Errorf("missing install target: set exactly one of WorkspaceRoot for project install, Global for user install, or SkillsDir for an explicit parent skills directory")
+	}
+	if modes > 1 {
+		return nil, fmt.Errorf("conflicting install targets: set exactly one of WorkspaceRoot, Global, or SkillsDir")
+	}
+
+	if opts.SkillsDir != "" {
+		return []installTarget{{Agent: "agents", Scope: "custom", SkillsDir: opts.SkillsDir}}, nil
 	}
 
 	if opts.Global {
@@ -79,23 +99,20 @@ func installTargets(opts InstallOptions) ([]InstallTarget, error) {
 		if err != nil {
 			return nil, err
 		}
-		targets := []InstallTarget{{Agent: "agents", Scope: "global", Path: defaultDir}}
+		targets := []installTarget{{Agent: "agents", Scope: "global", SkillsDir: defaultDir}}
 		home, err := os.UserHomeDir()
 		if err != nil {
 			return nil, err
 		}
 		if isDir(filepath.Join(home, ".claude")) {
-			targets = append(targets, InstallTarget{Agent: "claude", Scope: "global", Path: filepath.Join(home, ".claude", "skills")})
+			targets = append(targets, installTarget{Agent: "claude", Scope: "global", SkillsDir: filepath.Join(home, ".claude", "skills")})
 		}
 		return targets, nil
 	}
 
-	if opts.WorkspaceRoot == "" {
-		return nil, fmt.Errorf("missing workspace root")
-	}
-	targets := []InstallTarget{{Agent: "agents", Scope: "project", Path: ProjectSkillsDir(opts.WorkspaceRoot)}}
+	targets := []installTarget{{Agent: "agents", Scope: "project", SkillsDir: ProjectSkillsDir(opts.WorkspaceRoot)}}
 	if isDir(filepath.Join(opts.WorkspaceRoot, ".claude")) {
-		targets = append(targets, InstallTarget{Agent: "claude", Scope: "project", Path: filepath.Join(opts.WorkspaceRoot, ".claude", "skills")})
+		targets = append(targets, installTarget{Agent: "claude", Scope: "project", SkillsDir: filepath.Join(opts.WorkspaceRoot, ".claude", "skills")})
 	}
 	return targets, nil
 }

--- a/cli/internal/agentskill/agentskill_test.go
+++ b/cli/internal/agentskill/agentskill_test.go
@@ -83,14 +83,14 @@ func TestInstallGlobalUsesUserAgentSkillDirs(t *testing.T) {
 
 func TestInstallRejectsGlobalWithExplicitDir(t *testing.T) {
 	_, err := Install(InstallOptions{SkillsDir: t.TempDir(), Global: true}, "v1-test")
-	if err == nil || !strings.Contains(err.Error(), "set exactly one") {
+	if err == nil || !strings.Contains(err.Error(), "--global") || !strings.Contains(err.Error(), "--dir <path>") {
 		t.Fatalf("Install() error = %v, want install target conflict", err)
 	}
 }
 
 func TestInstallRequiresTarget(t *testing.T) {
 	_, err := Install(InstallOptions{}, "v1-test")
-	if err == nil || !strings.Contains(err.Error(), "WorkspaceRoot") || !strings.Contains(err.Error(), "Global") || !strings.Contains(err.Error(), "SkillsDir") {
+	if err == nil || !strings.Contains(err.Error(), "devopsellence workspace") || !strings.Contains(err.Error(), "--global") || !strings.Contains(err.Error(), "--dir <path>") {
 		t.Fatalf("Install() error = %v, want actionable missing target error", err)
 	}
 }

--- a/cli/internal/agentskill/agentskill_test.go
+++ b/cli/internal/agentskill/agentskill_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestInstallWritesBundledSkill(t *testing.T) {
 	dir := t.TempDir()
-	result, err := Install(dir, "v1-test")
+	result, err := Install(InstallOptions{SkillsDir: dir}, "v1-test")
 	if err != nil {
 		t.Fatalf("Install() error = %v", err)
 	}
@@ -22,6 +22,68 @@ func TestInstallWritesBundledSkill(t *testing.T) {
 	}
 	if len(data) == 0 {
 		t.Fatalf("%s is empty", path)
+	}
+}
+
+func TestInstallDefaultsToProjectAgentSkillDirs(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	if err := os.Mkdir(filepath.Join(workspaceRoot, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := Install(InstallOptions{WorkspaceRoot: workspaceRoot}, "v1-test")
+	if err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+
+	agentsPath := filepath.Join(workspaceRoot, ".agents", "skills", Name, "SKILL.md")
+	if _, err := os.Stat(agentsPath); err != nil {
+		t.Fatalf("expected project agents skill at %s: %v", agentsPath, err)
+	}
+	claudePath := filepath.Join(workspaceRoot, ".claude", "skills", Name, "SKILL.md")
+	if _, err := os.Stat(claudePath); err != nil {
+		t.Fatalf("expected project claude skill at %s: %v", claudePath, err)
+	}
+	if result.Path != filepath.Join(workspaceRoot, ".agents", "skills", Name) {
+		t.Fatalf("path = %q, want project agents skill path", result.Path)
+	}
+	if len(result.Paths) != 2 || result.Paths[0].Agent != "agents" || result.Paths[0].Scope != "project" || result.Paths[1].Agent != "claude" || result.Paths[1].Scope != "project" {
+		t.Fatalf("paths = %#v, want project agents and claude targets", result.Paths)
+	}
+}
+
+func TestInstallGlobalUsesUserAgentSkillDirs(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := os.Mkdir(filepath.Join(home, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := Install(InstallOptions{Global: true}, "v1-test")
+	if err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+
+	agentsPath := filepath.Join(home, ".agents", "skills", Name, "SKILL.md")
+	if _, err := os.Stat(agentsPath); err != nil {
+		t.Fatalf("expected global agents skill at %s: %v", agentsPath, err)
+	}
+	claudePath := filepath.Join(home, ".claude", "skills", Name, "SKILL.md")
+	if _, err := os.Stat(claudePath); err != nil {
+		t.Fatalf("expected global claude skill at %s: %v", claudePath, err)
+	}
+	if result.Path != filepath.Join(home, ".agents", "skills", Name) {
+		t.Fatalf("path = %q, want global agents skill path", result.Path)
+	}
+	if len(result.Paths) != 2 || result.Paths[0].Scope != "global" || result.Paths[1].Scope != "global" {
+		t.Fatalf("paths = %#v, want global targets", result.Paths)
+	}
+}
+
+func TestInstallRejectsGlobalWithExplicitDir(t *testing.T) {
+	_, err := Install(InstallOptions{SkillsDir: t.TempDir(), Global: true}, "v1-test")
+	if err == nil {
+		t.Fatal("Install() error = nil, want --dir/--global conflict")
 	}
 }
 

--- a/cli/internal/agentskill/agentskill_test.go
+++ b/cli/internal/agentskill/agentskill_test.go
@@ -3,6 +3,7 @@ package agentskill
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -82,8 +83,15 @@ func TestInstallGlobalUsesUserAgentSkillDirs(t *testing.T) {
 
 func TestInstallRejectsGlobalWithExplicitDir(t *testing.T) {
 	_, err := Install(InstallOptions{SkillsDir: t.TempDir(), Global: true}, "v1-test")
-	if err == nil {
-		t.Fatal("Install() error = nil, want --dir/--global conflict")
+	if err == nil || !strings.Contains(err.Error(), "set exactly one") {
+		t.Fatalf("Install() error = %v, want install target conflict", err)
+	}
+}
+
+func TestInstallRequiresTarget(t *testing.T) {
+	_, err := Install(InstallOptions{}, "v1-test")
+	if err == nil || !strings.Contains(err.Error(), "WorkspaceRoot") || !strings.Contains(err.Error(), "Global") || !strings.Contains(err.Error(), "SkillsDir") {
+		t.Fatalf("Install() error = %v, want actionable missing target error", err)
 	}
 }
 

--- a/cli/internal/workflow/app.go
+++ b/cli/internal/workflow/app.go
@@ -570,6 +570,11 @@ func (a *App) Init(ctx context.Context, opts InitOptions) error {
 			"project_slug":         initialized.Discovered.ProjectSlug,
 			"runtime_contract":     initRuntimeContract(resolvedConfig, initialized.Discovered, initRuntimeContractProvenance(initialized.Config, resolvedConfig, initialized.Environment.Name, initialized.CreatedConfig)),
 			"config":               initialized.Config,
+			"next_steps": []string{
+				"devopsellence skill install",
+				"devopsellence doctor",
+				"devopsellence deploy",
+			},
 		}
 		return nil
 	}

--- a/cli/internal/workflow/management_test.go
+++ b/cli/internal/workflow/management_test.go
@@ -65,6 +65,15 @@ func TestInitWritesConfigOnly(t *testing.T) {
 	if hints := jsonArrayFromMap(t, runtimeContract, "agent_hints"); len(hints) != 2 {
 		t.Fatalf("runtime_contract.agent_hints = %#v, want shared init port and healthcheck hints", hints)
 	}
+	stepValues := jsonArrayFromMap(t, payload, "next_steps")
+	steps := make([]string, 0, len(stepValues))
+	for _, value := range stepValues {
+		steps = append(steps, stringValueAny(value))
+	}
+	nextSteps := strings.Join(steps, "\n")
+	if !strings.Contains(nextSteps, "devopsellence skill install") {
+		t.Fatalf("next_steps = %q, want agent skill install hint", nextSteps)
+	}
 }
 
 func TestInitRuntimeContractUsesSelectedEnvironmentOverlay(t *testing.T) {

--- a/cli/internal/workflow/root.go
+++ b/cli/internal/workflow/root.go
@@ -533,6 +533,12 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 				if discoverErr != nil {
 					return ExitError{Code: 1, Err: discoverErr}
 				}
+				if _, statErr := os.Stat(app.ConfigStore.PathFor(discovered.WorkspaceRoot)); statErr != nil {
+					if os.IsNotExist(statErr) {
+						return ExitError{Code: 2, Err: errors.New("no devopsellence workspace found; run from a directory containing devopsellence.yml, or use --global or --dir <path>")}
+					}
+					return ExitError{Code: 1, Err: statErr}
+				}
 				installOpts.WorkspaceRoot = discovered.WorkspaceRoot
 			}
 			result, installErr := agentskill.Install(installOpts, version.String())

--- a/cli/internal/workflow/root.go
+++ b/cli/internal/workflow/root.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/devopsellence/cli/internal/agentskill"
+	"github.com/devopsellence/cli/internal/discovery"
 	"github.com/devopsellence/cli/internal/version"
 
 	"github.com/spf13/cobra"
@@ -514,26 +515,48 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 	root.AddCommand(aliasCommand)
 
 	var skillInstallDir string
+	var skillInstallGlobal bool
 	skillCommand := &cobra.Command{Use: "skill", Short: "Manage bundled AI agent skill"}
 	skillInstallCommand := &cobra.Command{
 		Use:   "install",
 		Short: "Install the bundled devopsellence agent skill",
 		RunE: func(_ *cobra.Command, _ []string) error {
-			result, installErr := agentskill.Install(skillInstallDir, version.String())
+			installOpts := agentskill.InstallOptions{
+				SkillsDir: skillInstallDir,
+				Global:    skillInstallGlobal,
+			}
+			if skillInstallDir == "" && !skillInstallGlobal {
+				discovered, discoverErr := discovery.Discover(app.Cwd)
+				if discoverErr != nil {
+					return ExitError{Code: 1, Err: discoverErr}
+				}
+				installOpts.WorkspaceRoot = discovered.WorkspaceRoot
+			}
+			result, installErr := agentskill.Install(installOpts, version.String())
 			if installErr != nil {
 				return ExitError{Code: 1, Err: installErr}
+			}
+			paths := make([]map[string]any, 0, len(result.Paths))
+			for _, target := range result.Paths {
+				paths = append(paths, map[string]any{
+					"agent": target.Agent,
+					"scope": target.Scope,
+					"path":  target.Path,
+				})
 			}
 			return app.Printer.PrintJSON(map[string]any{
 				"schema_version": outputSchemaVersion,
 				"action":         "installed",
 				"skill":          result.Name,
 				"path":           result.Path,
+				"paths":          paths,
 				"version":        result.Version,
 				"source":         result.Source,
 			})
 		},
 	}
-	skillInstallCommand.Flags().StringVar(&skillInstallDir, "dir", "", "Parent skills directory (default ~/.agents/skills)")
+	skillInstallCommand.Flags().StringVar(&skillInstallDir, "dir", "", "Parent skills directory (default <project>/.agents/skills)")
+	skillInstallCommand.Flags().BoolVar(&skillInstallGlobal, "global", false, "Install to user-level agent skill directories")
 	skillCommand.AddCommand(skillInstallCommand)
 	root.AddCommand(skillCommand)
 

--- a/cli/internal/workflow/root.go
+++ b/cli/internal/workflow/root.go
@@ -521,6 +521,9 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 		Use:   "install",
 		Short: "Install the bundled devopsellence agent skill",
 		RunE: func(_ *cobra.Command, _ []string) error {
+			if skillInstallDir != "" && skillInstallGlobal {
+				return ExitError{Code: 2, Err: errors.New("cannot use --dir with --global")}
+			}
 			installOpts := agentskill.InstallOptions{
 				SkillsDir: skillInstallDir,
 				Global:    skillInstallGlobal,

--- a/cli/internal/workflow/root_test.go
+++ b/cli/internal/workflow/root_test.go
@@ -175,6 +175,23 @@ func TestRootSkillInstallRejectsDirWithGlobalAsUsageError(t *testing.T) {
 	}
 }
 
+func TestRootSkillInstallRequiresWorkspaceForDefaultProjectInstall(t *testing.T) {
+	var stdout bytes.Buffer
+	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, t.TempDir())
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{"skill", "install"})
+
+	err := cmd.Execute()
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 2 {
+		t.Fatalf("error = %#v, want ExitError code 2", err)
+	}
+	if !strings.Contains(err.Error(), "devopsellence.yml") || !strings.Contains(err.Error(), "--global") || !strings.Contains(err.Error(), "--dir <path>") {
+		t.Fatalf("error = %v, want workspace/global/dir guidance", err)
+	}
+}
+
 func TestRootModeFlagIsNotGlobal(t *testing.T) {
 	t.Parallel()
 

--- a/cli/internal/workflow/root_test.go
+++ b/cli/internal/workflow/root_test.go
@@ -161,6 +161,20 @@ func TestRootSkillInstallDefaultsToProjectSkillDirs(t *testing.T) {
 	}
 }
 
+func TestRootSkillInstallRejectsDirWithGlobalAsUsageError(t *testing.T) {
+	var stdout bytes.Buffer
+	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, t.TempDir())
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{"skill", "install", "--dir", t.TempDir(), "--global"})
+
+	err := cmd.Execute()
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 2 {
+		t.Fatalf("error = %#v, want ExitError code 2", err)
+	}
+}
+
 func TestRootModeFlagIsNotGlobal(t *testing.T) {
 	t.Parallel()
 

--- a/cli/internal/workflow/root_test.go
+++ b/cli/internal/workflow/root_test.go
@@ -120,6 +120,45 @@ func TestRootSkillInstallWritesBundledSkill(t *testing.T) {
 	if payload["path"] != filepath.Join(skillsDir, "devopsellence") {
 		t.Fatalf("path = %#v, want %q", payload["path"], filepath.Join(skillsDir, "devopsellence"))
 	}
+	paths := jsonArrayFromMap(t, payload, "paths")
+	if len(paths) != 1 {
+		t.Fatalf("paths = %#v, want one explicit install target", paths)
+	}
+}
+
+func TestRootSkillInstallDefaultsToProjectSkillDirs(t *testing.T) {
+	cwd := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cwd, "devopsellence.yml"), []byte("schema_version: 1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(cwd, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var stdout bytes.Buffer
+	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, cwd)
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{"skill", "install"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	agentsPath := filepath.Join(cwd, ".agents", "skills", "devopsellence")
+	claudePath := filepath.Join(cwd, ".claude", "skills", "devopsellence")
+	if payload["path"] != agentsPath {
+		t.Fatalf("path = %#v, want %q", payload["path"], agentsPath)
+	}
+	if _, err := os.Stat(filepath.Join(agentsPath, "SKILL.md")); err != nil {
+		t.Fatalf("expected project agents skill: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(claudePath, "SKILL.md")); err != nil {
+		t.Fatalf("expected project claude skill: %v", err)
+	}
+	paths := jsonArrayFromMap(t, payload, "paths")
+	if len(paths) != 2 {
+		t.Fatalf("paths = %#v, want agents and claude targets", paths)
+	}
 }
 
 func TestRootModeFlagIsNotGlobal(t *testing.T) {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -6264,6 +6264,7 @@ func (a *App) SoloInit(context.Context, SoloInitOptions) error {
 		missing = append(missing, "node")
 	}
 	nextSteps := []string{
+		"devopsellence skill install",
 		"git init # if this app is not already a git checkout",
 		"git add . # include devopsellence.yml and app files",
 		"git commit -m 'initial deploy' # devopsellence deploys the current commit",

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -9877,6 +9877,9 @@ func TestSoloInitCreatesWorkspaceConfig(t *testing.T) {
 		steps = append(steps, stringValueAny(value))
 	}
 	nextSteps := strings.Join(steps, "\n")
+	if !strings.Contains(nextSteps, "devopsellence skill install") {
+		t.Fatalf("next_steps = %q, want agent skill install hint", nextSteps)
+	}
 	if !strings.Contains(nextSteps, "devopsellence node list --all # solo node names are global on this machine") {
 		t.Fatalf("next_steps = %q, want node-list collision guidance", nextSteps)
 	}

--- a/cli/scripts/release-local.sh
+++ b/cli/scripts/release-local.sh
@@ -119,6 +119,8 @@ install_agent_skill() {
 
   if [[ -n "$AGENT_SKILLS_DIR" ]]; then
     skill_args+=(--dir "$AGENT_SKILLS_DIR")
+  else
+    skill_args+=(--global)
   fi
 
   echo "installing devopsellence agent skill..."

--- a/control-plane/app/controllers/cli_installs_controller.rb
+++ b/control-plane/app/controllers/cli_installs_controller.rb
@@ -171,6 +171,8 @@ class CliInstallsController < ActionController::Base
 
         if [[ -n "$AGENT_SKILLS_DIR" ]]; then
           skill_args+=(--dir "$AGENT_SKILLS_DIR")
+        else
+          skill_args+=(--global)
         fi
 
         echo "installing devopsellence agent skill..."

--- a/control-plane/test/integration/installs_test.rb
+++ b/control-plane/test/integration/installs_test.rb
@@ -67,6 +67,7 @@ class InstallsTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "echo '$PATH_EXPORT' >> $RC_FILE"
     assert_includes response.body, "source $RC_FILE"
     assert_includes response.body, '"$INSTALL_DIR/$TARGET_NAME" skill install'
+    assert_includes response.body, "skill_args+=(--global)"
     refute_includes response.body, "npx --yes skills add"
     assert_includes response.body, 'curl -fsSL "$INSTALL_SCRIPT_URL?version=$CLI_VERSION" | bash -s -- --install-agent-skill'
   end
@@ -366,6 +367,10 @@ class InstallsTest < ActionDispatch::IntegrationTest
               --dir)
                 skills_dir="$2"
                 shift 2
+                ;;
+              --global)
+                skills_dir="$HOME/.agents/skills"
+                shift
                 ;;
               *)
                 echo "unexpected skill arg: $1" >&2


### PR DESCRIPTION
## Summary
- Change `devopsellence skill install` to default to project-local `.agents/skills/devopsellence`.
- Also install to project/global `.claude/skills/devopsellence` when the matching `.claude` directory exists.
- Add `--global` for user-level install targets, keep `--dir` as the explicit override, and include installed target metadata in JSON output.
- Add init next-step hints for `devopsellence skill install` and make CLI installer scripts pass `--global` when installing the skill outside a project.

## Validation
- `TMPDIR=/var/tmp/codex-devopsellence-tests mise run test:cli`
- `mise run test -- test/integration/installs_test.rb`
- `git diff --check`