### PR TITLE
Add vibe agent autonomy

### DIFF
--- a/cli/internal/workflow/root.go
+++ b/cli/internal/workflow/root.go
@@ -607,6 +607,7 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 	}
 	vibeCommand.Flags().StringVar(&vibeOpts.AIAgent, "ai-agent", "", "AI agent to seed: codex, claude, pi, or generic")
 	vibeCommand.Flags().StringVar(&vibeOpts.AgentEffort, "agent-effort", defaultVibeAgentEffort, "AI agent effort/thinking level: default, low, medium, high, or xhigh")
+	vibeCommand.Flags().StringVar(&vibeOpts.AgentAutonomy, "autonomy", defaultVibeAgentAutonomy, "Agent freedom: careful, builder, or full-access")
 	vibeCommand.Flags().StringVar(&vibeOpts.Idea, "idea", "", "App idea to seed into the AI agent prompt")
 	vibeCommand.Flags().StringVar(&vibeOpts.FirstWorkflow, "first-workflow", "", "First product workflow for the agent to build")
 	vibeCommand.Flags().StringVar(&vibeOpts.DeployGoal, "deploy-goal", defaultVibeDeployGoal, "Build/deploy goal: build-only, prepare-solo, dry-run, or deploy-with-approval")

--- a/cli/internal/workflow/root_test.go
+++ b/cli/internal/workflow/root_test.go
@@ -365,7 +365,7 @@ func TestRootVibePreparesRailsAppWorkspace(t *testing.T) {
 	payload := decodeJSONOutput(t, &stdout)
 	projectsDir := filepath.Join(home, defaultVibeProjectsDirName)
 	appDir := filepath.Join(projectsDir, "my-app")
-	if payload["directory"] != appDir || payload["projects_dir"] != projectsDir || payload["ai_agent"] != "codex" || payload["agent_effort"] != "high" || payload["app_stack"] != "rails-app" || payload["launch_requested"] != false {
+	if payload["directory"] != appDir || payload["projects_dir"] != projectsDir || payload["ai_agent"] != "codex" || payload["agent_effort"] != "high" || payload["agent_autonomy"] != "builder" || payload["app_stack"] != "rails-app" || payload["launch_requested"] != false {
 		t.Fatalf("payload = %#v, want prepared codex rails workspace", payload)
 	}
 	intent := jsonMapFromAny(t, payload["deployment_intent"])
@@ -394,11 +394,11 @@ func TestRootVibePreparesRailsAppWorkspace(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(prompt), "/goal") || !strings.Contains(string(prompt), "A tiny CRM") || !strings.Contains(string(prompt), "Deployment intent") || !strings.Contains(string(prompt), "Before any production mutation") || !strings.Contains(string(prompt), "Rails 8.1") {
+	if !strings.Contains(string(prompt), "/goal") || !strings.Contains(string(prompt), "A tiny CRM") || !strings.Contains(string(prompt), "Deployment intent") || !strings.Contains(string(prompt), "Agent autonomy") || !strings.Contains(string(prompt), "Before any production mutation") || !strings.Contains(string(prompt), "Rails 8.1") {
 		t.Fatalf("prompt = %q, want seeded codex prompt", prompt)
 	}
 	nextCommands := jsonArrayFromMap(t, payload, "next_commands")
-	if !jsonArrayContains(nextCommands, "codex -c 'model_reasoning_effort=\"high\"' 'Read .agents/prompts/devopsellence-vibe.md and follow it.'") {
+	if !jsonArrayContains(nextCommands, "codex --sandbox 'workspace-write' --ask-for-approval 'on-request' -c 'model_reasoning_effort=\"high\"' 'Read .agents/prompts/devopsellence-vibe.md and follow it.'") {
 		t.Fatalf("next_commands = %#v, want prompt-file agent command", nextCommands)
 	}
 	manifestData, err := os.ReadFile(filepath.Join(appDir, ".agents", "devopsellence-vibe.json"))
@@ -409,7 +409,7 @@ func TestRootVibePreparesRailsAppWorkspace(t *testing.T) {
 	if err := json.Unmarshal(manifestData, &manifest); err != nil {
 		t.Fatal(err)
 	}
-	if filepath.IsAbs(manifest.SkillDir) || filepath.IsAbs(manifest.PromptPath) || manifest.AppStack != "rails-app" || manifest.AgentEffort != "high" || manifest.TemplateVersion != defaultVibeTemplateVersion || manifest.DeploymentIntent.DeployGoal != "prepare-solo" {
+	if filepath.IsAbs(manifest.SkillDir) || filepath.IsAbs(manifest.PromptPath) || manifest.AppStack != "rails-app" || manifest.AgentEffort != "high" || manifest.AgentAutonomy != "builder" || manifest.TemplateVersion != defaultVibeTemplateVersion || manifest.DeploymentIntent.DeployGoal != "prepare-solo" {
 		t.Fatalf("manifest = %#v, want repo-relative paths", manifest)
 	}
 }
@@ -503,6 +503,7 @@ func TestRootVibeWizardCollectsDeployIntent(t *testing.T) {
 	var stderr bytes.Buffer
 	input := bytes.NewBufferString(strings.Join([]string{
 		"A tiny CRM for consultants",
+		"full-access",
 		"Track contacts and follow-ups",
 		"dry-run",
 		"solo",
@@ -523,13 +524,16 @@ func TestRootVibeWizardCollectsDeployIntent(t *testing.T) {
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v\nstderr=%s", err, stderr.String())
 	}
-	if !strings.Contains(stderr.String(), "Ctrl+C") || !strings.Contains(stderr.String(), "Server plan") {
+	if !strings.Contains(stderr.String(), "Ctrl+C") || !strings.Contains(stderr.String(), "Agent freedom") || !strings.Contains(stderr.String(), "Server plan") {
 		t.Fatalf("stderr = %q, want wizard guidance and questions", stderr.String())
 	}
 	payload := decodeJSONOutput(t, &stdout)
 	appDir := filepath.Join(home, defaultVibeProjectsDirName, "crm-app")
 	if payload["directory"] != appDir {
 		t.Fatalf("payload = %#v, want app under projects dir", payload)
+	}
+	if payload["agent_autonomy"] != "full-access" {
+		t.Fatalf("payload = %#v, want full-access agent autonomy", payload)
 	}
 	intent := jsonMapFromAny(t, payload["deployment_intent"])
 	if intent["deploy_goal"] != "dry-run" || intent["server_strategy"] != "hetzner" || intent["provider_auth_status"] != "missing" || intent["server_target"] != "prod-1" {
@@ -554,6 +558,9 @@ func TestRootVibeWizardCollectsDeployIntent(t *testing.T) {
 	if !stringSliceContains(manifest.NextCommands, "devopsellence provider login hetzner --token <token>") {
 		t.Fatalf("manifest.NextCommands = %#v, want secure Hetzner login hint", manifest.NextCommands)
 	}
+	if manifest.AgentAutonomy != "full-access" {
+		t.Fatalf("manifest.AgentAutonomy = %q, want full-access", manifest.AgentAutonomy)
+	}
 	promptData, err := os.ReadFile(filepath.Join(appDir, ".agents", "prompts", "devopsellence-vibe.md"))
 	if err != nil {
 		t.Fatal(err)
@@ -561,6 +568,8 @@ func TestRootVibeWizardCollectsDeployIntent(t *testing.T) {
 	prompt := string(promptData)
 	for _, want := range []string{
 		"Track contacts and follow-ups",
+		"full access",
+		"isolated VM",
 		"Hetzner auth is missing",
 		"run devopsellence deploy --dry-run",
 		"Cloudflare DNS changes only after the user confirms",
@@ -733,7 +742,7 @@ func TestRootVibeLaunchReportsSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(data) != "-c\nmodel_reasoning_effort=\"high\"\nRead .agents/prompts/devopsellence-vibe.md and follow it.\n" {
+	if string(data) != "--sandbox\nworkspace-write\n--ask-for-approval\non-request\n-c\nmodel_reasoning_effort=\"high\"\nRead .agents/prompts/devopsellence-vibe.md and follow it.\n" {
 		t.Fatalf("agent args = %q, want codex high-effort prompt-file launch", data)
 	}
 }
@@ -825,6 +834,32 @@ func TestRootVibeRejectsUnsupportedAgentEffort(t *testing.T) {
 	}
 }
 
+func TestRootVibeRejectsUnsupportedAgentAutonomy(t *testing.T) {
+	cwd := t.TempDir()
+	setFakeVibeHome(t, cwd)
+	installFakeVibeTools(t)
+	var stdout bytes.Buffer
+	cmd := NewRootCommand(bytes.NewBuffer(nil), &stdout, &stdout, cwd)
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{
+		"vibe", "my-app",
+		"--ai-agent", "generic",
+		"--autonomy", "reckless",
+		"--idea", "A tiny uptime page",
+		"--no-launch",
+	})
+
+	err := cmd.Execute()
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 2 {
+		t.Fatalf("error = %#v, want ExitError code 2", err)
+	}
+	if !strings.Contains(err.Error(), "unsupported agent autonomy") {
+		t.Fatalf("error = %v, want unsupported autonomy guidance", err)
+	}
+}
+
 func TestRootVibeRejectsUnsupportedDeployGoal(t *testing.T) {
 	cwd := t.TempDir()
 	setFakeVibeHome(t, cwd)
@@ -853,41 +888,86 @@ func TestRootVibeRejectsUnsupportedDeployGoal(t *testing.T) {
 
 func TestVibeAgentCommandIncludesEffort(t *testing.T) {
 	tests := []struct {
-		agent  string
-		effort string
-		want   string
+		agent    string
+		effort   string
+		autonomy string
+		want     string
 	}{
 		{
-			agent:  "codex",
-			effort: "high",
-			want:   "codex -c 'model_reasoning_effort=\"high\"' 'Read .agents/prompts/devopsellence-vibe.md and follow it.'",
+			agent:    "codex",
+			effort:   "high",
+			autonomy: "builder",
+			want:     "codex --sandbox 'workspace-write' --ask-for-approval 'on-request' -c 'model_reasoning_effort=\"high\"' 'Read .agents/prompts/devopsellence-vibe.md and follow it.'",
 		},
 		{
-			agent:  "claude",
-			effort: "high",
-			want:   "claude --effort high 'Read .agents/prompts/devopsellence-vibe.md and follow it.'",
+			agent:    "claude",
+			effort:   "high",
+			autonomy: "builder",
+			want:     "claude --permission-mode 'auto' --effort high 'Read .agents/prompts/devopsellence-vibe.md and follow it.'",
 		},
 		{
-			agent:  "pi",
-			effort: "high",
-			want:   "pi --thinking high 'Read .agents/prompts/devopsellence-vibe.md and follow it.'",
+			agent:    "pi",
+			effort:   "high",
+			autonomy: "builder",
+			want:     "pi --thinking high 'Read .agents/prompts/devopsellence-vibe.md and follow it.'",
 		},
 		{
-			agent:  "codex",
-			effort: "default",
-			want:   "codex 'Read .agents/prompts/devopsellence-vibe.md and follow it.'",
+			agent:    "codex",
+			effort:   "default",
+			autonomy: "careful",
+			want:     "codex --sandbox 'workspace-write' --ask-for-approval 'untrusted' 'Read .agents/prompts/devopsellence-vibe.md and follow it.'",
 		},
 		{
-			agent:  "generic",
-			effort: "high",
-			want:   "cat .agents/prompts/devopsellence-vibe.md",
+			agent:    "codex",
+			effort:   "high",
+			autonomy: "full-access",
+			want:     "codex --dangerously-bypass-approvals-and-sandbox -c 'model_reasoning_effort=\"high\"' 'Read .agents/prompts/devopsellence-vibe.md and follow it.'",
+		},
+		{
+			agent:    "claude",
+			effort:   "high",
+			autonomy: "full-access",
+			want:     "claude --dangerously-skip-permissions --effort high 'Read .agents/prompts/devopsellence-vibe.md and follow it.'",
+		},
+		{
+			agent:    "generic",
+			effort:   "high",
+			autonomy: "full-access",
+			want:     "cat .agents/prompts/devopsellence-vibe.md",
 		},
 	}
 	for _, tt := range tests {
-		got := vibeAgentCommand(tt.agent, tt.effort)
+		got := vibeAgentCommand(tt.agent, tt.effort, tt.autonomy)
 		if got != tt.want {
-			t.Fatalf("vibeAgentCommand(%q, %q) = %q, want %q", tt.agent, tt.effort, got, tt.want)
+			t.Fatalf("vibeAgentCommand(%q, %q, %q) = %q, want %q", tt.agent, tt.effort, tt.autonomy, got, tt.want)
 		}
+	}
+}
+
+func TestNormalizeVibeAgentAutonomy(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{name: "empty", value: "", want: defaultVibeAgentAutonomy},
+		{name: "default", value: "default", want: defaultVibeAgentAutonomy},
+		{name: "careful", value: "careful", want: "careful"},
+		{name: "builder", value: "builder", want: "builder"},
+		{name: "full", value: "full", want: "full-access"},
+		{name: "full access", value: "full access", want: "full-access"},
+		{name: "full_access", value: "full_access", want: "full-access"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := normalizeVibeAgentAutonomy(tt.value)
+			if err != nil {
+				t.Fatalf("normalizeVibeAgentAutonomy(%q) error = %v", tt.value, err)
+			}
+			if got != tt.want {
+				t.Fatalf("normalizeVibeAgentAutonomy(%q) = %q, want %q", tt.value, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/cli/internal/workflow/vibe.go
+++ b/cli/internal/workflow/vibe.go
@@ -20,6 +20,7 @@ type VibeOptions struct {
 	Directory         string
 	AIAgent           string
 	AgentEffort       string
+	AgentAutonomy     string
 	Idea              string
 	FirstWorkflow     string
 	DeployGoal        string
@@ -40,6 +41,7 @@ type vibeManifest struct {
 	SchemaVersion    int                  `json:"schema_version"`
 	AIAgent          string               `json:"ai_agent"`
 	AgentEffort      string               `json:"agent_effort"`
+	AgentAutonomy    string               `json:"agent_autonomy"`
 	DetectedAgents   []string             `json:"detected_agents"`
 	AppStack         string               `json:"app_stack"`
 	TemplateURL      string               `json:"template_url"`
@@ -69,6 +71,7 @@ const (
 	vibeAppStack               = "rails-app"
 	defaultVibeProjectsDirName = "devopsellence-projects"
 	defaultVibeAgentEffort     = "high"
+	defaultVibeAgentAutonomy   = "builder"
 	defaultVibeDeployGoal      = "prepare-solo"
 	defaultVibeMode            = "solo"
 	defaultVibeServerStrategy  = "none"
@@ -86,6 +89,11 @@ func (a *App) Vibe(ctx context.Context, opts VibeOptions) error {
 		return err
 	}
 	opts.AgentEffort = agentEffort
+	agentAutonomy, err := normalizeVibeAgentAutonomy(opts.AgentAutonomy)
+	if err != nil {
+		return err
+	}
+	opts.AgentAutonomy = agentAutonomy
 	reader := bufio.NewReader(a.In)
 	wizardMode := strings.TrimSpace(opts.Idea) == ""
 	if wizardMode {
@@ -137,6 +145,13 @@ func (a *App) Vibe(ctx context.Context, opts VibeOptions) error {
 	if len(opts.Idea) > 4096 {
 		return ExitError{Code: 2, Err: errors.New("app idea is too long; keep it under 4096 characters")}
 	}
+	if wizardMode {
+		autonomy, err := a.askVibeAgentAutonomy(reader, opts.AgentAutonomy)
+		if err != nil {
+			return err
+		}
+		opts.AgentAutonomy = autonomy
+	}
 	intent, err := a.resolveVibeDeploymentIntent(reader, opts, wizardMode)
 	if err != nil {
 		return err
@@ -177,18 +192,19 @@ func (a *App) Vibe(ctx context.Context, opts VibeOptions) error {
 		return err
 	}
 
-	prompt := vibePrompt(opts.AIAgent, templateURL, opts.Idea, intent)
+	prompt := vibePrompt(opts.AIAgent, opts.AgentAutonomy, templateURL, opts.Idea, intent)
 	promptPath := filepath.Join(promptsDir, "devopsellence-vibe.md")
 	if err := os.WriteFile(promptPath, []byte(prompt), 0o644); err != nil {
 		return fmt.Errorf("write prompt: %w", err)
 	}
 
-	agentCommand := vibeAgentCommand(opts.AIAgent, opts.AgentEffort)
+	agentCommand := vibeAgentCommand(opts.AIAgent, opts.AgentEffort, opts.AgentAutonomy)
 	nextCommands := vibeNextCommands(target, agentCommand, intent)
 	manifest := vibeManifest{
 		SchemaVersion:    outputSchemaVersion,
 		AIAgent:          opts.AIAgent,
 		AgentEffort:      opts.AgentEffort,
+		AgentAutonomy:    opts.AgentAutonomy,
 		DetectedAgents:   detectedAgents,
 		AppStack:         vibeAppStack,
 		TemplateURL:      templateURL,
@@ -222,6 +238,7 @@ func (a *App) Vibe(ctx context.Context, opts VibeOptions) error {
 		"projects_dir":      projectsDir,
 		"ai_agent":          opts.AIAgent,
 		"agent_effort":      opts.AgentEffort,
+		"agent_autonomy":    opts.AgentAutonomy,
 		"detected_agents":   detectedAgents,
 		"app_stack":         vibeAppStack,
 		"template_url":      templateURL,
@@ -240,7 +257,7 @@ func (a *App) Vibe(ctx context.Context, opts VibeOptions) error {
 	}
 	var launchErr error
 	if opts.Launch {
-		launchErr = a.launchVibeAgent(ctx, opts.AIAgent, opts.AgentEffort, target)
+		launchErr = a.launchVibeAgent(ctx, opts.AIAgent, opts.AgentEffort, opts.AgentAutonomy, target)
 		payload["launched"] = launchErr == nil
 		if launchErr != nil {
 			payload["launch_error"] = launchErr.Error()
@@ -279,6 +296,15 @@ func (a *App) askVibeQuestionDefault(reader *bufio.Reader, label, defaultValue s
 		return strings.TrimSpace(defaultValue), nil
 	}
 	return answer, nil
+}
+
+func (a *App) askVibeAgentAutonomy(reader *bufio.Reader, defaultValue string) (string, error) {
+	_, _ = fmt.Fprintln(a.Printer.Err, "Agent freedom: builder edits files and runs local commands; careful asks more; full-access skips agent sandbox/approval prompts and is only for isolated VMs/containers.")
+	autonomy, err := a.askVibeQuestionDefault(reader, "Agent freedom (builder, careful, full-access)", firstNonEmpty(defaultValue, defaultVibeAgentAutonomy))
+	if err != nil {
+		return "", err
+	}
+	return normalizeVibeAgentAutonomy(autonomy)
 }
 
 func (a *App) resolveVibeDeploymentIntent(reader *bufio.Reader, opts VibeOptions, ask bool) (vibeDeploymentIntent, error) {
@@ -543,6 +569,25 @@ func normalizeVibeAgentEffort(effort string) (string, error) {
 	}
 }
 
+func normalizeVibeAgentAutonomy(value string) (string, error) {
+	value = strings.ToLower(strings.TrimSpace(value))
+	value = strings.ReplaceAll(value, "_", "-")
+	value = strings.Join(strings.Fields(value), "-")
+	if value == "" || value == "default" {
+		value = defaultVibeAgentAutonomy
+	}
+	switch value {
+	case "careful":
+		return "careful", nil
+	case "builder", "build":
+		return "builder", nil
+	case "full", "full-access":
+		return "full-access", nil
+	default:
+		return "", ExitError{Code: 2, Err: fmt.Errorf("unsupported agent autonomy %q; use careful, builder, or full-access", value)}
+	}
+}
+
 func resolveVibeTarget(cwd, directory, idea, projectsDir string) (string, string, error) {
 	target := strings.TrimSpace(directory)
 	if target == "" {
@@ -734,7 +779,7 @@ func vibeTemplateURL(version string) string {
 	return "https://raw.githubusercontent.com/devopsellence/rails-app-template/" + version + "/template.rb"
 }
 
-func vibePrompt(agent, templateURL, idea string, intent vibeDeploymentIntent) string {
+func vibePrompt(agent, autonomy, templateURL, idea string, intent vibeDeploymentIntent) string {
 	var firstLine string
 	switch agent {
 	case "codex":
@@ -763,6 +808,12 @@ func vibePrompt(agent, templateURL, idea string, intent vibeDeploymentIntent) st
 		"- TLS email: " + firstNonEmpty(intent.TLSEmail, "ask before configuring ingress"),
 		"- External services: " + strings.Join(intent.Services, ", "),
 		"",
+		"Agent autonomy:",
+		"- Level: " + vibeAgentAutonomyLabel(autonomy),
+	}
+	lines = append(lines, vibeAgentAutonomyPromptLines(autonomy)...)
+	lines = append(lines,
+		"",
 		"Use .agents/skills/devopsellence-rails-app for app-building guidance.",
 		"Use .agents/skills/devopsellence for deploy, secrets, logs, status, rollback, and node operations.",
 		"Stay inside the blessed Rails baseline: Rails 8.1, PostgreSQL, Hotwire, Tailwind, Solid Queue/Cache/Cable, Active Storage, Sentry, OpenTelemetry, Minitest, Docker, and mise.",
@@ -772,7 +823,7 @@ func vibePrompt(agent, templateURL, idea string, intent vibeDeploymentIntent) st
 		"- Do not write provider tokens, API keys, passwords, or secret values into prompts, manifests, git, logs, or commits.",
 		"- Before any production mutation, run devopsellence deploy --dry-run and summarize the plan.",
 		"- Ask the user before provisioning nodes, changing DNS, setting secrets, or running a real deploy.",
-	}
+	)
 	lines = append(lines, vibeDeployGoalPromptLines(intent)...)
 	lines = append(lines, vibeServerPromptLines(intent)...)
 	lines = append(lines, vibeServicesPromptLines(intent)...)
@@ -791,6 +842,37 @@ func vibePromptServerPlan(intent vibeDeploymentIntent) string {
 		return "provision Hetzner node " + firstNonEmpty(intent.ServerTarget, "prod-1") + " (auth " + firstNonEmpty(intent.ProviderAuthStatus, "unknown") + ")"
 	default:
 		return "no server yet"
+	}
+}
+
+func vibeAgentAutonomyLabel(autonomy string) string {
+	switch autonomy {
+	case "careful":
+		return "careful"
+	case "full-access":
+		return "full access"
+	default:
+		return "builder"
+	}
+}
+
+func vibeAgentAutonomyPromptLines(autonomy string) []string {
+	switch autonomy {
+	case "careful":
+		return []string{
+			"- Ask before most meaningful changes. Keep edits small and explain the next step before changing behavior.",
+			"- Low-risk read-only inspection is okay without pausing.",
+		}
+	case "full-access":
+		return []string{
+			"- The agent command may run without sandbox or approval prompts. This is only appropriate inside an isolated VM, container, or disposable devbox.",
+			"- Even with full access, ask before reading secrets, spending money, provisioning infrastructure, changing DNS, deploying to production, deleting data, or running destructive git commands.",
+		}
+	default:
+		return []string{
+			"- Edit project files and run local build/test commands without pausing for every step.",
+			"- Ask before reading secrets, spending money, provisioning infrastructure, changing DNS, deploying to production, deleting data, or running destructive git commands.",
+		}
 	}
 }
 
@@ -860,12 +942,13 @@ func vibeNextCommands(target, agentCommand string, intent vibeDeploymentIntent) 
 	return append(commands, agentCommand)
 }
 
-func vibeAgentCommand(agent, effort string) string {
+func vibeAgentCommand(agent, effort, autonomy string) string {
 	if agent == "generic" {
 		return "cat .agents/prompts/devopsellence-vibe.md"
 	}
 	parts := []string{agent}
-	for _, arg := range vibeAgentEffortArgs(agent, effort) {
+	args := append(vibeAgentAutonomyArgs(agent, autonomy), vibeAgentEffortArgs(agent, effort)...)
+	for _, arg := range args {
 		if strings.HasPrefix(arg, "-") || arg == effort {
 			parts = append(parts, arg)
 		} else {
@@ -874,6 +957,31 @@ func vibeAgentCommand(agent, effort string) string {
 	}
 	parts = append(parts, shellQuote(vibePromptInstruction))
 	return strings.Join(parts, " ")
+}
+
+func vibeAgentAutonomyArgs(agent, autonomy string) []string {
+	switch agent {
+	case "codex":
+		switch autonomy {
+		case "careful":
+			return []string{"--sandbox", "workspace-write", "--ask-for-approval", "untrusted"}
+		case "full-access":
+			return []string{"--dangerously-bypass-approvals-and-sandbox"}
+		default:
+			return []string{"--sandbox", "workspace-write", "--ask-for-approval", "on-request"}
+		}
+	case "claude":
+		switch autonomy {
+		case "careful":
+			return []string{"--permission-mode", "default"}
+		case "full-access":
+			return []string{"--dangerously-skip-permissions"}
+		default:
+			return []string{"--permission-mode", "auto"}
+		}
+	default:
+		return nil
+	}
 }
 
 func vibeAgentEffortArgs(agent, effort string) []string {
@@ -892,7 +1000,7 @@ func vibeAgentEffortArgs(agent, effort string) []string {
 	}
 }
 
-func (a *App) launchVibeAgent(ctx context.Context, agent, effort, cwd string) error {
+func (a *App) launchVibeAgent(ctx context.Context, agent, effort, autonomy, cwd string) error {
 	if agent == "generic" {
 		return nil
 	}
@@ -900,7 +1008,8 @@ func (a *App) launchVibeAgent(ctx context.Context, agent, effort, cwd string) er
 	if _, err := a.LookPath(binary); err != nil {
 		return ExitError{Code: 2, Err: fmt.Errorf("%s not found; rerun with --no-launch and start it manually from .agents/prompts/devopsellence-vibe.md", binary)}
 	}
-	args := append(vibeAgentEffortArgs(agent, effort), vibePromptInstruction)
+	args := append(vibeAgentAutonomyArgs(agent, autonomy), vibeAgentEffortArgs(agent, effort)...)
+	args = append(args, vibePromptInstruction)
 	cmd := exec.CommandContext(ctx, binary, args...)
 	cmd.Dir = cwd
 	cmd.Stdin = a.In

--- a/docs-website/src/content/docs/getting-started/solo-quickstart.md
+++ b/docs-website/src/content/docs/getting-started/solo-quickstart.md
@@ -27,8 +27,9 @@ cd ~/devopsellence-projects/my-app
 
 Bare app names land under `~/devopsellence-projects`. Pass `./my-app` or an
 absolute path when the app should be created somewhere else. The wizard asks for
-deploy intent before scaffolding; press Ctrl+C during the questions to stop. Use
-`--no-agent` to generate the app and prompt without starting an AI agent.
+agent freedom and deploy intent before scaffolding; press Ctrl+C during the
+questions to stop. Use `--no-agent` to generate the app and prompt without
+starting an AI agent.
 
 <ol class="command-sequence" start="2">
   <li>Commit the app before the first deploy.</li>

--- a/docs-website/src/content/docs/guides/rails-app-template.md
+++ b/docs-website/src/content/docs/guides/rails-app-template.md
@@ -6,7 +6,8 @@ description: Start a production-minded Rails app with devopsellence, mise, and a
 `devopsellence vibe` creates one blessed Rails app shape instead of asking you
 to choose a stack. It uses the devopsellence Rails template, writes a local
 agent skill, seeds a prompt, initializes git, and can launch Codex, Claude Code,
-Pi, or another agent with high effort/thinking enabled.
+Pi, or another agent with high effort/thinking enabled and a simple autonomy
+choice.
 
 Run it without `--idea` to use the intake wizard. You can press Ctrl+C during
 the questions to stop before files are generated.
@@ -31,6 +32,7 @@ directory with `--projects-dir` or `DEVOPSELLENCE_PROJECTS_DIR`.
 The wizard captures deploy intent before the agent starts:
 
 - first workflow the agent should build;
+- agent freedom: builder, careful, or full-access;
 - build only, prepare for solo deploy, dry-run, or deploy after approval;
 - solo now, shared later, or decide later;
 - no server yet, an existing server, or a Hetzner node;
@@ -41,6 +43,13 @@ The wizard captures deploy intent before the agent starts:
 This intent is written to `.agents/devopsellence-vibe.json` and summarized in
 `.agents/prompts/devopsellence-vibe.md`. Tokens and secret values are never
 written there.
+
+The default autonomy is `builder`: the agent can edit files and run local
+build/test commands, but the prompt still tells it to ask before secrets, paid
+infrastructure, DNS changes, production deploys, destructive git commands, or
+data deletion. `careful` asks more often. `full-access` starts Codex or Claude
+without sandbox/approval prompts and is only appropriate inside an isolated VM,
+container, or disposable devbox.
 
 Prepare for a Hetzner-backed solo deploy without starting the agent:
 
@@ -79,6 +88,12 @@ Use the agent's own configured effort instead of the devopsellence default:
 
 ```bash
 devopsellence vibe my-crm --ai-agent=codex --agent-effort=default
+```
+
+Start Claude with full local access inside an isolated devbox:
+
+```bash
+devopsellence vibe my-crm --ai-agent=claude --autonomy=full-access
 ```
 
 The command runs Rails with the pinned template:

--- a/docs-website/src/content/docs/index.md
+++ b/docs-website/src/content/docs/index.md
@@ -45,8 +45,8 @@ cd ~/devopsellence-projects/my-app
 Bare app names created by `devopsellence vibe` land under
 `~/devopsellence-projects`. Pass `./my-app` or an absolute path when the app
 should be created somewhere else. The intake wizard asks for the app idea,
-first workflow, solo deploy intent, server plan, domain, and service choices
-before scaffolding; press Ctrl+C during the questions to stop.
+agent freedom, first workflow, solo deploy intent, server plan, domain, and
+service choices before scaffolding; press Ctrl+C during the questions to stop.
 
 - [Solo quickstart](/getting-started/solo-quickstart/) for the shortest path to
   one VM.

--- a/docs-website/src/content/docs/reference/cli.md
+++ b/docs-website/src/content/docs/reference/cli.md
@@ -63,6 +63,8 @@ devopsellence ingress check --wait 5m
 devopsellence vibe my-app
 devopsellence vibe my-app --ai-agent=codex --idea="A tiny CRM"
 devopsellence vibe my-app --ai-agent=codex --agent-effort=default --idea="A tiny CRM"
+devopsellence vibe my-app --ai-agent=codex --autonomy=careful --idea="A tiny CRM"
+devopsellence vibe my-app --ai-agent=claude --autonomy=full-access --idea="A tiny CRM"
 devopsellence vibe my-app --projects-dir ~/Work/apps --idea="A tiny CRM"
 devopsellence vibe my-app --deploy-goal=dry-run --server=hetzner --server-target=prod-1 --domain=app.example.com --tls-email=ops@example.com
 devopsellence vibe my-app --services=managed-postgres,object-storage,email,cloudflare-dns --idea="A tiny CRM"


### PR DESCRIPTION
## Summary
- add a single `--autonomy` / wizard choice for careful, builder, or full-access agent freedom
- map autonomy to Codex and Claude launch flags while keeping prompt boundaries around secrets, infra, DNS, deploys, and destructive ops
- persist autonomy in `.agents/devopsellence-vibe.json`, JSON output, docs, and the seeded prompt

## Validation
- `go test ./internal/agentskill ./internal/workflow -run 'Test(Install|Available|Bundled|RootSkill|RootVibe|PrepareVibe|VibeAgent|NormalizeVibe|TruncateVibeText)'`
- `npm run check`
- `git diff --check`
- `go build -o /tmp/devopsellence-vibe-autonomy ./cmd/devopsellence`
- dogfooded `devopsellence vibe dogfood-crm --ai-agent codex` with full-access autonomy and fake Rails/Codex tools under `/tmp/devopsellence-vibe-autonomy-dogfood-20260510-9-6f70b5`