### PR TITLE
Keep successful ingress checks nonfatal when state is read-only

### DIFF
--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -6868,7 +6868,7 @@ func (a *App) IngressCheck(ctx context.Context, opts IngressCheckOptions) error 
 			report.Environment = environmentName
 			if report.OK {
 				if err := recordSuccessfulSoloIngressCheckToStore(a.SoloState, workspaceRoot, environmentName, report); err != nil {
-					return err
+					report.Warnings = append(report.Warnings, "ingress check succeeded, but the local readiness record could not be saved: "+err.Error())
 				}
 			}
 
@@ -7359,6 +7359,7 @@ type ingressDNSReportResult struct {
 	ExpectedIPs   []string               `json:"expected_ips"`
 	Hosts         []ingressDNSHostResult `json:"hosts"`
 	Hints         []ingressHint          `json:"hints,omitempty"`
+	Warnings      []string               `json:"warnings,omitempty"`
 	NextSteps     []string               `json:"next_steps,omitempty"`
 }
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -1798,6 +1798,57 @@ func TestIngressCheckPersistsSuccessfulReadinessRecord(t *testing.T) {
 	}
 }
 
+func TestIngressCheckWarnsWhenSuccessfulReadinessRecordCannotBeSaved(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	cfg.Ingress = &config.IngressConfig{
+		Hosts: []string{"127.0.0.1"},
+		Rules: []config.IngressRuleConfig{{
+			Match:  config.IngressMatchConfig{Host: "127.0.0.1", PathPrefix: "/"},
+			Target: config.IngressTargetConfig{Service: config.DefaultWebServiceName, Port: "http"},
+		}},
+		TLS: config.IngressTLSConfig{Mode: "off"},
+	}
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	stateDir := t.TempDir()
+	soloState := solo.NewStateStore(filepath.Join(stateDir, "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.Node{
+			"node-a": {Host: "127.0.0.1", User: "root", Labels: []string{config.DefaultWebRole}},
+		},
+		Attachments: map[string]solo.AttachmentRecord{},
+	}
+	if _, _, err := current.AttachNode(workspaceRoot, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(stateDir, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chmod(stateDir, 0o755)
+	})
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState, ConfigStore: config.NewStore(), Cwd: workspaceRoot}
+	if err := app.IngressCheck(context.Background(), IngressCheckOptions{}); err != nil {
+		t.Fatalf("IngressCheck() error = %v, want success with warning", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	if payload["ok"] != true {
+		t.Fatalf("payload ok = %v, want true", payload["ok"])
+	}
+	warnings := jsonArrayFromMap(t, payload, "warnings")
+	if len(warnings) != 1 || !strings.Contains(stringValueAny(warnings[0]), "local readiness record could not be saved") {
+		t.Fatalf("warnings = %#v, want readiness record save warning", warnings)
+	}
+}
+
 func TestRecordSuccessfulSoloIngressCheckToStorePreservesFreshState(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))


### PR DESCRIPTION
## Summary
- keep ingress check success nonfatal when saving the local readiness record fails
- surface the save failure as a JSON warning
- add regression coverage for read-only solo state storage

## Tests
- go test ./internal/workflow -run 'TestIngressCheck'
- TMPDIR=/home/elvin/tmp-devopsellence-tests mise run test:cli