### PR TITLE
[codex] Remove lfg agent skill install option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,14 @@ asking it to invent production shell choreography.
 ### Quickstart
 
 ```bash
-curl -fsSL https://www.devopsellence.com/lfg.sh | bash -s -- --install-agent-skill
+curl -fsSL https://www.devopsellence.com/lfg.sh | bash
+devopsellence skill install --global
 cd my-app
 codex "deploy with devopsellence solo"
 ```
 
-`--install-agent-skill` installs the matching devopsellence agent skill from
-the CLI itself; it does not require npm or `npx`.
+`devopsellence skill install` installs the matching devopsellence agent skill
+from the CLI itself; it does not require npm or `npx`.
 
 Full docs: [docs.devopsellence.com](https://docs.devopsellence.com/).
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ asking it to invent production shell choreography.
 
 ```bash
 curl -fsSL https://www.devopsellence.com/lfg.sh | bash
-devopsellence skill install --global
+~/.local/bin/devopsellence skill install --global
 cd my-app
 codex "deploy with devopsellence solo"
 ```

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ codex "deploy with devopsellence solo"
 ```
 
 `devopsellence skill install` installs the matching devopsellence agent skill
-from the CLI itself; it does not require npm or `npx`.
+from the CLI itself.
 
 Full docs: [docs.devopsellence.com](https://docs.devopsellence.com/).
 

--- a/cli/scripts/release-local.sh
+++ b/cli/scripts/release-local.sh
@@ -113,4 +113,4 @@ case ":$PATH:" in
 esac
 
 echo "agent skill available; install it with:"
-echo "  $INSTALL_DIR/$TARGET_NAME skill install --global"
+echo "  \"$INSTALL_DIR/$TARGET_NAME\" skill install --global"

--- a/cli/scripts/release-local.sh
+++ b/cli/scripts/release-local.sh
@@ -5,8 +5,6 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 CLI_DIR="$ROOT_DIR/cli"
 TARGET_NAME="devopsellence"
 INSTALL_DIR="${DEVOPSELLENCE_CLI_INSTALL_DIR:-}"
-INSTALL_AGENT_SKILL="${DEVOPSELLENCE_INSTALL_AGENT_SKILL:-}"
-AGENT_SKILLS_DIR="${DEVOPSELLENCE_AGENT_SKILLS_DIR:-}"
 
 OS_RAW="$(uname -s | tr '[:upper:]' '[:lower:]')"
 ARCH_RAW="$(uname -m)"
@@ -114,24 +112,5 @@ case ":$PATH:" in
     ;;
 esac
 
-install_agent_skill() {
-  local skill_args=()
-
-  if [[ -n "$AGENT_SKILLS_DIR" ]]; then
-    skill_args+=(--dir "$AGENT_SKILLS_DIR")
-  else
-    skill_args+=(--global)
-  fi
-
-  echo "installing devopsellence agent skill..."
-  "$INSTALL_DIR/$TARGET_NAME" skill install "${skill_args[@]}"
-}
-
-case "$INSTALL_AGENT_SKILL" in
-  1|true|TRUE|yes|YES)
-    install_agent_skill
-    ;;
-  *)
-    echo "agent skill available; rerun installer with DEVOPSELLENCE_INSTALL_AGENT_SKILL=1"
-    ;;
-esac
+echo "agent skill available; install it with:"
+echo "  $INSTALL_DIR/$TARGET_NAME skill install --global"

--- a/control-plane/app/controllers/cli_installs_controller.rb
+++ b/control-plane/app/controllers/cli_installs_controller.rb
@@ -11,7 +11,6 @@ class CliInstallsController < ActionController::Base
     # For curl | bash installs, default the downloader to the exact host serving
     # the script so callers do not need to pass --base-url explicitly.
     default_base_url = ShellQuoting.single_quote(request.base_url)
-    script_install_url = ShellQuoting.single_quote("#{request.base_url}/lfg.sh")
     default_version = ShellQuoting.single_quote(params[:version].to_s.presence || Devopsellence::RuntimeConfig.current.stable_version)
 
     <<~SH
@@ -22,15 +21,12 @@ class CliInstallsController < ActionController::Base
       if [[ -z "$BASE_URL" ]]; then
         BASE_URL=#{default_base_url}
       fi
-      INSTALL_SCRIPT_URL=#{script_install_url}
       CLI_VERSION="${DEVOPSELLENCE_CLI_VERSION:-}"
       if [[ -z "$CLI_VERSION" ]]; then
         CLI_VERSION=#{default_version}
       fi
       CLI_CHECKSUM_URL="${DEVOPSELLENCE_CLI_CHECKSUM_URL:-}"
       INSTALL_DIR="${DEVOPSELLENCE_CLI_INSTALL_DIR:-}"
-      INSTALL_AGENT_SKILL="${DEVOPSELLENCE_INSTALL_AGENT_SKILL:-}"
-      AGENT_SKILLS_DIR="${DEVOPSELLENCE_AGENT_SKILLS_DIR:-}"
       TARGET_NAME="devopsellence"
 
       while [[ $# -gt 0 ]]; do
@@ -57,10 +53,6 @@ class CliInstallsController < ActionController::Base
             ;;
           --install-dir=*)
             INSTALL_DIR="${1#*=}"
-            shift
-            ;;
-          --install-agent-skill)
-            INSTALL_AGENT_SKILL=1
             shift
             ;;
           *)
@@ -166,19 +158,6 @@ class CliInstallsController < ActionController::Base
         printf '"%s"' "$value"
       }
 
-      install_agent_skill() {
-        local skill_args=()
-
-        if [[ -n "$AGENT_SKILLS_DIR" ]]; then
-          skill_args+=(--dir "$AGENT_SKILLS_DIR")
-        else
-          skill_args+=(--global)
-        fi
-
-        echo "installing devopsellence agent skill..."
-        "$INSTALL_DIR/$TARGET_NAME" skill install "${skill_args[@]}"
-      }
-
       echo "downloading devopsellence CLI..."
       curl -fsSL "$DOWNLOAD_URL" -o "$TMP_BIN"
       curl -fsSL "$CHECKSUM_URL" -o "$TMP_SUMS"
@@ -232,15 +211,8 @@ class CliInstallsController < ActionController::Base
           ;;
       esac
 
-      case "$INSTALL_AGENT_SKILL" in
-        1|true|TRUE|yes|YES)
-          install_agent_skill
-          ;;
-        *)
-          echo "agent skill available; install CLI + skill together with:"
-          echo "  curl -fsSL \"$INSTALL_SCRIPT_URL?version=$CLI_VERSION\" | bash -s -- --install-agent-skill"
-          ;;
-      esac
+      echo "agent skill available; install it with:"
+      echo "  $INSTALL_DIR/$TARGET_NAME skill install --global"
     SH
   end
 end

--- a/control-plane/app/controllers/cli_installs_controller.rb
+++ b/control-plane/app/controllers/cli_installs_controller.rb
@@ -212,7 +212,7 @@ class CliInstallsController < ActionController::Base
       esac
 
       echo "agent skill available; install it with:"
-      echo "  $INSTALL_DIR/$TARGET_NAME skill install --global"
+      echo "  \"$INSTALL_DIR/$TARGET_NAME\" skill install --global"
     SH
   end
 end

--- a/control-plane/test/integration/installs_test.rb
+++ b/control-plane/test/integration/installs_test.rb
@@ -57,19 +57,17 @@ class InstallsTest < ActionDispatch::IntegrationTest
     assert_includes response.body, 'BASE_URL="${DEVOPSELLENCE_BASE_URL:-}"'
     assert_includes response.body, "BASE_URL='https://dev.devopsellence.com'"
     assert_includes response.body, 'INSTALL_DIR="${DEVOPSELLENCE_CLI_INSTALL_DIR:-}"'
-    assert_includes response.body, 'INSTALL_AGENT_SKILL="${DEVOPSELLENCE_INSTALL_AGENT_SKILL:-}"'
-    assert_includes response.body, 'AGENT_SKILLS_DIR="${DEVOPSELLENCE_AGENT_SKILLS_DIR:-}"'
-    assert_includes response.body, "INSTALL_SCRIPT_URL='https://dev.devopsellence.com/lfg.sh'"
-    assert_includes response.body, "--install-agent-skill"
+    refute_includes response.body, "INSTALL_SCRIPT_URL"
+    refute_includes response.body, "DEVOPSELLENCE_INSTALL_AGENT_SKILL"
+    refute_includes response.body, "DEVOPSELLENCE_AGENT_SKILLS_DIR"
+    refute_includes response.body, "--install-agent-skill"
     assert_includes response.body, 'INSTALL_DIR="$HOME/.local/bin"'
     refute_includes response.body, 'INSTALL_DIR="/usr/local/bin"'
     assert_includes response.body, "PATH_EXPORT='export PATH=\"'\"$INSTALL_DIR\"':$PATH\"'"
     assert_includes response.body, "echo '$PATH_EXPORT' >> $RC_FILE"
     assert_includes response.body, "source $RC_FILE"
-    assert_includes response.body, '"$INSTALL_DIR/$TARGET_NAME" skill install'
-    assert_includes response.body, "skill_args+=(--global)"
+    assert_includes response.body, '$INSTALL_DIR/$TARGET_NAME skill install --global'
     refute_includes response.body, "npx --yes skills add"
-    assert_includes response.body, 'curl -fsSL "$INSTALL_SCRIPT_URL?version=$CLI_VERSION" | bash -s -- --install-agent-skill'
   end
 
   test "cli install script ignores configured public base url when choosing default download host" do
@@ -83,19 +81,18 @@ class InstallsTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_includes response.body, 'BASE_URL="${DEVOPSELLENCE_BASE_URL:-}"'
     assert_includes response.body, "BASE_URL='https://dev.devopsellence.com'"
-    assert_includes response.body, "INSTALL_SCRIPT_URL='https://dev.devopsellence.com/lfg.sh'"
+    refute_includes response.body, "INSTALL_SCRIPT_URL"
     refute_includes response.body, "https://app.devopsellence.com"
   end
 
-  test "cli install script skill rerun command keeps script host separate from download override" do
+  test "cli install script skill hint uses the installed cli" do
     https!
     host! "dev.devopsellence.com"
     get "/lfg.sh"
 
     assert_response :success
     assert_includes response.body, "BASE_URL='https://dev.devopsellence.com'"
-    assert_includes response.body, "INSTALL_SCRIPT_URL='https://dev.devopsellence.com/lfg.sh'"
-    assert_includes response.body, 'curl -fsSL "$INSTALL_SCRIPT_URL?version=$CLI_VERSION" | bash -s -- --install-agent-skill'
+    assert_includes response.body, "$INSTALL_DIR/$TARGET_NAME skill install --global"
     refute_includes response.body, 'curl -fsSL "$BASE_URL/lfg.sh'
   end
 
@@ -124,7 +121,7 @@ class InstallsTest < ActionDispatch::IntegrationTest
     assert_includes installed_cli, "prerelease build"
   end
 
-  test "cli install script can install the embedded agent skill when requested" do
+  test "cli install script leaves agent skill install to the cli command" do
     get "/lfg.sh", params: { version: "master-0053792f6aec" }
 
     assert_response :success
@@ -132,34 +129,16 @@ class InstallsTest < ActionDispatch::IntegrationTest
     stdout, stderr, status, installed_cli, installed_skill = run_cli_install_script(
       response.body,
       version: "master-0053792f6aec",
-      install_agent_skill: true
-    )
-
-    assert_predicate status, :success?, -> { "stdout:\n#{stdout}\nstderr:\n#{stderr}" }
-    assert_includes stdout, "installing devopsellence agent skill"
-    assert_includes stdout, '"action":"installed"'
-    assert_includes stdout, '"source":"embedded"'
-    assert_includes installed_cli, "prerelease build"
-    assert_equal "skill for master-0053792f6aec\n", installed_skill
-  end
-
-  test "cli install script installs requested agent skill without npx" do
-    get "/lfg.sh", params: { version: "master-0053792f6aec" }
-
-    assert_response :success
-
-    stdout, stderr, status, installed_cli, installed_skill = run_cli_install_script(
-      response.body,
-      version: "master-0053792f6aec",
-      install_agent_skill: true,
       include_npx: false
     )
 
     assert_predicate status, :success?, -> { "stdout:\n#{stdout}\nstderr:\n#{stderr}" }
-    assert_includes stdout, '"action":"installed"'
-    assert_includes stdout, '"source":"embedded"'
+    refute_includes stdout, "installing devopsellence agent skill"
+    refute_includes stdout, '"action":"installed"'
+    assert_includes stdout, "agent skill available; install it with:"
+    assert_includes stdout, "skill install --global"
     assert_includes installed_cli, "prerelease build"
-    assert_equal "skill for master-0053792f6aec\n", installed_skill
+    assert_nil installed_skill
   end
 
   test "cli install script defaults to user local bin on linux" do
@@ -294,7 +273,7 @@ class InstallsTest < ActionDispatch::IntegrationTest
 
   private
 
-  def run_cli_install_script(script_body, version:, install_dir: :explicit, install_agent_skill: false, include_npx: true)
+  def run_cli_install_script(script_body, version:, install_dir: :explicit, include_npx: true)
     Dir.mktmpdir("devopsellence-cli-install-test") do |tmpdir|
       fixtures_dir = File.join(tmpdir, "fixtures")
       fakebin_dir = File.join(tmpdir, "fakebin")
@@ -471,8 +450,6 @@ class InstallsTest < ActionDispatch::IntegrationTest
         "DEVOPSELLENCE_BASE_URL" => "https://downloads.devopsellence.test"
       }
       env["DEVOPSELLENCE_CLI_INSTALL_DIR"] = effective_install_dir if effective_install_dir
-      env["DEVOPSELLENCE_INSTALL_AGENT_SKILL"] = "1" if install_agent_skill
-
       working_dir = File.join(tmpdir, "work")
       FileUtils.mkdir_p(working_dir)
       stdout, stderr, status = Open3.capture3(env, script_path, chdir: working_dir)

--- a/control-plane/test/integration/installs_test.rb
+++ b/control-plane/test/integration/installs_test.rb
@@ -66,7 +66,7 @@ class InstallsTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "PATH_EXPORT='export PATH=\"'\"$INSTALL_DIR\"':$PATH\"'"
     assert_includes response.body, "echo '$PATH_EXPORT' >> $RC_FILE"
     assert_includes response.body, "source $RC_FILE"
-    assert_includes response.body, '$INSTALL_DIR/$TARGET_NAME skill install --global'
+    assert_includes response.body, "\"$INSTALL_DIR/$TARGET_NAME\" skill install --global"
     refute_includes response.body, "npx --yes skills add"
   end
 
@@ -92,7 +92,7 @@ class InstallsTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_includes response.body, "BASE_URL='https://dev.devopsellence.com'"
-    assert_includes response.body, "$INSTALL_DIR/$TARGET_NAME skill install --global"
+    assert_includes response.body, "\"$INSTALL_DIR/$TARGET_NAME\" skill install --global"
     refute_includes response.body, 'curl -fsSL "$BASE_URL/lfg.sh'
   end
 

--- a/docs-website/src/content/docs/getting-started/install.md
+++ b/docs-website/src/content/docs/getting-started/install.md
@@ -12,8 +12,7 @@ curl -fsSL https://www.devopsellence.com/lfg.sh | bash
 The installer writes to `~/.local/bin` by default. If that directory is not on
 your `PATH`, it prints the shell command to add it.
 
-devopsellence is AI-operator-first. To install the matching AI agent skill
-without requiring npm or `npx`:
+devopsellence is AI-operator-first. To install the matching AI agent skill:
 
 ```bash
 ~/.local/bin/devopsellence skill install --global

--- a/docs-website/src/content/docs/getting-started/install.md
+++ b/docs-website/src/content/docs/getting-started/install.md
@@ -16,7 +16,7 @@ devopsellence is AI-operator-first. To install the matching Codex skill without
 requiring npm or `npx`:
 
 ```bash
-devopsellence skill install --global
+~/.local/bin/devopsellence skill install --global
 ```
 
 Verify the workstation:

--- a/docs-website/src/content/docs/getting-started/install.md
+++ b/docs-website/src/content/docs/getting-started/install.md
@@ -12,11 +12,11 @@ curl -fsSL https://www.devopsellence.com/lfg.sh | bash
 The installer writes to `~/.local/bin` by default. If that directory is not on
 your `PATH`, it prints the shell command to add it.
 
-devopsellence is AI-operator-first. To install the CLI and matching Codex skill
-together without requiring npm or `npx`:
+devopsellence is AI-operator-first. To install the matching Codex skill without
+requiring npm or `npx`:
 
 ```bash
-curl -fsSL https://www.devopsellence.com/lfg.sh | bash -s -- --install-agent-skill
+devopsellence skill install --global
 ```
 
 Verify the workstation:

--- a/docs-website/src/content/docs/getting-started/install.md
+++ b/docs-website/src/content/docs/getting-started/install.md
@@ -12,8 +12,8 @@ curl -fsSL https://www.devopsellence.com/lfg.sh | bash
 The installer writes to `~/.local/bin` by default. If that directory is not on
 your `PATH`, it prints the shell command to add it.
 
-devopsellence is AI-operator-first. To install the matching Codex skill without
-requiring npm or `npx`:
+devopsellence is AI-operator-first. To install the matching AI agent skill
+without requiring npm or `npx`:
 
 ```bash
 ~/.local/bin/devopsellence skill install --global

--- a/docs-website/src/content/docs/index.md
+++ b/docs-website/src/content/docs/index.md
@@ -27,13 +27,14 @@ approval loop; the node agent stays deterministic.
 Already have a Dockerized app:
 
 ```bash
-curl -fsSL https://www.devopsellence.com/lfg.sh | bash -s -- --install-agent-skill
+curl -fsSL https://www.devopsellence.com/lfg.sh | bash
+devopsellence skill install --global
 cd my-app
 codex e "Deploy this app with devopsellence solo."
 ```
 
-`--install-agent-skill` installs the matching skill from the CLI itself; it does
-not require npm or `npx`.
+`devopsellence skill install` installs the matching skill from the CLI itself;
+it does not require npm or `npx`.
 
 Starting from an idea:
 

--- a/docs-website/src/content/docs/index.md
+++ b/docs-website/src/content/docs/index.md
@@ -28,7 +28,7 @@ Already have a Dockerized app:
 
 ```bash
 curl -fsSL https://www.devopsellence.com/lfg.sh | bash
-devopsellence skill install --global
+~/.local/bin/devopsellence skill install --global
 cd my-app
 codex e "Deploy this app with devopsellence solo."
 ```

--- a/docs-website/src/content/docs/index.md
+++ b/docs-website/src/content/docs/index.md
@@ -33,8 +33,8 @@ cd my-app
 codex e "Deploy this app with devopsellence solo."
 ```
 
-`devopsellence skill install` installs the matching skill from the CLI itself;
-it does not require npm or `npx`.
+`devopsellence skill install` installs the matching AI agent skill from the CLI
+itself.
 
 Starting from an idea:
 


### PR DESCRIPTION
## What changed

- Removed the `--install-agent-skill` argument and `DEVOPSELLENCE_INSTALL_AGENT_SKILL`/`DEVOPSELLENCE_AGENT_SKILLS_DIR` handling from the generated `lfg.sh` installer.
- Updated the installer and local release script to point users at `devopsellence skill install --global` after CLI installation.
- Updated README/docs quickstarts and Rails installer integration tests to treat skill installation as an explicit CLI command.

## Why

The skill installer now lives in the CLI as `devopsellence skill install`, so keeping a second install path in `lfg.sh` adds product surface without adding real capability.

## Validation

- `cd control-plane && mise run test -- test/integration/installs_test.rb`
- `bash -n cli/scripts/release-local.sh`
- `npm run check` in `docs-website`
- `git diff --check`