### PR TITLE
[codex] improve solo doctor first-deploy status checks

### DIFF
--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -4226,7 +4226,7 @@ func (a *App) SoloNodeDiagnose(ctx context.Context, opts SoloNodeDiagnoseOptions
 	diagnoseOK := soloChecksOK(checks)
 	payload["ok"] = diagnoseOK
 	if soloCheckFailed(checks, "ssh") {
-		payload["next_steps"] = []string{fmt.Sprintf("ssh -p %d %s true", node.Port, shellQuote(node.User+"@"+node.Host))}
+		payload["next_steps"] = []string{soloDoctorSSHNextStep(node)}
 		return a.printSoloDiagnoseResult(payload, diagnoseOK)
 	}
 	agentVersion := collectRemoteText(ctx, node, remoteAgentVersionCommand())

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -165,7 +165,8 @@ type SoloAgentUninstallOptions struct {
 }
 
 type SoloDoctorOptions struct {
-	Nodes []string
+	Nodes                    []string
+	AllowMissingStatusReport bool
 }
 
 type SoloSupportBundleOptions struct {
@@ -1954,15 +1955,34 @@ func soloNodeLogNextSteps(environment string, nodes map[string]config.Node) []st
 	return steps
 }
 
-func soloDoctorNextSteps(nodes map[string]config.Node) []string {
+func soloDoctorNextSteps(runtimeChecks []map[string]any, nodes map[string]config.Node) []string {
 	steps := []string{}
+	seen := map[string]bool{}
+	add := func(step string) {
+		step = strings.TrimSpace(step)
+		if step == "" || seen[step] {
+			return
+		}
+		seen[step] = true
+		steps = append(steps, step)
+	}
+	for _, check := range runtimeChecks {
+		if check["ok"] != false {
+			continue
+		}
+		nodeName, _ := check["node"].(string)
+		nextAction, _ := check["next_action"].(string)
+		if nextAction != "" {
+			add(strings.ReplaceAll(nextAction, "<node>", shellQuote(nodeName)))
+		}
+	}
+	if len(steps) > 0 {
+		return steps
+	}
 	for _, nodeName := range sortedNodeNames(nodes) {
 		node := nodes[nodeName]
-		steps = append(steps,
-			"devopsellence agent install "+shellQuote(nodeName),
-			"devopsellence node diagnose "+shellQuote(nodeName),
-			fmt.Sprintf("ssh -p %d %s true", node.Port, shellQuote(node.User+"@"+node.Host)),
-		)
+		add("devopsellence node diagnose " + shellQuote(nodeName))
+		add(fmt.Sprintf("ssh -p %d %s true", node.Port, shellQuote(node.User+"@"+node.Host)))
 	}
 	return steps
 }
@@ -4359,6 +4379,7 @@ type soloSecurityCheck struct {
 
 type soloRuntimeCheck struct {
 	OK         bool
+	Severity   string
 	Observed   string
 	NextAction string
 }
@@ -4392,7 +4413,7 @@ func soloAgentVersionCheck(ctx context.Context, node config.Node) soloRuntimeChe
 	return check
 }
 
-func soloAgentStatusReportCheck(ctx context.Context, node config.Node) soloRuntimeCheck {
+func soloAgentStatusReportCheck(ctx context.Context, node config.Node, allowMissing bool) soloRuntimeCheck {
 	statusPath := path.Join(firstNonEmpty(node.AgentStateDir, "/var/lib/devopsellence"), "status.json")
 	result, err := readNodeStatus(ctx, node)
 	check := soloRuntimeCheck{OK: true}
@@ -4403,9 +4424,15 @@ func soloAgentStatusReportCheck(ctx context.Context, node config.Node) soloRunti
 		return check
 	}
 	if result.Missing {
+		if allowMissing {
+			check.Observed = "no workload deployed yet; no status report expected at " + statusPath
+			check.Severity = "warning"
+			check.NextAction = "run devopsellence deploy when ready to publish the first workload"
+			return check
+		}
 		check.OK = false
 		check.Observed = "missing expected status report at " + statusPath
-		check.NextAction = "reinstall or restart the agent, then rerun devopsellence doctor"
+		check.NextAction = "run devopsellence node diagnose <node> and inspect the agent status path"
 		return check
 	}
 	if strings.TrimSpace(result.Status.Time) == "" {
@@ -5368,6 +5395,14 @@ func (a *App) soloRuntimeDoctorChecks(ctx context.Context, opts SoloDoctorOption
 			} else {
 				failed = true
 				result["detail"] = strings.TrimSpace(err.Error())
+				switch check.name {
+				case "ssh":
+					result["next_action"] = "fix SSH connectivity, then rerun devopsellence doctor"
+				case "docker":
+					result["next_action"] = "make Docker reachable on the node, then rerun devopsellence doctor"
+				case "agent":
+					result["next_action"] = "run devopsellence agent install <node>"
+				}
 			}
 			results = append(results, result)
 		}
@@ -5385,7 +5420,7 @@ func (a *App) soloRuntimeDoctorChecks(ctx context.Context, opts SoloDoctorOption
 			failed = true
 		}
 		results = append(results, versionResult)
-		statusReportCheck := soloAgentStatusReportCheck(ctx, node)
+		statusReportCheck := soloAgentStatusReportCheck(ctx, node, opts.AllowMissingStatusReport)
 		if !statusReportCheck.OK {
 			failed = true
 		}
@@ -5408,6 +5443,9 @@ func soloRuntimeAgentVersionCheckResult(nodeName string, check soloRuntimeCheck)
 		"ok":     check.OK,
 		"detail": check.Observed,
 	}
+	if check.Severity != "" {
+		result["severity"] = check.Severity
+	}
 	if check.NextAction != "" {
 		result["next_action"] = check.NextAction
 	}
@@ -5421,10 +5459,35 @@ func soloRuntimeStatusReportCheckResult(nodeName string, check soloRuntimeCheck)
 		"ok":     check.OK,
 		"detail": check.Observed,
 	}
+	if check.Severity != "" {
+		result["severity"] = check.Severity
+	}
 	if check.NextAction != "" {
 		result["next_action"] = check.NextAction
 	}
 	return result
+}
+
+func soloRuntimeDoctorWarnings(checks []map[string]any) []string {
+	warnings := []string{}
+	for _, check := range checks {
+		severity, _ := check["severity"].(string)
+		if severity != "warning" {
+			continue
+		}
+		name, _ := check["check"].(string)
+		node, _ := check["node"].(string)
+		detail, _ := check["detail"].(string)
+		warning := strings.TrimSpace(detail)
+		if warning == "" {
+			continue
+		}
+		if node != "" && name != "" {
+			warning = node + " " + name + ": " + warning
+		}
+		warnings = append(warnings, warning)
+	}
+	return warnings
 }
 
 func soloSkippedSecurityChecksAfterSSHFailure() []soloSecurityCheck {
@@ -5555,18 +5618,30 @@ func (a *App) SoloDoctor(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		runtimeChecks, runtimeFailed, err := a.soloRuntimeDoctorChecks(ctx, SoloDoctorOptions{Nodes: nodeNames})
+		hasCurrentRelease := false
+		if _, _, ok, releaseErr := current.CurrentRelease(discovered.WorkspaceRoot, environmentName); releaseErr != nil {
+			return releaseErr
+		} else {
+			hasCurrentRelease = ok
+		}
+		runtimeChecks, runtimeFailed, err := a.soloRuntimeDoctorChecks(ctx, SoloDoctorOptions{
+			Nodes:                    nodeNames,
+			AllowMissingStatusReport: !hasCurrentRelease,
+		})
 		if err != nil {
 			return err
 		}
 		payload["runtime_checks"] = runtimeChecks
 		payload["ok"] = !runtimeFailed
+		if warnings := soloRuntimeDoctorWarnings(runtimeChecks); len(warnings) > 0 {
+			payload["warnings"] = warnings
+		}
 		if runtimeFailed {
 			nodes, err := a.resolveNodes(current, nodeNames)
 			if err != nil {
 				return err
 			}
-			payload["next_steps"] = soloDoctorNextSteps(nodes)
+			payload["next_steps"] = soloDoctorNextSteps(runtimeChecks, nodes)
 		}
 		if err := a.Printer.PrintJSON(payload); err != nil {
 			return err

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1972,19 +1972,33 @@ func soloDoctorNextSteps(runtimeChecks []map[string]any, nodes map[string]config
 		}
 		nodeName, _ := check["node"].(string)
 		nextAction, _ := check["next_action"].(string)
-		if nextAction != "" {
-			add(strings.ReplaceAll(nextAction, "<node>", shellQuote(nodeName)))
+		if step := soloDoctorRunnableNextStep(nextAction, nodeName); step != "" {
+			add(step)
 		}
-	}
-	if len(steps) > 0 {
-		return steps
 	}
 	for _, nodeName := range sortedNodeNames(nodes) {
 		node := nodes[nodeName]
 		add("devopsellence node diagnose " + shellQuote(nodeName))
-		add(fmt.Sprintf("ssh -p %d %s true", node.Port, shellQuote(node.User+"@"+node.Host)))
+		add(soloDoctorSSHNextStep(node))
 	}
 	return steps
+}
+
+func soloDoctorRunnableNextStep(nextAction, nodeName string) string {
+	nextAction = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(nextAction), "run "))
+	nextAction = strings.ReplaceAll(nextAction, "<node>", shellQuote(nodeName))
+	if strings.HasPrefix(nextAction, "devopsellence ") || strings.HasPrefix(nextAction, "ssh ") {
+		return nextAction
+	}
+	return ""
+}
+
+func soloDoctorSSHNextStep(node config.Node) string {
+	port := node.Port
+	if port == 0 {
+		port = 22
+	}
+	return fmt.Sprintf("ssh -p %d %s true", port, shellQuote(node.User+"@"+node.Host))
 }
 
 func (a *App) ensureLocalSoloSnapshotImage(ctx context.Context, imageTag string) error {
@@ -4391,24 +4405,24 @@ func soloAgentVersionCheck(ctx context.Context, node config.Node) soloRuntimeChe
 	if diag.Err != nil || diag.ExitCode != 0 {
 		check.OK = false
 		check.Observed = "unknown: " + diagnosticErrorMessage(diag)
-		check.NextAction = "run devopsellence node diagnose <node>"
+		check.NextAction = "devopsellence node diagnose <node>"
 		return check
 	}
 	observed := strings.TrimSpace(diag.Stdout)
 	if observed == "" {
 		check.OK = false
 		check.Observed = "unknown: agent version not reported"
-		check.NextAction = "run devopsellence node diagnose <node>"
+		check.NextAction = "devopsellence node diagnose <node>"
 		return check
 	}
 	check.Observed = observed
 	switch soloAgentVersionStatus(observed, target) {
 	case "mismatch":
 		check.OK = false
-		check.NextAction = "run devopsellence agent upgrade <node>"
+		check.NextAction = "devopsellence agent upgrade <node>"
 	case "unknown":
 		check.OK = false
-		check.NextAction = "run devopsellence node diagnose <node>"
+		check.NextAction = "devopsellence node diagnose <node>"
 	}
 	return check
 }
@@ -4420,7 +4434,7 @@ func soloAgentStatusReportCheck(ctx context.Context, node config.Node, allowMiss
 	if err != nil {
 		check.OK = false
 		check.Observed = "unknown: read " + statusPath + ": " + err.Error()
-		check.NextAction = "run devopsellence node diagnose <node> and inspect the agent status path"
+		check.NextAction = "devopsellence node diagnose <node>"
 		return check
 	}
 	if result.Missing {
@@ -4432,20 +4446,20 @@ func soloAgentStatusReportCheck(ctx context.Context, node config.Node, allowMiss
 		}
 		check.OK = false
 		check.Observed = "missing expected status report at " + statusPath
-		check.NextAction = "run devopsellence node diagnose <node> and inspect the agent status path"
+		check.NextAction = "devopsellence node diagnose <node>"
 		return check
 	}
 	if strings.TrimSpace(result.Status.Time) == "" {
 		check.OK = false
 		check.Observed = "status report at " + statusPath + " is missing time"
-		check.NextAction = "run devopsellence node diagnose <node> and inspect the agent status writer"
+		check.NextAction = "devopsellence node diagnose <node>"
 		return check
 	}
 	statusTime, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(result.Status.Time))
 	if err != nil {
 		check.OK = false
 		check.Observed = "status report at " + statusPath + " has invalid time " + shellQuote(result.Status.Time)
-		check.NextAction = "run devopsellence node diagnose <node> and inspect the agent status writer"
+		check.NextAction = "devopsellence node diagnose <node>"
 		return check
 	}
 	age := time.Since(statusTime)
@@ -5397,18 +5411,18 @@ func (a *App) soloRuntimeDoctorChecks(ctx context.Context, opts SoloDoctorOption
 				result["detail"] = strings.TrimSpace(err.Error())
 				switch check.name {
 				case "ssh":
-					result["next_action"] = "fix SSH connectivity, then rerun devopsellence doctor"
+					result["next_action"] = soloDoctorSSHNextStep(node)
 				case "docker":
-					result["next_action"] = "make Docker reachable on the node, then rerun devopsellence doctor"
+					result["next_action"] = "devopsellence node diagnose <node>"
 				case "agent":
-					result["next_action"] = "run devopsellence agent install <node>"
+					result["next_action"] = "devopsellence agent install <node>"
 				}
 			}
 			results = append(results, result)
 		}
 		if !sshOK {
-			results = append(results, soloRuntimeAgentVersionCheckResult(name, soloRuntimeCheck{OK: false, Observed: "skipped: ssh check failed", NextAction: "fix SSH connectivity, then rerun devopsellence doctor"}))
-			results = append(results, soloRuntimeStatusReportCheckResult(name, soloRuntimeCheck{OK: false, Observed: "skipped: ssh check failed", NextAction: "fix SSH connectivity, then rerun devopsellence doctor"}))
+			results = append(results, soloRuntimeAgentVersionCheckResult(name, soloRuntimeCheck{OK: false, Observed: "skipped: ssh check failed", NextAction: soloDoctorSSHNextStep(node)}))
+			results = append(results, soloRuntimeStatusReportCheckResult(name, soloRuntimeCheck{OK: false, Observed: "skipped: ssh check failed", NextAction: soloDoctorSSHNextStep(node)}))
 			for _, check := range soloSkippedSecurityChecksAfterSSHFailure() {
 				results = append(results, soloRuntimeSecurityCheckResult(name, check))
 			}

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -4441,7 +4441,7 @@ func soloAgentStatusReportCheck(ctx context.Context, node config.Node, allowMiss
 		if allowMissing {
 			check.Observed = "no workload deployed yet; no status report expected at " + statusPath
 			check.Severity = "warning"
-			check.NextAction = "run devopsellence deploy when ready to publish the first workload"
+			check.NextAction = "devopsellence deploy"
 			return check
 		}
 		check.OK = false

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -2391,6 +2391,9 @@ func TestSoloDoctorWarnsWhenAgentStatusReportMissingBeforeFirstDeploy(t *testing
 			if check["ok"] != true || check["severity"] != "warning" || !strings.Contains(stringValueAny(check["detail"]), "no workload deployed yet") || !strings.Contains(stringValueAny(check["detail"]), "/var/lib/devopsellence/status.json") {
 				t.Fatalf("agent_status_report = %#v, want no-workload warning", check)
 			}
+			if check["next_action"] != "devopsellence deploy" {
+				t.Fatalf("agent_status_report next_action = %#v, want runnable deploy command", check["next_action"])
+			}
 			warnings := jsonArrayFromMap(t, payload, "warnings")
 			if len(warnings) != 1 || !strings.Contains(stringValueAny(warnings[0]), "no workload deployed yet") {
 				t.Fatalf("warnings = %#v, want no-workload warning", warnings)

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -2347,7 +2347,7 @@ func TestSoloDoctorScopesRuntimeChecksToCurrentEnvironment(t *testing.T) {
 	}
 }
 
-func TestSoloDoctorFailsWhenAgentStatusReportMissingAtExpectedPath(t *testing.T) {
+func TestSoloDoctorWarnsWhenAgentStatusReportMissingBeforeFirstDeploy(t *testing.T) {
 	installFakeSoloCommands(t, []fakeSSHResponse{{stdout: soloStatusMissingSentinel + "\n"}})
 
 	workspaceRoot := t.TempDir()
@@ -2377,9 +2377,67 @@ func TestSoloDoctorFailsWhenAgentStatusReportMissingAtExpectedPath(t *testing.T)
 		ConfigStore: config.NewStore(),
 		Cwd:         workspaceRoot,
 	}
+	if err := app.SoloDoctor(context.Background()); err != nil {
+		t.Fatalf("SoloDoctor() error = %v, want missing status warning before first deploy", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	if payload["ok"] != true {
+		t.Fatalf("payload ok = %#v, want true", payload["ok"])
+	}
+	checks := jsonArrayFromMap(t, payload, "runtime_checks")
+	for _, item := range checks {
+		check := jsonMapFromAny(t, item)
+		if check["check"] == "agent_status_report" {
+			if check["ok"] != true || check["severity"] != "warning" || !strings.Contains(stringValueAny(check["detail"]), "no workload deployed yet") || !strings.Contains(stringValueAny(check["detail"]), "/var/lib/devopsellence/status.json") {
+				t.Fatalf("agent_status_report = %#v, want no-workload warning", check)
+			}
+			warnings := jsonArrayFromMap(t, payload, "warnings")
+			if len(warnings) != 1 || !strings.Contains(stringValueAny(warnings[0]), "no workload deployed yet") {
+				t.Fatalf("warnings = %#v, want no-workload warning", warnings)
+			}
+			if _, ok := payload["next_steps"]; ok {
+				t.Fatalf("next_steps = %#v, want no failure next steps", payload["next_steps"])
+			}
+			return
+		}
+	}
+	t.Fatalf("runtime_checks = %#v, want agent_status_report", checks)
+}
+
+func TestSoloDoctorFailsWhenAgentStatusReportMissingForCurrentRelease(t *testing.T) {
+	installFakeSoloCommands(t, []fakeSSHResponse{{stdout: soloStatusMissingSentinel + "\n"}})
+
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	commitTestRepo(t, workspaceRoot)
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.Node{
+			"node-a": {Host: "203.0.113.10", User: "root"},
+		},
+	}
+	if _, _, err := current.AttachNode(workspaceRoot, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	seedSoloCurrentRelease(t, &current, workspaceRoot, "production", "abc1234")
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{
+		Printer:     output.New(&stdout, io.Discard),
+		Docker:      &fakeDocker{},
+		SoloState:   soloState,
+		ConfigStore: config.NewStore(),
+		Cwd:         workspaceRoot,
+	}
 	err := app.SoloDoctor(context.Background())
 	if err == nil {
-		t.Fatal("SoloDoctor() error = nil, want missing status report failure")
+		t.Fatal("SoloDoctor() error = nil, want missing status report failure for current release")
 	}
 	payload := decodeJSONOutput(t, &stdout)
 	if payload["ok"] != false {
@@ -2391,6 +2449,17 @@ func TestSoloDoctorFailsWhenAgentStatusReportMissingAtExpectedPath(t *testing.T)
 		if check["check"] == "agent_status_report" {
 			if check["ok"] != false || !strings.Contains(stringValueAny(check["detail"]), "/var/lib/devopsellence/status.json") {
 				t.Fatalf("agent_status_report = %#v, want expected status path failure", check)
+			}
+			if strings.Contains(stringValueAny(check["next_action"]), "agent install") {
+				t.Fatalf("agent_status_report next_action = %q, want diagnose guidance", stringValueAny(check["next_action"]))
+			}
+			steps := jsonArrayFromMap(t, payload, "next_steps")
+			joinedSteps := ""
+			for _, step := range steps {
+				joinedSteps += stringValueAny(step) + "\n"
+			}
+			if len(steps) == 0 || strings.Contains(joinedSteps, "agent install") {
+				t.Fatalf("next_steps = %#v, want diagnose guidance without agent install", steps)
 			}
 			return
 		}

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -4490,7 +4490,7 @@ exit 255
 	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
 	current := solo.State{
 		Nodes: map[string]config.Node{
-			"node-a": {Host: "203.0.113.10", User: "root", Port: 22},
+			"node-a": {Host: "203.0.113.10", User: "root"},
 		},
 	}
 	if err := soloState.Write(current); err != nil {

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -2454,12 +2454,18 @@ func TestSoloDoctorFailsWhenAgentStatusReportMissingForCurrentRelease(t *testing
 				t.Fatalf("agent_status_report next_action = %q, want diagnose guidance", stringValueAny(check["next_action"]))
 			}
 			steps := jsonArrayFromMap(t, payload, "next_steps")
-			joinedSteps := ""
-			for _, step := range steps {
-				joinedSteps += stringValueAny(step) + "\n"
+			wantSteps := []any{
+				"devopsellence node diagnose 'node-a'",
+				"ssh -p 22 'root@203.0.113.10' true",
 			}
-			if len(steps) == 0 || strings.Contains(joinedSteps, "agent install") {
-				t.Fatalf("next_steps = %#v, want diagnose guidance without agent install", steps)
+			if !reflect.DeepEqual(steps, wantSteps) {
+				t.Fatalf("next_steps = %#v, want runnable diagnose and SSH guidance", steps)
+			}
+			for _, step := range steps {
+				text := stringValueAny(step)
+				if strings.HasPrefix(text, "run ") || strings.Contains(text, " and ") || strings.Contains(text, "agent install") {
+					t.Fatalf("next_steps = %#v, want runnable diagnose guidance without agent install/prose", steps)
+				}
 			}
 			return
 		}


### PR DESCRIPTION
## Summary
- treat a missing agent status report as a warning before the first solo deploy
- keep missing status fatal once a current local release exists
- derive doctor next steps from the failed runtime checks instead of always suggesting agent install

## Validation
- go test ./internal/workflow -run 'TestSoloDoctor'
- TMPDIR=/home/elvin/tmp-devopsellence-tests mise run test:cli

Note: a plain local `mise run test:cli` is polluted by an existing `/tmp/devopsellence.yml`; isolated `TMPDIR` avoids that local-only state.