### PR TITLE
Clarify solo status when ingress is not configured

### DIFF
--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -2269,6 +2269,7 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 		warnings, _ := payload["warnings"].([]string)
 		payload["warnings"] = append(warnings, message)
 	}
+	statusRuntimeVerified := allSettled && hasCurrent && readErrors == 0 && statusErrors == 0 && statusMismatches == 0 && missingStatuses == 0
 	if len(verifiedPublicURLs) > 0 {
 		if allSettled {
 			payload["public_urls"] = verifiedPublicURLs
@@ -2280,8 +2281,14 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 		payload["configured_public_urls"] = configuredPublicURLs
 		payload["public_url_status"] = soloPublicURLStatus(cfg)
 		appendPayloadWarning(soloPublicURLWarning(cfg, environmentName))
+	} else if !soloPublicIngressConfigured(cfg) {
+		payload["public_url_status"] = "not_configured"
+		if statusRuntimeVerified {
+			payload["public_url_message"] = "internal health OK, but no public ingress is configured; run `devopsellence ingress set" + soloEnvFlag(environmentName) + " --host <hostname> --service <service>` to publish it"
+		} else {
+			payload["public_url_message"] = "no public ingress configured; run `devopsellence ingress set" + soloEnvFlag(environmentName) + " --host <hostname> --service <service>` to publish it"
+		}
 	}
-	statusRuntimeVerified := allSettled && hasCurrent && readErrors == 0 && statusErrors == 0 && statusMismatches == 0 && missingStatuses == 0
 	payload["runtime_verified"] = soloRuntimeVerifiedPayload(soloRuntimeVerification{
 		DesiredStateRevision: statusRuntimeVerified,
 		Healthcheck:          statusRuntimeVerified,
@@ -2945,7 +2952,7 @@ func soloPlannedDNSCheck(cfg *config.ProjectConfig, nodes map[string]config.Node
 }
 
 func soloStatusPublicURLs(cfg *config.ProjectConfig, nodes map[string]config.Node) []string {
-	if cfg == nil || len(nodes) == 0 {
+	if cfg == nil || cfg.Ingress == nil || len(nodes) == 0 {
 		return nil
 	}
 	scheme := ingressURLScheme(cfg)
@@ -2963,6 +2970,10 @@ func soloStatusPublicURLs(cfg *config.ProjectConfig, nodes map[string]config.Nod
 		}
 	}
 	return publicURLsForHosts(scheme, hosts)
+}
+
+func soloPublicIngressConfigured(cfg *config.ProjectConfig) bool {
+	return cfg != nil && cfg.Ingress != nil
 }
 
 func ingressConfiguredPublicURLs(cfg *config.ProjectConfig) []string {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -2972,10 +2972,6 @@ func soloStatusPublicURLs(cfg *config.ProjectConfig, nodes map[string]config.Nod
 	return publicURLsForHosts(scheme, hosts)
 }
 
-func soloPublicIngressConfigured(cfg *config.ProjectConfig) bool {
-	return cfg != nil && cfg.Ingress != nil
-}
-
 func soloPublicIngressKnownUnconfigured(cfg *config.ProjectConfig) bool {
 	return cfg != nil && cfg.Ingress == nil
 }

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -2281,7 +2281,7 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 		payload["configured_public_urls"] = configuredPublicURLs
 		payload["public_url_status"] = soloPublicURLStatus(cfg)
 		appendPayloadWarning(soloPublicURLWarning(cfg, environmentName))
-	} else if !soloPublicIngressConfigured(cfg) {
+	} else if soloPublicIngressKnownUnconfigured(cfg) {
 		payload["public_url_status"] = "not_configured"
 		if statusRuntimeVerified {
 			payload["public_url_message"] = "internal health OK, but no public ingress is configured; run `devopsellence ingress set" + soloEnvFlag(environmentName) + " --host <hostname> --service <service>` to publish it"
@@ -2974,6 +2974,10 @@ func soloStatusPublicURLs(cfg *config.ProjectConfig, nodes map[string]config.Nod
 
 func soloPublicIngressConfigured(cfg *config.ProjectConfig) bool {
 	return cfg != nil && cfg.Ingress != nil
+}
+
+func soloPublicIngressKnownUnconfigured(cfg *config.ProjectConfig) bool {
+	return cfg != nil && cfg.Ingress == nil
 }
 
 func ingressConfiguredPublicURLs(cfg *config.ProjectConfig) []string {

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -1261,6 +1261,32 @@ func TestSoloStatusReportsInternalHealthWhenNoPublicIngressConfigured(t *testing
 	}
 }
 
+func TestSoloStatusDoesNotClaimNoIngressWhenConfigUnknown(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	installFakeSoloCommands(t, []fakeSSHResponse{{stdout: `{"time":"2026-04-27T10:42:45Z","revision":"rev","phase":"settled","summary":{"environments":1,"services":1}}` + "\n"}})
+
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{Nodes: map[string]config.Node{
+		"node-a": {Host: "203.0.113.10", User: "root", Labels: []string{config.DefaultWebRole}},
+	}}
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState, ConfigStore: config.NewStore(), Cwd: workspaceRoot}
+	if err := app.SoloStatus(context.Background(), SoloStatusOptions{Nodes: []string{"node-a"}}); err != nil {
+		t.Fatalf("SoloStatus() error = %v", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	if _, ok := payload["public_url_status"]; ok {
+		t.Fatalf("payload = %#v, did not want public_url_status when config is unknown", payload)
+	}
+	if _, ok := payload["public_url_message"]; ok {
+		t.Fatalf("payload = %#v, did not want public_url_message when config is unknown", payload)
+	}
+}
+
 func TestSoloStatusUsesResolvedEnvironmentOverlay(t *testing.T) {
 	t.Setenv("DEVOPSELLENCE_ENVIRONMENT", "staging")
 	workspaceRoot := t.TempDir()

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -1214,6 +1214,53 @@ func TestSoloStatusIncludesPublicURLs(t *testing.T) {
 	}
 }
 
+func TestSoloStatusReportsInternalHealthWhenNoPublicIngressConfigured(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	installFakeSoloCommands(t, []fakeSSHResponse{{stdout: `{"time":"2026-04-27T10:42:45Z","revision":"rev","phase":"settled","summary":{"environments":1,"services":1}}` + "\n"}})
+
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{
+		Nodes: map[string]config.Node{
+			"node-a": {Host: "203.0.113.10", User: "root", Labels: []string{config.DefaultWebRole}},
+		},
+	}
+	if _, _, err := current.AttachNode(workspaceRoot, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	seedSoloCurrentRelease(t, &current, workspaceRoot, "production", "rev")
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState, ConfigStore: config.NewStore(), Cwd: workspaceRoot}
+	if err := app.SoloStatus(context.Background(), SoloStatusOptions{}); err != nil {
+		t.Fatalf("SoloStatus() error = %v", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	if _, ok := payload["public_urls"]; ok {
+		t.Fatalf("payload = %#v, did not want public_urls without ingress", payload)
+	}
+	if _, ok := payload["configured_public_urls"]; ok {
+		t.Fatalf("payload = %#v, did not want configured_public_urls without ingress", payload)
+	}
+	if payload["public_url_status"] != "not_configured" {
+		t.Fatalf("public_url_status = %#v, want not_configured", payload["public_url_status"])
+	}
+	message := stringValueAny(payload["public_url_message"])
+	if !strings.Contains(message, "internal health OK") || !strings.Contains(message, "no public ingress is configured") {
+		t.Fatalf("public_url_message = %q, want internal-health/no-ingress guidance", message)
+	}
+	runtimeVerified := jsonMapFromAny(t, payload["runtime_verified"])
+	if runtimeVerified["ready"] != true || runtimeVerified["desired_state_revision"] != true || runtimeVerified["healthcheck"] != true {
+		t.Fatalf("runtime_verified = %#v, want internal runtime ready", runtimeVerified)
+	}
+}
+
 func TestSoloStatusUsesResolvedEnvironmentOverlay(t *testing.T) {
 	t.Setenv("DEVOPSELLENCE_ENVIRONMENT", "staging")
 	workspaceRoot := t.TempDir()


### PR DESCRIPTION
## Summary
- stop treating node IPs as public URLs when a solo app has no ingress config
- report `public_url_status: not_configured` with internal-health guidance when runtime is healthy but unpublished
- add regression coverage for healthy no-ingress status output

## Validation
- go test ./internal/workflow -run 'TestSoloStatus(ReportsInternalHealthWhenNoPublicIngressConfigured|IncludesPublicURLs|UsesConfiguredPublicURLsWhenNodeIsNotSettled)'\n- TMPDIR=/home/elvin/tmp-devopsellence-tests mise run test:cli\n- git diff --check