### PR TITLE
Allow solo SSH config override

### DIFF
--- a/cli/internal/solo/ssh.go
+++ b/cli/internal/solo/ssh.go
@@ -12,18 +12,25 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/devopsellence/cli/internal/state"
 	"github.com/devopsellence/devopsellence/deployment-core/pkg/deploycore/config"
 )
 
+const sshConfigEnv = "DEVOPSELLENCE_SSH_CONFIG"
+
 func sshArgs(node config.Node, command string) []string {
-	args := []string{
+	args := []string{}
+	if configPath := sshConfigPathOverride(); configPath != "" {
+		args = append(args, "-F", configPath)
+	}
+	args = append(args,
 		"-o", "BatchMode=yes",
 		"-o", "ConnectTimeout=10",
 		"-o", "StrictHostKeyChecking=accept-new",
 		"-p", strconv.Itoa(node.Port),
-	}
+	)
 	if knownHostsPath := managedKnownHostsPath(node); knownHostsPath != "" {
 		args = append(args, "-o", "UserKnownHostsFile="+knownHostsPath)
 	}
@@ -32,6 +39,18 @@ func sshArgs(node config.Node, command string) []string {
 	}
 	args = append(args, fmt.Sprintf("%s@%s", node.User, node.Host), command)
 	return args
+}
+
+func sshConfigPathOverride() string {
+	value := strings.TrimSpace(os.Getenv(sshConfigEnv))
+	switch strings.ToLower(value) {
+	case "", "default":
+		return ""
+	case "none":
+		return os.DevNull
+	default:
+		return value
+	}
 }
 
 func managedKnownHostsPath(node config.Node) string {

--- a/cli/internal/solo/ssh_test.go
+++ b/cli/internal/solo/ssh_test.go
@@ -63,6 +63,35 @@ func TestSSHArgsUseManagedKnownHostsForProviderNodes(t *testing.T) {
 	}
 }
 
+func TestSSHArgsUseSSHConfigOverride(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateDir)
+	t.Setenv(sshConfigEnv, "/dev/null")
+	node := config.Node{User: "root", Host: "203.0.113.10", Port: 22}
+
+	got := sshArgs(node, "true")
+	want := []string{
+		"-F", "/dev/null",
+		"-o", "BatchMode=yes",
+		"-o", "ConnectTimeout=10",
+		"-o", "StrictHostKeyChecking=accept-new",
+		"-p", "22",
+		"-o", "UserKnownHostsFile=" + managedKnownHostsPath(node),
+		"root@203.0.113.10",
+		"true",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("sshArgs() = %#v, want %#v", got, want)
+	}
+}
+
+func TestSSHArgsUseDevNullForNoneSSHConfigOverride(t *testing.T) {
+	t.Setenv(sshConfigEnv, "none")
+	if got := sshConfigPathOverride(); got != os.DevNull {
+		t.Fatalf("sshConfigPathOverride() = %q, want %q", got, os.DevNull)
+	}
+}
+
 func TestRemoveKnownHostsDeletesManagedFile(t *testing.T) {
 	stateDir := t.TempDir()
 	t.Setenv("XDG_STATE_HOME", stateDir)

--- a/cli/internal/workflow/root.go
+++ b/cli/internal/workflow/root.go
@@ -964,6 +964,7 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 		Long: strings.Join([]string{
 			"Create or register a node for the selected workspace mode.",
 			"Solo --host nodes must be reachable over SSH with the selected key. devopsellence stores SSH host keys in its own state directory and uses StrictHostKeyChecking=accept-new, so first contact does not write to ~/.ssh/known_hosts.",
+			"If local SSH config is broken or too opinionated, set DEVOPSELLENCE_SSH_CONFIG=/dev/null to make devopsellence pass `ssh -F /dev/null`.",
 			"The solo agent install can install Docker on supported Ubuntu VMs when Docker is missing; otherwise install Docker yourself or make the SSH user able to run docker via passwordless sudo.",
 			"If SSH validation fails as root, retry with the image default user such as ubuntu, debian, or ec2-user, and verify passwordless sudo with `ssh <user>@<host> sudo -n true` before installing the agent.",
 		}, "\n"),


### PR DESCRIPTION
## Summary
- add DEVOPSELLENCE_SSH_CONFIG to pass an explicit ssh -F config file for solo SSH calls
- support DEVOPSELLENCE_SSH_CONFIG=none as a portable dev-null shortcut
- document the /dev/null workaround in node create help

## Tests
- go test ./internal/solo
- TMPDIR=/home/elvin/tmp-devopsellence-tests go test ./internal/workflow -run 'TestRoot'
- TMPDIR=/home/elvin/tmp-devopsellence-tests mise run test:cli