### PR TITLE
[codex] Improve solo preflight diagnostics

### DIFF
--- a/cli/internal/git/git.go
+++ b/cli/internal/git/git.go
@@ -20,13 +20,17 @@ func (Client) CurrentSHA(root string) (string, error) {
 	cmd.Stdout = &out
 	cmd.Stderr = &out
 	if err := cmd.Run(); err != nil {
-		return "", fmt.Errorf("could not determine git SHA from %s. commit the app and run inside a git checkout", root)
+		return "", currentSHAError(root)
 	}
 	sha := strings.TrimSpace(out.String())
 	if !shaPattern.MatchString(sha) {
-		return "", fmt.Errorf("could not determine git SHA from %s. commit the app and run inside a git checkout", root)
+		return "", currentSHAError(root)
 	}
 	return sha, nil
+}
+
+func currentSHAError(root string) error {
+	return fmt.Errorf("could not determine git SHA from %s. commit the app and run inside a git checkout. For a fresh app, run `git add .` and `git commit -m 'initial deploy'` first", root)
 }
 
 func (Client) StatusEntries(root string, ignorePaths []string) ([]string, error) {

--- a/cli/internal/git/git_test.go
+++ b/cli/internal/git/git_test.go
@@ -1,0 +1,24 @@
+package git
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestCurrentSHASuggestsInitialCommitForFreshRepo(t *testing.T) {
+	root := t.TempDir()
+	if err := exec.Command("git", "-C", root, "init").Run(); err != nil {
+		t.Fatalf("git init: %v", err)
+	}
+
+	_, err := (Client{}).CurrentSHA(root)
+	if err == nil {
+		t.Fatal("CurrentSHA() error = nil, want fresh repo error")
+	}
+	for _, want := range []string{"git add .", "git commit -m 'initial deploy'"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("CurrentSHA() error = %v, want %q", err, want)
+		}
+	}
+}

--- a/cli/internal/solo/ssh.go
+++ b/cli/internal/solo/ssh.go
@@ -92,10 +92,19 @@ func (e *SSHError) Error() string {
 	if e == nil {
 		return "ssh error"
 	}
+	hint := sshConfigRecoveryHint(e.Stderr)
 	if e.Stderr != "" {
-		return fmt.Sprintf("ssh %s@%s: %v: %s", e.User, e.Host, e.Err, e.Stderr)
+		return fmt.Sprintf("ssh %s@%s: %v: %s%s", e.User, e.Host, e.Err, e.Stderr, hint)
 	}
-	return fmt.Sprintf("ssh %s@%s: %v", e.User, e.Host, e.Err)
+	return fmt.Sprintf("ssh %s@%s: %v%s", e.User, e.Host, e.Err, hint)
+}
+
+func sshConfigRecoveryHint(stderr string) string {
+	lower := strings.ToLower(stderr)
+	if strings.Contains(lower, "bad owner or permissions") && strings.Contains(lower, ".ssh/config") {
+		return " Set DEVOPSELLENCE_SSH_CONFIG=none to skip the local SSH config for devopsellence, or fix ~/.ssh/config ownership and permissions."
+	}
+	return ""
 }
 
 func (e *SSHError) Unwrap() error {

--- a/cli/internal/solo/ssh_test.go
+++ b/cli/internal/solo/ssh_test.go
@@ -1,9 +1,11 @@
 package solo
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/devopsellence/devopsellence/deployment-core/pkg/deploycore/config"
@@ -89,6 +91,18 @@ func TestSSHArgsUseDevNullForNoneSSHConfigOverride(t *testing.T) {
 	t.Setenv(sshConfigEnv, "none")
 	if got := sshConfigPathOverride(); got != os.DevNull {
 		t.Fatalf("sshConfigPathOverride() = %q, want %q", got, os.DevNull)
+	}
+}
+
+func TestSSHErrorSuggestsSkippingBadLocalSSHConfig(t *testing.T) {
+	err := (&SSHError{
+		User:   "root",
+		Host:   "203.0.113.10",
+		Err:    errors.New("exit status 255"),
+		Stderr: "Bad owner or permissions on /home/alice/.ssh/config\n",
+	}).Error()
+	if !strings.Contains(err, "DEVOPSELLENCE_SSH_CONFIG=none") {
+		t.Fatalf("SSHError.Error() = %q, want SSH config recovery hint", err)
 	}
 }
 

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1446,7 +1446,7 @@ func (a *App) prepareRepublishPlans(ctx context.Context, current solo.State, nod
 }
 
 func explainCohostedIngressConflict(err error, snapshots []desiredstate.DeploySnapshot) error {
-	if err == nil || len(snapshots) < 2 || !strings.Contains(err.Error(), "cannot merge ingress for co-hosted environments with different settings") {
+	if err == nil || len(snapshots) < 2 || !strings.Contains(err.Error(), desiredstate.CohostedIngressDifferentSettingsErrorPrefix) {
 		return err
 	}
 	return fmt.Errorf("%w; co-hosted ingress settings: %s", err, cohostedIngressSettingsSummary(snapshots))
@@ -5950,6 +5950,8 @@ func railsSecretKeyBaseCheck(workspaceRoot string, cfg config.ProjectConfig, env
 	return "", fmt.Errorf("Rails app detected, but service %q does not configure SECRET_KEY_BASE; run `bin/rails secret | devopsellence secret set SECRET_KEY_BASE --service %s --env %s --stdin` before deploying", serviceName, shellQuote(serviceName), shellQuote(environmentName))
 }
 
+var railsGemRegexp = regexp.MustCompile(`(?m)^\s*gem\s+['"]rails['"]`)
+
 func workspaceLooksLikeRails(workspaceRoot string) bool {
 	if _, err := os.Stat(filepath.Join(workspaceRoot, "bin", "rails")); err == nil {
 		return true
@@ -5958,7 +5960,7 @@ func workspaceLooksLikeRails(workspaceRoot string) bool {
 	if err != nil {
 		return false
 	}
-	return regexp.MustCompile(`(?m)^\s*gem\s+['"]rails['"]`).Match(data)
+	return railsGemRegexp.Match(data)
 }
 
 func (a *App) SoloNodeCreate(ctx context.Context, opts SoloNodeCreateOptions) error {

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -1446,7 +1446,7 @@ func (a *App) prepareRepublishPlans(ctx context.Context, current solo.State, nod
 }
 
 func explainCohostedIngressConflict(err error, snapshots []desiredstate.DeploySnapshot) error {
-	if err == nil || len(snapshots) < 2 || !strings.Contains(err.Error(), "cannot merge ingress for co-hosted environments") {
+	if err == nil || len(snapshots) < 2 || !strings.Contains(err.Error(), "cannot merge ingress for co-hosted environments with different settings") {
 		return err
 	}
 	return fmt.Errorf("%w; co-hosted ingress settings: %s", err, cohostedIngressSettingsSummary(snapshots))

--- a/cli/internal/workflow/solo.go
+++ b/cli/internal/workflow/solo.go
@@ -231,7 +231,13 @@ type soloNodeStatus struct {
 	Phase        string                      `json:"phase"`
 	Revision     string                      `json:"revision"`
 	Error        string                      `json:"error,omitempty"`
+	Ingress      *soloNodeIngressStatus      `json:"ingress,omitempty"`
 	Environments []soloNodeStatusEnvironment `json:"environments"`
+}
+
+type soloNodeIngressStatus struct {
+	TLSStatus string `json:"tls_status,omitempty"`
+	TLSError  string `json:"tls_error,omitempty"`
 }
 
 type soloNodeStatusEnvironment struct {
@@ -1424,7 +1430,7 @@ func (a *App) prepareRepublishPlans(ctx context.Context, current solo.State, nod
 			NodePeers:    inputs.peers,
 		})
 		if err != nil {
-			errs = append(errs, soloRepublishErrorEntry{node: nodeName, operation: "build desired state", err: err})
+			errs = append(errs, soloRepublishErrorEntry{node: nodeName, operation: "build desired state", err: explainCohostedIngressConflict(err, inputs.snapshots)})
 			continue
 		}
 		prepared[nodeName] = preparedNodePublication{
@@ -1437,6 +1443,45 @@ func (a *App) prepareRepublishPlans(ctx context.Context, current solo.State, nod
 		return nil, &soloRepublishError{entries: errs}
 	}
 	return prepared, nil
+}
+
+func explainCohostedIngressConflict(err error, snapshots []desiredstate.DeploySnapshot) error {
+	if err == nil || len(snapshots) < 2 || !strings.Contains(err.Error(), "cannot merge ingress for co-hosted environments") {
+		return err
+	}
+	return fmt.Errorf("%w; co-hosted ingress settings: %s", err, cohostedIngressSettingsSummary(snapshots))
+}
+
+func cohostedIngressSettingsSummary(snapshots []desiredstate.DeploySnapshot) string {
+	items := []string{}
+	for _, snapshot := range snapshots {
+		if snapshot.Ingress == nil {
+			continue
+		}
+		items = append(items, fmt.Sprintf("%s (%s): hosts=%s tls=%s redirect_http=%t",
+			firstNonEmpty(strings.TrimSpace(snapshot.Environment), "unknown"),
+			firstNonEmpty(strings.TrimSpace(snapshot.WorkspaceRoot), strings.TrimSpace(snapshot.WorkspaceKey), "unknown-workspace"),
+			strings.Join(snapshot.Ingress.Hosts, ","),
+			cohostedIngressTLSSummary(snapshot.Ingress.TLS),
+			snapshot.Ingress.RedirectHTTP,
+		))
+	}
+	if len(items) == 0 {
+		return "none"
+	}
+	sort.Strings(items)
+	return strings.Join(items, "; ")
+}
+
+func cohostedIngressTLSSummary(tls desiredstate.IngressTLSJSON) string {
+	parts := []string{"mode=" + firstNonEmpty(strings.TrimSpace(tls.Mode), "off")}
+	if email := strings.TrimSpace(tls.Email); email != "" {
+		parts = append(parts, "email="+email)
+	}
+	if ca := strings.TrimSpace(tls.CADirectoryURL); ca != "" {
+		parts = append(parts, "ca_directory_url="+ca)
+	}
+	return strings.Join(parts, ",")
 }
 
 func (a *App) republishPreparedNodes(ctx context.Context, prepared map[string]preparedNodePublication) (map[string]string, error) {
@@ -2208,6 +2253,14 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 	statusMismatches := 0
 	missingStatuses := 0
 	allSettled := true
+	ingressTLSStatuses := map[string]string{}
+	ingressTLSErrors := map[string]string{}
+	ingressNodes := map[string]bool{}
+	for name, node := range nodes {
+		if soloNodeCanRunIngress(node, cfg) {
+			ingressNodes[name] = true
+		}
+	}
 
 	for name, node := range nodes {
 		result, err := readNodeStatus(ctx, node)
@@ -2238,6 +2291,14 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 			})
 
 			continue
+		}
+		if ingressNodes[name] && result.Status.Ingress != nil {
+			if tlsStatus := strings.TrimSpace(result.Status.Ingress.TLSStatus); tlsStatus != "" {
+				ingressTLSStatuses[name] = tlsStatus
+			}
+			if tlsErr := strings.TrimSpace(result.Status.Ingress.TLSError); tlsErr != "" {
+				ingressTLSErrors[name] = tlsErr
+			}
 		}
 
 		if !localReleaseKnown {
@@ -2314,8 +2375,20 @@ func (a *App) SoloStatus(ctx context.Context, opts SoloStatusOptions) error {
 		}
 	} else if len(configuredPublicURLs) > 0 {
 		payload["configured_public_urls"] = configuredPublicURLs
-		payload["public_url_status"] = soloPublicURLStatus(cfg)
-		appendPayloadWarning(soloPublicURLWarning(cfg, environmentName))
+		publicURLStatus := soloPublicURLStatus(cfg)
+		publicURLWarning := soloPublicURLWarning(cfg, environmentName)
+		if ingressRequiresTLSReadiness(cfg) && allIngressNodesReportTLSReady(ingressNodes, ingressTLSStatuses) {
+			publicURLStatus = "configured_tls_ready"
+			publicURLWarning = "HTTPS public URLs are configured and node certificates report ready, but endpoint reachability has not been verified yet; run `devopsellence ingress check" + soloEnvFlag(environmentName) + " --wait 5m` before treating them as externally reachable"
+		}
+		payload["public_url_status"] = publicURLStatus
+		if len(ingressTLSStatuses) > 0 {
+			payload["ingress_tls_status"] = ingressTLSStatuses
+		}
+		if len(ingressTLSErrors) > 0 {
+			payload["ingress_tls_errors"] = ingressTLSErrors
+		}
+		appendPayloadWarning(publicURLWarning)
 	} else if soloPublicIngressKnownUnconfigured(cfg) {
 		payload["public_url_status"] = "not_configured"
 		if statusRuntimeVerified {
@@ -3035,6 +3108,18 @@ func soloPublicURLStatus(cfg *config.ProjectConfig) string {
 		return "configured_tls_pending"
 	}
 	return "configured_pending"
+}
+
+func allIngressNodesReportTLSReady(ingressNodes map[string]bool, statuses map[string]string) bool {
+	if len(ingressNodes) == 0 {
+		return false
+	}
+	for nodeName := range ingressNodes {
+		if !strings.EqualFold(strings.TrimSpace(statuses[nodeName]), "ready") {
+			return false
+		}
+	}
+	return true
 }
 
 func soloPublicURLWarning(cfg *config.ProjectConfig, environment ...string) string {
@@ -5744,6 +5829,17 @@ func (a *App) SoloDoctor(ctx context.Context) error {
 		return a.ConfigStore.PathFor(discovered.WorkspaceRoot), nil
 	})
 
+	addCheck("rails_secret_key_base", func() (string, error) {
+		if discoveryErr != nil {
+			return "", discoveryErr
+		}
+		if cfg == nil {
+			return "skipped: config unavailable", nil
+		}
+		environmentName := a.effectiveEnvironment("", cfg)
+		return railsSecretKeyBaseCheck(discovered.WorkspaceRoot, *cfg, environmentName)
+	})
+
 	addCheck("nodes", func() (string, error) {
 		var err error
 		current, err = a.readSoloState()
@@ -5828,6 +5924,41 @@ func (a *App) SoloDoctor(ctx context.Context) error {
 	}
 	return nil
 
+}
+
+func railsSecretKeyBaseCheck(workspaceRoot string, cfg config.ProjectConfig, environmentName string) (string, error) {
+	if !workspaceLooksLikeRails(workspaceRoot) {
+		return "not a Rails app", nil
+	}
+	resolved, err := config.ResolveEnvironmentConfig(cfg, environmentName)
+	if err != nil {
+		return "", err
+	}
+	serviceName, ok := resolved.PrimaryWebServiceName()
+	if !ok {
+		return "Rails app detected; no primary web service configured", nil
+	}
+	service := resolved.Services[serviceName]
+	if _, ok := service.Env["SECRET_KEY_BASE"]; ok {
+		return "SECRET_KEY_BASE configured in service env", nil
+	}
+	for _, ref := range service.SecretRefs {
+		if strings.EqualFold(strings.TrimSpace(ref.Name), "SECRET_KEY_BASE") {
+			return "SECRET_KEY_BASE configured as a service secret_ref", nil
+		}
+	}
+	return "", fmt.Errorf("Rails app detected, but service %q does not configure SECRET_KEY_BASE; run `bin/rails secret | devopsellence secret set SECRET_KEY_BASE --service %s --env %s --stdin` before deploying", serviceName, shellQuote(serviceName), shellQuote(environmentName))
+}
+
+func workspaceLooksLikeRails(workspaceRoot string) bool {
+	if _, err := os.Stat(filepath.Join(workspaceRoot, "bin", "rails")); err == nil {
+		return true
+	}
+	data, err := os.ReadFile(filepath.Join(workspaceRoot, "Gemfile"))
+	if err != nil {
+		return false
+	}
+	return regexp.MustCompile(`(?m)^\s*gem\s+['"]rails['"]`).Match(data)
 }
 
 func (a *App) SoloNodeCreate(ctx context.Context, opts SoloNodeCreateOptions) error {

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -1700,7 +1700,14 @@ func TestSoloStatusSurfacesAgentTLSReadyBeforeEndpointVerification(t *testing.T)
 		t.Fatalf("payload = %#v, node TLS readiness alone must not emit verified public_urls", payload)
 	}
 	warnings := jsonArrayFromMap(t, payload, "warnings")
-	if len(warnings) == 0 || !strings.Contains(stringValueAny(warnings[0]), "devopsellence ingress check --env 'production' --wait 5m") {
+	foundIngressCheckGuidance := false
+	for _, warning := range warnings {
+		if strings.Contains(stringValueAny(warning), "devopsellence ingress check --env 'production' --wait 5m") {
+			foundIngressCheckGuidance = true
+			break
+		}
+	}
+	if !foundIngressCheckGuidance {
 		t.Fatalf("warnings = %#v, want ingress check guidance", warnings)
 	}
 	runtimeVerified := jsonMapFromAny(t, payload["runtime_verified"])

--- a/cli/internal/workflow/solo_test.go
+++ b/cli/internal/workflow/solo_test.go
@@ -1657,6 +1657,58 @@ func TestSoloStatusTreatsTLSVerifiedCheckAsReadyPublicURL(t *testing.T) {
 	}
 }
 
+func TestSoloStatusSurfacesAgentTLSReadyBeforeEndpointVerification(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	cfg.Ingress = &config.IngressConfig{
+		Hosts: []string{"app.example.com"},
+		Rules: []config.IngressRuleConfig{{
+			Match:  config.IngressMatchConfig{Host: "app.example.com", PathPrefix: "/"},
+			Target: config.IngressTargetConfig{Service: config.DefaultWebServiceName, Port: "http"},
+		}},
+		TLS: config.IngressTLSConfig{Mode: "auto"},
+	}
+	if _, err := config.Write(workspaceRoot, cfg); err != nil {
+		t.Fatal(err)
+	}
+	installFakeSoloCommands(t, []fakeSSHResponse{{stdout: `{"revision":"rev","phase":"settled","ingress":{"tls_status":"ready"},"summary":{"environments":1,"services":1}}` + "\n"}})
+
+	soloState := solo.NewStateStore(filepath.Join(t.TempDir(), "solo-state.json"))
+	current := solo.State{Nodes: map[string]config.Node{"node-a": {Host: "203.0.113.10", User: "root", Labels: []string{config.DefaultWebRole}}}}
+	if _, _, err := current.AttachNode(workspaceRoot, "production", "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	seedSoloCurrentRelease(t, &current, workspaceRoot, "production", "rev")
+	if err := soloState.Write(current); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app := &App{Printer: output.New(&stdout, io.Discard), SoloState: soloState, ConfigStore: config.NewStore(), Cwd: workspaceRoot}
+	if err := app.SoloStatus(context.Background(), SoloStatusOptions{}); err != nil {
+		t.Fatalf("SoloStatus() error = %v", err)
+	}
+	payload := decodeJSONOutput(t, &stdout)
+	if payload["public_url_status"] != "configured_tls_ready" {
+		t.Fatalf("public_url_status = %#v, want configured_tls_ready", payload["public_url_status"])
+	}
+	statuses := jsonMapFromAny(t, payload["ingress_tls_status"])
+	if statuses["node-a"] != "ready" {
+		t.Fatalf("ingress_tls_status = %#v, want node-a ready", statuses)
+	}
+	if _, ok := payload["public_urls"]; ok {
+		t.Fatalf("payload = %#v, node TLS readiness alone must not emit verified public_urls", payload)
+	}
+	warnings := jsonArrayFromMap(t, payload, "warnings")
+	if len(warnings) == 0 || !strings.Contains(stringValueAny(warnings[0]), "devopsellence ingress check --env 'production' --wait 5m") {
+		t.Fatalf("warnings = %#v, want ingress check guidance", warnings)
+	}
+	runtimeVerified := jsonMapFromAny(t, payload["runtime_verified"])
+	if runtimeVerified["tls"] != false || runtimeVerified["endpoint_probe"] != false {
+		t.Fatalf("runtime_verified = %#v, endpoint TLS should remain unverified", runtimeVerified)
+	}
+}
+
 func TestSoloVerifiedIngressPublicURLsRejectsRecordWhenSelectedNodesHaveNoWebIPs(t *testing.T) {
 	cfg := config.DefaultProjectConfig("solo", "demo", "production")
 	cfg.Ingress = &config.IngressConfig{
@@ -11448,10 +11500,55 @@ func TestPrepareRepublishPlansReportsCohostedIngressSettingsBeforePublish(t *tes
 	if !strings.Contains(err.Error(), "cannot merge ingress for co-hosted environments with different settings") || !strings.Contains(err.Error(), "TLS") || !strings.Contains(err.Error(), "redirect_http") {
 		t.Fatalf("prepareRepublishPlans() error = %v, want TLS/redirect_http mismatch", err)
 	}
+	for _, want := range []string{"co-hosted ingress settings", "hosts=a.example.com", "hosts=b.example.com", "tls=mode=off", "tls=mode=manual", "redirect_http=false", "redirect_http=true"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("prepareRepublishPlans() error = %v, want %q", err, want)
+		}
+	}
 	for _, nodeName := range []string{"node-a", "node-b"} {
 		if !strings.Contains(err.Error(), "["+nodeName+"] build desired state:") {
 			t.Fatalf("prepareRepublishPlans() error = %v, want %s planning error", err, nodeName)
 		}
+	}
+}
+
+func TestRailsSecretKeyBaseCheckFailsWhenRailsAppMissingSecret(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(workspaceRoot, "Gemfile"), []byte(`gem "rails"`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+
+	_, err := railsSecretKeyBaseCheck(workspaceRoot, cfg, "production")
+	if err == nil {
+		t.Fatal("railsSecretKeyBaseCheck() error = nil, want missing SECRET_KEY_BASE")
+	}
+	for _, want := range []string{"Rails app detected", "SECRET_KEY_BASE", "bin/rails secret", "devopsellence secret set SECRET_KEY_BASE"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("railsSecretKeyBaseCheck() error = %v, want %q", err, want)
+		}
+	}
+}
+
+func TestRailsSecretKeyBaseCheckAcceptsSecretRef(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(workspaceRoot, "bin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workspaceRoot, "bin", "rails"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	service := cfg.Services[config.DefaultWebServiceName]
+	service.SecretRefs = []config.SecretRef{{Name: "SECRET_KEY_BASE", Secret: "devopsellence://plaintext/SECRET_KEY_BASE"}}
+	cfg.Services[config.DefaultWebServiceName] = service
+
+	detail, err := railsSecretKeyBaseCheck(workspaceRoot, cfg, "production")
+	if err != nil {
+		t.Fatalf("railsSecretKeyBaseCheck() error = %v", err)
+	}
+	if !strings.Contains(detail, "secret_ref") {
+		t.Fatalf("detail = %q, want secret_ref", detail)
 	}
 }
 

--- a/deployment-core/pkg/deploycore/desiredstate/desiredstate.go
+++ b/deployment-core/pkg/deploycore/desiredstate/desiredstate.go
@@ -113,6 +113,8 @@ type NodePeerJSON struct {
 
 type ScopedSecrets map[string]map[string]string
 
+const CohostedIngressDifferentSettingsErrorPrefix = "cannot merge ingress for co-hosted environments with different settings"
+
 func (s ScopedSecrets) ValuesForService(serviceName string) map[string]string {
 	merged := map[string]string{}
 	for key, value := range s[""] {
@@ -418,7 +420,7 @@ func mergeIngressForNode(labels []string, snapshots []DeploySnapshot, environmen
 			if merged.RedirectHTTP != snapshot.Ingress.RedirectHTTP {
 				differingSettings = append(differingSettings, "redirect_http")
 			}
-			return nil, fmt.Errorf("cannot merge ingress for co-hosted environments with different settings: %s", strings.Join(differingSettings, ", "))
+			return nil, fmt.Errorf("%s: %s", CohostedIngressDifferentSettingsErrorPrefix, strings.Join(differingSettings, ", "))
 		}
 		for _, host := range snapshot.Ingress.Hosts {
 			if hostSet[host] {


### PR DESCRIPTION
## Summary
- add co-hosted ingress conflict details showing each environment host, TLS mode, and redirect_http setting
- surface agent-reported ingress TLS readiness in solo status without claiming endpoint verification
- add Rails SECRET_KEY_BASE doctor guidance plus clearer SSH config and fresh-git-repo errors

## Validation
- TMPDIR=/home/elvin/tmp/dxe-cli-test mise run test:cli
