### PR TITLE
[codex] Shorten Codex quickstart prompt

### DIFF
--- a/docs-website/src/content/docs/index.md
+++ b/docs-website/src/content/docs/index.md
@@ -30,7 +30,7 @@ Already have a Dockerized app:
 curl -fsSL https://www.devopsellence.com/lfg.sh | bash
 ~/.local/bin/devopsellence skill install --global
 cd my-app
-codex e "Deploy this app with devopsellence solo."
+codex "deploy with devopsellence solo"
 ```
 
 `devopsellence skill install` installs the matching AI agent skill from the CLI


### PR DESCRIPTION
## Summary
- replace the docs landing quickstart invocation with the shorter `codex "deploy with devopsellence solo"` form
- keep the README and docs landing quickstart aligned

## Validation
- `npm run check` in `docs-website`
- `npm run build` in `docs-website`