### PR TITLE
Explain IP ingress TLS limits

### DIFF
--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -6651,7 +6651,7 @@ func ingressSetWarnings(hosts []string, tlsMode string) []string {
 	case "off":
 		return []string{"IP ingress hosts are HTTP only with --tls-mode off; use a DNS hostname with --tls-mode auto or manual for TLS/HTTPS."}
 	default:
-		return []string{"IP ingress hosts do not work with ACME/browser-valid HTTPS; use a DNS hostname for TLS/HTTPS, or set --tls-mode off for HTTP only."}
+		return []string{"ACME/browser-trusted TLS for IP ingress hosts requires a certificate with the IP address in the SAN; use a DNS hostname for automatic TLS, install a trusted manual certificate with an IP SAN, or set --tls-mode off for HTTP only."}
 	}
 }
 

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -6631,13 +6631,38 @@ func (a *App) IngressSet(_ context.Context, opts IngressSetOptions) error {
 		return err
 	}
 
-	return a.Printer.PrintJSON(map[string]any{
+	payload := map[string]any{
 		"schema_version": outputSchemaVersion,
 		"environment":    selectedEnvironment,
 		"ingress":        ingress,
 		"config_path":    a.ConfigStore.PathFor(discovered.WorkspaceRoot),
-	})
+	}
+	if warnings := ingressSetWarnings(hosts, tlsMode); len(warnings) > 0 {
+		payload["warnings"] = warnings
+	}
+	return a.Printer.PrintJSON(payload)
+}
 
+func ingressSetWarnings(hosts []string, tlsMode string) []string {
+	if !ingressHostsIncludeIP(hosts) {
+		return nil
+	}
+	switch strings.ToLower(strings.TrimSpace(tlsMode)) {
+	case "off":
+		return []string{"IP ingress hosts are HTTP only with --tls-mode off; use a DNS hostname with --tls-mode auto or manual for TLS/HTTPS."}
+	default:
+		return []string{"IP ingress hosts do not work with ACME/browser-valid HTTPS; use a DNS hostname for TLS/HTTPS, or set --tls-mode off for HTTP only."}
+	}
+}
+
+func ingressHostsIncludeIP(hosts []string) bool {
+	for _, host := range hosts {
+		value := strings.Trim(strings.TrimSpace(host), "[]")
+		if net.ParseIP(value) != nil {
+			return true
+		}
+	}
+	return false
 }
 
 func (a *App) SoloIngressCertInstall(ctx context.Context, opts SoloIngressCertInstallOptions) error {

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -10862,6 +10862,41 @@ func TestIngressSetWarnsIPHostIsHTTPOnlyWithTLSOff(t *testing.T) {
 	}
 }
 
+func TestIngressSetWarnsIPHostNeedsDNSOrIPSanForTLS(t *testing.T) {
+	for _, tlsMode := range []string{"auto", "manual"} {
+		t.Run(tlsMode, func(t *testing.T) {
+			dir := t.TempDir()
+			cfg := config.DefaultProjectConfig("solo", "demo", config.DefaultEnvironment)
+			if _, err := config.Write(dir, cfg); err != nil {
+				t.Fatal(err)
+			}
+
+			var stdout bytes.Buffer
+			app := &App{
+				Cwd:         dir,
+				ConfigStore: config.NewStore(),
+				Printer:     output.New(&stdout, io.Discard),
+			}
+			if err := app.IngressSet(context.Background(), IngressSetOptions{
+				Hosts:   []string{"203.0.113.10"},
+				TLSMode: tlsMode,
+			}); err != nil {
+				t.Fatalf("IngressSet() error = %v", err)
+			}
+
+			payload := decodeJSONOutput(t, &stdout)
+			warnings := jsonArrayFromMap(t, payload, "warnings")
+			warning := ""
+			if len(warnings) > 0 {
+				warning = stringValueAny(warnings[0])
+			}
+			if len(warnings) != 1 || !strings.Contains(warning, "automatic TLS") || !strings.Contains(warning, "IP SAN") || !strings.Contains(warning, "--tls-mode off") {
+				t.Fatalf("warnings = %#v, want DNS/manual-IP-SAN/TLS-off guidance", warnings)
+			}
+		})
+	}
+}
+
 func TestIngressSetWritesSelectedEnvironmentOverlay(t *testing.T) {
 	t.Setenv("DEVOPSELLENCE_ENVIRONMENT", "staging")
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -10835,6 +10835,33 @@ func TestIngressSetPreservesExistingServiceWhenFlagOmitted(t *testing.T) {
 	}
 }
 
+func TestIngressSetWarnsIPHostIsHTTPOnlyWithTLSOff(t *testing.T) {
+	dir := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", config.DefaultEnvironment)
+	if _, err := config.Write(dir, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{
+		Cwd:         dir,
+		ConfigStore: config.NewStore(),
+		Printer:     output.New(&stdout, io.Discard),
+	}
+	if err := app.IngressSet(context.Background(), IngressSetOptions{
+		Hosts:   []string{"203.0.113.10"},
+		TLSMode: "off",
+	}); err != nil {
+		t.Fatalf("IngressSet() error = %v", err)
+	}
+
+	payload := decodeJSONOutput(t, &stdout)
+	warnings := jsonArrayFromMap(t, payload, "warnings")
+	if len(warnings) != 1 || !strings.Contains(stringValueAny(warnings[0]), "HTTP only") || !strings.Contains(stringValueAny(warnings[0]), "DNS hostname") {
+		t.Fatalf("warnings = %#v, want IP host HTTP-only/TLS guidance", warnings)
+	}
+}
+
 func TestIngressSetWritesSelectedEnvironmentOverlay(t *testing.T) {
 	t.Setenv("DEVOPSELLENCE_ENVIRONMENT", "staging")
 


### PR DESCRIPTION
## Summary
- add ingress set warnings when configured hosts are raw IP addresses
- distinguish HTTP-only TLS-off usage from DNS-required TLS/HTTPS usage
- add regression coverage for the raw-IP HTTP-only guidance

## Tests
- go test ./internal/workflow -run 'TestIngressSet|TestIngressHostsIncludeIP|TestIngressSetWarnings'
- TMPDIR=/home/elvin/tmp-devopsellence-tests mise run test:cli