### PR TITLE
[codex] add deploy intake to vibe

### DIFF
--- a/cli/internal/workflow/root.go
+++ b/cli/internal/workflow/root.go
@@ -594,7 +594,7 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 	var vibeNoLaunch bool
 	vibeOpts.Launch = true
 	vibeCommand := &cobra.Command{
-		Use:   "vibe [directory]",
+		Use:   "vibe [name-or-directory]",
 		Short: "Generate a blessed Rails app and start an AI-agent build loop",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -606,7 +606,17 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 		},
 	}
 	vibeCommand.Flags().StringVar(&vibeOpts.AIAgent, "ai-agent", "", "AI agent to seed: codex, claude, pi, or generic")
+	vibeCommand.Flags().StringVar(&vibeOpts.AgentEffort, "agent-effort", defaultVibeAgentEffort, "AI agent effort/thinking level: default, low, medium, high, or xhigh")
 	vibeCommand.Flags().StringVar(&vibeOpts.Idea, "idea", "", "App idea to seed into the AI agent prompt")
+	vibeCommand.Flags().StringVar(&vibeOpts.FirstWorkflow, "first-workflow", "", "First product workflow for the agent to build")
+	vibeCommand.Flags().StringVar(&vibeOpts.DeployGoal, "deploy-goal", defaultVibeDeployGoal, "Build/deploy goal: build-only, prepare-solo, dry-run, or deploy-with-approval")
+	vibeCommand.Flags().StringVar(&vibeOpts.DevopsellenceMode, "devopsellence-mode", defaultVibeMode, "Deployment mode intent: solo, shared-later, or decide-later")
+	vibeCommand.Flags().StringVar(&vibeOpts.ServerStrategy, "server", defaultVibeServerStrategy, "Server plan: none, existing, or hetzner")
+	vibeCommand.Flags().StringVar(&vibeOpts.ServerTarget, "server-target", "", "Existing node/server name or desired provider node name")
+	vibeCommand.Flags().StringVar(&vibeOpts.Domain, "domain", vibeDomainLater, "Domain intent, or later")
+	vibeCommand.Flags().StringVar(&vibeOpts.TLSEmail, "tls-email", "", "TLS email to use when configuring ingress")
+	vibeCommand.Flags().StringVar(&vibeOpts.Services, "services", "later", "Comma-separated external services: later, managed-postgres, object-storage, email, cloudflare-dns")
+	vibeCommand.Flags().StringVar(&vibeOpts.ProjectsDir, "projects-dir", "", "Directory for bare app names (default ~/devopsellence-projects or DEVOPSELLENCE_PROJECTS_DIR)")
 	vibeCommand.Flags().StringVar(&vibeOpts.TemplateVersion, "template-version", defaultVibeTemplateVersion, "devopsellence Rails template version")
 	vibeCommand.Flags().BoolVar(&vibeNoLaunch, "no-launch", false, "Prepare the Rails app without starting the AI agent")
 	vibeCommand.Flags().BoolVar(&vibeOpts.NoAgent, "no-agent", false, "Prepare the Rails app and prompt without selecting or starting an AI agent")

--- a/cli/internal/workflow/root_test.go
+++ b/cli/internal/workflow/root_test.go
@@ -542,6 +542,17 @@ func TestRootVibeWizardCollectsDeployIntent(t *testing.T) {
 	if !jsonArrayContains(nextCommands, "devopsellence provider login hetzner --token <token>") {
 		t.Fatalf("next_commands = %#v, want secure Hetzner login hint", nextCommands)
 	}
+	manifestData, err := os.ReadFile(filepath.Join(appDir, ".agents", "devopsellence-vibe.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var manifest vibeManifest
+	if err := json.Unmarshal(manifestData, &manifest); err != nil {
+		t.Fatal(err)
+	}
+	if !stringSliceContains(manifest.NextCommands, "devopsellence provider login hetzner --token <token>") {
+		t.Fatalf("manifest.NextCommands = %#v, want secure Hetzner login hint", manifest.NextCommands)
+	}
 	promptData, err := os.ReadFile(filepath.Join(appDir, ".agents", "prompts", "devopsellence-vibe.md"))
 	if err != nil {
 		t.Fatal(err)
@@ -876,6 +887,29 @@ func TestVibeAgentCommandIncludesEffort(t *testing.T) {
 		if got != tt.want {
 			t.Fatalf("vibeAgentCommand(%q, %q) = %q, want %q", tt.agent, tt.effort, got, tt.want)
 		}
+	}
+}
+
+func TestNormalizeVibeLater(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{name: "empty", value: "", want: vibeDomainLater},
+		{name: "none", value: "none", want: vibeDomainLater},
+		{name: "no", value: "no", want: vibeDomainLater},
+		{name: "lower later", value: "later", want: vibeDomainLater},
+		{name: "title later", value: "Later", want: vibeDomainLater},
+		{name: "upper later", value: "LATER", want: vibeDomainLater},
+		{name: "domain", value: "crm.example.com", want: "crm.example.com"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeVibeLater(tt.value); got != tt.want {
+				t.Fatalf("normalizeVibeLater(%q) = %q, want %q", tt.value, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/cli/internal/workflow/root_test.go
+++ b/cli/internal/workflow/root_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/devopsellence/cli/internal/solo"
 	"github.com/devopsellence/cli/internal/state"
@@ -910,6 +911,16 @@ func TestNormalizeVibeLater(t *testing.T) {
 				t.Fatalf("normalizeVibeLater(%q) = %q, want %q", tt.value, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestTruncateVibeTextPreservesUTF8(t *testing.T) {
+	got := truncateVibeText("abå😊cd", 4)
+	if got != "abå😊" {
+		t.Fatalf("truncateVibeText() = %q, want rune-boundary truncation", got)
+	}
+	if !utf8.ValidString(got) {
+		t.Fatalf("truncateVibeText() returned invalid UTF-8: %q", got)
 	}
 }
 

--- a/cli/internal/workflow/root_test.go
+++ b/cli/internal/workflow/root_test.go
@@ -77,9 +77,23 @@ case "${1:-}" in
 esac
 `)
 	for _, agent := range agents {
-		writeExecutable(t, filepath.Join(binDir, agent), "#!/usr/bin/env bash\nexit 0\n")
+		writeExecutable(t, filepath.Join(binDir, agent), `#!/usr/bin/env bash
+set -euo pipefail
+if [ -n "${VIBE_AGENT_ARGS_FILE:-}" ]; then
+  printf '%s\n' "$@" > "$VIBE_AGENT_ARGS_FILE"
+fi
+exit 0
+`)
 	}
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+"/usr/bin:/bin")
+}
+
+func setFakeVibeHome(t *testing.T, cwd string) string {
+	t.Helper()
+	home := filepath.Join(cwd, "home")
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_STATE_HOME", filepath.Join(cwd, "state"))
+	return home
 }
 
 func TestRootVersionCommand(t *testing.T) {
@@ -331,6 +345,7 @@ func TestRootSkillInstallRequiresWorkspaceForDefaultProjectInstall(t *testing.T)
 
 func TestRootVibePreparesRailsAppWorkspace(t *testing.T) {
 	cwd := t.TempDir()
+	home := setFakeVibeHome(t, cwd)
 	installFakeVibeTools(t)
 	var stdout bytes.Buffer
 	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, cwd)
@@ -347,9 +362,14 @@ func TestRootVibePreparesRailsAppWorkspace(t *testing.T) {
 		t.Fatalf("Execute() error = %v", err)
 	}
 	payload := decodeJSONOutput(t, &stdout)
-	appDir := filepath.Join(cwd, "my-app")
-	if payload["directory"] != appDir || payload["ai_agent"] != "codex" || payload["app_stack"] != "rails-app" || payload["launch_requested"] != false {
+	projectsDir := filepath.Join(home, defaultVibeProjectsDirName)
+	appDir := filepath.Join(projectsDir, "my-app")
+	if payload["directory"] != appDir || payload["projects_dir"] != projectsDir || payload["ai_agent"] != "codex" || payload["agent_effort"] != "high" || payload["app_stack"] != "rails-app" || payload["launch_requested"] != false {
 		t.Fatalf("payload = %#v, want prepared codex rails workspace", payload)
+	}
+	intent := jsonMapFromAny(t, payload["deployment_intent"])
+	if intent["deploy_goal"] != "prepare-solo" || intent["devopsellence_mode"] != "solo" || intent["server_strategy"] != "none" {
+		t.Fatalf("deployment_intent = %#v, want solo prepare defaults", intent)
 	}
 	if payload["template_version"] != defaultVibeTemplateVersion || payload["template_url"] != vibeTemplateURL(defaultVibeTemplateVersion) || payload["initial_commit"] != true {
 		t.Fatalf("payload = %#v, want pinned template and initial commit", payload)
@@ -373,11 +393,11 @@ func TestRootVibePreparesRailsAppWorkspace(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(prompt), "/goal") || !strings.Contains(string(prompt), "A tiny CRM") || !strings.Contains(string(prompt), "Rails 8.1") {
+	if !strings.Contains(string(prompt), "/goal") || !strings.Contains(string(prompt), "A tiny CRM") || !strings.Contains(string(prompt), "Deployment intent") || !strings.Contains(string(prompt), "Before any production mutation") || !strings.Contains(string(prompt), "Rails 8.1") {
 		t.Fatalf("prompt = %q, want seeded codex prompt", prompt)
 	}
 	nextCommands := jsonArrayFromMap(t, payload, "next_commands")
-	if !jsonArrayContains(nextCommands, "codex 'Read .agents/prompts/devopsellence-vibe.md and follow it.'") {
+	if !jsonArrayContains(nextCommands, "codex -c 'model_reasoning_effort=\"high\"' 'Read .agents/prompts/devopsellence-vibe.md and follow it.'") {
 		t.Fatalf("next_commands = %#v, want prompt-file agent command", nextCommands)
 	}
 	manifestData, err := os.ReadFile(filepath.Join(appDir, ".agents", "devopsellence-vibe.json"))
@@ -388,8 +408,198 @@ func TestRootVibePreparesRailsAppWorkspace(t *testing.T) {
 	if err := json.Unmarshal(manifestData, &manifest); err != nil {
 		t.Fatal(err)
 	}
-	if filepath.IsAbs(manifest.SkillDir) || filepath.IsAbs(manifest.PromptPath) || manifest.AppStack != "rails-app" || manifest.TemplateVersion != defaultVibeTemplateVersion {
+	if filepath.IsAbs(manifest.SkillDir) || filepath.IsAbs(manifest.PromptPath) || manifest.AppStack != "rails-app" || manifest.AgentEffort != "high" || manifest.TemplateVersion != defaultVibeTemplateVersion || manifest.DeploymentIntent.DeployGoal != "prepare-solo" {
 		t.Fatalf("manifest = %#v, want repo-relative paths", manifest)
+	}
+}
+
+func TestRootVibeHonorsExplicitRelativePath(t *testing.T) {
+	cwd := t.TempDir()
+	setFakeVibeHome(t, cwd)
+	installFakeVibeTools(t)
+	var stdout bytes.Buffer
+	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, cwd)
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{
+		"vibe", "./my-app",
+		"--ai-agent", "generic",
+		"--idea", "A tiny uptime page",
+		"--no-launch",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	appDir := filepath.Join(cwd, "my-app")
+	if payload["directory"] != appDir || payload["projects_dir"] != "" {
+		t.Fatalf("payload = %#v, want explicit relative path under cwd", payload)
+	}
+	if _, err := os.Stat(filepath.Join(appDir, ".agents", "devopsellence-vibe.json")); err != nil {
+		t.Fatalf("expected explicit path app: %v", err)
+	}
+}
+
+func TestRootVibeUsesConfiguredProjectsDir(t *testing.T) {
+	cwd := t.TempDir()
+	home := setFakeVibeHome(t, cwd)
+	installFakeVibeTools(t)
+	var stdout bytes.Buffer
+	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, cwd)
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{
+		"vibe", "my-app",
+		"--projects-dir", "~/custom-projects",
+		"--ai-agent", "generic",
+		"--idea", "A tiny uptime page",
+		"--no-launch",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	projectsDir := filepath.Join(home, "custom-projects")
+	appDir := filepath.Join(projectsDir, "my-app")
+	if payload["directory"] != appDir || payload["projects_dir"] != projectsDir {
+		t.Fatalf("payload = %#v, want configured projects dir", payload)
+	}
+}
+
+func TestRootVibeUsesProjectsDirEnvironment(t *testing.T) {
+	cwd := t.TempDir()
+	setFakeVibeHome(t, cwd)
+	installFakeVibeTools(t)
+	envProjectsDir := filepath.Join(cwd, "env-projects")
+	t.Setenv("DEVOPSELLENCE_PROJECTS_DIR", envProjectsDir)
+	var stdout bytes.Buffer
+	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, cwd)
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{
+		"vibe", "my-app",
+		"--ai-agent", "generic",
+		"--idea", "A tiny uptime page",
+		"--no-launch",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	if payload["directory"] != filepath.Join(envProjectsDir, "my-app") || payload["projects_dir"] != envProjectsDir {
+		t.Fatalf("payload = %#v, want env projects dir", payload)
+	}
+}
+
+func TestRootVibeWizardCollectsDeployIntent(t *testing.T) {
+	cwd := t.TempDir()
+	home := setFakeVibeHome(t, cwd)
+	installFakeVibeTools(t)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	input := bytes.NewBufferString(strings.Join([]string{
+		"A tiny CRM for consultants",
+		"Track contacts and follow-ups",
+		"dry-run",
+		"solo",
+		"hetzner",
+		"prod-1",
+		"crm.example.com",
+		"ops@example.com",
+		"managed-postgres,cloudflare-dns",
+	}, "\n") + "\n")
+	cmd := NewRootCommand(input, &stdout, &stderr, cwd)
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{
+		"vibe", "crm-app",
+		"--no-launch",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\nstderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "Ctrl+C") || !strings.Contains(stderr.String(), "Server plan") {
+		t.Fatalf("stderr = %q, want wizard guidance and questions", stderr.String())
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	appDir := filepath.Join(home, defaultVibeProjectsDirName, "crm-app")
+	if payload["directory"] != appDir {
+		t.Fatalf("payload = %#v, want app under projects dir", payload)
+	}
+	intent := jsonMapFromAny(t, payload["deployment_intent"])
+	if intent["deploy_goal"] != "dry-run" || intent["server_strategy"] != "hetzner" || intent["provider_auth_status"] != "missing" || intent["server_target"] != "prod-1" {
+		t.Fatalf("deployment_intent = %#v, want hetzner dry-run intent", intent)
+	}
+	services := jsonArrayFromMap(t, intent, "services")
+	if !jsonArrayContains(services, "managed-postgres") || !jsonArrayContains(services, "cloudflare-dns") {
+		t.Fatalf("services = %#v, want managed postgres and Cloudflare DNS", services)
+	}
+	nextCommands := jsonArrayFromMap(t, payload, "next_commands")
+	if !jsonArrayContains(nextCommands, "devopsellence provider login hetzner --token <token>") {
+		t.Fatalf("next_commands = %#v, want secure Hetzner login hint", nextCommands)
+	}
+	promptData, err := os.ReadFile(filepath.Join(appDir, ".agents", "prompts", "devopsellence-vibe.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	prompt := string(promptData)
+	for _, want := range []string{
+		"Track contacts and follow-ups",
+		"Hetzner auth is missing",
+		"run devopsellence deploy --dry-run",
+		"Cloudflare DNS changes only after the user confirms",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("prompt missing %q:\n%s", want, prompt)
+		}
+	}
+}
+
+func TestRootVibeHetznerAuthStatusDoesNotLeakToken(t *testing.T) {
+	cwd := t.TempDir()
+	home := setFakeVibeHome(t, cwd)
+	installFakeVibeTools(t)
+	t.Setenv("DEVOPSELLENCE_HETZNER_API_TOKEN", "super-secret-token")
+	var stdout bytes.Buffer
+	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, cwd)
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{
+		"vibe", "crm-app",
+		"--ai-agent", "generic",
+		"--idea", "A tiny CRM",
+		"--server", "hetzner",
+		"--server-target", "prod-1",
+		"--no-launch",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	intent := jsonMapFromAny(t, payload["deployment_intent"])
+	if intent["provider_auth_status"] != "available" || intent["provider_auth_source"] != "DEVOPSELLENCE_HETZNER_API_TOKEN" {
+		t.Fatalf("deployment_intent = %#v, want env auth status without token", intent)
+	}
+	appDir := filepath.Join(home, defaultVibeProjectsDirName, "crm-app")
+	for _, path := range []string{
+		filepath.Join(appDir, ".agents", "devopsellence-vibe.json"),
+		filepath.Join(appDir, ".agents", "prompts", "devopsellence-vibe.md"),
+	} {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(string(data), "super-secret-token") {
+			t.Fatalf("%s leaked provider token", path)
+		}
+	}
+	if strings.Contains(stdout.String(), "super-secret-token") {
+		t.Fatalf("stdout leaked provider token: %s", stdout.String())
 	}
 }
 
@@ -408,7 +618,7 @@ func TestRootVibeAppendsSecretPatternsToExistingGitignore(t *testing.T) {
 	cmd.SetOut(&stdout)
 	cmd.SetErr(&stdout)
 	cmd.SetArgs([]string{
-		"vibe", "existing-app",
+		"vibe", "./existing-app",
 		"--ai-agent", "generic",
 		"--idea", "A tiny uptime API",
 		"--no-launch",
@@ -437,7 +647,7 @@ func TestRootVibeAppendsSecretPatternsToExistingGitignore(t *testing.T) {
 	cmd.SetOut(&stdout)
 	cmd.SetErr(&stdout)
 	cmd.SetArgs([]string{
-		"vibe", "existing-app",
+		"vibe", "./existing-app",
 		"--ai-agent", "generic",
 		"--idea", "A tiny uptime API",
 		"--no-launch",
@@ -457,6 +667,7 @@ func TestRootVibeAppendsSecretPatternsToExistingGitignore(t *testing.T) {
 
 func TestRootVibeNoAgentUsesGeneric(t *testing.T) {
 	cwd := t.TempDir()
+	home := setFakeVibeHome(t, cwd)
 	installFakeVibeTools(t)
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
@@ -477,7 +688,7 @@ func TestRootVibeNoAgentUsesGeneric(t *testing.T) {
 	if payload["ai_agent"] != "generic" || payload["app_stack"] != "rails-app" || payload["launch_requested"] != false {
 		t.Fatalf("payload = %#v, want generic rails app workspace", payload)
 	}
-	path := filepath.Join(cwd, "rails-app", ".agents", "skills", "devopsellence-rails-app", "SKILL.md")
+	path := filepath.Join(home, defaultVibeProjectsDirName, "rails-app", ".agents", "skills", "devopsellence-rails-app", "SKILL.md")
 	if _, err := os.Stat(path); err != nil {
 		t.Fatalf("expected rails app skill at %s: %v", path, err)
 	}
@@ -485,7 +696,10 @@ func TestRootVibeNoAgentUsesGeneric(t *testing.T) {
 
 func TestRootVibeLaunchReportsSuccess(t *testing.T) {
 	cwd := t.TempDir()
+	setFakeVibeHome(t, cwd)
 	installFakeVibeTools(t, "codex")
+	argsPath := filepath.Join(cwd, "agent-args.txt")
+	t.Setenv("VIBE_AGENT_ARGS_FILE", argsPath)
 	var stdout bytes.Buffer
 	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, cwd)
 	cmd.SetOut(&stdout)
@@ -503,10 +717,18 @@ func TestRootVibeLaunchReportsSuccess(t *testing.T) {
 	if payload["launch_requested"] != true || payload["launched"] != true {
 		t.Fatalf("payload = %#v, want successful launch reported", payload)
 	}
+	data, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "-c\nmodel_reasoning_effort=\"high\"\nRead .agents/prompts/devopsellence-vibe.md and follow it.\n" {
+		t.Fatalf("agent args = %q, want codex high-effort prompt-file launch", data)
+	}
 }
 
 func TestRootVibeRejectsMissingLaunchAgentBeforeScaffold(t *testing.T) {
 	cwd := t.TempDir()
+	home := setFakeVibeHome(t, cwd)
 	installFakeVibeTools(t)
 	var stdout bytes.Buffer
 	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, cwd)
@@ -523,7 +745,7 @@ func TestRootVibeRejectsMissingLaunchAgentBeforeScaffold(t *testing.T) {
 	if !errors.As(err, &exitErr) || exitErr.Code != 2 {
 		t.Fatalf("error = %#v, want ExitError code 2", err)
 	}
-	if _, statErr := os.Stat(filepath.Join(cwd, "missing-agent")); !errors.Is(statErr, os.ErrNotExist) {
+	if _, statErr := os.Stat(filepath.Join(home, defaultVibeProjectsDirName, "missing-agent")); !errors.Is(statErr, os.ErrNotExist) {
 		t.Fatalf("generated app exists after missing agent preflight: %v", statErr)
 	}
 }
@@ -562,6 +784,98 @@ func TestRootVibeRejectsBlankPromptedAgent(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "missing ai agent") {
 		t.Fatalf("error = %v, want missing ai agent", err)
+	}
+}
+
+func TestRootVibeRejectsUnsupportedAgentEffort(t *testing.T) {
+	cwd := t.TempDir()
+	setFakeVibeHome(t, cwd)
+	installFakeVibeTools(t)
+	var stdout bytes.Buffer
+	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, cwd)
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{
+		"vibe", "my-app",
+		"--ai-agent", "generic",
+		"--agent-effort", "max",
+		"--idea", "A tiny uptime page",
+		"--no-launch",
+	})
+
+	err := cmd.Execute()
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 2 {
+		t.Fatalf("error = %#v, want ExitError code 2", err)
+	}
+	if !strings.Contains(err.Error(), "unsupported agent effort") {
+		t.Fatalf("error = %v, want unsupported effort guidance", err)
+	}
+}
+
+func TestRootVibeRejectsUnsupportedDeployGoal(t *testing.T) {
+	cwd := t.TempDir()
+	setFakeVibeHome(t, cwd)
+	installFakeVibeTools(t)
+	var stdout bytes.Buffer
+	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, cwd)
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{
+		"vibe", "my-app",
+		"--ai-agent", "generic",
+		"--deploy-goal", "ship-it",
+		"--idea", "A tiny uptime page",
+		"--no-launch",
+	})
+
+	err := cmd.Execute()
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 2 {
+		t.Fatalf("error = %#v, want ExitError code 2", err)
+	}
+	if !strings.Contains(err.Error(), "unsupported deploy goal") {
+		t.Fatalf("error = %v, want unsupported deploy goal guidance", err)
+	}
+}
+
+func TestVibeAgentCommandIncludesEffort(t *testing.T) {
+	tests := []struct {
+		agent  string
+		effort string
+		want   string
+	}{
+		{
+			agent:  "codex",
+			effort: "high",
+			want:   "codex -c 'model_reasoning_effort=\"high\"' 'Read .agents/prompts/devopsellence-vibe.md and follow it.'",
+		},
+		{
+			agent:  "claude",
+			effort: "high",
+			want:   "claude --effort high 'Read .agents/prompts/devopsellence-vibe.md and follow it.'",
+		},
+		{
+			agent:  "pi",
+			effort: "high",
+			want:   "pi --thinking high 'Read .agents/prompts/devopsellence-vibe.md and follow it.'",
+		},
+		{
+			agent:  "codex",
+			effort: "default",
+			want:   "codex 'Read .agents/prompts/devopsellence-vibe.md and follow it.'",
+		},
+		{
+			agent:  "generic",
+			effort: "high",
+			want:   "cat .agents/prompts/devopsellence-vibe.md",
+		},
+	}
+	for _, tt := range tests {
+		got := vibeAgentCommand(tt.agent, tt.effort)
+		if got != tt.want {
+			t.Fatalf("vibeAgentCommand(%q, %q) = %q, want %q", tt.agent, tt.effort, got, tt.want)
+		}
 	}
 }
 

--- a/cli/internal/workflow/vibe.go
+++ b/cli/internal/workflow/vibe.go
@@ -184,7 +184,7 @@ func (a *App) Vibe(ctx context.Context, opts VibeOptions) error {
 	}
 
 	agentCommand := vibeAgentCommand(opts.AIAgent, opts.AgentEffort)
-	manifestNextCommands := []string{agentCommand}
+	nextCommands := vibeNextCommands(target, agentCommand, intent)
 	manifest := vibeManifest{
 		SchemaVersion:    outputSchemaVersion,
 		AIAgent:          opts.AIAgent,
@@ -197,9 +197,8 @@ func (a *App) Vibe(ctx context.Context, opts VibeOptions) error {
 		PromptPath:       filepath.Join(".agents", "prompts", "devopsellence-vibe.md"),
 		Idea:             opts.Idea,
 		DeploymentIntent: intent,
-		NextCommands:     manifestNextCommands,
+		NextCommands:     nextCommands,
 	}
-	nextCommands := vibeNextCommands(target, agentCommand, intent)
 	manifestPath := filepath.Join(agentsDir, "devopsellence-vibe.json")
 	data, err := json.MarshalIndent(manifest, "", "  ")
 	if err != nil {
@@ -447,7 +446,7 @@ func normalizeVibeServerStrategy(value string) (string, error) {
 
 func normalizeVibeLater(value string) string {
 	value = strings.TrimSpace(value)
-	if value == "" || strings.EqualFold(value, "none") || strings.EqualFold(value, "no") {
+	if value == "" || strings.EqualFold(value, vibeDomainLater) || strings.EqualFold(value, "none") || strings.EqualFold(value, "no") {
 		return vibeDomainLater
 	}
 	return value

--- a/cli/internal/workflow/vibe.go
+++ b/cli/internal/workflow/vibe.go
@@ -17,31 +17,63 @@ import (
 )
 
 type VibeOptions struct {
-	Directory       string
-	AIAgent         string
-	Idea            string
-	TemplateVersion string
-	Launch          bool
-	NoAgent         bool
-	Force           bool
+	Directory         string
+	AIAgent           string
+	AgentEffort       string
+	Idea              string
+	FirstWorkflow     string
+	DeployGoal        string
+	DevopsellenceMode string
+	ServerStrategy    string
+	ServerTarget      string
+	Domain            string
+	TLSEmail          string
+	Services          string
+	ProjectsDir       string
+	TemplateVersion   string
+	Launch            bool
+	NoAgent           bool
+	Force             bool
 }
 
 type vibeManifest struct {
-	SchemaVersion   int      `json:"schema_version"`
-	AIAgent         string   `json:"ai_agent"`
-	DetectedAgents  []string `json:"detected_agents"`
-	AppStack        string   `json:"app_stack"`
-	TemplateURL     string   `json:"template_url"`
-	TemplateVersion string   `json:"template_version"`
-	SkillDir        string   `json:"skill_dir"`
-	PromptPath      string   `json:"prompt_path"`
-	Idea            string   `json:"idea"`
-	NextCommands    []string `json:"next_commands"`
+	SchemaVersion    int                  `json:"schema_version"`
+	AIAgent          string               `json:"ai_agent"`
+	AgentEffort      string               `json:"agent_effort"`
+	DetectedAgents   []string             `json:"detected_agents"`
+	AppStack         string               `json:"app_stack"`
+	TemplateURL      string               `json:"template_url"`
+	TemplateVersion  string               `json:"template_version"`
+	SkillDir         string               `json:"skill_dir"`
+	PromptPath       string               `json:"prompt_path"`
+	Idea             string               `json:"idea"`
+	DeploymentIntent vibeDeploymentIntent `json:"deployment_intent"`
+	NextCommands     []string             `json:"next_commands"`
+}
+
+type vibeDeploymentIntent struct {
+	FirstWorkflow      string   `json:"first_workflow"`
+	DeployGoal         string   `json:"deploy_goal"`
+	DevopsellenceMode  string   `json:"devopsellence_mode"`
+	ServerStrategy     string   `json:"server_strategy"`
+	ServerTarget       string   `json:"server_target,omitempty"`
+	Provider           string   `json:"provider,omitempty"`
+	ProviderAuthStatus string   `json:"provider_auth_status,omitempty"`
+	ProviderAuthSource string   `json:"provider_auth_source,omitempty"`
+	Domain             string   `json:"domain"`
+	TLSEmail           string   `json:"tls_email,omitempty"`
+	Services           []string `json:"services"`
 }
 
 const (
 	vibeAppStack               = "rails-app"
+	defaultVibeProjectsDirName = "devopsellence-projects"
+	defaultVibeAgentEffort     = "high"
+	defaultVibeDeployGoal      = "prepare-solo"
+	defaultVibeMode            = "solo"
+	defaultVibeServerStrategy  = "none"
 	defaultVibeTemplateVersion = "v0.1.3"
+	vibeDomainLater            = "later"
 	vibePromptInstruction      = "Read .agents/prompts/devopsellence-vibe.md and follow it."
 )
 
@@ -49,7 +81,16 @@ var vibeSlugPattern = regexp.MustCompile(`[^a-z0-9]+`)
 
 func (a *App) Vibe(ctx context.Context, opts VibeOptions) error {
 	opts.AIAgent = strings.ToLower(strings.TrimSpace(opts.AIAgent))
+	agentEffort, err := normalizeVibeAgentEffort(opts.AgentEffort)
+	if err != nil {
+		return err
+	}
+	opts.AgentEffort = agentEffort
 	reader := bufio.NewReader(a.In)
+	wizardMode := strings.TrimSpace(opts.Idea) == ""
+	if wizardMode {
+		_, _ = fmt.Fprintln(a.Printer.Err, "devopsellence vibe intake. Press Ctrl+C anytime before scaffolding to stop.")
+	}
 	detectedAgents := a.detectVibeAgents()
 	if opts.NoAgent {
 		opts.AIAgent = "generic"
@@ -96,6 +137,10 @@ func (a *App) Vibe(ctx context.Context, opts VibeOptions) error {
 	if len(opts.Idea) > 4096 {
 		return ExitError{Code: 2, Err: errors.New("app idea is too long; keep it under 4096 characters")}
 	}
+	intent, err := a.resolveVibeDeploymentIntent(reader, opts, wizardMode)
+	if err != nil {
+		return err
+	}
 	opts.TemplateVersion = strings.TrimSpace(opts.TemplateVersion)
 	if opts.TemplateVersion == "" {
 		opts.TemplateVersion = defaultVibeTemplateVersion
@@ -105,12 +150,9 @@ func (a *App) Vibe(ctx context.Context, opts VibeOptions) error {
 		return err
 	}
 
-	target := strings.TrimSpace(opts.Directory)
-	if target == "" {
-		target = vibeSlug(opts.Idea)
-	}
-	if !filepath.IsAbs(target) {
-		target = filepath.Join(a.Cwd, target)
+	target, projectsDir, err := resolveVibeTarget(a.Cwd, opts.Directory, opts.Idea, opts.ProjectsDir)
+	if err != nil {
+		return err
 	}
 	if err := prepareVibeDirectory(target, opts.Force); err != nil {
 		return err
@@ -135,27 +177,29 @@ func (a *App) Vibe(ctx context.Context, opts VibeOptions) error {
 		return err
 	}
 
-	prompt := vibePrompt(opts.AIAgent, templateURL, opts.Idea)
+	prompt := vibePrompt(opts.AIAgent, templateURL, opts.Idea, intent)
 	promptPath := filepath.Join(promptsDir, "devopsellence-vibe.md")
 	if err := os.WriteFile(promptPath, []byte(prompt), 0o644); err != nil {
 		return fmt.Errorf("write prompt: %w", err)
 	}
 
-	agentCommand := vibeAgentCommand(opts.AIAgent)
+	agentCommand := vibeAgentCommand(opts.AIAgent, opts.AgentEffort)
 	manifestNextCommands := []string{agentCommand}
 	manifest := vibeManifest{
-		SchemaVersion:   outputSchemaVersion,
-		AIAgent:         opts.AIAgent,
-		DetectedAgents:  detectedAgents,
-		AppStack:        vibeAppStack,
-		TemplateURL:     templateURL,
-		TemplateVersion: opts.TemplateVersion,
-		SkillDir:        filepath.Join(".agents", "skills"),
-		PromptPath:      filepath.Join(".agents", "prompts", "devopsellence-vibe.md"),
-		Idea:            opts.Idea,
-		NextCommands:    manifestNextCommands,
+		SchemaVersion:    outputSchemaVersion,
+		AIAgent:          opts.AIAgent,
+		AgentEffort:      opts.AgentEffort,
+		DetectedAgents:   detectedAgents,
+		AppStack:         vibeAppStack,
+		TemplateURL:      templateURL,
+		TemplateVersion:  opts.TemplateVersion,
+		SkillDir:         filepath.Join(".agents", "skills"),
+		PromptPath:       filepath.Join(".agents", "prompts", "devopsellence-vibe.md"),
+		Idea:             opts.Idea,
+		DeploymentIntent: intent,
+		NextCommands:     manifestNextCommands,
 	}
-	nextCommands := []string{"cd " + shellQuote(target), agentCommand}
+	nextCommands := vibeNextCommands(target, agentCommand, intent)
 	manifestPath := filepath.Join(agentsDir, "devopsellence-vibe.json")
 	data, err := json.MarshalIndent(manifest, "", "  ")
 	if err != nil {
@@ -173,28 +217,31 @@ func (a *App) Vibe(ctx context.Context, opts VibeOptions) error {
 	}
 
 	payload := map[string]any{
-		"schema_version":   outputSchemaVersion,
-		"action":           "initialized",
-		"directory":        target,
-		"ai_agent":         opts.AIAgent,
-		"detected_agents":  detectedAgents,
-		"app_stack":        vibeAppStack,
-		"template_url":     templateURL,
-		"template_version": opts.TemplateVersion,
-		"skill_id":         agentskill.RailsAppID,
-		"skill_name":       agentskill.RailsAppName,
-		"skill":            agentskill.RailsAppName,
-		"skill_dir":        skillsDir,
-		"prompt_path":      promptPath,
-		"manifest_path":    manifestPath,
-		"initial_commit":   initialCommit,
-		"launch_requested": opts.Launch,
-		"launched":         false,
-		"next_commands":    nextCommands,
+		"schema_version":    outputSchemaVersion,
+		"action":            "initialized",
+		"directory":         target,
+		"projects_dir":      projectsDir,
+		"ai_agent":          opts.AIAgent,
+		"agent_effort":      opts.AgentEffort,
+		"detected_agents":   detectedAgents,
+		"app_stack":         vibeAppStack,
+		"template_url":      templateURL,
+		"template_version":  opts.TemplateVersion,
+		"skill_id":          agentskill.RailsAppID,
+		"skill_name":        agentskill.RailsAppName,
+		"skill":             agentskill.RailsAppName,
+		"skill_dir":         skillsDir,
+		"prompt_path":       promptPath,
+		"manifest_path":     manifestPath,
+		"deployment_intent": intent,
+		"initial_commit":    initialCommit,
+		"launch_requested":  opts.Launch,
+		"launched":          false,
+		"next_commands":     nextCommands,
 	}
 	var launchErr error
 	if opts.Launch {
-		launchErr = a.launchVibeAgent(ctx, opts.AIAgent, target)
+		launchErr = a.launchVibeAgent(ctx, opts.AIAgent, opts.AgentEffort, target)
 		payload["launched"] = launchErr == nil
 		if launchErr != nil {
 			payload["launch_error"] = launchErr.Error()
@@ -213,6 +260,246 @@ func (a *App) askVibeQuestion(reader *bufio.Reader, label string) (string, error
 		return "", ExitError{Code: 2, Err: fmt.Errorf("missing %s; pass it with a flag for non-interactive use", strings.ToLower(label))}
 	}
 	return strings.TrimSpace(answer), nil
+}
+
+func (a *App) askVibeQuestionDefault(reader *bufio.Reader, label, defaultValue string) (string, error) {
+	if strings.TrimSpace(defaultValue) != "" {
+		_, _ = fmt.Fprintf(a.Printer.Err, "%s [%s]: ", label, defaultValue)
+	} else {
+		_, _ = fmt.Fprintf(a.Printer.Err, "%s: ", label)
+	}
+	answer, err := reader.ReadString('\n')
+	answer = strings.TrimSpace(answer)
+	if err != nil && answer == "" {
+		if strings.TrimSpace(defaultValue) != "" {
+			return strings.TrimSpace(defaultValue), nil
+		}
+		return "", ExitError{Code: 2, Err: fmt.Errorf("missing %s; pass it with a flag for non-interactive use", strings.ToLower(label))}
+	}
+	if answer == "" {
+		return strings.TrimSpace(defaultValue), nil
+	}
+	return answer, nil
+}
+
+func (a *App) resolveVibeDeploymentIntent(reader *bufio.Reader, opts VibeOptions, ask bool) (vibeDeploymentIntent, error) {
+	firstWorkflow := strings.TrimSpace(opts.FirstWorkflow)
+	deployGoal := strings.TrimSpace(opts.DeployGoal)
+	mode := strings.TrimSpace(opts.DevopsellenceMode)
+	serverStrategy := strings.TrimSpace(opts.ServerStrategy)
+	serverTarget := strings.TrimSpace(opts.ServerTarget)
+	domain := strings.TrimSpace(opts.Domain)
+	tlsEmail := strings.TrimSpace(opts.TLSEmail)
+	services := strings.TrimSpace(opts.Services)
+
+	if ask {
+		var err error
+		firstWorkflow, err = a.askVibeQuestionDefault(reader, "First workflow the agent should build", firstNonEmpty(firstWorkflow, "derive from the app idea"))
+		if err != nil {
+			return vibeDeploymentIntent{}, err
+		}
+		deployGoal, err = a.askVibeQuestionDefault(reader, "Build/deploy goal (build-only, prepare-solo, dry-run, deploy-with-approval)", firstNonEmpty(deployGoal, defaultVibeDeployGoal))
+		if err != nil {
+			return vibeDeploymentIntent{}, err
+		}
+		mode, err = a.askVibeQuestionDefault(reader, "devopsellence mode (solo, shared-later, decide-later)", firstNonEmpty(mode, defaultVibeMode))
+		if err != nil {
+			return vibeDeploymentIntent{}, err
+		}
+		serverStrategy, err = a.askVibeQuestionDefault(reader, "Server plan (none, existing, hetzner)", firstNonEmpty(serverStrategy, defaultVibeServerStrategy))
+		if err != nil {
+			return vibeDeploymentIntent{}, err
+		}
+		normalizedServerStrategy, err := normalizeVibeServerStrategy(serverStrategy)
+		if err != nil {
+			return vibeDeploymentIntent{}, err
+		}
+		if normalizedServerStrategy == "existing" {
+			serverTarget, err = a.askVibeQuestionDefault(reader, "Existing server or node name", firstNonEmpty(serverTarget, "prod-1"))
+			if err != nil {
+				return vibeDeploymentIntent{}, err
+			}
+		}
+		if normalizedServerStrategy == "hetzner" {
+			serverTarget, err = a.askVibeQuestionDefault(reader, "Hetzner node name", firstNonEmpty(serverTarget, "prod-1"))
+			if err != nil {
+				return vibeDeploymentIntent{}, err
+			}
+		}
+		domain, err = a.askVibeQuestionDefault(reader, "Domain (or later)", firstNonEmpty(domain, vibeDomainLater))
+		if err != nil {
+			return vibeDeploymentIntent{}, err
+		}
+		if normalizeVibeLater(domain) != vibeDomainLater {
+			tlsEmail, err = a.askVibeQuestionDefault(reader, "TLS email", tlsEmail)
+			if err != nil {
+				return vibeDeploymentIntent{}, err
+			}
+		}
+		services, err = a.askVibeQuestionDefault(reader, "External services (later, managed-postgres, object-storage, email, cloudflare-dns)", firstNonEmpty(services, "later"))
+		if err != nil {
+			return vibeDeploymentIntent{}, err
+		}
+	}
+
+	firstWorkflow = firstNonEmpty(strings.TrimSpace(firstWorkflow), "derive from the app idea")
+	deployGoal, err := normalizeVibeDeployGoal(deployGoal)
+	if err != nil {
+		return vibeDeploymentIntent{}, err
+	}
+	mode, err = normalizeVibeMode(mode)
+	if err != nil {
+		return vibeDeploymentIntent{}, err
+	}
+	serverStrategy, err = normalizeVibeServerStrategy(serverStrategy)
+	if err != nil {
+		return vibeDeploymentIntent{}, err
+	}
+	if serverStrategy == "existing" {
+		serverTarget = firstNonEmpty(serverTarget, "existing server to be confirmed")
+	}
+	if serverStrategy == "hetzner" {
+		serverTarget = firstNonEmpty(serverTarget, "prod-1")
+	}
+	domain = normalizeVibeLater(domain)
+	parsedServices, err := normalizeVibeServices(services)
+	if err != nil {
+		return vibeDeploymentIntent{}, err
+	}
+	intent := vibeDeploymentIntent{
+		FirstWorkflow:     truncateVibeText(firstWorkflow, 2048),
+		DeployGoal:        deployGoal,
+		DevopsellenceMode: mode,
+		ServerStrategy:    serverStrategy,
+		ServerTarget:      truncateVibeText(serverTarget, 512),
+		Domain:            truncateVibeText(domain, 512),
+		TLSEmail:          truncateVibeText(tlsEmail, 512),
+		Services:          parsedServices,
+	}
+	if intent.ServerStrategy == "hetzner" {
+		intent.Provider = providerHetzner
+		_, source, err := providerToken(a.ProviderState, providerHetzner)
+		if err != nil {
+			return vibeDeploymentIntent{}, err
+		}
+		if strings.TrimSpace(source) == "" {
+			intent.ProviderAuthStatus = "missing"
+		} else {
+			intent.ProviderAuthStatus = "available"
+			intent.ProviderAuthSource = source
+		}
+	}
+	return intent, nil
+}
+
+func normalizeVibeDeployGoal(value string) (string, error) {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if value == "" {
+		value = defaultVibeDeployGoal
+	}
+	switch value {
+	case "build", "build-only":
+		return "build-only", nil
+	case "prepare", "prepare-solo", "prepare-deploy":
+		return "prepare-solo", nil
+	case "dry-run", "deploy-dry-run":
+		return "dry-run", nil
+	case "deploy", "deploy-with-approval":
+		return "deploy-with-approval", nil
+	default:
+		return "", ExitError{Code: 2, Err: fmt.Errorf("unsupported deploy goal %q; use build-only, prepare-solo, dry-run, or deploy-with-approval", value)}
+	}
+}
+
+func normalizeVibeMode(value string) (string, error) {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if value == "" {
+		value = defaultVibeMode
+	}
+	switch value {
+	case "solo":
+		return "solo", nil
+	case "shared-later", "shared":
+		return "shared-later", nil
+	case "decide-later", "later", "decide":
+		return "decide-later", nil
+	default:
+		return "", ExitError{Code: 2, Err: fmt.Errorf("unsupported devopsellence mode %q; use solo, shared-later, or decide-later", value)}
+	}
+}
+
+func normalizeVibeServerStrategy(value string) (string, error) {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if value == "" {
+		value = defaultVibeServerStrategy
+	}
+	switch value {
+	case "none", "later", "no-server":
+		return "none", nil
+	case "existing", "existing-server":
+		return "existing", nil
+	case "hetzner", "provision-hetzner":
+		return "hetzner", nil
+	default:
+		return "", ExitError{Code: 2, Err: fmt.Errorf("unsupported server plan %q; use none, existing, or hetzner", value)}
+	}
+}
+
+func normalizeVibeLater(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" || strings.EqualFold(value, "none") || strings.EqualFold(value, "no") {
+		return vibeDomainLater
+	}
+	return value
+}
+
+func normalizeVibeServices(value string) ([]string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return []string{"later"}, nil
+	}
+	parts := strings.FieldsFunc(value, func(r rune) bool {
+		return r == ',' || r == ';' || r == '\n'
+	})
+	seen := map[string]bool{}
+	var services []string
+	for _, part := range parts {
+		service := strings.ToLower(strings.TrimSpace(part))
+		if service == "" {
+			continue
+		}
+		service = strings.ReplaceAll(service, "_", "-")
+		switch service {
+		case "later", "managed-postgres", "object-storage", "email", "cloudflare-dns":
+		default:
+			return nil, ExitError{Code: 2, Err: fmt.Errorf("unsupported external service %q; use later, managed-postgres, object-storage, email, or cloudflare-dns", service)}
+		}
+		if !seen[service] {
+			seen[service] = true
+			services = append(services, service)
+		}
+	}
+	if len(services) == 0 {
+		return []string{"later"}, nil
+	}
+	if len(services) > 1 && seen["later"] {
+		filtered := services[:0]
+		for _, service := range services {
+			if service != "later" {
+				filtered = append(filtered, service)
+			}
+		}
+		services = filtered
+	}
+	return services, nil
+}
+
+func truncateVibeText(value string, max int) string {
+	value = strings.TrimSpace(value)
+	if len(value) <= max {
+		return value
+	}
+	return strings.TrimSpace(value[:max])
 }
 
 func supportedVibeAgent(agent string) bool {
@@ -238,6 +525,78 @@ func vibeAgentChoiceHint(agents []string) string {
 	choices := append([]string(nil), agents...)
 	choices = append(choices, "generic")
 	return "(" + strings.Join(choices, ", ") + ")"
+}
+
+func normalizeVibeAgentEffort(effort string) (string, error) {
+	effort = strings.ToLower(strings.TrimSpace(effort))
+	if effort == "" {
+		return defaultVibeAgentEffort, nil
+	}
+	switch effort {
+	case "default", "low", "medium", "high", "xhigh":
+		return effort, nil
+	default:
+		return "", ExitError{Code: 2, Err: fmt.Errorf("unsupported agent effort %q; use default, low, medium, high, or xhigh", effort)}
+	}
+}
+
+func resolveVibeTarget(cwd, directory, idea, projectsDir string) (string, string, error) {
+	target := strings.TrimSpace(directory)
+	if target == "" {
+		target = vibeSlug(idea)
+	}
+	if isExplicitVibePath(target) {
+		expanded, err := expandVibePath(cwd, target)
+		return expanded, "", err
+	}
+	resolvedProjectsDir, err := resolveVibeProjectsDir(cwd, projectsDir)
+	if err != nil {
+		return "", "", err
+	}
+	return filepath.Join(resolvedProjectsDir, target), resolvedProjectsDir, nil
+}
+
+func isExplicitVibePath(path string) bool {
+	if filepath.IsAbs(path) || path == "." || path == ".." || strings.HasPrefix(path, "~") {
+		return true
+	}
+	return strings.Contains(path, "/") || strings.Contains(path, `\`)
+}
+
+func resolveVibeProjectsDir(cwd, configured string) (string, error) {
+	dir := strings.TrimSpace(configured)
+	if dir == "" {
+		dir = strings.TrimSpace(os.Getenv("DEVOPSELLENCE_PROJECTS_DIR"))
+	}
+	if dir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil || strings.TrimSpace(home) == "" {
+			return "", ExitError{Code: 2, Err: errors.New("cannot determine home directory; pass --projects-dir")}
+		}
+		dir = filepath.Join(home, defaultVibeProjectsDirName)
+	}
+	return expandVibePath(cwd, dir)
+}
+
+func expandVibePath(cwd, path string) (string, error) {
+	path = strings.TrimSpace(path)
+	if path == "~" || strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil || strings.TrimSpace(home) == "" {
+			return "", ExitError{Code: 2, Err: errors.New("cannot determine home directory")}
+		}
+		if path == "~" {
+			path = home
+		} else {
+			path = filepath.Join(home, strings.TrimPrefix(path, "~/"))
+		}
+	} else if strings.HasPrefix(path, "~") {
+		return "", ExitError{Code: 2, Err: fmt.Errorf("unsupported home-relative path %q; use ~/path or an absolute path", path)}
+	}
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path), nil
+	}
+	return filepath.Clean(filepath.Join(cwd, path)), nil
 }
 
 func prepareVibeDirectory(path string, force bool) error {
@@ -372,7 +731,7 @@ func vibeTemplateURL(version string) string {
 	return "https://raw.githubusercontent.com/devopsellence/rails-app-template/" + version + "/template.rb"
 }
 
-func vibePrompt(agent, templateURL, idea string) string {
+func vibePrompt(agent, templateURL, idea string, intent vibeDeploymentIntent) string {
 	var firstLine string
 	switch agent {
 	case "codex":
@@ -384,7 +743,7 @@ func vibePrompt(agent, templateURL, idea string) string {
 	default:
 		firstLine = "Build this Rails app idea using the installed devopsellence Rails app skill."
 	}
-	return strings.Join([]string{
+	lines := []string{
 		firstLine,
 		"",
 		"App idea:",
@@ -392,24 +751,145 @@ func vibePrompt(agent, templateURL, idea string) string {
 		"",
 		"Rails template: " + templateURL,
 		"",
+		"Deployment intent:",
+		"- First workflow: " + intent.FirstWorkflow,
+		"- devopsellence mode: " + intent.DevopsellenceMode,
+		"- Build/deploy goal: " + intent.DeployGoal,
+		"- Server plan: " + vibePromptServerPlan(intent),
+		"- Domain: " + intent.Domain,
+		"- TLS email: " + firstNonEmpty(intent.TLSEmail, "ask before configuring ingress"),
+		"- External services: " + strings.Join(intent.Services, ", "),
+		"",
 		"Use .agents/skills/devopsellence-rails-app for app-building guidance.",
 		"Use .agents/skills/devopsellence for deploy, secrets, logs, status, rollback, and node operations.",
 		"Stay inside the blessed Rails baseline: Rails 8.1, PostgreSQL, Hotwire, Tailwind, Solid Queue/Cache/Cable, Active Storage, Sentry, OpenTelemetry, Minitest, Docker, and mise.",
 		"Do not add Redis, Sidekiq, React, GraphQL, Elasticsearch, Kubernetes, or an admin framework unless the product need is explicit.",
-		"Before any production mutation, run devopsellence deploy --dry-run.",
-		"After deploy, report devopsellence status, app logs, node logs, and HTTPS evidence when ingress is configured.",
 		"",
-	}, "\n")
+		"Deployment rules:",
+		"- Do not write provider tokens, API keys, passwords, or secret values into prompts, manifests, git, logs, or commits.",
+		"- Before any production mutation, run devopsellence deploy --dry-run and summarize the plan.",
+		"- Ask the user before provisioning nodes, changing DNS, setting secrets, or running a real deploy.",
+	}
+	lines = append(lines, vibeDeployGoalPromptLines(intent)...)
+	lines = append(lines, vibeServerPromptLines(intent)...)
+	lines = append(lines, vibeServicesPromptLines(intent)...)
+	lines = append(lines,
+		"- After deploy, report devopsellence status, app logs, node logs, and HTTPS evidence when ingress is configured.",
+		"",
+	)
+	return strings.Join(lines, "\n")
 }
 
-func vibeAgentCommand(agent string) string {
+func vibePromptServerPlan(intent vibeDeploymentIntent) string {
+	switch intent.ServerStrategy {
+	case "existing":
+		return "existing server/node " + firstNonEmpty(intent.ServerTarget, "to be confirmed")
+	case "hetzner":
+		return "provision Hetzner node " + firstNonEmpty(intent.ServerTarget, "prod-1") + " (auth " + firstNonEmpty(intent.ProviderAuthStatus, "unknown") + ")"
+	default:
+		return "no server yet"
+	}
+}
+
+func vibeDeployGoalPromptLines(intent vibeDeploymentIntent) []string {
+	switch intent.DeployGoal {
+	case "build-only":
+		return []string{"- Build and test the product locally. Do not initialize, provision, dry-run, or deploy devopsellence unless the user asks."}
+	case "dry-run":
+		return []string{"- After the app is ready, prepare devopsellence solo and run only devopsellence deploy --dry-run, then report what would happen."}
+	case "deploy-with-approval":
+		return []string{"- After the app is ready, prepare devopsellence solo, run devopsellence deploy --dry-run, ask for approval, and only then run devopsellence deploy."}
+	default:
+		return []string{"- Prepare the app for devopsellence solo, but stop before real deploy unless the user explicitly approves."}
+	}
+}
+
+func vibeServerPromptLines(intent vibeDeploymentIntent) []string {
+	switch intent.ServerStrategy {
+	case "existing":
+		return []string{
+			"- Target existing server/node: " + firstNonEmpty(intent.ServerTarget, "ask the user which server to use") + ".",
+			"- If the node is not already registered, ask for SSH host/user/key details before running devopsellence node create.",
+		}
+	case "hetzner":
+		lines := []string{
+			"- Target provider: Hetzner.",
+			"- Desired node name: " + firstNonEmpty(intent.ServerTarget, "prod-1") + ".",
+		}
+		if intent.ProviderAuthStatus == "available" {
+			lines = append(lines, "- Hetzner auth appears available from "+intent.ProviderAuthSource+". Do not print or inspect the token value.")
+		} else {
+			lines = append(lines,
+				"- Hetzner auth is missing. Stop before provisioning and ask the user to run `devopsellence provider login hetzner --token <token>` or set `DEVOPSELLENCE_HETZNER_API_TOKEN`/`HCLOUD_TOKEN`.",
+			)
+		}
+		return lines
+	default:
+		return []string{"- No server is selected yet. Do not create or attach nodes until the user chooses existing server or Hetzner provisioning."}
+	}
+}
+
+func vibeServicesPromptLines(intent vibeDeploymentIntent) []string {
+	if len(intent.Services) == 0 || (len(intent.Services) == 1 && intent.Services[0] == "later") {
+		return []string{"- External services are later. Keep the initial app local/portable and mark service follow-ups explicitly."}
+	}
+	var lines []string
+	for _, service := range intent.Services {
+		switch service {
+		case "managed-postgres":
+			lines = append(lines, "- Plan managed PostgreSQL before production data; keep local development simple until credentials are provided through devopsellence secrets.")
+		case "object-storage":
+			lines = append(lines, "- Plan S3-compatible object storage for uploads; do not commit access keys.")
+		case "email":
+			lines = append(lines, "- Plan transactional email provider setup; keep API keys in devopsellence secrets.")
+		case "cloudflare-dns":
+			lines = append(lines, "- Plan Cloudflare DNS changes only after the user confirms the zone and approves DNS mutation.")
+		}
+	}
+	return lines
+}
+
+func vibeNextCommands(target, agentCommand string, intent vibeDeploymentIntent) []string {
+	commands := []string{"cd " + shellQuote(target)}
+	if intent.ServerStrategy == "hetzner" && intent.ProviderAuthStatus == "missing" {
+		commands = append(commands, "devopsellence provider login hetzner --token <token>")
+	}
+	return append(commands, agentCommand)
+}
+
+func vibeAgentCommand(agent, effort string) string {
 	if agent == "generic" {
 		return "cat .agents/prompts/devopsellence-vibe.md"
 	}
-	return agent + " '" + vibePromptInstruction + "'"
+	parts := []string{agent}
+	for _, arg := range vibeAgentEffortArgs(agent, effort) {
+		if strings.HasPrefix(arg, "-") || arg == effort {
+			parts = append(parts, arg)
+		} else {
+			parts = append(parts, shellQuote(arg))
+		}
+	}
+	parts = append(parts, shellQuote(vibePromptInstruction))
+	return strings.Join(parts, " ")
 }
 
-func (a *App) launchVibeAgent(ctx context.Context, agent, cwd string) error {
+func vibeAgentEffortArgs(agent, effort string) []string {
+	if effort == "" || effort == "default" || agent == "generic" {
+		return nil
+	}
+	switch agent {
+	case "codex":
+		return []string{"-c", `model_reasoning_effort="` + effort + `"`}
+	case "claude":
+		return []string{"--effort", effort}
+	case "pi":
+		return []string{"--thinking", effort}
+	default:
+		return nil
+	}
+}
+
+func (a *App) launchVibeAgent(ctx context.Context, agent, effort, cwd string) error {
 	if agent == "generic" {
 		return nil
 	}
@@ -417,7 +897,8 @@ func (a *App) launchVibeAgent(ctx context.Context, agent, cwd string) error {
 	if _, err := a.LookPath(binary); err != nil {
 		return ExitError{Code: 2, Err: fmt.Errorf("%s not found; rerun with --no-launch and start it manually from .agents/prompts/devopsellence-vibe.md", binary)}
 	}
-	cmd := exec.CommandContext(ctx, binary, vibePromptInstruction)
+	args := append(vibeAgentEffortArgs(agent, effort), vibePromptInstruction)
+	cmd := exec.CommandContext(ctx, binary, args...)
 	cmd.Dir = cwd
 	cmd.Stdin = a.In
 	cmd.Stdout = a.Printer.Err

--- a/cli/internal/workflow/vibe.go
+++ b/cli/internal/workflow/vibe.go
@@ -495,10 +495,14 @@ func normalizeVibeServices(value string) ([]string, error) {
 
 func truncateVibeText(value string, max int) string {
 	value = strings.TrimSpace(value)
-	if len(value) <= max {
+	if max <= 0 {
+		return ""
+	}
+	runes := []rune(value)
+	if len(runes) <= max {
 		return value
 	}
-	return strings.TrimSpace(value[:max])
+	return strings.TrimSpace(string(runes[:max]))
 }
 
 func supportedVibeAgent(agent string) bool {

--- a/docs-website/src/content/docs/getting-started/solo-quickstart.md
+++ b/docs-website/src/content/docs/getting-started/solo-quickstart.md
@@ -21,10 +21,14 @@ If you want Codex, Claude Code, Pi, or another AI coding agent to create or
 prepare the app first, start from the [Rails app template](/guides/rails-app-template/):
 
 ```bash
-devopsellence vibe my-app --ai-agent=codex --idea="A tiny CRM"
+devopsellence vibe my-app
+cd ~/devopsellence-projects/my-app
 ```
 
-Use `--no-agent` to generate the app and prompt without starting an AI agent.
+Bare app names land under `~/devopsellence-projects`. Pass `./my-app` or an
+absolute path when the app should be created somewhere else. The wizard asks for
+deploy intent before scaffolding; press Ctrl+C during the questions to stop. Use
+`--no-agent` to generate the app and prompt without starting an AI agent.
 
 <ol class="command-sequence" start="2">
   <li>Commit the app before the first deploy.</li>

--- a/docs-website/src/content/docs/guides/rails-app-template.md
+++ b/docs-website/src/content/docs/guides/rails-app-template.md
@@ -6,12 +6,61 @@ description: Start a production-minded Rails app with devopsellence, mise, and a
 `devopsellence vibe` creates one blessed Rails app shape instead of asking you
 to choose a stack. It uses the devopsellence Rails template, writes a local
 agent skill, seeds a prompt, initializes git, and can launch Codex, Claude Code,
-Pi, or another agent.
+Pi, or another agent with high effort/thinking enabled.
+
+Run it without `--idea` to use the intake wizard. You can press Ctrl+C during
+the questions to stop before files are generated.
+
+```bash
+devopsellence vibe my-crm
+```
 
 ```bash
 devopsellence vibe my-crm \
   --ai-agent=codex \
   --idea="A tiny CRM for solo consultants"
+cd ~/devopsellence-projects/my-crm
+```
+
+Bare app names land under `~/devopsellence-projects`. Pass `./my-crm` or an
+absolute path when the app should be created somewhere else. Override the base
+directory with `--projects-dir` or `DEVOPSELLENCE_PROJECTS_DIR`.
+
+## Deployment Intake
+
+The wizard captures deploy intent before the agent starts:
+
+- first workflow the agent should build;
+- build only, prepare for solo deploy, dry-run, or deploy after approval;
+- solo now, shared later, or decide later;
+- no server yet, an existing server, or a Hetzner node;
+- domain and TLS email;
+- external service plans such as managed Postgres, object storage, email, and
+  Cloudflare DNS.
+
+This intent is written to `.agents/devopsellence-vibe.json` and summarized in
+`.agents/prompts/devopsellence-vibe.md`. Tokens and secret values are never
+written there.
+
+Prepare for a Hetzner-backed solo deploy without starting the agent:
+
+```bash
+devopsellence vibe my-crm \
+  --idea="A tiny CRM for solo consultants" \
+  --server=hetzner \
+  --server-target=prod-1 \
+  --deploy-goal=dry-run \
+  --domain=crm.example.com \
+  --tls-email=ops@example.com \
+  --services=managed-postgres,cloudflare-dns \
+  --no-agent
+```
+
+If Hetzner auth is missing, the prompt tells the agent to stop before
+provisioning and ask the user to run:
+
+```bash
+devopsellence provider login hetzner --token <token>
 ```
 
 Prepare the app and prompt without starting an agent:
@@ -24,6 +73,12 @@ Pin a template release when reproducing a scaffold:
 
 ```bash
 devopsellence vibe my-crm --template-version=v0.1.3 --no-agent
+```
+
+Use the agent's own configured effort instead of the devopsellence default:
+
+```bash
+devopsellence vibe my-crm --ai-agent=codex --agent-effort=default
 ```
 
 The command runs Rails with the pinned template:

--- a/docs-website/src/content/docs/index.md
+++ b/docs-website/src/content/docs/index.md
@@ -24,6 +24,8 @@ approval loop; the node agent stays deterministic.
 
 ## Start here
 
+Already have a Dockerized app:
+
 ```bash
 curl -fsSL https://www.devopsellence.com/lfg.sh | bash -s -- --install-agent-skill
 cd my-app
@@ -33,8 +35,23 @@ codex e "Deploy this app with devopsellence solo."
 `--install-agent-skill` installs the matching skill from the CLI itself; it does
 not require npm or `npx`.
 
+Starting from an idea:
+
+```bash
+devopsellence vibe my-app
+cd ~/devopsellence-projects/my-app
+```
+
+Bare app names created by `devopsellence vibe` land under
+`~/devopsellence-projects`. Pass `./my-app` or an absolute path when the app
+should be created somewhere else. The intake wizard asks for the app idea,
+first workflow, solo deploy intent, server plan, domain, and service choices
+before scaffolding; press Ctrl+C during the questions to stop.
+
 - [Solo quickstart](/getting-started/solo-quickstart/) for the shortest path to
   one VM.
+- [Rails app template](/guides/rails-app-template/) for turning an app idea into
+  a production-minded Rails workspace with local agent skills.
 - [Ingress and TLS](/guides/ingress-tls/) for hostnames, DNS checks, and HTTPS
   verification.
 - [Basecamp Fizzy on Rails](/examples/fizzy-rails-solo/) for a real Rails app

--- a/docs-website/src/content/docs/reference/cli.md
+++ b/docs-website/src/content/docs/reference/cli.md
@@ -62,7 +62,7 @@ devopsellence ingress check --wait 5m
 ```bash
 devopsellence vibe my-app
 devopsellence vibe my-app --ai-agent=codex --idea="A tiny CRM"
-devopsellence vibe my-app --agent-effort=default --idea="A tiny CRM"
+devopsellence vibe my-app --ai-agent=codex --agent-effort=default --idea="A tiny CRM"
 devopsellence vibe my-app --projects-dir ~/Work/apps --idea="A tiny CRM"
 devopsellence vibe my-app --deploy-goal=dry-run --server=hetzner --server-target=prod-1 --domain=app.example.com --tls-email=ops@example.com
 devopsellence vibe my-app --services=managed-postgres,object-storage,email,cloudflare-dns --idea="A tiny CRM"

--- a/docs-website/src/content/docs/reference/cli.md
+++ b/docs-website/src/content/docs/reference/cli.md
@@ -60,7 +60,12 @@ devopsellence ingress check --wait 5m
 ## Agent skills
 
 ```bash
+devopsellence vibe my-app
 devopsellence vibe my-app --ai-agent=codex --idea="A tiny CRM"
+devopsellence vibe my-app --agent-effort=default --idea="A tiny CRM"
+devopsellence vibe my-app --projects-dir ~/Work/apps --idea="A tiny CRM"
+devopsellence vibe my-app --deploy-goal=dry-run --server=hetzner --server-target=prod-1 --domain=app.example.com --tls-email=ops@example.com
+devopsellence vibe my-app --services=managed-postgres,object-storage,email,cloudflare-dns --idea="A tiny CRM"
 devopsellence vibe my-app --idea="A tiny CRM" --no-agent
 devopsellence vibe my-app --ai-agent=claude --idea="A tiny CRM" --no-launch
 devopsellence skill list


### PR DESCRIPTION
## Summary
- add deploy-intent intake to `devopsellence vibe` for first workflow, deploy goal, devopsellence mode, server plan, domain/TLS, and external service choices
- default bare app names to `~/devopsellence-projects`, add `--projects-dir`, and launch agents with high effort/thinking by default
- write deploy intent into `.agents/devopsellence-vibe.json` and the seeded prompt, including Hetzner auth status without storing token material
- document the wizard, Ctrl+C stop point, Hetzner auth boundary, and new flags

## Validation
- `go test ./internal/agentskill ./internal/workflow -run 'Test(Install|Available|Bundled|RootSkill|RootVibe|PrepareVibe|VibeAgent)'`
- `npm run check` in `docs-website`
- `git diff --check`
- dogfood run: `/tmp/devopsellence-vibe-intake-dogfood-20260509-3-fodvoa`