### PR TITLE
Clarify reused service revisions in agent status

### DIFF
--- a/agent/internal/engine/docker/docker.go
+++ b/agent/internal/engine/docker/docker.go
@@ -68,6 +68,7 @@ func (e *Engine) listContainers(ctx context.Context, filters client.Filters) ([]
 			Running:     c.State == "running",
 			Managed:     c.Labels[engine.LabelManaged] == "true",
 			Hash:        c.Labels[engine.LabelHash],
+			Revision:    c.Labels[engine.LabelRevision],
 			Environment: c.Labels[engine.LabelEnvironment],
 			Service:     c.Labels[engine.LabelService],
 			ServiceKind: c.Labels[engine.LabelServiceKind],

--- a/agent/internal/engine/engine.go
+++ b/agent/internal/engine/engine.go
@@ -163,6 +163,7 @@ type ContainerState struct {
 	Running     bool
 	Managed     bool
 	Hash        string
+	Revision    string
 	Environment string
 	Service     string
 	ServiceKind string

--- a/agent/internal/reconcile/reconcile.go
+++ b/agent/internal/reconcile/reconcile.go
@@ -718,24 +718,10 @@ func containerInspectSummary(info engine.ContainerInfo) string {
 
 func (r *Reconciler) specForService(runtime desiredstate.RuntimeService) (string, string, engine.ContainerSpec, error) {
 	service := runtime.Service
-	network, err := r.environmentNetwork(runtime.EnvironmentName)
-	if err != nil {
-		return "", "", engine.ContainerSpec{}, err
-	}
-	hash, err := desiredstate.HashService(service)
+	hash, network, aliases, err := r.runtimeServiceHash(runtime)
 	if err != nil {
 		return "", "", engine.ContainerSpec{}, fmt.Errorf("hash service %s/%s: %w", runtime.EnvironmentName, runtime.ServiceName, err)
 	}
-
-	aliases := []string(nil)
-	if strings.TrimSpace(network) != "" {
-		alias, err := desiredstate.ServiceNetworkAlias(runtime.ServiceName)
-		if err != nil {
-			return "", "", engine.ContainerSpec{}, err
-		}
-		aliases = []string{alias}
-	}
-	hash = runtimeContainerHash(hash, r.opts.LogConfig, network, aliases)
 	name, err := desiredstate.ServiceContainerName(runtime.EnvironmentName, runtime.ServiceName, runtime.EnvironmentRevision, hash)
 	if err != nil {
 		return "", "", engine.ContainerSpec{}, err
@@ -769,6 +755,26 @@ func (r *Reconciler) specForService(runtime desiredstate.RuntimeService) (string
 	}
 
 	return name, hash, spec, nil
+}
+
+func (r *Reconciler) runtimeServiceHash(runtime desiredstate.RuntimeService) (string, string, []string, error) {
+	network, err := r.environmentNetwork(runtime.EnvironmentName)
+	if err != nil {
+		return "", "", nil, err
+	}
+	hash, err := desiredstate.HashService(runtime.Service)
+	if err != nil {
+		return "", "", nil, err
+	}
+	aliases := []string(nil)
+	if strings.TrimSpace(network) != "" {
+		alias, err := desiredstate.ServiceNetworkAlias(runtime.ServiceName)
+		if err != nil {
+			return "", "", nil, err
+		}
+		aliases = []string{alias}
+	}
+	return runtimeContainerHash(hash, r.opts.LogConfig, network, aliases), network, aliases, nil
 }
 
 func (r *Reconciler) specForTask(environmentName string, task *desiredstatepb.Task, revision string, network string) (string, string, engine.ContainerSpec, error) {

--- a/agent/internal/reconcile/reconcile.go
+++ b/agent/internal/reconcile/reconcile.go
@@ -720,7 +720,7 @@ func (r *Reconciler) specForService(runtime desiredstate.RuntimeService) (string
 	service := runtime.Service
 	hash, network, aliases, err := r.runtimeServiceHash(runtime)
 	if err != nil {
-		return "", "", engine.ContainerSpec{}, fmt.Errorf("hash service %s/%s: %w", runtime.EnvironmentName, runtime.ServiceName, err)
+		return "", "", engine.ContainerSpec{}, fmt.Errorf("compute runtime service hash for %s/%s: %w", runtime.EnvironmentName, runtime.ServiceName, err)
 	}
 	name, err := desiredstate.ServiceContainerName(runtime.EnvironmentName, runtime.ServiceName, runtime.EnvironmentRevision, hash)
 	if err != nil {

--- a/agent/internal/reconcile/reconcile_test.go
+++ b/agent/internal/reconcile/reconcile_test.go
@@ -55,6 +55,7 @@ func (f *fakeEngine) CreateAndStart(_ context.Context, spec engine.ContainerSpec
 		Image:       spec.Image,
 		Running:     true,
 		Hash:        spec.Labels[engine.LabelHash],
+		Revision:    spec.Labels[engine.LabelRevision],
 		Environment: spec.Labels[engine.LabelEnvironment],
 		Service:     spec.Labels[engine.LabelService],
 		ServiceKind: spec.Labels[engine.LabelServiceKind],

--- a/agent/internal/reconcile/status.go
+++ b/agent/internal/reconcile/status.go
@@ -114,23 +114,15 @@ func (r *Reconciler) serviceStatus(ctx context.Context, service *desiredstatepb.
 }
 
 func (r *Reconciler) expectedRuntimeServiceHash(environmentName, serviceName string, service *desiredstatepb.Service) string {
-	hash, err := desiredstate.HashService(service)
+	hash, _, _, err := r.runtimeServiceHash(desiredstate.RuntimeService{
+		EnvironmentName: environmentName,
+		ServiceName:     serviceName,
+		Service:         service,
+	})
 	if err != nil {
 		return ""
 	}
-	network, err := r.environmentNetwork(environmentName)
-	if err != nil {
-		return ""
-	}
-	aliases := []string(nil)
-	if strings.TrimSpace(network) != "" {
-		alias, err := desiredstate.ServiceNetworkAlias(serviceName)
-		if err != nil {
-			return ""
-		}
-		aliases = []string{alias}
-	}
-	return runtimeContainerHash(hash, r.opts.LogConfig, network, aliases)
+	return hash
 }
 
 func serviceRevisionStatus(current *engine.ContainerState, environmentRevision, expectedHash string) (string, string) {

--- a/agent/internal/reconcile/status.go
+++ b/agent/internal/reconcile/status.go
@@ -2,6 +2,7 @@ package reconcile
 
 import (
 	"context"
+	"strings"
 
 	"github.com/devopsellence/devopsellence/agent/internal/desiredstate"
 	"github.com/devopsellence/devopsellence/agent/internal/desiredstatepb"
@@ -48,7 +49,8 @@ func (r *Reconciler) CurrentStatus(ctx context.Context, desired *desiredstatepb.
 			}
 			summary.Services++
 			current := pickCurrentContainer(existingByService[runtimeServiceKey(environment.GetName(), service.GetName())])
-			serviceStatus := r.serviceStatus(ctx, service, current)
+			expectedHash := r.expectedRuntimeServiceHash(environment.GetName(), service.GetName(), service)
+			serviceStatus := r.serviceStatus(ctx, service, current, envStatus.Revision, expectedHash)
 			if serviceStatus.Phase == report.PhaseError {
 				summary.UnhealthyServices++
 			}
@@ -64,7 +66,7 @@ func (r *Reconciler) CurrentStatus(ctx context.Context, desired *desiredstatepb.
 	return summary, environments, nil
 }
 
-func (r *Reconciler) serviceStatus(ctx context.Context, service *desiredstatepb.Service, current *engine.ContainerState) report.ServiceStatus {
+func (r *Reconciler) serviceStatus(ctx context.Context, service *desiredstatepb.Service, current *engine.ContainerState, environmentRevision, expectedHash string) report.ServiceStatus {
 	serviceStatus := report.ServiceStatus{
 		Name:  service.GetName(),
 		Kind:  desiredstate.ServiceKind(service),
@@ -77,7 +79,9 @@ func (r *Reconciler) serviceStatus(ctx context.Context, service *desiredstatepb.
 	}
 
 	serviceStatus.Container = current.Name
+	serviceStatus.ContainerRevision = strings.TrimSpace(current.Revision)
 	serviceStatus.Hash = current.Hash
+	serviceStatus.RevisionStatus, serviceStatus.RevisionMessage = serviceRevisionStatus(current, environmentRevision, expectedHash)
 
 	if !current.Running {
 		serviceStatus.State = "stopped"
@@ -107,6 +111,41 @@ func (r *Reconciler) serviceStatus(ctx context.Context, service *desiredstatepb.
 	}
 
 	return serviceStatus
+}
+
+func (r *Reconciler) expectedRuntimeServiceHash(environmentName, serviceName string, service *desiredstatepb.Service) string {
+	hash, err := desiredstate.HashService(service)
+	if err != nil {
+		return ""
+	}
+	network, err := r.environmentNetwork(environmentName)
+	if err != nil {
+		return ""
+	}
+	aliases := []string(nil)
+	if strings.TrimSpace(network) != "" {
+		alias, err := desiredstate.ServiceNetworkAlias(serviceName)
+		if err != nil {
+			return ""
+		}
+		aliases = []string{alias}
+	}
+	return runtimeContainerHash(hash, r.opts.LogConfig, network, aliases)
+}
+
+func serviceRevisionStatus(current *engine.ContainerState, environmentRevision, expectedHash string) (string, string) {
+	if current == nil {
+		return "", ""
+	}
+	containerRevision := strings.TrimSpace(current.Revision)
+	environmentRevision = strings.TrimSpace(environmentRevision)
+	if containerRevision == "" || environmentRevision == "" || containerRevision == environmentRevision {
+		return "", ""
+	}
+	if strings.TrimSpace(expectedHash) != "" && strings.TrimSpace(current.Hash) == strings.TrimSpace(expectedHash) {
+		return "reused_from_previous_release", "container was reused from an earlier release because this service config did not change; environment revision is the current rollout revision"
+	}
+	return "previous_release", "container is still labeled with an earlier release revision; environment revision is the current desired rollout revision"
 }
 
 func environmentRevision(desired *desiredstatepb.DesiredState, environment *desiredstatepb.Environment) string {

--- a/agent/internal/reconcile/status_test.go
+++ b/agent/internal/reconcile/status_test.go
@@ -42,6 +42,64 @@ func TestCurrentStatusPrefersErrorOverReconcilingForEnvironmentPhase(t *testing.
 	}
 }
 
+func TestCurrentStatusExplainsReusedPreviousRevisionService(t *testing.T) {
+	eng := newFakeEngine()
+	service := workerService("postgres", nil)
+	hash, err := desiredstate.HashService(service)
+	if err != nil {
+		t.Fatalf("hash: %v", err)
+	}
+	rec := New(eng, Options{Network: "devopsellence", StopTimeout: time.Second})
+	network, err := rec.environmentNetwork("production")
+	if err != nil {
+		t.Fatalf("environment network: %v", err)
+	}
+	alias, err := desiredstate.ServiceNetworkAlias("postgres")
+	if err != nil {
+		t.Fatalf("service alias: %v", err)
+	}
+	hash = runtimeContainerHash(hash, nil, network, []string{alias})
+	name, err := desiredstate.ServiceContainerName("production", "postgres", "oldsha", hash)
+	if err != nil {
+		t.Fatalf("service container name: %v", err)
+	}
+	eng.containers[name] = engine.ContainerState{
+		Name:        name,
+		Running:     true,
+		Hash:        hash,
+		Revision:    "oldsha",
+		Environment: "production",
+		Service:     "postgres",
+		ServiceKind: "worker",
+	}
+
+	_, environments, err := rec.CurrentStatus(context.Background(), &desiredstatepb.DesiredState{
+		SchemaVersion: 2,
+		Revision:      "node-rev",
+		Environments: []*desiredstatepb.Environment{{
+			Name:     "production",
+			Revision: "newsha",
+			Services: []*desiredstatepb.Service{service},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("current status: %v", err)
+	}
+	if len(environments) != 1 || len(environments[0].Services) != 1 {
+		t.Fatalf("environments = %#v, want one service", environments)
+	}
+	status := environments[0].Services[0]
+	if status.ContainerRevision != "oldsha" {
+		t.Fatalf("container_revision = %q, want oldsha", status.ContainerRevision)
+	}
+	if status.RevisionStatus != "reused_from_previous_release" {
+		t.Fatalf("revision_status = %q, want reused_from_previous_release", status.RevisionStatus)
+	}
+	if status.RevisionMessage == "" {
+		t.Fatalf("revision_message empty, want previous-release explanation")
+	}
+}
+
 func TestCurrentStatusKeepsEnvironmentStatusesSeparate(t *testing.T) {
 	eng := newFakeEngine()
 	prodName, err := desiredstate.ServiceContainerName("production", "web", "rev-1", "hash-prod")

--- a/agent/internal/report/status.go
+++ b/agent/internal/report/status.go
@@ -37,13 +37,16 @@ type EnvironmentStatus struct {
 }
 
 type ServiceStatus struct {
-	Name      string `json:"name"`
-	Kind      string `json:"kind,omitempty"`
-	Phase     Phase  `json:"phase,omitempty"`
-	Container string `json:"container,omitempty"`
-	State     string `json:"state,omitempty"`
-	Health    string `json:"health,omitempty"`
-	Hash      string `json:"hash,omitempty"`
+	Name              string `json:"name"`
+	Kind              string `json:"kind,omitempty"`
+	Phase             Phase  `json:"phase,omitempty"`
+	Container         string `json:"container,omitempty"`
+	ContainerRevision string `json:"container_revision,omitempty"`
+	RevisionStatus    string `json:"revision_status,omitempty"`
+	RevisionMessage   string `json:"revision_message,omitempty"`
+	State             string `json:"state,omitempty"`
+	Health            string `json:"health,omitempty"`
+	Hash              string `json:"hash,omitempty"`
 }
 
 type TaskStatus struct {


### PR DESCRIPTION
## Summary
- include managed container label revisions in agent container state and service status JSON
- mark services as reused from a previous release when the container revision differs but the service hash still matches desired config
- add a regression for unchanged sidecar/service config under a newer environment revision

## Tests
- go test ./internal/reconcile -run 'TestCurrentStatusExplainsReusedPreviousRevisionService|TestCurrentStatusKeepsEnvironmentStatusesSeparate|TestReconcileRestart' -count=1\n- go test ./... -count=1 (agent/)\n- mise run test:agent\n- git diff --check