### PR TITLE
[codex] add llms.txt entrypoints

### DIFF
--- a/control-plane/Gemfile.lock
+++ b/control-plane/Gemfile.lock
@@ -223,17 +223,17 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.5)
-    nokogiri (1.19.2-aarch64-linux-gnu)
+    nokogiri (1.19.3-aarch64-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.19.2-aarch64-linux-musl)
+    nokogiri (1.19.3-aarch64-linux-musl)
       racc (~> 1.4)
-    nokogiri (1.19.2-arm-linux-gnu)
+    nokogiri (1.19.3-arm-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.19.2-arm-linux-musl)
+    nokogiri (1.19.3-arm-linux-musl)
       racc (~> 1.4)
-    nokogiri (1.19.2-x86_64-linux-gnu)
+    nokogiri (1.19.3-x86_64-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.19.2-x86_64-linux-musl)
+    nokogiri (1.19.3-x86_64-linux-musl)
       racc (~> 1.4)
     oauth2 (2.0.18)
       faraday (>= 0.17.3, < 4.0)
@@ -586,12 +586,12 @@ CHECKSUMS
   net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8
   net-smtp (0.5.1) sha256=ed96a0af63c524fceb4b29b0d352195c30d82dd916a42f03c62a3a70e5b70736
   nio4r (2.7.5) sha256=6c90168e48fb5f8e768419c93abb94ba2b892a1d0602cb06eef16d8b7df1dca1
-  nokogiri (1.19.2-aarch64-linux-gnu) sha256=c34d5c8208025587554608e98fd88ab125b29c80f9352b821964e9a5d5cfbd19
-  nokogiri (1.19.2-aarch64-linux-musl) sha256=7f6b4b0202d507326841a4f790294bf75098aef50c7173443812e3ac5cb06515
-  nokogiri (1.19.2-arm-linux-gnu) sha256=b7fa1139016f3dc850bda1260988f0d749934a939d04ef2da13bec060d7d5081
-  nokogiri (1.19.2-arm-linux-musl) sha256=61114d44f6742ff72194a1b3020967201e2eb982814778d130f6471c11f9828c
-  nokogiri (1.19.2-x86_64-linux-gnu) sha256=fa8feca882b73e871a9845f3817a72e9734c8e974bdc4fbad6e4bc6e8076b94f
-  nokogiri (1.19.2-x86_64-linux-musl) sha256=93128448e61a9383a30baef041bf1f5817e22f297a1d400521e90294445069a8
+  nokogiri (1.19.3-aarch64-linux-gnu) sha256=46b89e5d7b9e844c2ee360794240c6ea2a4e6fa0c5892a4ed487db621224b639
+  nokogiri (1.19.3-aarch64-linux-musl) sha256=8392dfdcd21be7a94dbbe9ccc138dea01b97b24cb2dc02a114ca98bfb1d9a0b7
+  nokogiri (1.19.3-arm-linux-gnu) sha256=3919d5ffc334ad778a4a9eb88fda7dcb8b1fb58c8a52ac640c6dcd2f038e774f
+  nokogiri (1.19.3-arm-linux-musl) sha256=9ce1cb6346bb9c67b1550eb537aa183ead91e4b6eadb2f36ade02d8dd2a79fb6
+  nokogiri (1.19.3-x86_64-linux-gnu) sha256=2f5078620fe12e83669b5b17311b32532a8153d02eee7ad06948b926d6080976
+  nokogiri (1.19.3-x86_64-linux-musl) sha256=248c906d2166eca5efb56d52fdee5f9a1f51d69a72e2b64fdac647b4ce39ea3f
   oauth2 (2.0.18) sha256=bacf11e470dfb963f17348666d0a75c7b29ca65bc48fd47be9057cf91a403287
   omniauth (2.1.4) sha256=42a05b0496f0d22e1dd85d42aaf602f064e36bb47a6826a27ab55e5ba608763c
   omniauth-github (2.0.1) sha256=8ff8e70ac6d6db9d52485eef52cfa894938c941496e66b52b5e2773ade3ccad4

--- a/control-plane/public/llms.txt
+++ b/control-plane/public/llms.txt
@@ -1,0 +1,33 @@
+# devopsellence
+
+> devopsellence is an AI-operator-first deployment toolkit for containerized apps on familiar VMs.
+
+devopsellence gives AI coding and operations assistants a narrow, auditable command surface for deploying Dockerized apps without introducing a PaaS, Kubernetes-lite layer, or hidden scheduler.
+
+Use the docs site for implementation details. Use the main website for product positioning, installation, and entry points.
+
+## Start
+
+- [Install the CLI](https://www.devopsellence.com/lfg.sh): Shell installer for the current devopsellence CLI.
+- [Documentation](https://docs.devopsellence.com/): Public docs for installing, deploying, operating, and troubleshooting devopsellence.
+- [Solo quickstart](https://docs.devopsellence.com/getting-started/solo-quickstart/): Short path for deploying a Dockerized app to one VM.
+- [GitHub repository](https://github.com/devopsellence/devopsellence): Public source for the CLI, agent, deployment core, control plane, and docs site.
+
+## Product Boundaries
+
+- [Runtime model](https://docs.devopsellence.com/concepts/runtime-model/): Core model for desired state, releases, services, nodes, and status.
+- [Solo and shared](https://docs.devopsellence.com/concepts/solo-and-shared/): Management topology differences; not separate deployment systems.
+- [AI operator model](https://docs.devopsellence.com/concepts/agent-primary/): Why the CLI is shaped for AI assistants acting for humans.
+- [Node agent and desired state](https://docs.devopsellence.com/concepts/agent-desired-state/): How nodes reconcile published intent.
+
+## Operations
+
+- [CLI commands](https://docs.devopsellence.com/reference/cli/): AI-operator-safe command groups for deploys, status, logs, nodes, secrets, ingress, and skills.
+- [devopsellence.yml](https://docs.devopsellence.com/reference/devopsellence-yml/): App configuration schema.
+- [Ingress and TLS](https://docs.devopsellence.com/guides/ingress-tls/): Hostnames, DNS checks, and HTTPS verification.
+- [Rollback](https://docs.devopsellence.com/guides/rollback/): Rollback workflow and boundaries.
+
+## Optional
+
+- [Preview terms](https://www.devopsellence.com/terms): Terms for the public control plane.
+- [Privacy](https://www.devopsellence.com/privacy): Privacy information for the public control plane.

--- a/docs-website/public/llms.txt
+++ b/docs-website/public/llms.txt
@@ -1,0 +1,54 @@
+# devopsellence docs
+
+> Documentation for deploying and operating containerized apps on familiar VMs with devopsellence.
+
+devopsellence is AI-operator-first: commands should expose explicit plan/apply boundaries, structured status, deterministic errors, and ordinary-tool escape hatches. It targets Dockerized apps on VMs, not PaaS or Kubernetes-lite abstractions.
+
+Solo and shared are management topologies over the same deployment model. Solo is SSH-first local operation. Shared is control-plane-backed team operation where node agents pull published desired state.
+
+## Start
+
+- [Overview](https://docs.devopsellence.com/getting-started/overview/): Product overview and starting points.
+- [Install](https://docs.devopsellence.com/getting-started/install/): CLI installation and agent skill setup.
+- [Solo quickstart](https://docs.devopsellence.com/getting-started/solo-quickstart/): Shortest path to deploy an app to one VM.
+- [Shared overview](https://docs.devopsellence.com/getting-started/shared-overview/): Control-plane-backed workflow for teams.
+
+## Concepts
+
+- [Runtime model](https://docs.devopsellence.com/concepts/runtime-model/): Desired state, releases, services, tasks, nodes, status, and reconciliation.
+- [Solo and shared](https://docs.devopsellence.com/concepts/solo-and-shared/): Management topology differences and shared runtime semantics.
+- [Node agent and desired state](https://docs.devopsellence.com/concepts/agent-desired-state/): Agent reconciliation model.
+- [AI operator model](https://docs.devopsellence.com/concepts/agent-primary/): AI assistant as the primary operator acting for a human.
+
+## Guides
+
+- [Deploy with solo](https://docs.devopsellence.com/guides/solo-deploy/): Full solo deploy walkthrough.
+- [Deploy with shared](https://docs.devopsellence.com/guides/shared-deploy/): Shared-mode deploy workflow.
+- [GitHub Actions](https://docs.devopsellence.com/guides/github-actions/): CI integration.
+- [Secrets](https://docs.devopsellence.com/guides/secrets/): Secret management workflow.
+- [Supporting services](https://docs.devopsellence.com/guides/supporting-services/): Redis, Memcached, and similar companion services.
+- [Ingress and TLS](https://docs.devopsellence.com/guides/ingress-tls/): DNS, hostnames, Envoy ingress, and automatic TLS.
+- [Rollback](https://docs.devopsellence.com/guides/rollback/): Rollback workflow.
+- [Backup and restore](https://docs.devopsellence.com/guides/backup-restore/): State backup and recovery guidance.
+- [Troubleshooting](https://docs.devopsellence.com/guides/troubleshooting/): Diagnostic flow for common failures.
+- [Cleanup](https://docs.devopsellence.com/guides/cleanup/): Removing apps, nodes, and local state.
+
+## Examples
+
+- [Basecamp Fizzy on Rails](https://docs.devopsellence.com/examples/fizzy-rails-solo/): Rails app deployed with solo mode.
+- [Flue agents on Node.js](https://docs.devopsellence.com/examples/flue-node-solo/): Node.js webhook agent server deployed as an ordinary containerized service.
+
+## Reference
+
+- [devopsellence.yml](https://docs.devopsellence.com/reference/devopsellence-yml/): App configuration reference.
+- [CLI commands](https://docs.devopsellence.com/reference/cli/): Common command groups and examples.
+- [Result JSON](https://docs.devopsellence.com/reference/result-json/): Structured output contract for AI operators.
+- [Environment variables](https://docs.devopsellence.com/reference/environment-variables/): Supported environment variables.
+
+## Optional
+
+- [CloudStack VMs](https://docs.devopsellence.com/guides/cloudstack-vms/): Using CloudStack as an infrastructure source for VMs.
+- [Cloudprober](https://docs.devopsellence.com/guides/cloudprober/): User-managed monitoring workload guidance.
+- [Operate this docs site](https://docs.devopsellence.com/operate/docs-website/): How the docs website is built and deployed.
+- [Main website](https://www.devopsellence.com/): Product homepage and installer entry point.
+- [GitHub repository](https://github.com/devopsellence/devopsellence): Public source for devopsellence.


### PR DESCRIPTION
## Summary

Adds `/llms.txt` support for both public web properties:

- `control-plane/public/llms.txt` for `www.devopsellence.com`
- `docs-website/public/llms.txt` for `docs.devopsellence.com`

The main website file stays compact and points agents toward the docs, installer, product boundaries, and public repo. The docs-site file is a curated index across getting started, concepts, guides, examples, and reference pages.

Also updates the locked Nokogiri patch version from `1.19.2` to `1.19.3` after CI's `bundler-audit` flagged the previous lockfile version.

## Validation

- `npm ci` in `docs-website/`
- `npm run build` in `docs-website/`
- confirmed `docs-website/public/llms.txt` is copied byte-for-byte to `docs-website/dist/llms.txt`
- `git diff --check -- control-plane/Gemfile.lock control-plane/public/llms.txt docs-website/public/llms.txt`
- Ruby shape check for H1, summary blockquote, H2 sections, and markdown links in both files
- `bin/bundler-audit` in `control-plane/`
- Ruby lockfile check confirming all Nokogiri locked specs are `1.19.3`