### PR TITLE
Clarify solo plaintext secret warning

### DIFF
--- a/cli/internal/workflow/root_test.go
+++ b/cli/internal/workflow/root_test.go
@@ -1158,6 +1158,23 @@ func TestRootSoloSecretSetHonorsEnvironmentAndService(t *testing.T) {
 	if setPayload["reference"] != nil {
 		t.Fatalf("reference = %#v, want omitted for plaintext secret", setPayload["reference"])
 	}
+	warnings := jsonArrayFromMap(t, setPayload, "warnings")
+	if len(warnings) != 1 {
+		t.Fatalf("warnings = %#v, want plaintext storage warning", warnings)
+	}
+	warning := stringValueAny(warnings[0])
+	for _, want := range []string{
+		"stored unencrypted in the local devopsellence solo state file",
+		"demos or local operator-managed deployments only",
+		"devopsellence secret set 'DATABASE_URL' --service 'web' --env 'staging' --store 1password --op-ref op://<vault>/<item>/<field>",
+	} {
+		if !strings.Contains(warning, want) {
+			t.Fatalf("warning = %q, want %q", warning, want)
+		}
+	}
+	if strings.Contains(warning, "postgres://staging") {
+		t.Fatalf("warning leaks secret value: %q", warning)
+	}
 	if setPayload["state_path"] != solo.DefaultStatePath() {
 		t.Fatalf("state_path = %#v, want solo state path", setPayload["state_path"])
 	}

--- a/cli/internal/workflow/root_test.go
+++ b/cli/internal/workflow/root_test.go
@@ -1166,7 +1166,7 @@ func TestRootSoloSecretSetHonorsEnvironmentAndService(t *testing.T) {
 	for _, want := range []string{
 		"stored unencrypted in the local devopsellence solo state file",
 		"demos or local operator-managed deployments only",
-		"devopsellence secret set 'DATABASE_URL' --service 'web' --env 'staging' --store 1password --op-ref op://<vault>/<item>/<field>",
+		"devopsellence secret set 'DATABASE_URL' --service 'web' --env 'staging' --store 1password --op-ref 'op://<vault>/<item>/<field>'",
 	} {
 		if !strings.Contains(warning, want) {
 			t.Fatalf("warning = %q, want %q", warning, want)

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -3136,7 +3136,7 @@ func (a *App) soloSecretsSet(opts SoloSecretsSetOptions) error {
 		payload["reference"] = record.Reference
 	}
 	if record.Store == solo.SecretStorePlaintext {
-		payload["warnings"] = []string{"solo plaintext secrets are stored locally in the devopsellence solo state file; use --store 1password --op-ref for production secrets"}
+		payload["warnings"] = []string{soloPlaintextSecretWarning(record)}
 	}
 	if a.SoloState != nil && strings.TrimSpace(a.SoloState.Path) != "" {
 		payload["state_path"] = a.SoloState.Path
@@ -3191,6 +3191,15 @@ func soloSecretConfigRef(record solo.SecretRecord) config.SecretRef {
 		secret = strings.TrimSpace(record.Reference)
 	}
 	return config.SecretRef{Name: record.Name, Secret: secret}
+}
+
+func soloPlaintextSecretWarning(record solo.SecretRecord) string {
+	command := fmt.Sprintf("devopsellence secret set %s --service %s --env %s --store 1password --op-ref op://<vault>/<item>/<field>",
+		shellQuote(record.Name),
+		shellQuote(record.ServiceName),
+		shellQuote(record.Environment),
+	)
+	return "solo plaintext secrets are stored unencrypted in the local devopsellence solo state file for this machine; use this for demos or local operator-managed deployments only. For production, save the secret in 1Password and replace this local value with: " + command
 }
 
 func serviceSecretRefConflict(service config.ServiceConfig, name string) bool {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -3194,10 +3194,11 @@ func soloSecretConfigRef(record solo.SecretRecord) config.SecretRef {
 }
 
 func soloPlaintextSecretWarning(name, serviceName, environment string) string {
-	command := fmt.Sprintf("devopsellence secret set %s --service %s --env %s --store 1password --op-ref op://<vault>/<item>/<field>",
+	command := fmt.Sprintf("devopsellence secret set %s --service %s --env %s --store 1password --op-ref %s",
 		shellQuote(name),
 		shellQuote(serviceName),
 		shellQuote(environment),
+		shellQuote("op://<vault>/<item>/<field>"),
 	)
 	return "solo plaintext secrets are stored unencrypted in the local devopsellence solo state file for this machine; use this for demos or local operator-managed deployments only. For production, save the secret in 1Password and replace this local value with: " + command
 }

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -3136,7 +3136,7 @@ func (a *App) soloSecretsSet(opts SoloSecretsSetOptions) error {
 		payload["reference"] = record.Reference
 	}
 	if record.Store == solo.SecretStorePlaintext {
-		payload["warnings"] = []string{soloPlaintextSecretWarning(record)}
+		payload["warnings"] = []string{soloPlaintextSecretWarning(record.Name, record.ServiceName, record.Environment)}
 	}
 	if a.SoloState != nil && strings.TrimSpace(a.SoloState.Path) != "" {
 		payload["state_path"] = a.SoloState.Path
@@ -3193,11 +3193,11 @@ func soloSecretConfigRef(record solo.SecretRecord) config.SecretRef {
 	return config.SecretRef{Name: record.Name, Secret: secret}
 }
 
-func soloPlaintextSecretWarning(record solo.SecretRecord) string {
+func soloPlaintextSecretWarning(name, serviceName, environment string) string {
 	command := fmt.Sprintf("devopsellence secret set %s --service %s --env %s --store 1password --op-ref op://<vault>/<item>/<field>",
-		shellQuote(record.Name),
-		shellQuote(record.ServiceName),
-		shellQuote(record.Environment),
+		shellQuote(name),
+		shellQuote(serviceName),
+		shellQuote(environment),
 	)
 	return "solo plaintext secrets are stored unencrypted in the local devopsellence solo state file for this machine; use this for demos or local operator-managed deployments only. For production, save the secret in 1Password and replace this local value with: " + command
 }


### PR DESCRIPTION
## Summary
- expand the solo plaintext-secret warning to call out local unencrypted storage and demo/local-only suitability
- include an exact 1Password replacement command using the selected key/service/env
- assert the warning avoids leaking the secret value

## Tests
- TMPDIR=/home/elvin/tmp-devopsellence-tests GOCACHE=$(pwd)/.gocache go test ./internal/workflow -run 'TestRootSoloSecretSetHonorsEnvironmentAndService|TestRootSoloSecretSetAcceptsOnePasswordReference' -count=1 -v\n- TMPDIR=/home/elvin/tmp-devopsellence-tests GOCACHE=$(pwd)/.gocache go test ./... -count=1\n- TMPDIR=/home/elvin/tmp-devopsellence-tests mise run test:cli\n- git diff --check