### PR TITLE
[codex] Fix solo dogfood regressions

### DIFF
--- a/agent/internal/authority/solo/authority.go
+++ b/agent/internal/authority/solo/authority.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"time"
 
 	"github.com/devopsellence/devopsellence/agent/internal/authority"
 	"github.com/devopsellence/devopsellence/agent/internal/desiredstatecache"
@@ -20,8 +19,6 @@ type Authority struct {
 	read   func(string) ([]byte, error)
 
 	// cached state for change detection
-	modTime time.Time
-	size    int64
 	digest  [sha256.Size]byte
 	desired *authority.FetchResult
 }
@@ -69,8 +66,6 @@ func (a *Authority) Fetch(_ context.Context) (*authority.FetchResult, error) {
 	if err != nil {
 		return nil, fmt.Errorf("load desired state: %w", err)
 	}
-	a.modTime = info.ModTime()
-	a.size = info.Size()
 	a.digest = digest
 	if !present {
 		a.desired = nil

--- a/agent/internal/authority/solo/authority.go
+++ b/agent/internal/authority/solo/authority.go
@@ -17,6 +17,7 @@ import (
 type Authority struct {
 	path   string
 	logger *slog.Logger
+	read   func(string) ([]byte, error)
 
 	// cached state for change detection
 	modTime time.Time
@@ -29,6 +30,7 @@ func New(path string, logger *slog.Logger) *Authority {
 	return &Authority{
 		path:   path,
 		logger: logger,
+		read:   os.ReadFile,
 	}
 }
 
@@ -36,13 +38,22 @@ func (a *Authority) Fetch(_ context.Context) (*authority.FetchResult, error) {
 	info, err := os.Stat(a.path)
 	if err != nil {
 		if os.IsNotExist(err) {
+			a.desired = nil
 			return nil, authority.ErrNoDesiredState
 		}
 		return nil, fmt.Errorf("stat desired state file: %w", err)
 	}
 
-	data, err := os.ReadFile(a.path)
+	read := a.read
+	if read == nil {
+		read = os.ReadFile
+	}
+	data, err := read(a.path)
 	if err != nil {
+		if os.IsNotExist(err) {
+			a.desired = nil
+			return nil, authority.ErrNoDesiredState
+		}
 		return nil, fmt.Errorf("read desired state file: %w", err)
 	}
 	digest := sha256.Sum256(data)

--- a/agent/internal/authority/solo/authority.go
+++ b/agent/internal/authority/solo/authority.go
@@ -2,6 +2,7 @@ package solo
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"log/slog"
 	"os"
@@ -20,6 +21,7 @@ type Authority struct {
 	// cached state for change detection
 	modTime time.Time
 	size    int64
+	digest  [sha256.Size]byte
 	desired *authority.FetchResult
 }
 
@@ -39,24 +41,38 @@ func (a *Authority) Fetch(_ context.Context) (*authority.FetchResult, error) {
 		return nil, fmt.Errorf("stat desired state file: %w", err)
 	}
 
-	// Return cached result if file hasn't changed.
-	if a.desired != nil && info.ModTime().Equal(a.modTime) && info.Size() == a.size {
+	data, err := os.ReadFile(a.path)
+	if err != nil {
+		return nil, fmt.Errorf("read desired state file: %w", err)
+	}
+	digest := sha256.Sum256(data)
+
+	// Return cached result if file content hasn't changed. The content digest
+	// keeps rapid solo republish operations safe on filesystems with coarse
+	// timestamp resolution.
+	if a.desired != nil && info.ModTime().Equal(a.modTime) && info.Size() == a.size && digest == a.digest {
 		return a.desired, nil
 	}
 
-	desired, present, err := desiredstatecache.LoadOverride(a.path)
+	desired, present, err := desiredstatecache.ParseOverride(data)
 	if err != nil {
 		return nil, fmt.Errorf("load desired state: %w", err)
 	}
+	a.modTime = info.ModTime()
+	a.size = info.Size()
+	a.digest = digest
 	if !present {
+		a.desired = nil
 		return nil, authority.ErrNoDesiredState
 	}
 
-	a.modTime = info.ModTime()
-	a.size = info.Size()
+	sequence := info.ModTime().UnixMilli()
+	if a.desired != nil && sequence <= a.desired.Sequence {
+		sequence = a.desired.Sequence + 1
+	}
 	a.desired = &authority.FetchResult{
 		Desired:  desired,
-		Sequence: info.ModTime().UnixMilli(),
+		Sequence: sequence,
 	}
 
 	a.logger.Info("loaded desired state from file", "path", a.path, "revision", desired.GetRevision())

--- a/agent/internal/authority/solo/authority.go
+++ b/agent/internal/authority/solo/authority.go
@@ -60,8 +60,8 @@ func (a *Authority) Fetch(_ context.Context) (*authority.FetchResult, error) {
 
 	// Return cached result if file content hasn't changed. The content digest
 	// keeps rapid solo republish operations safe on filesystems with coarse
-	// timestamp resolution.
-	if a.desired != nil && info.ModTime().Equal(a.modTime) && info.Size() == a.size && digest == a.digest {
+	// timestamp resolution while avoiding reconciles for metadata-only changes.
+	if a.desired != nil && digest == a.digest {
 		return a.desired, nil
 	}
 

--- a/agent/internal/authority/solo/authority_test.go
+++ b/agent/internal/authority/solo/authority_test.go
@@ -118,6 +118,28 @@ func TestFetch_ReReadsSameSizeSameModTimeOverwrite(t *testing.T) {
 	}
 }
 
+func TestFetch_ReadMissingFileReturnsNoDesiredState(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "desired-state-override.json")
+	state := `{"schemaVersion":2,"revision":"v1","environments":[]}`
+	if err := os.WriteFile(path, []byte(state), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	a := New(path, observability.NewLogger(0))
+	a.read = func(string) ([]byte, error) {
+		return nil, os.ErrNotExist
+	}
+
+	_, err := a.Fetch(context.Background())
+	if err != authority.ErrNoDesiredState {
+		t.Fatalf("expected ErrNoDesiredState for read race, got %v", err)
+	}
+	if a.desired != nil {
+		t.Fatal("expected cached desired state to be cleared")
+	}
+}
+
 func TestFetch_DisabledOverride(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "desired-state-override.json")

--- a/agent/internal/authority/solo/authority_test.go
+++ b/agent/internal/authority/solo/authority_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/devopsellence/devopsellence/agent/internal/authority"
 	"github.com/devopsellence/devopsellence/agent/internal/observability"
@@ -67,6 +68,53 @@ func TestFetch_CachesOnSameFile(t *testing.T) {
 
 	if r1 != r2 {
 		t.Error("expected cached result to be the same pointer")
+	}
+}
+
+func TestFetch_ReReadsSameSizeSameModTimeOverwrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "desired-state-override.json")
+	modTime := time.Unix(1_700_000_000, 0)
+
+	state1 := `{"schemaVersion":2,"revision":"v1","environments":[]}`
+	state2 := `{"schemaVersion":2,"revision":"v2","environments":[]}`
+	if len(state1) != len(state2) {
+		t.Fatalf("test states must have same size: %d != %d", len(state1), len(state2))
+	}
+	if err := os.WriteFile(path, []byte(state1), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(path, modTime, modTime); err != nil {
+		t.Fatal(err)
+	}
+
+	a := New(path, observability.NewLogger(0))
+	r1, err := a.Fetch(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r1.Desired.GetRevision() != "v1" {
+		t.Fatalf("revision = %q, want v1", r1.Desired.GetRevision())
+	}
+
+	if err := os.WriteFile(path, []byte(state2), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(path, modTime, modTime); err != nil {
+		t.Fatal(err)
+	}
+	r2, err := a.Fetch(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r2 == r1 {
+		t.Fatal("Fetch returned cached result after same-size same-modtime overwrite")
+	}
+	if r2.Desired.GetRevision() != "v2" {
+		t.Fatalf("revision = %q, want v2", r2.Desired.GetRevision())
+	}
+	if r2.Sequence <= r1.Sequence {
+		t.Fatalf("sequence = %d, want greater than %d", r2.Sequence, r1.Sequence)
 	}
 }
 

--- a/agent/internal/authority/solo/authority_test.go
+++ b/agent/internal/authority/solo/authority_test.go
@@ -71,6 +71,35 @@ func TestFetch_CachesOnSameFile(t *testing.T) {
 	}
 }
 
+func TestFetch_CachesSameContentWithNewModTime(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "desired-state-override.json")
+
+	state := `{"schemaVersion":2,"revision":"v1","environments":[]}`
+	if err := os.WriteFile(path, []byte(state), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	a := New(path, observability.NewLogger(0))
+	r1, err := a.Fetch(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	newModTime := time.Now().Add(time.Hour)
+	if err := os.Chtimes(path, newModTime, newModTime); err != nil {
+		t.Fatal(err)
+	}
+	r2, err := a.Fetch(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if r1 != r2 {
+		t.Fatal("expected metadata-only change to reuse cached result")
+	}
+}
+
 func TestFetch_ReReadsSameSizeSameModTimeOverwrite(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "desired-state-override.json")

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -3027,7 +3027,7 @@ func ingressRequiresDNSPreflight(cfg *config.ProjectConfig) bool {
 	if cfg == nil || cfg.Ingress == nil {
 		return false
 	}
-	return len(concreteIngressHosts(cfg)) > 0 || ingressRequiresTLSReadiness(cfg)
+	return len(concreteIngressHosts(cfg)) > 0 || strings.EqualFold(strings.TrimSpace(cfg.Ingress.TLS.Mode), "auto")
 }
 
 func soloPublicURLStatus(cfg *config.ProjectConfig) string {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -7559,6 +7559,7 @@ type ingressTLSProbeResult struct {
 }
 
 var ingressTLSProbe = defaultIngressTLSProbe
+var ingressDNSLookupHost = net.DefaultResolver.LookupHost
 
 type ingressHint struct {
 	Code            string            `json:"code"`
@@ -7686,7 +7687,7 @@ func ingressReadinessReport(ctx context.Context, cfg *config.ProjectConfig, sele
 	}
 	for _, host := range hosts {
 		result := ingressDNSHostResult{Host: host}
-		resolved, err := net.DefaultResolver.LookupHost(ctx, host)
+		resolved, err := ingressDNSLookupHost(ctx, host)
 		if err != nil {
 			result.Error = err.Error()
 		}

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -7611,11 +7611,19 @@ func ingressReadinessErrorKind(report ingressDNSReportResult) string {
 	return "ingress_dns_not_ready"
 }
 
-const soloStatusMissingSentinel = "__DEVOPSELLENCE_STATUS_MISSING__"
+const (
+	soloStatusMissingSentinel  = "__DEVOPSELLENCE_STATUS_MISSING__"
+	ingressDNSPreflightTimeout = 30 * time.Second
+)
 
 func (a *App) checkIngressBeforeDeploy(ctx context.Context, cfg *config.ProjectConfig, nodes map[string]config.Node, skip bool, environment ...string) error {
 	if skip || !ingressRequiresDNSPreflight(cfg) {
 		return nil
+	}
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, ingressDNSPreflightTimeout)
+		defer cancel()
 	}
 	report, err := ingressDNSReport(ctx, cfg, nodes, firstNonEmpty(environment...))
 	if err != nil {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -3027,7 +3027,7 @@ func ingressRequiresDNSPreflight(cfg *config.ProjectConfig) bool {
 	if cfg == nil || cfg.Ingress == nil {
 		return false
 	}
-	return strings.EqualFold(strings.TrimSpace(cfg.Ingress.TLS.Mode), "auto")
+	return len(concreteIngressHosts(cfg)) > 0 || ingressRequiresTLSReadiness(cfg)
 }
 
 func soloPublicURLStatus(cfg *config.ProjectConfig) string {

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -2292,13 +2292,18 @@ func TestCheckIngressBeforeDeployAllowsManualTLSWithoutConcreteHostnames(t *test
 func TestCheckIngressBeforeDeployRequiresDNSForConcreteHTTPHost(t *testing.T) {
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")
 	cfg.Ingress = &config.IngressConfig{
-		Hosts: []string{"definitely-not-resolving-devopsellence-test.invalid"},
+		Hosts: []string{"app.example"},
 		Rules: []config.IngressRuleConfig{{
-			Match:  config.IngressMatchConfig{Host: "definitely-not-resolving-devopsellence-test.invalid", PathPrefix: "/"},
+			Match:  config.IngressMatchConfig{Host: "app.example", PathPrefix: "/"},
 			Target: config.IngressTargetConfig{Service: config.DefaultWebServiceName, Port: "http"},
 		}},
 		TLS: config.IngressTLSConfig{Mode: "off"},
 	}
+	oldLookup := ingressDNSLookupHost
+	ingressDNSLookupHost = func(context.Context, string) ([]string, error) {
+		return nil, errors.New("lookup failed")
+	}
+	t.Cleanup(func() { ingressDNSLookupHost = oldLookup })
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -2279,7 +2279,9 @@ func TestCheckIngressBeforeDeployAllowsManualTLSWithoutConcreteHostnames(t *test
 		TLS:   config.IngressTLSConfig{Mode: "manual"},
 	}
 
-	err := (&App{}).checkIngressBeforeDeploy(context.Background(), &cfg, map[string]config.Node{
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err := (&App{}).checkIngressBeforeDeploy(ctx, &cfg, map[string]config.Node{
 		"node-a": {Host: "127.0.0.1", User: "root", Labels: []string{config.DefaultWebRole}},
 	}, false)
 	if err != nil {
@@ -2298,7 +2300,9 @@ func TestCheckIngressBeforeDeployRequiresDNSForConcreteHTTPHost(t *testing.T) {
 		TLS: config.IngressTLSConfig{Mode: "off"},
 	}
 
-	err := (&App{}).checkIngressBeforeDeploy(context.Background(), &cfg, map[string]config.Node{
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err := (&App{}).checkIngressBeforeDeploy(ctx, &cfg, map[string]config.Node{
 		"node-a": {Host: "127.0.0.1", User: "root", Labels: []string{config.DefaultWebRole}},
 	}, false)
 	if err == nil {

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -2271,6 +2271,22 @@ func TestCheckIngressBeforeDeployTreatsAutoTLSModeCaseInsensitively(t *testing.T
 	}
 }
 
+func TestCheckIngressBeforeDeployAllowsManualTLSWithoutConcreteHostnames(t *testing.T) {
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	cfg.Ingress = &config.IngressConfig{
+		Hosts: []string{"*"},
+		Rules: []config.IngressRuleConfig{{Target: config.IngressTargetConfig{Service: config.DefaultWebServiceName}}},
+		TLS:   config.IngressTLSConfig{Mode: "manual"},
+	}
+
+	err := (&App{}).checkIngressBeforeDeploy(context.Background(), &cfg, map[string]config.Node{
+		"node-a": {Host: "127.0.0.1", User: "root", Labels: []string{config.DefaultWebRole}},
+	}, false)
+	if err != nil {
+		t.Fatalf("checkIngressBeforeDeploy() error = %v, want nil", err)
+	}
+}
+
 func TestCheckIngressBeforeDeployRequiresDNSForConcreteHTTPHost(t *testing.T) {
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")
 	cfg.Ingress = &config.IngressConfig{

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -2271,6 +2271,28 @@ func TestCheckIngressBeforeDeployTreatsAutoTLSModeCaseInsensitively(t *testing.T
 	}
 }
 
+func TestCheckIngressBeforeDeployRequiresDNSForConcreteHTTPHost(t *testing.T) {
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	cfg.Ingress = &config.IngressConfig{
+		Hosts: []string{"definitely-not-resolving-devopsellence-test.invalid"},
+		Rules: []config.IngressRuleConfig{{
+			Match:  config.IngressMatchConfig{Host: "definitely-not-resolving-devopsellence-test.invalid", PathPrefix: "/"},
+			Target: config.IngressTargetConfig{Service: config.DefaultWebServiceName, Port: "http"},
+		}},
+		TLS: config.IngressTLSConfig{Mode: "off"},
+	}
+
+	err := (&App{}).checkIngressBeforeDeploy(context.Background(), &cfg, map[string]config.Node{
+		"node-a": {Host: "127.0.0.1", User: "root", Labels: []string{config.DefaultWebRole}},
+	}, false)
+	if err == nil {
+		t.Fatal("checkIngressBeforeDeploy() error = nil, want DNS readiness failure")
+	}
+	if !strings.Contains(err.Error(), "ingress DNS is not ready") || !strings.Contains(err.Error(), "update DNS") {
+		t.Fatalf("error = %q, want DNS mismatch guidance", err.Error())
+	}
+}
+
 func TestCheckIngressBeforeDeployIncludesSSLIPHintFields(t *testing.T) {
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")
 	cfg.Ingress = &config.IngressConfig{
@@ -6636,7 +6658,7 @@ func TestSoloDeployDryRunUsesExplicitEnvironmentWithoutDNS(t *testing.T) {
 	}
 }
 
-func TestSoloDeployDryRunDoesNotRequireDNSPreflightForManualTLS(t *testing.T) {
+func TestSoloDeployDryRunPlansRequiredDNSPreflightForManualTLS(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")
 	cfg.Ingress = &config.IngressConfig{
@@ -6672,8 +6694,8 @@ func TestSoloDeployDryRunDoesNotRequireDNSPreflightForManualTLS(t *testing.T) {
 		t.Fatalf("payload = %#v, want TLS pending dry-run", payload)
 	}
 	planned := jsonMapFromAny(t, payload["planned_dns_check"])
-	if planned["live_lookup"] != false || planned["required"] != false || planned["skipped"] != false || planned["check_command"] != "devopsellence ingress check --env 'production'" {
-		t.Fatalf("planned_dns_check = %#v, want optional manual-TLS DNS check", planned)
+	if planned["live_lookup"] != false || planned["required"] != true || planned["skipped"] != false || planned["check_command"] != "devopsellence ingress check --env 'production'" {
+		t.Fatalf("planned_dns_check = %#v, want required manual-TLS DNS check", planned)
 	}
 }
 


### PR DESCRIPTION
## Summary
- make solo agent desired-state override caching content-aware so rapid detach republish overwrites are not missed
- require deploy DNS preflight for any configured public ingress hostname, including HTTP and manual TLS
- add regressions for same-size/same-mtime override rewrites, broken HTTP host DNS, and manual TLS dry-run planning

## Root cause
- Solo authority cached desired-state overrides by mtime and size only, which can miss rapid same-size rewrites and keep reconciling stale environments.
- Solo deploy only required DNS preflight for `tls.mode: auto`, so HTTP public hostnames could be reported ready even when they did not resolve.

## Validation
- `mise run test:agent -- ./internal/authority/solo ./internal/reconcile`
- `mise run test:cli -- ./internal/workflow -run 'TestCheckIngressBeforeDeploy|TestSoloDeployDryRunPlansRequiredDNSPreflightForManualTLS|TestSoloDeployDryRunReportsConfiguredURLsAndDNSPlan'`\n- `git diff --check`\n\nCloses #213\nCloses #214