### PR TITLE
[codex] Document release task companion readiness

### DIFF
--- a/docs-website/src/content/docs/guides/solo-deploy.md
+++ b/docs-website/src/content/docs/guides/solo-deploy.md
@@ -36,6 +36,8 @@ For app data, use an ordinary backup service with restic and the existing
 
 For Redis, Memcached, and other companion containers, add another service with
 a custom `image`. See [Supporting services](/guides/supporting-services/).
+Release tasks that need a companion service should also account for service
+readiness before running migrations or setup commands.
 
 To create a Hetzner-backed solo node:
 

--- a/docs-website/src/content/docs/guides/supporting-services.md
+++ b/docs-website/src/content/docs/guides/supporting-services.md
@@ -83,6 +83,20 @@ devopsellence deploy
 In shared mode, use the same config shape. The control plane and node agent use
 the same desired-state model; only image publication and secret storage differ.
 
+## Release tasks
+
+Treat companion services as runtime dependencies that may need their own
+readiness checks before a release task uses them. A release task can run after
+devopsellence has published desired state, but a container may exist before the
+service inside it accepts connections.
+
+Release tasks that need a database, cache, or queue should include retry or wait
+logic before running migrations or setup commands.
+
+Current `devopsellence.yml` supporting services are scheduled as workload
+services. They do not yet expose first-class dependency or readiness settings,
+so do not rely on this as a complete sidecar dependency system.
+
 ## Operational notes
 
 Use named volumes for state you expect to keep across deploys. For Redis, that

--- a/test/e2e/solo_e2e.rb
+++ b/test/e2e/solo_e2e.rb
@@ -14,6 +14,7 @@
 #      deploy, check status
 #   5. Assert: app container running, status.json settled, secrets resolved
 #   6. Restart the agent, deploy a second release, rollback, and detach cleanup
+#   7. Verify release tasks can resolve pre-bootstrapped accessory services
 #
 # Usage:
 #   ruby test/e2e/solo_e2e.rb
@@ -173,6 +174,7 @@ class SoloE2E
     @envoy_https_port = available_port(33_000 + SecureRandom.random_number(1000))
     @node_container = "devopsellence-solo-node-#{@run_id}"
     @node_image = "devopsellence/solo-e2e-node:#{@run_id}"
+    @release_task_accessory_image = "devopsellence/solo-e2e-release-accessory:#{@run_id}"
     @run_labels = {
       "devopsellence.e2e" => "1",
       "devopsellence.e2e.run_id" => @run_id,
@@ -217,6 +219,7 @@ class SoloE2E
     step("rollback") { rollback_to_previous_release! }
     step("assert rollback") { assert_runtime_state!(expected_workload_revision: @initial_workload_revision, expected_plain_env: "hello-solo") }
     step("detach cleanup") { assert_detach_cleanup! }
+    step("release task accessory bootstrap") { assert_release_task_bootstraps_accessory! }
 
     puts "\n[ok] solo e2e passed"
   ensure
@@ -931,6 +934,79 @@ PY
     puts "[ok] Detach cleared desired state and removed workload containers"
   end
 
+  def assert_release_task_bootstraps_accessory!
+    build_release_task_accessory_image!
+    revision = "release-accessory-#{@run_id.tr("-", "_")}"
+    desired = {
+      "schemaVersion" => 2,
+      "revision" => revision,
+      "environments" => [
+        {
+          "name" => "production",
+          "revision" => revision,
+          "services" => [
+            {
+              "name" => "db",
+              "kind" => "accessory",
+              "image" => @release_task_accessory_image,
+              "entrypoint" => ["/bin/sh", "-c"],
+              "command" => ["trap : TERM INT; while true; do sleep 60; done"]
+            }
+          ],
+          "tasks" => [
+            {
+              "name" => "release",
+              "image" => @release_task_accessory_image,
+              "entrypoint" => ["/bin/sh", "-c"],
+              "command" => ["getent hosts db >/dev/null"]
+            }
+          ]
+        }
+      ]
+    }
+    desired_payload = JSON.pretty_generate(desired)
+    quoted_path = Shellwords.escape(@desired_state_path)
+    ssh_to_node_with_stdin!("cat > #{quoted_path} && touch #{quoted_path}", desired_payload)
+
+    status = nil
+    wait_until!(timeout: 120) do
+      output = ssh_to_node!("cat #{@status_path} 2>/dev/null || echo '{}'")
+      begin
+        status = JSON.parse(output)
+        status["revision"] == revision && status["phase"] == "settled"
+      rescue JSON::ParserError
+        false
+      end
+    end
+
+    environment = status.fetch("environments").find { |entry| entry["name"] == "production" }
+    raise "accessory bootstrap status missing production environment: #{status.inspect}" unless environment
+
+    service = environment.fetch("services").find { |entry| entry["name"] == "db" }
+    raise "accessory bootstrap status missing db service: #{status.inspect}" unless service
+    raise "db service kind = #{service['kind'].inspect}, want accessory" unless service["kind"] == "accessory"
+
+    db_containers = ssh_to_node!(
+      "docker ps --filter label=devopsellence.managed=true " \
+      "--filter label=devopsellence.service=db " \
+      "--filter label=devopsellence.revision=#{Shellwords.escape(revision)} " \
+      "--format '{{.Names}} {{.Status}}'"
+    ).lines.map(&:strip).reject(&:empty?)
+    raise "db accessory container not running for revision #{revision}" if db_containers.empty?
+
+    puts "[ok] Release task resolved accessory DNS before runtime reconcile: #{db_containers.join(', ')}"
+  end
+
+  def build_release_task_accessory_image!
+    image_dir = @image_build_dir.join("release-accessory")
+    FileUtils.rm_rf(image_dir)
+    FileUtils.mkdir_p(image_dir)
+    image_dir.join("Dockerfile").write(<<~DOCKERFILE)
+      FROM alpine:3.22
+    DOCKERFILE
+    run!("docker", "build", "-t", @release_task_accessory_image, image_dir.to_s, chdir: MONOREPO_ROOT.to_s, timeout: 300)
+  end
+
   def current_revision
     @current_revision ||= capture!("git", "rev-parse", "--short=7", "HEAD", chdir: @app_dir.to_s).strip
   end
@@ -948,6 +1024,22 @@ PY
       "root@127.0.0.1",
       command,
       chdir: MONOREPO_ROOT.to_s
+    )
+  end
+
+  def ssh_to_node_with_stdin!(command, input)
+    run!(
+      "ssh",
+      "-o", "BatchMode=yes",
+      "-o", "StrictHostKeyChecking=no",
+      "-o", "UserKnownHostsFile=/dev/null",
+      "-i", @ssh_private_key.to_s,
+      "-p", @ssh_port.to_s,
+      "root@127.0.0.1",
+      command,
+      chdir: MONOREPO_ROOT.to_s,
+      timeout: 30,
+      input: input
     )
   end
 
@@ -1305,6 +1397,7 @@ PY
       run!("docker", "network", "rm", network, chdir: MONOREPO_ROOT.to_s, timeout: 60)
     end
     run!("docker", "image", "rm", "-f", @node_image, chdir: MONOREPO_ROOT.to_s, timeout: 60)
+    run!("docker", "image", "rm", "-f", @release_task_accessory_image, chdir: MONOREPO_ROOT.to_s, timeout: 60) if @release_task_accessory_image
     FileUtils.rm_rf(@state_dir)
     FileUtils.rm_rf(@app_root_dir)
   rescue StandardError => e

--- a/test/e2e/solo_e2e.rb
+++ b/test/e2e/solo_e2e.rb
@@ -973,13 +973,16 @@ PY
       output = ssh_to_node!("cat #{@status_path} 2>/dev/null || echo '{}'")
       begin
         status = JSON.parse(output)
-        status["revision"] == revision && status["phase"] == "settled"
+        status["revision"] == revision &&
+          status["phase"] == "settled" &&
+          !status.key?("task") &&
+          production_db_service_status(status)
       rescue JSON::ParserError
         false
       end
     end
 
-    environment = status.fetch("environments").find { |entry| entry["name"] == "production" }
+    environment = status.fetch("environments", []).find { |entry| entry["name"] == "production" }
     raise "accessory bootstrap status missing production environment: #{status.inspect}" unless environment
 
     service = environment.fetch("services").find { |entry| entry["name"] == "db" }
@@ -995,6 +998,11 @@ PY
     raise "db accessory container not running for revision #{revision}" if db_containers.empty?
 
     puts "[ok] Release task resolved accessory DNS before runtime reconcile: #{db_containers.join(', ')}"
+  end
+
+  def production_db_service_status(status)
+    environment = status.fetch("environments", []).find { |entry| entry["name"] == "production" }
+    environment&.fetch("services", [])&.find { |entry| entry["name"] == "db" }
   end
 
   def build_release_task_accessory_image!
@@ -1396,12 +1404,19 @@ PY
     managed_networks.each do |network|
       run!("docker", "network", "rm", network, chdir: MONOREPO_ROOT.to_s, timeout: 60)
     end
-    run!("docker", "image", "rm", "-f", @node_image, chdir: MONOREPO_ROOT.to_s, timeout: 60)
-    run!("docker", "image", "rm", "-f", @release_task_accessory_image, chdir: MONOREPO_ROOT.to_s, timeout: 60) if @release_task_accessory_image
+    remove_image_if_present(@node_image)
+    remove_image_if_present(@release_task_accessory_image)
     FileUtils.rm_rf(@state_dir)
     FileUtils.rm_rf(@app_root_dir)
   rescue StandardError => e
     puts "[warn] cleanup error: #{e.message}"
+  end
+
+  def remove_image_if_present(image)
+    return if image.to_s.empty?
+    return unless system_success?("docker", "image", "inspect", image, chdir: MONOREPO_ROOT.to_s)
+
+    run!("docker", "image", "rm", "-f", image, chdir: MONOREPO_ROOT.to_s, timeout: 60)
   end
 
   def resolve_checkout_root

--- a/test/e2e/solo_e2e.rb
+++ b/test/e2e/solo_e2e.rb
@@ -958,7 +958,7 @@ PY
               "name" => "release",
               "image" => @release_task_accessory_image,
               "entrypoint" => ["/bin/sh", "-c"],
-              "command" => ["getent hosts db >/dev/null"]
+              "command" => ["getent hosts db >/dev/null && sleep 5"]
             }
           ]
         }
@@ -967,6 +967,20 @@ PY
     desired_payload = JSON.pretty_generate(desired)
     quoted_path = Shellwords.escape(@desired_state_path)
     ssh_to_node_with_stdin!("cat > #{quoted_path} && touch #{quoted_path}", desired_payload)
+
+    wait_until!(timeout: 120) do
+      output = ssh_to_node!("cat #{@status_path} 2>/dev/null || echo '{}'")
+      begin
+        status = JSON.parse(output)
+        task = status["task"]
+        status["revision"] == revision &&
+          task &&
+          task["name"] == "release" &&
+          task["phase"] == "reconciling"
+      rescue JSON::ParserError
+        false
+      end
+    end
 
     status = nil
     wait_until!(timeout: 120) do


### PR DESCRIPTION
## Summary
- document release-task readiness guidance for companion services without exposing internal service-kind terminology
- add solo e2e coverage that exercises the internal release-task support-service bootstrap path

## Validation
- ruby -c test/e2e/solo_e2e.rb
- cd docs-website && npm run check
- cd docs-website && npm run build
- DEVOPSELLENCE_E2E_APP_TMPDIR=/home/elvin/tmp/dxe2e mise run e2e-solo
- git diff --check

## Notes
- The public docs keep this at the companion-service readiness level. The e2e writes raw desired state because PR #206 is an agent-level internal desired-state behavior.