### PR TITLE
Bootstrap accessory services before release tasks

### DIFF
--- a/agent/internal/agent/agent.go
+++ b/agent/internal/agent/agent.go
@@ -128,7 +128,23 @@ func (a *Agent) reconcileOnce(ctx context.Context) error {
 		return err
 	}
 
-	for _, task := range desiredstate.RuntimeTasks(desired) {
+	tasks := desiredstate.RuntimeTasks(desired)
+	if len(tasks) > 0 {
+		result, err := a.reconciler.ReconcileSupportServices(ctx, desired)
+		if err != nil {
+			a.metrics.ReconcileErrors.Inc()
+			a.reportStatus(ctx, report.Status{
+				Time:     start,
+				Phase:    report.PhaseError,
+				Revision: desired.Revision,
+				Error:    err.Error(),
+			}, fetched.Sequence)
+			return err
+		}
+		a.recordReconcileResult(result)
+	}
+
+	for _, task := range tasks {
 		if err := a.ensureTaskSatisfied(ctx, fetched.Sequence, task.EnvironmentName, task.EnvironmentRevision, task.Task, true); err != nil {
 			a.metrics.ReconcileErrors.Inc()
 			return err
@@ -147,9 +163,7 @@ func (a *Agent) reconcileOnce(ctx context.Context) error {
 		return err
 	}
 
-	a.metrics.ContainersCreated.Add(float64(result.Created))
-	a.metrics.ContainersUpdated.Add(float64(result.Updated))
-	a.metrics.ContainersRemoved.Add(float64(result.Removed))
+	a.recordReconcileResult(result)
 
 	diskCareStatus := a.runDiskCare(ctx, desired, fetched.Sequence)
 
@@ -185,6 +199,12 @@ func (a *Agent) reconcileOnce(ctx context.Context) error {
 	)
 
 	return nil
+}
+
+func (a *Agent) recordReconcileResult(result reconcile.Result) {
+	a.metrics.ContainersCreated.Add(float64(result.Created))
+	a.metrics.ContainersUpdated.Add(float64(result.Updated))
+	a.metrics.ContainersRemoved.Add(float64(result.Removed))
 }
 
 func (a *Agent) runDiskCare(ctx context.Context, desired *desiredstatepb.DesiredState, sequence int64) *report.DiskCareStatus {

--- a/agent/internal/agent/agent.go
+++ b/agent/internal/agent/agent.go
@@ -129,10 +129,13 @@ func (a *Agent) reconcileOnce(ctx context.Context) error {
 	}
 
 	tasks := desiredstate.RuntimeTasks(desired)
-	if len(tasks) > 0 {
+	supportServicesReady := false
+	ensureSupportServices := func() error {
+		if supportServicesReady {
+			return nil
+		}
 		result, err := a.reconciler.ReconcileSupportServices(ctx, desired)
 		if err != nil {
-			a.metrics.ReconcileErrors.Inc()
 			a.reportStatus(ctx, report.Status{
 				Time:     start,
 				Phase:    report.PhaseError,
@@ -142,10 +145,12 @@ func (a *Agent) reconcileOnce(ctx context.Context) error {
 			return err
 		}
 		a.recordReconcileResult(result)
+		supportServicesReady = true
+		return nil
 	}
 
 	for _, task := range tasks {
-		if err := a.ensureTaskSatisfied(ctx, fetched.Sequence, task.EnvironmentName, task.EnvironmentRevision, task.Task, true); err != nil {
+		if err := a.ensureTaskSatisfied(ctx, fetched.Sequence, task.EnvironmentName, task.EnvironmentRevision, task.Task, true, ensureSupportServices); err != nil {
 			a.metrics.ReconcileErrors.Inc()
 			return err
 		}
@@ -233,10 +238,10 @@ func (a *Agent) runDiskCare(ctx context.Context, desired *desiredstatepb.Desired
 }
 
 func (a *Agent) runTaskOnce(ctx context.Context, sequence int64, revision string, task *desiredstatepb.Task) error {
-	return a.ensureTaskSatisfied(ctx, sequence, desiredstate.DefaultEnvironmentName, revision, task, false)
+	return a.ensureTaskSatisfied(ctx, sequence, desiredstate.DefaultEnvironmentName, revision, task, false, nil)
 }
 
-func (a *Agent) ensureTaskSatisfied(ctx context.Context, sequence int64, environmentName string, revision string, task *desiredstatepb.Task, suppressSuccessReport bool) error {
+func (a *Agent) ensureTaskSatisfied(ctx context.Context, sequence int64, environmentName string, revision string, task *desiredstatepb.Task, suppressSuccessReport bool, beforeRun func() error) error {
 	taskHash, err := desiredstate.HashTask(task)
 	if err != nil {
 		a.reportStatus(ctx, report.Status{
@@ -255,6 +260,11 @@ func (a *Agent) ensureTaskSatisfied(ctx context.Context, sequence int64, environ
 	storeName := taskStoreName(environmentName, task.GetName())
 	if a.taskStore != nil && a.taskStore.Satisfied(storeName, sequence, taskHash) {
 		return nil
+	}
+	if beforeRun != nil {
+		if err := beforeRun(); err != nil {
+			return err
+		}
 	}
 
 	start := time.Now()

--- a/agent/internal/agent/agent.go
+++ b/agent/internal/agent/agent.go
@@ -21,7 +21,7 @@ import (
 type Agent struct {
 	authority              authority.Authority
 	reporter               report.Reporter
-	reconciler             *reconcile.Reconciler
+	reconciler             runtimeReconciler
 	diagnoser              Diagnoser
 	diskCare               DiskCare
 	diskCareMinInterval    time.Duration
@@ -40,6 +40,14 @@ type Diagnoser interface {
 	RunOnce(ctx context.Context, desiredStateSequence int64) error
 }
 
+type runtimeReconciler interface {
+	Reconcile(ctx context.Context, desired *desiredstatepb.DesiredState) (reconcile.Result, error)
+	ReconcileSupportServices(ctx context.Context, desired *desiredstatepb.DesiredState, environmentName string) (reconcile.Result, error)
+	RunTask(ctx context.Context, environmentName string, revision string, task *desiredstatepb.Task) (reconcile.TaskResult, error)
+	CurrentStatus(ctx context.Context, desired *desiredstatepb.DesiredState) (*report.Summary, []report.EnvironmentStatus, error)
+	IngressStatus(desired *desiredstatepb.DesiredState) *report.IngressStatus
+}
+
 // DiskCare performs best-effort node-local cleanup after successful reconcile.
 type DiskCare interface {
 	Run(ctx context.Context, desired *desiredstatepb.DesiredState) (*report.DiskCareStatus, error)
@@ -47,7 +55,7 @@ type DiskCare interface {
 
 const defaultDiskCareMinInterval = 5 * time.Minute
 
-func New(authority authority.Authority, reconciler *reconcile.Reconciler, reporter report.Reporter, interval time.Duration, logger *slog.Logger, metrics *observability.Metrics, taskStore *lifecycle.Store) *Agent {
+func New(authority authority.Authority, reconciler runtimeReconciler, reporter report.Reporter, interval time.Duration, logger *slog.Logger, metrics *observability.Metrics, taskStore *lifecycle.Store) *Agent {
 	return &Agent{
 		authority:           authority,
 		reconciler:          reconciler,
@@ -129,12 +137,13 @@ func (a *Agent) reconcileOnce(ctx context.Context) error {
 	}
 
 	tasks := desiredstate.RuntimeTasks(desired)
-	supportServicesReady := false
-	ensureSupportServices := func() error {
-		if supportServicesReady {
+	supportServicesReady := map[string]bool{}
+	supportResult := reconcile.Result{}
+	ensureSupportServices := func(environmentName string) error {
+		if supportServicesReady[environmentName] {
 			return nil
 		}
-		result, err := a.reconciler.ReconcileSupportServices(ctx, desired)
+		result, err := a.reconciler.ReconcileSupportServices(ctx, desired, environmentName)
 		if err != nil {
 			a.reportStatus(ctx, report.Status{
 				Time:     start,
@@ -145,12 +154,16 @@ func (a *Agent) reconcileOnce(ctx context.Context) error {
 			return err
 		}
 		a.recordReconcileResult(result)
-		supportServicesReady = true
+		supportResult = addReconcileMutations(supportResult, result)
+		supportServicesReady[environmentName] = true
 		return nil
 	}
 
 	for _, task := range tasks {
-		if err := a.ensureTaskSatisfied(ctx, fetched.Sequence, task.EnvironmentName, task.EnvironmentRevision, task.Task, true, ensureSupportServices); err != nil {
+		beforeRun := func() error {
+			return ensureSupportServices(task.EnvironmentName)
+		}
+		if err := a.ensureTaskSatisfied(ctx, fetched.Sequence, task.EnvironmentName, task.EnvironmentRevision, task.Task, true, beforeRun); err != nil {
 			a.metrics.ReconcileErrors.Inc()
 			return err
 		}
@@ -169,6 +182,7 @@ func (a *Agent) reconcileOnce(ctx context.Context) error {
 	}
 
 	a.recordReconcileResult(result)
+	reportResult := addReconcileMutations(result, supportResult)
 
 	diskCareStatus := a.runDiskCare(ctx, desired, fetched.Sequence)
 
@@ -188,7 +202,7 @@ func (a *Agent) reconcileOnce(ctx context.Context) error {
 		Time:         start,
 		Phase:        report.PhaseSettled,
 		Revision:     desired.Revision,
-		Message:      fmt.Sprintf("created=%d updated=%d removed=%d unchanged=%d", result.Created, result.Updated, result.Removed, result.Unchanged),
+		Message:      fmt.Sprintf("created=%d updated=%d removed=%d unchanged=%d", reportResult.Created, reportResult.Updated, reportResult.Removed, reportResult.Unchanged),
 		Summary:      summary,
 		Ingress:      a.reconciler.IngressStatus(desired),
 		DiskCare:     diskCareStatus,
@@ -196,10 +210,10 @@ func (a *Agent) reconcileOnce(ctx context.Context) error {
 	}, fetched.Sequence)
 
 	a.logger.Info("reconcile ok",
-		"created", result.Created,
-		"updated", result.Updated,
-		"removed", result.Removed,
-		"unchanged", result.Unchanged,
+		"created", reportResult.Created,
+		"updated", reportResult.Updated,
+		"removed", reportResult.Removed,
+		"unchanged", reportResult.Unchanged,
 		"duration", time.Since(start).String(),
 	)
 
@@ -210,6 +224,13 @@ func (a *Agent) recordReconcileResult(result reconcile.Result) {
 	a.metrics.ContainersCreated.Add(float64(result.Created))
 	a.metrics.ContainersUpdated.Add(float64(result.Updated))
 	a.metrics.ContainersRemoved.Add(float64(result.Removed))
+}
+
+func addReconcileMutations(total reconcile.Result, delta reconcile.Result) reconcile.Result {
+	total.Created += delta.Created
+	total.Updated += delta.Updated
+	total.Removed += delta.Removed
+	return total
 }
 
 func (a *Agent) runDiskCare(ctx context.Context, desired *desiredstatepb.DesiredState, sequence int64) *report.DiskCareStatus {

--- a/agent/internal/agent/agent_test.go
+++ b/agent/internal/agent/agent_test.go
@@ -92,6 +92,7 @@ type fakeEngine struct {
 	images     map[string]bool
 	created    []engine.ContainerSpec
 	waitCalls  []string
+	listCalls  int
 	ops        []string
 }
 
@@ -103,6 +104,7 @@ func newFakeEngine() *fakeEngine {
 }
 
 func (f *fakeEngine) ListManaged(ctx context.Context) ([]engine.ContainerState, error) {
+	f.listCalls++
 	out := make([]engine.ContainerState, 0, len(f.containers))
 	for _, c := range f.containers {
 		out = append(out, c)
@@ -606,6 +608,58 @@ func TestReleaseTaskBootstrapsAccessoryBeforeTaskThenRuntimeContainers(t *testin
 	}
 	if len(eng.containers) != 2 {
 		t.Fatalf("expected runtime container after release task, got %#v", eng.containers)
+	}
+}
+
+func TestSatisfiedReleaseTaskSkipsSupportServiceBootstrapPass(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+
+	desired := desiredWithWeb("rev-1")
+	desired.Environments[0].Services = append(desired.Environments[0].Services, &desiredstatepb.Service{
+		Name:  "postgres",
+		Kind:  "accessory",
+		Image: "postgres:16",
+	})
+	task := &desiredstatepb.Task{
+		Name:    "release",
+		Image:   "busybox",
+		Command: []string{"sh", "-c", "echo migrate"},
+	}
+	desired.Environments[0].Tasks = []*desiredstatepb.Task{task}
+
+	store := lifecycle.NewStore(filepath.Join(t.TempDir(), "lifecycle-state.json"))
+	taskHash, err := desiredstate.HashTask(task)
+	if err != nil {
+		t.Fatalf("hash task: %v", err)
+	}
+	if err := store.MarkSatisfied(taskStoreName("production", "release"), 9, taskHash); err != nil {
+		t.Fatalf("mark task satisfied: %v", err)
+	}
+
+	eng := newFakeEngine()
+	eng.images["busybox"] = true
+	eng.images["postgres:16"] = true
+	reconciler := reconcile.New(eng, reconcile.Options{
+		Network:    "devopsellence",
+		WebPort:    3000,
+		Envoy:      &fakeEnvoy{},
+		HTTPProber: staticHTTPProber{},
+	})
+	reporter := &captureReporter{}
+	metrics := observability.NewMetrics(prometheus.NewRegistry())
+	ag := New(&fakeAuthority{desired: desired, sequence: 9}, reconciler, reporter, time.Minute, logger, metrics, store)
+
+	if err := ag.reconcileOnce(context.Background()); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if len(eng.waitCalls) != 0 {
+		t.Fatalf("wait calls = %d, want 0", len(eng.waitCalls))
+	}
+	if eng.listCalls != 2 {
+		t.Fatalf("managed list calls = %d, want 2", eng.listCalls)
+	}
+	if len(reporter.calls) != 1 || reporter.calls[0].Phase != report.PhaseSettled {
+		t.Fatalf("expected only final settled report, got %#v", reporter.calls)
 	}
 }
 

--- a/agent/internal/agent/agent_test.go
+++ b/agent/internal/agent/agent_test.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -91,6 +92,7 @@ type fakeEngine struct {
 	images     map[string]bool
 	created    []engine.ContainerSpec
 	waitCalls  []string
+	ops        []string
 }
 
 func newFakeEngine() *fakeEngine {
@@ -110,6 +112,7 @@ func (f *fakeEngine) ListManaged(ctx context.Context) ([]engine.ContainerState, 
 
 func (f *fakeEngine) CreateAndStart(ctx context.Context, spec engine.ContainerSpec) error {
 	f.created = append(f.created, spec)
+	f.ops = append(f.ops, "create:"+spec.Name)
 	f.containers[spec.Name] = engine.ContainerState{
 		Name:        spec.Name,
 		Image:       spec.Image,
@@ -131,6 +134,7 @@ func (f *fakeEngine) Start(ctx context.Context, name string) error {
 
 func (f *fakeEngine) Wait(ctx context.Context, name string) (int64, error) {
 	f.waitCalls = append(f.waitCalls, name)
+	f.ops = append(f.ops, "wait:"+name)
 	return 0, nil
 }
 
@@ -545,11 +549,17 @@ func TestNoReportWhenNoDesiredState(t *testing.T) {
 	}
 }
 
-func TestReleaseTaskRunsBeforeReconcilingRuntimeContainers(t *testing.T) {
+func TestReleaseTaskBootstrapsAccessoryBeforeTaskThenRuntimeContainers(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
 
 	desired := desiredWithWeb("rev-1")
 	desired.Environments[0].Services[0].Command = []string{"sh", "-c", "sleep 1"}
+	desired.Environments[0].Services = append(desired.Environments[0].Services, &desiredstatepb.Service{
+		Name:    "postgres",
+		Kind:    "accessory",
+		Image:   "postgres:16",
+		Command: []string{"postgres"},
+	})
 	desired.Environments[0].Tasks = []*desiredstatepb.Task{{
 		Name:    "release",
 		Image:   "busybox",
@@ -558,6 +568,7 @@ func TestReleaseTaskRunsBeforeReconcilingRuntimeContainers(t *testing.T) {
 
 	eng := newFakeEngine()
 	eng.images["busybox"] = true
+	eng.images["postgres:16"] = true
 	reconciler := reconcile.New(eng, reconcile.Options{
 		Network:    "devopsellence",
 		WebPort:    3000,
@@ -584,9 +595,27 @@ func TestReleaseTaskRunsBeforeReconcilingRuntimeContainers(t *testing.T) {
 	if reporter.calls[1].Phase != report.PhaseSettled || reporter.calls[1].Task != nil {
 		t.Fatalf("expected final settled runtime report, got %#v", reporter.calls[1])
 	}
-	if len(eng.containers) != 1 {
+	postgresCreate := findOp(eng.ops, "create:svc-production-postgres-")
+	releaseWait := findOp(eng.ops, "wait:svc-release-rev-1-")
+	webCreate := findOp(eng.ops, "create:svc-production-web-")
+	if postgresCreate == -1 || releaseWait == -1 || webCreate == -1 {
+		t.Fatalf("missing expected operation, ops=%#v", eng.ops)
+	}
+	if !(postgresCreate < releaseWait && releaseWait < webCreate) {
+		t.Fatalf("expected accessory create before release task and web create after, ops=%#v", eng.ops)
+	}
+	if len(eng.containers) != 2 {
 		t.Fatalf("expected runtime container after release task, got %#v", eng.containers)
 	}
+}
+
+func findOp(ops []string, prefix string) int {
+	for i, op := range ops {
+		if strings.HasPrefix(op, prefix) {
+			return i
+		}
+	}
+	return -1
 }
 
 func TestEnvironmentTasksAreSatisfiedPerEnvironment(t *testing.T) {

--- a/agent/internal/agent/agent_test.go
+++ b/agent/internal/agent/agent_test.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -92,7 +93,6 @@ type fakeEngine struct {
 	images     map[string]bool
 	created    []engine.ContainerSpec
 	waitCalls  []string
-	listCalls  int
 	ops        []string
 }
 
@@ -104,7 +104,6 @@ func newFakeEngine() *fakeEngine {
 }
 
 func (f *fakeEngine) ListManaged(ctx context.Context) ([]engine.ContainerState, error) {
-	f.listCalls++
 	out := make([]engine.ContainerState, 0, len(f.containers))
 	for _, c := range f.containers {
 		out = append(out, c)
@@ -237,6 +236,35 @@ type staticHTTPProber struct{}
 
 func (staticHTTPProber) Get(ctx context.Context, target string, timeout time.Duration) (int, error) {
 	return 200, nil
+}
+
+type spyReconciler struct {
+	supportCalls  []string
+	runTaskCalls  []string
+	reconcileRuns int
+}
+
+func (s *spyReconciler) Reconcile(context.Context, *desiredstatepb.DesiredState) (reconcile.Result, error) {
+	s.reconcileRuns++
+	return reconcile.Result{}, nil
+}
+
+func (s *spyReconciler) ReconcileSupportServices(_ context.Context, _ *desiredstatepb.DesiredState, environmentName string) (reconcile.Result, error) {
+	s.supportCalls = append(s.supportCalls, environmentName)
+	return reconcile.Result{}, nil
+}
+
+func (s *spyReconciler) RunTask(_ context.Context, environmentName string, _ string, task *desiredstatepb.Task) (reconcile.TaskResult, error) {
+	s.runTaskCalls = append(s.runTaskCalls, environmentName+"/"+task.GetName())
+	return reconcile.TaskResult{}, nil
+}
+
+func (s *spyReconciler) CurrentStatus(context.Context, *desiredstatepb.DesiredState) (*report.Summary, []report.EnvironmentStatus, error) {
+	return &report.Summary{}, nil, nil
+}
+
+func (s *spyReconciler) IngressStatus(*desiredstatepb.DesiredState) *report.IngressStatus {
+	return nil
 }
 
 func TestAgentReconcileE2E(t *testing.T) {
@@ -597,6 +625,9 @@ func TestReleaseTaskBootstrapsAccessoryBeforeTaskThenRuntimeContainers(t *testin
 	if reporter.calls[1].Phase != report.PhaseSettled || reporter.calls[1].Task != nil {
 		t.Fatalf("expected final settled runtime report, got %#v", reporter.calls[1])
 	}
+	if !strings.Contains(reporter.calls[1].Message, "created=2") {
+		t.Fatalf("expected support and runtime creates in final message, got %q", reporter.calls[1].Message)
+	}
 	postgresCreate := findOp(eng.ops, "create:svc-production-postgres-")
 	releaseWait := findOp(eng.ops, "wait:svc-release-rev-1-")
 	webCreate := findOp(eng.ops, "create:svc-production-web-")
@@ -611,15 +642,52 @@ func TestReleaseTaskBootstrapsAccessoryBeforeTaskThenRuntimeContainers(t *testin
 	}
 }
 
+func TestReleaseTaskBootstrapsSupportServicesForTaskEnvironment(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+
+	desired := &desiredstatepb.DesiredState{
+		SchemaVersion: 2,
+		Revision:      "rev-1",
+		Environments: []*desiredstatepb.Environment{
+			{
+				Name:     "production",
+				Revision: "rev-1",
+				Tasks: []*desiredstatepb.Task{{
+					Name:    "release",
+					Image:   "busybox",
+					Command: []string{"sh", "-c", "echo migrate"},
+				}},
+			},
+			{Name: "staging", Revision: "rev-1"},
+		},
+	}
+	reconciler := &spyReconciler{}
+	reporter := &captureReporter{}
+	metrics := observability.NewMetrics(prometheus.NewRegistry())
+	ag := New(&fakeAuthority{desired: desired, sequence: 9}, reconciler, reporter, time.Minute, logger, metrics, lifecycle.NewStore(filepath.Join(t.TempDir(), "lifecycle-state.json")))
+
+	if err := ag.reconcileOnce(context.Background()); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if !reflect.DeepEqual(reconciler.supportCalls, []string{"production"}) {
+		t.Fatalf("support calls = %#v, want production only", reconciler.supportCalls)
+	}
+	if !reflect.DeepEqual(reconciler.runTaskCalls, []string{"production/release"}) {
+		t.Fatalf("task calls = %#v, want production release", reconciler.runTaskCalls)
+	}
+}
+
 func TestSatisfiedReleaseTaskSkipsSupportServiceBootstrapPass(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
 
-	desired := desiredWithWeb("rev-1")
-	desired.Environments[0].Services = append(desired.Environments[0].Services, &desiredstatepb.Service{
-		Name:  "postgres",
-		Kind:  "accessory",
-		Image: "postgres:16",
-	})
+	desired := &desiredstatepb.DesiredState{
+		SchemaVersion: 2,
+		Revision:      "rev-1",
+		Environments: []*desiredstatepb.Environment{{
+			Name:     "production",
+			Revision: "rev-1",
+		}},
+	}
 	task := &desiredstatepb.Task{
 		Name:    "release",
 		Image:   "busybox",
@@ -636,15 +704,7 @@ func TestSatisfiedReleaseTaskSkipsSupportServiceBootstrapPass(t *testing.T) {
 		t.Fatalf("mark task satisfied: %v", err)
 	}
 
-	eng := newFakeEngine()
-	eng.images["busybox"] = true
-	eng.images["postgres:16"] = true
-	reconciler := reconcile.New(eng, reconcile.Options{
-		Network:    "devopsellence",
-		WebPort:    3000,
-		Envoy:      &fakeEnvoy{},
-		HTTPProber: staticHTTPProber{},
-	})
+	reconciler := &spyReconciler{}
 	reporter := &captureReporter{}
 	metrics := observability.NewMetrics(prometheus.NewRegistry())
 	ag := New(&fakeAuthority{desired: desired, sequence: 9}, reconciler, reporter, time.Minute, logger, metrics, store)
@@ -652,11 +712,14 @@ func TestSatisfiedReleaseTaskSkipsSupportServiceBootstrapPass(t *testing.T) {
 	if err := ag.reconcileOnce(context.Background()); err != nil {
 		t.Fatalf("reconcile: %v", err)
 	}
-	if len(eng.waitCalls) != 0 {
-		t.Fatalf("wait calls = %d, want 0", len(eng.waitCalls))
+	if len(reconciler.supportCalls) != 0 {
+		t.Fatalf("support calls = %#v, want none", reconciler.supportCalls)
 	}
-	if eng.listCalls != 2 {
-		t.Fatalf("managed list calls = %d, want 2", eng.listCalls)
+	if len(reconciler.runTaskCalls) != 0 {
+		t.Fatalf("task calls = %#v, want none", reconciler.runTaskCalls)
+	}
+	if reconciler.reconcileRuns != 1 {
+		t.Fatalf("runtime reconcile calls = %d, want 1", reconciler.reconcileRuns)
 	}
 	if len(reporter.calls) != 1 || reporter.calls[0].Phase != report.PhaseSettled {
 		t.Fatalf("expected only final settled report, got %#v", reporter.calls)

--- a/agent/internal/reconcile/reconcile.go
+++ b/agent/internal/reconcile/reconcile.go
@@ -96,10 +96,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, desired *desiredstatepb.Desi
 	return r.reconcile(ctx, desired, reconcileScope{prune: true, syncEnvoy: true})
 }
 
-func (r *Reconciler) ReconcileSupportServices(ctx context.Context, desired *desiredstatepb.DesiredState) (Result, error) {
+func (r *Reconciler) ReconcileSupportServices(ctx context.Context, desired *desiredstatepb.DesiredState, environmentName string) (Result, error) {
+	environmentName = strings.TrimSpace(environmentName)
 	return r.reconcile(ctx, desired, reconcileScope{
 		include: func(service desiredstate.RuntimeService) bool {
-			return service.ServiceKind == desiredstate.ServiceKindAccessory
+			return service.EnvironmentName == environmentName && service.ServiceKind == desiredstate.ServiceKindAccessory
 		},
 	})
 }

--- a/agent/internal/reconcile/reconcile.go
+++ b/agent/internal/reconcile/reconcile.go
@@ -79,6 +79,12 @@ type TaskResult struct {
 	ExitCode int64
 }
 
+type reconcileScope struct {
+	include   func(desiredstate.RuntimeService) bool
+	prune     bool
+	syncEnvoy bool
+}
+
 func New(eng engine.Engine, opts Options) *Reconciler {
 	if opts.HTTPProber == nil {
 		opts.HTTPProber = newDefaultHTTPProber()
@@ -87,13 +93,25 @@ func New(eng engine.Engine, opts Options) *Reconciler {
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, desired *desiredstatepb.DesiredState) (Result, error) {
+	return r.reconcile(ctx, desired, reconcileScope{prune: true, syncEnvoy: true})
+}
+
+func (r *Reconciler) ReconcileSupportServices(ctx context.Context, desired *desiredstatepb.DesiredState) (Result, error) {
+	return r.reconcile(ctx, desired, reconcileScope{
+		include: func(service desiredstate.RuntimeService) bool {
+			return service.ServiceKind == desiredstate.ServiceKindAccessory
+		},
+	})
+}
+
+func (r *Reconciler) reconcile(ctx context.Context, desired *desiredstatepb.DesiredState, scope reconcileScope) (Result, error) {
 	result := Result{}
-	runtimeServices := desiredstate.RuntimeServices(desired)
+	runtimeServices := selectedRuntimeServices(desiredstate.RuntimeServices(desired), scope.include)
 	workloadNetworks, err := r.ensureRuntimeNetworks(ctx, runtimeServices)
 	if err != nil {
 		return result, err
 	}
-	if len(workloadNetworks) == 0 {
+	if scope.syncEnvoy && len(workloadNetworks) == 0 {
 		if err := r.syncEnvoyWorkloadNetworks(ctx, workloadNetworks); err != nil {
 			return result, err
 		}
@@ -132,6 +150,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, desired *desiredstatepb.Desi
 	if reconcileErr != nil {
 		return result, reconcileErr
 	}
+	if !scope.prune {
+		return result, nil
+	}
 	for _, c := range existing {
 		if _, ok := desiredByService[containerServiceKey(c)]; ok {
 			continue
@@ -146,6 +167,19 @@ func (r *Reconciler) Reconcile(ctx context.Context, desired *desiredstatepb.Desi
 	}
 
 	return result, nil
+}
+
+func selectedRuntimeServices(services []desiredstate.RuntimeService, include func(desiredstate.RuntimeService) bool) []desiredstate.RuntimeService {
+	if include == nil {
+		return services
+	}
+	selected := make([]desiredstate.RuntimeService, 0, len(services))
+	for _, service := range services {
+		if include(service) {
+			selected = append(selected, service)
+		}
+	}
+	return selected
 }
 
 func (r *Reconciler) RunTask(ctx context.Context, environmentName string, revision string, task *desiredstatepb.Task) (TaskResult, error) {

--- a/agent/internal/reconcile/reconcile_test.go
+++ b/agent/internal/reconcile/reconcile_test.go
@@ -646,6 +646,33 @@ func TestReconcileRemoveExtra(t *testing.T) {
 	}
 }
 
+func TestReconcileSupportServicesOnlyCreatesAccessoriesWithoutPruning(t *testing.T) {
+	eng := newFakeEngine()
+	eng.images["postgres:16"] = true
+	eng.containers["old-web"] = engine.ContainerState{Name: "old-web", Image: "httpbin", Running: true, Hash: "x", Environment: "production", Service: "web", ServiceKind: "web"}
+
+	rec := New(eng, Options{Network: "devopsellence", StopTimeout: 10 * time.Second})
+	result, err := rec.ReconcileSupportServices(context.Background(), desiredState(
+		webService(80, "/up"),
+		&desiredstatepb.Service{Name: "postgres", Kind: "accessory", Image: "postgres:16"},
+	))
+	if err != nil {
+		t.Fatalf("reconcile support services: %v", err)
+	}
+	if result.Created != 1 || result.Removed != 0 {
+		t.Fatalf("expected created=1 removed=0 got %#v", result)
+	}
+	if len(eng.created) != 1 || eng.created[0].Labels[engine.LabelService] != "postgres" {
+		t.Fatalf("expected only postgres created, got %#v", eng.created)
+	}
+	if _, ok := eng.containers["old-web"]; !ok {
+		t.Fatal("expected existing web container to remain")
+	}
+	if len(eng.removed) != 0 {
+		t.Fatalf("expected no removals, got %#v", eng.removed)
+	}
+}
+
 func TestReconcileMissingImage(t *testing.T) {
 	eng := newFakeEngine()
 	eng.pullErr = errors.New("not found")

--- a/agent/internal/reconcile/reconcile_test.go
+++ b/agent/internal/reconcile/reconcile_test.go
@@ -646,16 +646,34 @@ func TestReconcileRemoveExtra(t *testing.T) {
 	}
 }
 
-func TestReconcileSupportServicesOnlyCreatesAccessoriesWithoutPruning(t *testing.T) {
+func TestReconcileSupportServicesOnlyCreatesEnvironmentAccessoriesWithoutPruning(t *testing.T) {
 	eng := newFakeEngine()
 	eng.images["postgres:16"] = true
 	eng.containers["old-web"] = engine.ContainerState{Name: "old-web", Image: "httpbin", Running: true, Hash: "x", Environment: "production", Service: "web", ServiceKind: "web"}
+	eng.pullErr = errors.New("unrelated environment should not be pulled")
 
 	rec := New(eng, Options{Network: "devopsellence", StopTimeout: 10 * time.Second})
-	result, err := rec.ReconcileSupportServices(context.Background(), desiredState(
-		webService(80, "/up"),
-		&desiredstatepb.Service{Name: "postgres", Kind: "accessory", Image: "postgres:16"},
-	))
+	result, err := rec.ReconcileSupportServices(context.Background(), &desiredstatepb.DesiredState{
+		SchemaVersion: 2,
+		Revision:      "node-plan-1",
+		Environments: []*desiredstatepb.Environment{
+			{
+				Name:     "production",
+				Revision: "rev-1",
+				Services: []*desiredstatepb.Service{
+					webService(80, "/up"),
+					{Name: "postgres", Kind: "accessory", Image: "postgres:16"},
+				},
+			},
+			{
+				Name:     "staging",
+				Revision: "rev-1",
+				Services: []*desiredstatepb.Service{
+					{Name: "postgres", Kind: "accessory", Image: "private/postgres:16"},
+				},
+			},
+		},
+	}, "production")
 	if err != nil {
 		t.Fatalf("reconcile support services: %v", err)
 	}


### PR DESCRIPTION
## Summary
- reconcile accessory/support services for the task environment before release tasks run
- keep that pre-task reconcile scoped and non-pruning so web/worker rollout waits until after the task
- include support-pass mutations in the final settled/log summary
- cover ordering, environment scoping, satisfied-task skip, and no-prune behavior

## Validation
- go test ./internal/reconcile -run 'TestReconcileSupportServicesOnlyCreatesEnvironmentAccessoriesWithoutPruning|TestReconcilePullsMissingPublicAccessoryImageWithoutAuth|TestReconcileRemoveExtra'
- go test ./internal/agent -run 'TestReleaseTaskBootstrapsAccessoryBeforeTaskThenRuntimeContainers|TestReleaseTaskBootstrapsSupportServicesForTaskEnvironment|TestSatisfiedReleaseTaskSkipsSupportServiceBootstrapPass|TestEnvironmentTasksAreSatisfiedPerEnvironment'
- mise run test:agent
- git diff --check
