### PR TITLE
[codex] reframe vibe docs positioning

### DIFF
--- a/docs-website/astro.config.mjs
+++ b/docs-website/astro.config.mjs
@@ -42,7 +42,7 @@ export default defineConfig({
           items: [
             { label: "Deploy with solo", link: "/guides/solo-deploy/" },
             { label: "Deploy with shared", link: "/guides/shared-deploy/" },
-            { label: "Rails app template", link: "/guides/rails-app-template/" },
+            { label: "Build with vibe", link: "/guides/rails-app-template/" },
             { label: "CloudStack VMs", link: "/guides/cloudstack-vms/" },
             { label: "GitHub Actions", link: "/guides/github-actions/" },
             { label: "Secrets", link: "/guides/secrets/" },

--- a/docs-website/package-lock.json
+++ b/docs-website/package-lock.json
@@ -3474,9 +3474,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {

--- a/docs-website/src/content/docs/getting-started/solo-quickstart.md
+++ b/docs-website/src/content/docs/getting-started/solo-quickstart.md
@@ -15,7 +15,7 @@ devopsellence init --mode solo
 ```
 
 Start from an app that already has a Dockerfile, or let devopsellence prepare an
-AI-first web app workspace first.
+AI-first web app workspace.
 
 If you want Codex, Claude Code, Pi, or another AI coding agent to create or
 prepare the app first, start from [Build with vibe](/guides/rails-app-template/):

--- a/docs-website/src/content/docs/getting-started/solo-quickstart.md
+++ b/docs-website/src/content/docs/getting-started/solo-quickstart.md
@@ -14,11 +14,11 @@ and the `devopsellence` CLI.
 devopsellence init --mode solo
 ```
 
-Start from an app that already has a Dockerfile, or let devopsellence generate
-the blessed Rails baseline first.
+Start from an app that already has a Dockerfile, or let devopsellence prepare an
+AI-first web app workspace first.
 
 If you want Codex, Claude Code, Pi, or another AI coding agent to create or
-prepare the app first, start from the [Rails app template](/guides/rails-app-template/):
+prepare the app first, start from [Build with vibe](/guides/rails-app-template/):
 
 ```bash
 devopsellence vibe my-app

--- a/docs-website/src/content/docs/guides/rails-app-template.md
+++ b/docs-website/src/content/docs/guides/rails-app-template.md
@@ -1,13 +1,17 @@
 ---
-title: Rails app template
-description: Start a production-minded Rails app with devopsellence, mise, and a local AI-agent skill.
+title: Build a web app with vibe
+description: Start a batteries-included Rails app with an AI-first build, test, and deploy workflow.
 ---
 
-`devopsellence vibe` creates one blessed Rails app shape instead of asking you
-to choose a stack. It uses the devopsellence Rails template, writes a local
-agent skill, seeds a prompt, initializes git, and can launch Codex, Claude Code,
-Pi, or another agent with high effort/thinking enabled and a simple autonomy
-choice.
+`devopsellence vibe` turns an app idea into a production-minded web app
+workspace for an AI coding agent. It picks one blessed Rails baseline, writes a
+local agent skill, captures deploy intent, seeds a prompt, initializes git, and
+can launch Codex, Claude Code, Pi, or another agent with high effort/thinking
+enabled and a simple autonomy choice.
+
+This feature is experimental inside devopsellence. It lives here for now so
+releases and maintenance stay simple, but the app-building workflow will likely
+move into its own companion project as the boundary becomes clearer.
 
 Run it without `--idea` to use the intake wizard. You can press Ctrl+C during
 the questions to stop before files are generated.
@@ -96,7 +100,7 @@ Start Claude with full local access inside an isolated devbox:
 devopsellence vibe my-crm --ai-agent=claude --autonomy=full-access
 ```
 
-The command runs Rails with the pinned template:
+The command currently uses Rails and the pinned template as the scaffold engine:
 
 ```bash
 rails new my-crm \

--- a/docs-website/src/content/docs/index.md
+++ b/docs-website/src/content/docs/index.md
@@ -50,8 +50,8 @@ service choices before scaffolding; press Ctrl+C during the questions to stop.
 
 - [Solo quickstart](/getting-started/solo-quickstart/) for the shortest path to
   one VM.
-- [Rails app template](/guides/rails-app-template/) for turning an app idea into
-  a production-minded Rails workspace with local agent skills.
+- [Build with vibe](/guides/rails-app-template/) for turning an app idea into a
+  batteries-included Rails workspace with local agent skills and deploy intent.
 - [Ingress and TLS](/guides/ingress-tls/) for hostnames, DNS checks, and HTTPS
   verification.
 - [Basecamp Fizzy on Rails](/examples/fizzy-rails-solo/) for a real Rails app


### PR DESCRIPTION
## Summary
- reframe the vibe guide around building a web app with vibe instead of the Rails template implementation detail
- add an explicit note that vibe is experimental inside devopsellence and likely to move into a companion project later
- update the docs-site lockfile to resolve the transitive fast-uri high-severity advisory

## Validation
- cd docs-website && npm audit --json
- cd docs-website && npm ls fast-uri
- cd docs-website && mise run build
- git diff --check