### PR TITLE
Document portable SSH config opt-out

### DIFF
--- a/cli/internal/workflow/root.go
+++ b/cli/internal/workflow/root.go
@@ -965,7 +965,7 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 		Long: strings.Join([]string{
 			"Create or register a node for the selected workspace mode.",
 			"Solo --host nodes must be reachable over SSH with the selected key. devopsellence stores SSH host keys in its own state directory and uses StrictHostKeyChecking=accept-new, so first contact does not write to ~/.ssh/known_hosts.",
-			"If local SSH config is broken or too opinionated, set DEVOPSELLENCE_SSH_CONFIG=/dev/null to make devopsellence pass `ssh -F /dev/null`.",
+			"If local SSH config is broken or too opinionated, set DEVOPSELLENCE_SSH_CONFIG=none to skip local SSH config; on Unix, DEVOPSELLENCE_SSH_CONFIG=/dev/null is equivalent.",
 			"The solo agent install can install Docker on supported Ubuntu VMs when Docker is missing; otherwise install Docker yourself or make the SSH user able to run docker via passwordless sudo.",
 			"If SSH validation fails as root, retry with the image default user such as ubuntu, debian, or ec2-user, and verify passwordless sudo with `ssh <user>@<host> sudo -n true` before installing the agent.",
 		}, "\n"),


### PR DESCRIPTION
## Summary
- update node create help to recommend DEVOPSELLENCE_SSH_CONFIG=none
- keep /dev/null documented as the Unix equivalent

## Validation
- go test ./internal/solo -count=1
- TMPDIR=<isolated outside /tmp> go test ./internal/workflow -run Test -count=1
- git diff --check