### PR TITLE
Treat solo Envoy listener as expected public port

### DIFF
--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -4937,6 +4937,9 @@ func expectedDevopsellenceEnvoyPublicPortsFromItems(value any) map[string]bool {
 			continue
 		}
 		for _, port := range dockerPublishedPublicPorts(stringFromAny(container["Ports"])) {
+			if port != "8000" {
+				continue
+			}
 			expected[port] = true
 		}
 	}
@@ -4947,9 +4950,18 @@ func expectedDevopsellenceEnvoyPublicPortsFromItems(value any) map[string]bool {
 }
 
 func devopsellenceEnvoyContainer(container map[string]any) bool {
-	name := strings.ToLower(stringFromAny(container["Names"]))
+	name := strings.TrimPrefix(strings.TrimSpace(strings.ToLower(stringFromAny(container["Names"]))), "/")
 	labels := strings.ToLower(stringFromAny(container["Labels"]))
-	return strings.Contains(name, "devopsellence-envoy") || strings.Contains(labels, "devopsellence.system=envoy")
+	return name == "devopsellence-envoy" || (dockerLabelsContain(labels, "devopsellence.managed=true") && dockerLabelsContain(labels, "devopsellence.system=envoy"))
+}
+
+func dockerLabelsContain(labels, expected string) bool {
+	for _, label := range strings.Split(labels, ",") {
+		if strings.TrimSpace(label) == expected {
+			return true
+		}
+	}
+	return false
 }
 
 func dockerPublishedPublicPorts(ports string) []string {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -4853,7 +4853,7 @@ func unexpectedPublicListeningPorts(lines []string, sshPort int) []string {
 	if sshPort == 0 {
 		sshPort = 22
 	}
-	expected := map[string]bool{strconv.Itoa(sshPort): true, "80": true, "443": true}
+	expected := map[string]bool{strconv.Itoa(sshPort): true, "80": true, "443": true, "8000": true}
 	seen := map[string]bool{}
 	for _, line := range lines {
 		for _, port := range publicPortsFromListeningLine(line) {
@@ -4873,17 +4873,29 @@ func unexpectedPublicListeningPorts(lines []string, sshPort int) []string {
 
 func expectedPublicListeningPortDetails(lines []string) []string {
 	seenACME := false
+	seenEnvoy := false
 	for _, line := range lines {
 		for _, port := range publicPortsFromListeningLine(line) {
 			if expectedDevopsellenceACMEListener(line, port) {
 				seenACME = true
 			}
+			if expectedDevopsellenceEnvoyListener(port) {
+				seenEnvoy = true
+			}
 		}
 	}
-	if !seenACME {
-		return nil
+	details := []string{}
+	if seenEnvoy {
+		details = append(details, "8000 is the devopsellence Envoy listener used before public ingress is configured")
 	}
-	return []string{"15980 is the devopsellence agent ACME HTTP-01 listener used for auto TLS challenges"}
+	if seenACME {
+		details = append(details, "15980 is the devopsellence agent ACME HTTP-01 listener used for auto TLS challenges")
+	}
+	return details
+}
+
+func expectedDevopsellenceEnvoyListener(port string) bool {
+	return port == "8000"
 }
 
 func expectedDevopsellenceACMEListener(line, port string) bool {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -4259,7 +4259,8 @@ func (a *App) SoloNodeDiagnose(ctx context.Context, opts SoloNodeDiagnoseOptions
 	payload["ports"] = ports
 	portLines, _ := ports["lines"].([]string)
 	portsTruncated, _ := ports["truncated"].(bool)
-	security := a.soloNodeSecurityDiagnostics(ctx, node, portLines, portsTruncated, ports)
+	expectedManagedPublicPorts := expectedDevopsellenceEnvoyPublicPortsFromDockerSnapshot(dockerSnapshot)
+	security := a.soloNodeSecurityDiagnostics(ctx, node, portLines, portsTruncated, ports, expectedManagedPublicPorts)
 	payload["security"] = security
 	if !diagnosticSectionsOK(agent, dockerSnapshot, ports) {
 		diagnoseOK = false
@@ -4528,20 +4529,20 @@ func soloAgentObservedVersion(observed string) string {
 	return ""
 }
 
-func (a *App) soloNodeSecurityDiagnostics(ctx context.Context, node config.Node, portLines []string, portsTruncated bool, portDiagnostic map[string]any) map[string]any {
-	checks := soloNodeSecurityChecks(ctx, node, portLines, portsTruncated, portDiagnostic)
+func (a *App) soloNodeSecurityDiagnostics(ctx context.Context, node config.Node, portLines []string, portsTruncated bool, portDiagnostic map[string]any, expectedManagedPublicPorts ...map[string]bool) map[string]any {
+	checks := soloNodeSecurityChecks(ctx, node, portLines, portsTruncated, portDiagnostic, expectedManagedPublicPorts...)
 	items, ok := soloNodeSecurityCheckItems(checks)
 	return map[string]any{"ok": ok, "checks": items}
 }
 
-func soloNodeSecurityChecks(ctx context.Context, node config.Node, portLines []string, portsTruncated bool, portDiagnostic map[string]any) []soloSecurityCheck {
+func soloNodeSecurityChecks(ctx context.Context, node config.Node, portLines []string, portsTruncated bool, portDiagnostic map[string]any, expectedManagedPublicPorts ...map[string]bool) []soloSecurityCheck {
 	return []soloSecurityCheck{
 		soloSSHPasswordAuthCheck(ctx, node),
 		soloAgentStatePermissionsCheck(ctx, node),
 		soloTLSKeyPermissionsCheck(ctx, node),
 		soloDockerSocketMountsCheck(ctx, node),
 		soloPrivilegedContainersCheck(ctx, node),
-		soloPublicListeningPortsCheck(ctx, node, portLines, portsTruncated, portDiagnostic),
+		soloPublicListeningPortsCheck(ctx, node, portLines, portsTruncated, portDiagnostic, expectedManagedPublicPorts...),
 	}
 }
 
@@ -4747,7 +4748,7 @@ func soloPrivilegedContainersCheck(ctx context.Context, node config.Node) soloSe
 	return check
 }
 
-func soloPublicListeningPortsCheck(ctx context.Context, node config.Node, portLines []string, portsTruncated bool, portDiagnostic map[string]any) soloSecurityCheck {
+func soloPublicListeningPortsCheck(ctx context.Context, node config.Node, portLines []string, portsTruncated bool, portDiagnostic map[string]any, expectedManagedPublicPorts ...map[string]bool) soloSecurityCheck {
 	check := soloSecurityCheck{Name: "public_listening_ports", OK: true, Severity: "medium"}
 	if portDiagnostic != nil && portDiagnostic["ok"] != true {
 		check.OK = false
@@ -4777,8 +4778,8 @@ func soloPublicListeningPortsCheck(ctx context.Context, node config.Node, portLi
 		check.NextAction = "install ss or netstat on the node, then rerun devopsellence node diagnose"
 		return check
 	}
-	expectedDetails := expectedPublicListeningPortDetails(portLines)
-	ports := unexpectedPublicListeningPorts(portLines, node.Port)
+	expectedDetails := expectedPublicListeningPortDetails(portLines, expectedManagedPublicPorts...)
+	ports := unexpectedPublicListeningPorts(portLines, node.Port, expectedManagedPublicPorts...)
 	if len(ports) > 0 {
 		check.OK = false
 		check.Observed = "unexpected public listening ports: " + strings.Join(ports, ", ")
@@ -4849,7 +4850,7 @@ func hasListenAddress(line string) bool {
 	return false
 }
 
-func unexpectedPublicListeningPorts(lines []string, sshPort int) []string {
+func unexpectedPublicListeningPorts(lines []string, sshPort int, expectedManagedPublicPorts ...map[string]bool) []string {
 	if sshPort == 0 {
 		sshPort = 22
 	}
@@ -4857,7 +4858,7 @@ func unexpectedPublicListeningPorts(lines []string, sshPort int) []string {
 	seen := map[string]bool{}
 	for _, line := range lines {
 		for _, port := range publicPortsFromListeningLine(line) {
-			if expected[port] || expectedDevopsellenceEnvoyListener(line, port) || expectedDevopsellenceACMEListener(line, port) || seen[port] {
+			if expected[port] || expectedManagedPublicPort(port, expectedManagedPublicPorts...) || expectedDevopsellenceACMEListener(line, port) || seen[port] {
 				continue
 			}
 			seen[port] = true
@@ -4871,7 +4872,7 @@ func unexpectedPublicListeningPorts(lines []string, sshPort int) []string {
 	return ports
 }
 
-func expectedPublicListeningPortDetails(lines []string) []string {
+func expectedPublicListeningPortDetails(lines []string, expectedManagedPublicPorts ...map[string]bool) []string {
 	seenACME := false
 	seenEnvoy := false
 	for _, line := range lines {
@@ -4879,14 +4880,14 @@ func expectedPublicListeningPortDetails(lines []string) []string {
 			if expectedDevopsellenceACMEListener(line, port) {
 				seenACME = true
 			}
-			if expectedDevopsellenceEnvoyListener(line, port) {
+			if port == "8000" && expectedManagedPublicPort(port, expectedManagedPublicPorts...) {
 				seenEnvoy = true
 			}
 		}
 	}
 	details := []string{}
 	if seenEnvoy {
-		details = append(details, "8000 is the devopsellence Envoy listener used before public ingress is configured")
+		details = append(details, "8000 is the devopsellence Envoy listener published by the managed Envoy container")
 	}
 	if seenACME {
 		details = append(details, "15980 is the devopsellence agent ACME HTTP-01 listener used for auto TLS challenges")
@@ -4894,12 +4895,80 @@ func expectedPublicListeningPortDetails(lines []string) []string {
 	return details
 }
 
-func expectedDevopsellenceEnvoyListener(line, port string) bool {
-	if port != "8000" {
-		return false
+func expectedManagedPublicPort(port string, expectedManagedPublicPorts ...map[string]bool) bool {
+	for _, ports := range expectedManagedPublicPorts {
+		if ports[port] {
+			return true
+		}
 	}
-	normalized := strings.ToLower(line)
-	return strings.Contains(normalized, "devopsellence") || strings.Contains(normalized, "envoy") || strings.Contains(normalized, "docker-proxy")
+	return false
+}
+
+func expectedDevopsellenceEnvoyPublicPortsFromRemote(ctx context.Context, node config.Node) map[string]bool {
+	diag := runRemoteDiagnostic(ctx, node, remoteDockerPSJSONCommand())
+	if diag.Err != nil || diag.ExitCode != 0 {
+		return nil
+	}
+	items := []any{}
+	for _, line := range splitNonFinalEmptyLines(diag.Stdout) {
+		line = strings.TrimSpace(line)
+		if line == "" || line == soloDiagnoseTruncatedMarker {
+			continue
+		}
+		var item map[string]any
+		if err := json.Unmarshal([]byte(line), &item); err == nil {
+			items = append(items, item)
+		}
+	}
+	return expectedDevopsellenceEnvoyPublicPortsFromItems(items)
+}
+
+func expectedDevopsellenceEnvoyPublicPortsFromDockerSnapshot(snapshot map[string]any) map[string]bool {
+	containers, _ := snapshot["containers"].(map[string]any)
+	return expectedDevopsellenceEnvoyPublicPortsFromItems(containers["items"])
+}
+
+func expectedDevopsellenceEnvoyPublicPortsFromItems(value any) map[string]bool {
+	items, _ := value.([]any)
+	expected := map[string]bool{}
+	for _, item := range items {
+		container, ok := item.(map[string]any)
+		if !ok || !devopsellenceEnvoyContainer(container) {
+			continue
+		}
+		for _, port := range dockerPublishedPublicPorts(stringFromAny(container["Ports"])) {
+			expected[port] = true
+		}
+	}
+	if len(expected) == 0 {
+		return nil
+	}
+	return expected
+}
+
+func devopsellenceEnvoyContainer(container map[string]any) bool {
+	name := strings.ToLower(stringFromAny(container["Names"]))
+	labels := strings.ToLower(stringFromAny(container["Labels"]))
+	return strings.Contains(name, "devopsellence-envoy") || strings.Contains(labels, "devopsellence.system=envoy")
+}
+
+func dockerPublishedPublicPorts(ports string) []string {
+	result := []string{}
+	seen := map[string]bool{}
+	for _, item := range strings.Split(ports, ",") {
+		published := strings.TrimSpace(strings.SplitN(item, "->", 2)[0])
+		if published == "" || published == item {
+			continue
+		}
+		host, port, ok := splitListenAddress(published)
+		if !ok || !isPublicListenHost(host) || seen[port] {
+			continue
+		}
+		seen[port] = true
+		result = append(result, port)
+	}
+	sort.Strings(result)
+	return result
 }
 
 func expectedDevopsellenceACMEListener(line, port string) bool {
@@ -5466,7 +5535,8 @@ func (a *App) soloRuntimeDoctorChecks(ctx context.Context, opts SoloDoctorOption
 			failed = true
 		}
 		results = append(results, soloRuntimeStatusReportCheckResult(name, statusReportCheck))
-		for _, check := range soloNodeSecurityChecks(ctx, node, nil, false, nil) {
+		expectedManagedPublicPorts := expectedDevopsellenceEnvoyPublicPortsFromRemote(ctx, node)
+		for _, check := range soloNodeSecurityChecks(ctx, node, nil, false, nil, expectedManagedPublicPorts) {
 			result := soloRuntimeSecurityCheckResult(name, check)
 			if !check.OK {
 				failed = true

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -4853,11 +4853,11 @@ func unexpectedPublicListeningPorts(lines []string, sshPort int) []string {
 	if sshPort == 0 {
 		sshPort = 22
 	}
-	expected := map[string]bool{strconv.Itoa(sshPort): true, "80": true, "443": true, "8000": true}
+	expected := map[string]bool{strconv.Itoa(sshPort): true, "80": true, "443": true}
 	seen := map[string]bool{}
 	for _, line := range lines {
 		for _, port := range publicPortsFromListeningLine(line) {
-			if expected[port] || expectedDevopsellenceACMEListener(line, port) || seen[port] {
+			if expected[port] || expectedDevopsellenceEnvoyListener(line, port) || expectedDevopsellenceACMEListener(line, port) || seen[port] {
 				continue
 			}
 			seen[port] = true
@@ -4879,7 +4879,7 @@ func expectedPublicListeningPortDetails(lines []string) []string {
 			if expectedDevopsellenceACMEListener(line, port) {
 				seenACME = true
 			}
-			if expectedDevopsellenceEnvoyListener(port) {
+			if expectedDevopsellenceEnvoyListener(line, port) {
 				seenEnvoy = true
 			}
 		}
@@ -4894,8 +4894,12 @@ func expectedPublicListeningPortDetails(lines []string) []string {
 	return details
 }
 
-func expectedDevopsellenceEnvoyListener(port string) bool {
-	return port == "8000"
+func expectedDevopsellenceEnvoyListener(line, port string) bool {
+	if port != "8000" {
+		return false
+	}
+	normalized := strings.ToLower(line)
+	return strings.Contains(normalized, "devopsellence") || strings.Contains(normalized, "envoy") || strings.Contains(normalized, "docker-proxy")
 }
 
 func expectedDevopsellenceACMEListener(line, port string) bool {

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -4394,11 +4394,21 @@ func TestExpectedDevopsellenceEnvoyPublicPortsFromDockerSnapshot(t *testing.T) {
 		"containers": map[string]any{"items": []any{
 			map[string]any{
 				"Names": "devopsellence-envoy",
-				"Ports": "0.0.0.0:8000->8000/tcp, :::8000->8000/tcp",
+				"Ports": "0.0.0.0:8000->8000/tcp, :::8000->8000/tcp, 0.0.0.0:8001->8001/tcp",
 			},
 			map[string]any{
-				"Names": "other",
-				"Ports": "0.0.0.0:8001->8000/tcp",
+				"Names": "not-devopsellence-envoy-copy",
+				"Ports": "0.0.0.0:8002->8000/tcp",
+			},
+			map[string]any{
+				"Names":  "other",
+				"Labels": "devopsellence.managed=true,devopsellence.system=envoy",
+				"Ports":  "0.0.0.0:8000->8000/tcp",
+			},
+			map[string]any{
+				"Names":  "other",
+				"Labels": "devopsellence.system=envoy",
+				"Ports":  "0.0.0.0:8003->8000/tcp",
 			},
 		}},
 	}

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -4374,6 +4374,20 @@ func TestUnexpectedPublicListeningPortsAllowsDevopsellenceEnvoyPort(t *testing.T
 	}
 }
 
+func TestUnexpectedPublicListeningPortsFlagsUnattributedEnvoyPort(t *testing.T) {
+	lines := []string{
+		"LISTEN 0 4096 0.0.0.0:8000 0.0.0.0:*",
+	}
+	ports := unexpectedPublicListeningPorts(lines, 22)
+	if !reflect.DeepEqual(ports, []string{"8000"}) {
+		t.Fatalf("unexpected ports = %#v, want unattributed 8000 flagged", ports)
+	}
+	details := expectedPublicListeningPortDetails(lines)
+	if len(details) != 0 {
+		t.Fatalf("expected details = %#v, want no Envoy explanation without attribution", details)
+	}
+}
+
 func TestUnexpectedPublicListeningPortsAllowsDevopsellenceACMEBackend(t *testing.T) {
 	lines := []string{
 		"LISTEN 0 4096 0.0.0.0:15980 0.0.0.0:* users:((\"devopsellence\",pid=1234,fd=9))",

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -4364,11 +4364,12 @@ func TestUnexpectedPublicListeningPortsAllowsDevopsellenceEnvoyPort(t *testing.T
 		"LISTEN 0 4096 0.0.0.0:8000 0.0.0.0:* users:((\"docker-proxy\",pid=1234,fd=4))",
 		"LISTEN 0 4096 0.0.0.0:8001 0.0.0.0:* users:((\"docker-proxy\",pid=1235,fd=4))",
 	}
-	ports := unexpectedPublicListeningPorts(lines, 22)
+	expected := map[string]bool{"8000": true}
+	ports := unexpectedPublicListeningPorts(lines, 22, expected)
 	if !reflect.DeepEqual(ports, []string{"8001"}) {
 		t.Fatalf("unexpected ports = %#v, want only non-envoy port flagged", ports)
 	}
-	details := expectedPublicListeningPortDetails(lines)
+	details := expectedPublicListeningPortDetails(lines, expected)
 	if len(details) != 1 || !strings.Contains(details[0], "Envoy listener") {
 		t.Fatalf("expected details = %#v, want Envoy explanation", details)
 	}
@@ -4385,6 +4386,25 @@ func TestUnexpectedPublicListeningPortsFlagsUnattributedEnvoyPort(t *testing.T) 
 	details := expectedPublicListeningPortDetails(lines)
 	if len(details) != 0 {
 		t.Fatalf("expected details = %#v, want no Envoy explanation without attribution", details)
+	}
+}
+
+func TestExpectedDevopsellenceEnvoyPublicPortsFromDockerSnapshot(t *testing.T) {
+	snapshot := map[string]any{
+		"containers": map[string]any{"items": []any{
+			map[string]any{
+				"Names": "devopsellence-envoy",
+				"Ports": "0.0.0.0:8000->8000/tcp, :::8000->8000/tcp",
+			},
+			map[string]any{
+				"Names": "other",
+				"Ports": "0.0.0.0:8001->8000/tcp",
+			},
+		}},
+	}
+	ports := expectedDevopsellenceEnvoyPublicPortsFromDockerSnapshot(snapshot)
+	if !reflect.DeepEqual(ports, map[string]bool{"8000": true}) {
+		t.Fatalf("expected managed public ports = %#v, want only devopsellence envoy port", ports)
 	}
 }
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -4359,6 +4359,21 @@ func TestUnexpectedPublicListeningPortsAllowsConfiguredSSHPort(t *testing.T) {
 	}
 }
 
+func TestUnexpectedPublicListeningPortsAllowsDevopsellenceEnvoyPort(t *testing.T) {
+	lines := []string{
+		"LISTEN 0 4096 0.0.0.0:8000 0.0.0.0:* users:((\"docker-proxy\",pid=1234,fd=4))",
+		"LISTEN 0 4096 0.0.0.0:8001 0.0.0.0:* users:((\"docker-proxy\",pid=1235,fd=4))",
+	}
+	ports := unexpectedPublicListeningPorts(lines, 22)
+	if !reflect.DeepEqual(ports, []string{"8001"}) {
+		t.Fatalf("unexpected ports = %#v, want only non-envoy port flagged", ports)
+	}
+	details := expectedPublicListeningPortDetails(lines)
+	if len(details) != 1 || !strings.Contains(details[0], "Envoy listener") {
+		t.Fatalf("expected details = %#v, want Envoy explanation", details)
+	}
+}
+
 func TestUnexpectedPublicListeningPortsAllowsDevopsellenceACMEBackend(t *testing.T) {
 	lines := []string{
 		"LISTEN 0 4096 0.0.0.0:15980 0.0.0.0:* users:((\"devopsellence\",pid=1234,fd=9))",


### PR DESCRIPTION
## Summary
- allow the default devopsellence Envoy listener on port 8000 in solo public-port diagnostics
- include an expected-port explanation when node diagnose sees that listener
- add regression coverage so adjacent ports are still flagged

## Validation
- go test ./internal/workflow -run 'TestUnexpectedPublicListeningPorts|TestSoloPublicListeningPortsCheckFailsWhenOutputIncomplete'\n- TMPDIR=/home/elvin/tmp-devopsellence-tests mise run test:cli\n- git diff --check