### PR TITLE
Skip streaming images already present by ID

### DIFF
--- a/cli/internal/docker/docker.go
+++ b/cli/internal/docker/docker.go
@@ -245,6 +245,14 @@ func (Runner) ImageMetadata(ctx context.Context, reference string) (ImageMetadat
 	return parseImageMetadata(output)
 }
 
+func (Runner) ImageID(ctx context.Context, reference string) (string, error) {
+	output, err := run(ctx, nil, "", nil, "docker", "image", "inspect", reference, "--format", "{{.Id}}")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(output), nil
+}
+
 func parseImageMetadata(output string) (ImageMetadata, error) {
 	output = strings.TrimSpace(output)
 	if output == "" || output == "null" {

--- a/cli/internal/workflow/app.go
+++ b/cli/internal/workflow/app.go
@@ -168,6 +168,7 @@ type DockerClient interface {
 	Login(ctx context.Context, registryHost, username, password, configDir string) error
 	WithTemporaryConfig(ctx context.Context, fn func(string) error) error
 	BuildAndPush(ctx context.Context, contextPath, dockerfile, target string, platforms []string, configDir string, update, log func(string)) (string, error)
+	ImageID(ctx context.Context, reference string) (string, error)
 	ImageMetadata(ctx context.Context, reference string) (docker.ImageMetadata, error)
 }
 

--- a/cli/internal/workflow/management_test.go
+++ b/cli/internal/workflow/management_test.go
@@ -3266,6 +3266,8 @@ type fakeDocker struct {
 	loginRegistry    string
 	updates          []string
 	delay            time.Duration
+	imageID          string
+	imageIDErr       error
 	imageMetadata    docker.ImageMetadata
 	imageMetadataErr error
 }
@@ -3302,6 +3304,16 @@ func (f *fakeDocker) ImageMetadata(_ context.Context, _ string) (docker.ImageMet
 	return f.imageMetadata, f.imageMetadataErr
 }
 
+func (f *fakeDocker) ImageID(_ context.Context, _ string) (string, error) {
+	if f.imageIDErr != nil {
+		return "", f.imageIDErr
+	}
+	if f.imageID != "" {
+		return f.imageID, nil
+	}
+	return "sha256:fake-image-id", nil
+}
+
 type dockerUnavailableStub struct{}
 
 func (d *dockerUnavailableStub) Installed() bool { return true }
@@ -3322,6 +3334,10 @@ func (d *dockerUnavailableStub) BuildAndPush(_ context.Context, _, _, _ string, 
 
 func (d *dockerUnavailableStub) ImageMetadata(_ context.Context, _ string) (docker.ImageMetadata, error) {
 	panic("unexpected ImageMetadata call")
+}
+
+func (d *dockerUnavailableStub) ImageID(_ context.Context, _ string) (string, error) {
+	panic("unexpected ImageID call")
 }
 
 func makeRubyRoot(t *testing.T, moduleName string) string {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1442,6 +1442,7 @@ func (a *App) prepareRepublishPlans(ctx context.Context, current solo.State, nod
 func (a *App) republishPreparedNodes(ctx context.Context, prepared map[string]preparedNodePublication) (map[string]string, error) {
 	type localImageCheck struct {
 		once sync.Once
+		id   string
 		err  error
 	}
 	var mu sync.Mutex
@@ -1486,11 +1487,27 @@ func (a *App) republishPreparedNodes(ctx context.Context, prepared map[string]pr
 				}
 				localImageChecksMu.Unlock()
 				check.once.Do(func() {
-					check.err = a.ensureLocalSoloSnapshotImage(ctx, image)
+					check.id, check.err = a.localSoloSnapshotImageID(ctx, image)
 				})
 				if check.err != nil {
 					appendSoloRepublishError(&mu, &errs, name, "local image precheck", check.err)
 					return
+				}
+				if strings.TrimSpace(check.id) != "" {
+					present, err := remoteNodeHasImage(ctx, node, check.id)
+					if err != nil {
+						appendSoloRepublishError(&mu, &errs, name, "remote image id check", err)
+						return
+					}
+					if present {
+						progress := a.soloProgress("devopsellence deploy", map[string]any{"node": name, "image": image, "step": "image_transfer"})
+						progress("Remote image content already present; tagging image.")
+						if err := remoteTagNodeImage(ctx, node, check.id, image); err != nil {
+							appendSoloRepublishError(&mu, &errs, name, "remote image tag", err)
+							return
+						}
+						continue
+					}
 				}
 				if err := transferImage(ctx, node, image, a.soloProgress("devopsellence deploy", map[string]any{"node": name, "image": image, "step": "image_transfer"})); err != nil {
 					appendSoloRepublishError(&mu, &errs, name, "image transfer", err)
@@ -1909,6 +1926,11 @@ func remoteNodeHasImage(ctx context.Context, node config.Node, imageTag string) 
 	return strings.TrimSpace(out) == "present", nil
 }
 
+func remoteTagNodeImage(ctx context.Context, node config.Node, source, target string) error {
+	_, err := solo.RunSSH(ctx, node, remoteDockerImageTagCommand(source, target), nil)
+	return err
+}
+
 func (a *App) soloProgress(operation string, fields map[string]any) func(string) {
 	return func(message string) {
 		message = strings.TrimSpace(message)
@@ -2002,16 +2024,29 @@ func soloDoctorSSHNextStep(node config.Node) string {
 }
 
 func (a *App) ensureLocalSoloSnapshotImage(ctx context.Context, imageTag string) error {
+	_, err := a.localSoloSnapshotImageID(ctx, imageTag)
+	return err
+}
+
+func (a *App) localSoloSnapshotImageID(ctx context.Context, imageTag string) (string, error) {
 	if strings.TrimSpace(imageTag) == "" {
-		return nil
+		return "", nil
 	}
 	if a.Docker == nil {
-		return errors.New("docker client is not configured")
+		return "", errors.New("docker client is not configured")
+	}
+	id, err := a.Docker.ImageID(ctx, imageTag)
+	if err != nil {
+		return "", fmt.Errorf("local snapshot image %q is unavailable; rebuild or redeploy the attached workspace before republishing solo node state: %w", imageTag, err)
+	}
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return "", fmt.Errorf("local snapshot image %q is unavailable; Docker returned an empty image ID", imageTag)
 	}
 	if _, err := a.Docker.ImageMetadata(ctx, imageTag); err != nil {
-		return fmt.Errorf("local snapshot image %q is unavailable; rebuild or redeploy the attached workspace before republishing solo node state: %w", imageTag, err)
+		return "", fmt.Errorf("local snapshot image %q is unavailable; rebuild or redeploy the attached workspace before republishing solo node state: %w", imageTag, err)
 	}
-	return nil
+	return id, nil
 }
 
 func soloNodeDesiredStateInputs(current solo.State, nodeName string) ([]desiredstate.DeploySnapshot, map[string]string, []desiredstate.NodePeer, []string, error) {
@@ -8722,6 +8757,12 @@ func remoteDockerLoadCommand() string {
 func remoteDockerImageInspectCommand(imageTag string) string {
 	quotedImage := shellQuote(imageTag)
 	return fmt.Sprintf("if docker image inspect %s >/dev/null 2>&1; then echo present; elif command -v sudo >/dev/null 2>&1 && sudo -n docker image inspect %s >/dev/null 2>&1; then echo present; else echo missing; fi", quotedImage, quotedImage)
+}
+
+func remoteDockerImageTagCommand(source, target string) string {
+	quotedSource := shellQuote(source)
+	quotedTarget := shellQuote(target)
+	return fmt.Sprintf("if docker image inspect %[1]s >/dev/null 2>&1; then docker tag %[1]s %[2]s; elif command -v sudo >/dev/null 2>&1 && sudo -n docker image inspect %[1]s >/dev/null 2>&1; then sudo -n docker tag %[1]s %[2]s; else echo 'Docker image %[1]s is not present on the node.' >&2; exit 1; fi", quotedSource, quotedTarget)
 }
 
 func remoteReadFileCommand(path string) string {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1471,7 +1471,7 @@ func (a *App) republishPreparedNodes(ctx context.Context, prepared map[string]pr
 				}
 			}
 			for _, image := range inputs.images {
-				present, err := remoteNodeHasImage(ctx, node, image)
+				present, err := remoteNodeHasImageReference(ctx, node, image)
 				if err != nil {
 					appendSoloRepublishError(&mu, &errs, name, "remote image check", err)
 					return
@@ -1494,7 +1494,7 @@ func (a *App) republishPreparedNodes(ctx context.Context, prepared map[string]pr
 					return
 				}
 				if strings.TrimSpace(check.id) != "" {
-					present, err := remoteNodeHasImage(ctx, node, check.id)
+					present, err := remoteNodeHasImageReference(ctx, node, check.id)
 					if err != nil {
 						appendSoloRepublishError(&mu, &errs, name, "remote image id check", err)
 						return
@@ -1918,8 +1918,8 @@ func desiredStateRevision(data []byte) (string, error) {
 	return payload.Revision, nil
 }
 
-func remoteNodeHasImage(ctx context.Context, node config.Node, imageTag string) (bool, error) {
-	out, err := solo.RunSSH(ctx, node, remoteDockerImageInspectCommand(imageTag), nil)
+func remoteNodeHasImageReference(ctx context.Context, node config.Node, reference string) (bool, error) {
+	out, err := solo.RunSSH(ctx, node, remoteDockerImageInspectCommand(reference), nil)
 	if err != nil {
 		return false, err
 	}
@@ -8754,8 +8754,8 @@ func remoteDockerLoadCommand() string {
 	return "if docker info >/dev/null 2>&1; then gunzip | docker load; elif command -v sudo >/dev/null 2>&1 && sudo -n docker info >/dev/null 2>&1; then gunzip | sudo -n docker load; else echo 'Docker is not reachable. Add this SSH user to the docker group or enable passwordless sudo for docker.' >&2; docker info >/dev/null 2>&1; exit 1; fi"
 }
 
-func remoteDockerImageInspectCommand(imageTag string) string {
-	quotedImage := shellQuote(imageTag)
+func remoteDockerImageInspectCommand(reference string) string {
+	quotedImage := shellQuote(reference)
 	return fmt.Sprintf("if docker image inspect %s >/dev/null 2>&1; then echo present; elif command -v sudo >/dev/null 2>&1 && sudo -n docker image inspect %s >/dev/null 2>&1; then echo present; else echo missing; fi", quotedImage, quotedImage)
 }
 

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -903,7 +903,21 @@ if [[ "$command" == "true" ]]; then
   fi
   exit 0
 fi
+if [[ "$command" == *"docker tag"* ]]; then
+  exit 0
+fi
+
 if [[ "$command" == *"docker image inspect"* ]]; then
+  missing_image="${DEVOPSELLENCE_FAKE_SSH_IMAGE_TAG_MISSING:-}"
+  present_image_id="${DEVOPSELLENCE_FAKE_SSH_IMAGE_ID_PRESENT:-}"
+  if [[ -n "$present_image_id" && "$command" == *"$present_image_id"* ]]; then
+    printf 'present\n'
+    exit 0
+  fi
+  if [[ -n "$missing_image" && "$command" == *"$missing_image"* ]]; then
+    printf 'missing\n'
+    exit 0
+  fi
   printf 'present\n'
   exit 0
 fi
@@ -5325,6 +5339,67 @@ func TestRepublishNodesReportsRemoteDockerCheck(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "[web-a] remote docker check:") {
 		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestRepublishNodesTagsExistingRemoteImageIDInsteadOfStreaming(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	commandLog := filepath.Join(t.TempDir(), "ssh-commands.log")
+	t.Setenv("DEVOPSELLENCE_FAKE_SSH_COMMAND_LOG", commandLog)
+	t.Setenv("DEVOPSELLENCE_FAKE_SSH_IMAGE_TAG_MISSING", "demo:abc1234")
+	t.Setenv("DEVOPSELLENCE_FAKE_SSH_IMAGE_ID_PRESENT", "sha256:local-image")
+	installFakeSoloCommands(t, nil)
+
+	app := &App{
+		Printer:     output.New(io.Discard, io.Discard),
+		Docker:      &fakeDocker{imageID: "sha256:local-image"},
+		ConfigStore: config.NewStore(),
+	}
+	current := solo.State{
+		Nodes: map[string]config.Node{
+			"web-a": {Host: "203.0.113.10", User: "root", Labels: []string{config.DefaultWebRole}},
+		},
+		Attachments: map[string]solo.AttachmentRecord{
+			workspaceRoot + "\nproduction": {
+				WorkspaceRoot: workspaceRoot,
+				WorkspaceKey:  workspaceRoot,
+				Environment:   "production",
+				NodeNames:     []string{"web-a"},
+			},
+		},
+		Snapshots: map[string]desiredstate.DeploySnapshot{
+			workspaceRoot + "\nproduction": {
+				WorkspaceRoot: workspaceRoot,
+				WorkspaceKey:  workspaceRoot,
+				Environment:   "production",
+				Revision:      "abc1234",
+				Image:         "demo:abc1234",
+				Metadata:      desiredstate.SnapshotMetadata{ConfigPath: filepath.Join(workspaceRoot, "devopsellence.yml")},
+			},
+		},
+	}
+
+	revisions, err := app.republishNodes(context.Background(), current, []string{"web-a"})
+	if err != nil {
+		t.Fatalf("republish: %v", err)
+	}
+	if strings.TrimSpace(revisions["web-a"]) == "" {
+		t.Fatalf("revisions = %#v, want web-a desired-state revision", revisions)
+	}
+	data, err := os.ReadFile(commandLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	commands := string(data)
+	if !strings.Contains(commands, "docker tag 'sha256:local-image' 'demo:abc1234'") {
+		t.Fatalf("commands = %s, want remote docker tag", commands)
+	}
+	if strings.Contains(commands, "docker load") {
+		t.Fatalf("commands = %s, did not expect image stream", commands)
 	}
 }
 
@@ -10608,7 +10683,21 @@ if [[ "$command" == *"desired-state set-override"* ]]; then
   exit 0
 fi
 
+if [[ "$command" == *"docker tag"* ]]; then
+  exit 0
+fi
+
 if [[ "$command" == *"docker image inspect"* ]]; then
+  missing_image="${DEVOPSELLENCE_FAKE_SSH_IMAGE_TAG_MISSING:-}"
+  present_image_id="${DEVOPSELLENCE_FAKE_SSH_IMAGE_ID_PRESENT:-}"
+  if [[ -n "$present_image_id" && "$command" == *"$present_image_id"* ]]; then
+    printf 'present\n'
+    exit 0
+  fi
+  if [[ -n "$missing_image" && "$command" == *"$missing_image"* ]]; then
+    printf 'missing\n'
+    exit 0
+  fi
   printf 'present\n'
   exit 0
 fi


### PR DESCRIPTION
## Summary
- skip solo image streaming when the remote node already has the same local image ID under another tag
- tag the existing remote image ID to the desired release tag before publishing desired state
- keep the existing exact-tag skip and local image precheck behavior

## Validation
- go test ./internal/workflow -run 'TestRepublishNodesTagsExistingRemoteImageIDInsteadOfStreaming|TestEnsureLocalSoloSnapshotImageReturnsActionableError|TestRepublishNodesReportsRemoteDockerCheck' -count=1
- go test ./internal/docker -run 'TestImageMetadata|TestParseImageMetadata'
- TMPDIR=/home/elvin/Work/devopsellence/tmp-cli-test-XXXXXX mise run test:cli
- git diff --check

Note: local default /tmp contains an unrelated /tmp/devopsellence.yml, so the full CLI test was run with TMPDIR outside /tmp and outside this repo.
