### PR TITLE
[codex] Improve vibe app guidance and docs

### DIFF
--- a/cli/internal/agentskill/agentskill_test.go
+++ b/cli/internal/agentskill/agentskill_test.go
@@ -40,7 +40,12 @@ func TestInstallWritesAppSkillByID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadFile(%q) error = %v", path, err)
 	}
-	if !strings.Contains(string(data), "Go") || !strings.Contains(string(data), "vanilla") {
+	for _, want := range []string{"Go", "vanilla", "Do not add React", "Do not create a frontend build step", "docker build --target test ."} {
+		if !strings.Contains(string(data), want) {
+			t.Fatalf("%s missing %q", path, want)
+		}
+	}
+	if strings.Contains(string(data), "golangci-lint") || strings.Contains(string(data), "Motion library") {
 		t.Fatalf("%s does not look like the app skill", path)
 	}
 }

--- a/cli/internal/agentskill/agentskill_test.go
+++ b/cli/internal/agentskill/agentskill_test.go
@@ -40,7 +40,7 @@ func TestInstallWritesAppSkillByID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadFile(%q) error = %v", path, err)
 	}
-	for _, want := range []string{"Go", "vanilla", "Do not add React", "Do not create a frontend build step", "docker build --target test ."} {
+	for _, want := range []string{"Go", "vanilla", "Do not add React", "Do not create a frontend build step", "subtraction pass", "docker build --target test ."} {
 		if !strings.Contains(string(data), want) {
 			t.Fatalf("%s missing %q", path, want)
 		}

--- a/cli/internal/agentskill/devopsellence-app/SKILL.md
+++ b/cli/internal/agentskill/devopsellence-app/SKILL.md
@@ -6,20 +6,85 @@ homepage: https://www.devopsellence.com
 
 # devopsellence app
 
-Use this skill when building the web app created by `devopsellence vibe`.
+Use this skill when building or iterating on the web app created by
+`devopsellence vibe`.
 
-Product shape:
+Mission:
 
-- Build one deployable web app, not a stack selection.
-- Use Go for the backend.
-- Use standard web platform pieces first: HTML, CSS, forms, and small vanilla JavaScript only when it improves the workflow.
-- Prefer `net/http`, `html/template`, and SQLite for the first durable version.
-- Keep the Dockerfile and `devopsellence.yml` current as the app changes.
-- Keep Docker as the required local tool. Go may be installed locally, but the Dockerfile owns the portable build and test path.
+- Turn the user's idea into one polished, deployable native-web app.
+- Keep the app understandable enough that a human can inspect, edit, deploy,
+  and revert it without learning a framework-specific stack.
+- Treat the generated app as a durable product baseline, not a throwaway demo.
 
-Development loop:
+Hard constraints:
 
-1. Preserve the generated app as a working baseline before adding features.
-2. Run `docker build --target test .` after backend changes.
-3. Run `docker build .` when deployment files changed.
-4. Keep the app usable without a frontend build step unless the user explicitly asks for one.
+- Use Go, `net/http`, `html/template`, SQLite, semantic HTML, handcrafted CSS,
+  and small vanilla JavaScript.
+- Do not add React, Vue, Svelte, Next, Astro, HTMX, Tailwind, npm, Vite,
+  bundlers, transpilers, frontend package managers, or CDN UI kits unless the
+  user explicitly overrides this constraint.
+- Do not create a frontend build step.
+- Prefer server-rendered pages, HTML forms, POST/redirect/GET, and progressive
+  enhancement before client-side state.
+- Keep Docker as the portable local tool. Go may be installed locally, but the
+  Dockerfile owns the repeatable build and test path.
+- Keep `devopsellence.yml`, the Dockerfile, health checks, ports, and persistent
+  volume wiring current as the app changes.
+
+Work loop:
+
+1. Preserve the generated baseline and understand the user's app idea.
+2. Derive the smallest real product workflow that proves the app concept.
+3. Make a short implementation plan with data model, pages, actions, and states.
+4. Implement in small reversible slices; commit/checkpoint before risky changes
+   when git is available.
+5. Run `docker build --target test .` after backend or data changes.
+6. Run `docker build .` after Dockerfile or deploy-surface changes.
+7. Keep the app deployable after every feature slice.
+
+Product shaping:
+
+- Start from the user's actual workflow, not generic CRUD scaffolding.
+- Name domain concepts in user language.
+- Build complete first-use, empty, success, validation, and error states.
+- Prefer one coherent app flow over many shallow pages.
+- Mark larger ideas as follow-ups instead of adding hidden abstractions early.
+
+Go implementation:
+
+- Keep handlers small and explicit.
+- Pass `context.Context` into database work and use bounded timeouts for writes
+  or reads that can block.
+- Check and return errors deliberately; use redirects for successful form
+  submissions.
+- Keep schema migrations simple and append-only in code until the user needs a
+  migration system.
+- Write table-driven tests for handlers, validation, persistence, and security
+  boundaries that matter.
+- Do not add goroutines, background jobs, queues, caches, or service layers
+  unless the product need is clear.
+
+Native UI craft:
+
+- Use semantic HTML first: forms, labels, buttons, headings, tables, lists,
+  `dialog`, `details`, and native validation where they fit.
+- Use CSS custom properties, modern selectors, grid, flexbox, container queries,
+  and media queries for responsive layouts.
+- Choose a clear visual direction that matches the app's domain, but keep it
+  practical and maintainable.
+- Avoid generic AI card soup, placeholder-heavy layouts, oversized marketing
+  sections, and decorative effects that obscure the workflow.
+- Add vanilla JavaScript only for direct interaction wins such as optimistic
+  affordances, dialogs, inline filtering, previews, or keyboard ergonomics.
+- Keep JavaScript optional where reasonable; the core workflow should survive a
+  plain form submit.
+
+Deploy readiness:
+
+- Keep `/healthz` fast and tied to real app readiness.
+- Keep runtime configuration in env vars and `devopsellence.yml`, not hardcoded
+  secrets.
+- Keep persistent data under `/data` when deploying with the generated volume.
+- Use `devopsellence deploy --dry-run` before a real deploy.
+- After deploy, report status, logs, health, and public URL evidence when
+  ingress is configured.

--- a/cli/internal/agentskill/devopsellence-app/SKILL.md
+++ b/cli/internal/agentskill/devopsellence-app/SKILL.md
@@ -38,9 +38,12 @@ Work loop:
 3. Make a short implementation plan with data model, pages, actions, and states.
 4. Implement in small reversible slices; commit/checkpoint before risky changes
    when git is available.
-5. Run `docker build --target test .` after backend or data changes.
-6. Run `docker build .` after Dockerfile or deploy-surface changes.
-7. Keep the app deployable after every feature slice.
+5. After each slice, run a subtraction pass: remove unused routes, handlers,
+   styles, helpers, placeholder content, stale tests, and speculative
+   abstractions while preserving user-confirmed behavior.
+6. Run `docker build --target test .` after backend or data changes.
+7. Run `docker build .` after Dockerfile or deploy-surface changes.
+8. Keep the app deployable after every feature slice.
 
 Product shaping:
 
@@ -49,6 +52,8 @@ Product shaping:
 - Build complete first-use, empty, success, validation, and error states.
 - Prefer one coherent app flow over many shallow pages.
 - Mark larger ideas as follow-ups instead of adding hidden abstractions early.
+- Prefer subtraction and clearer existing code over new abstractions; add
+  structure only when it removes real complexity.
 
 Go implementation:
 

--- a/cli/internal/workflow/root_test.go
+++ b/cli/internal/workflow/root_test.go
@@ -398,7 +398,7 @@ func TestRootVibePreparesGoWebWorkspace(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(prompt), "/goal") || !strings.Contains(string(prompt), "A tiny CRM") || !strings.Contains(string(prompt), "Deployment intent") || !strings.Contains(string(prompt), "Agent autonomy") || !strings.Contains(string(prompt), "ask the user to confirm before changing app behavior") || !strings.Contains(string(prompt), "Before any production mutation") || !strings.Contains(string(prompt), "Go, net/http") || !strings.Contains(string(prompt), "vanilla HTML/CSS/JavaScript") {
+	if !strings.Contains(string(prompt), "/goal") || !strings.Contains(string(prompt), "A tiny CRM") || !strings.Contains(string(prompt), "Deployment intent") || !strings.Contains(string(prompt), "Agent autonomy") || !strings.Contains(string(prompt), "ask the user to confirm before changing app behavior") || !strings.Contains(string(prompt), "Before any production mutation") || !strings.Contains(string(prompt), "Go, net/http") || !strings.Contains(string(prompt), "vanilla HTML/CSS/JavaScript") || !strings.Contains(string(prompt), "Do not introduce a frontend framework") {
 		t.Fatalf("prompt = %q, want seeded codex prompt", prompt)
 	}
 	for _, unwanted := range []string{"App stack", "Rails", "index.php", "stack-expansion"} {
@@ -410,7 +410,7 @@ func TestRootVibePreparesGoWebWorkspace(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(appSkill), "Go") || !strings.Contains(string(appSkill), "vanilla") || strings.Contains(string(appSkill), "Rails") || strings.Contains(string(appSkill), "index.php") {
+	if !strings.Contains(string(appSkill), "Go") || !strings.Contains(string(appSkill), "vanilla") || !strings.Contains(string(appSkill), "Do not add React") || !strings.Contains(string(appSkill), "Do not create a frontend build step") || strings.Contains(string(appSkill), "Rails") || strings.Contains(string(appSkill), "index.php") {
 		t.Fatalf("app skill = %q, want Go and vanilla web guidance", appSkill)
 	}
 	nextCommands := jsonArrayFromMap(t, payload, "next_commands")

--- a/cli/internal/workflow/root_test.go
+++ b/cli/internal/workflow/root_test.go
@@ -398,7 +398,7 @@ func TestRootVibePreparesGoWebWorkspace(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(prompt), "/goal") || !strings.Contains(string(prompt), "A tiny CRM") || !strings.Contains(string(prompt), "Deployment intent") || !strings.Contains(string(prompt), "Agent autonomy") || !strings.Contains(string(prompt), "ask the user to confirm before changing app behavior") || !strings.Contains(string(prompt), "Before any production mutation") || !strings.Contains(string(prompt), "Go, net/http") || !strings.Contains(string(prompt), "vanilla HTML/CSS/JavaScript") || !strings.Contains(string(prompt), "Do not introduce a frontend framework") {
+	if !strings.Contains(string(prompt), "/goal") || !strings.Contains(string(prompt), "A tiny CRM") || !strings.Contains(string(prompt), "Deployment intent") || !strings.Contains(string(prompt), "Agent autonomy") || !strings.Contains(string(prompt), "ask the user to confirm before changing app behavior") || !strings.Contains(string(prompt), "Before any production mutation") || !strings.Contains(string(prompt), "Go, net/http") || !strings.Contains(string(prompt), "vanilla HTML/CSS/JavaScript") || !strings.Contains(string(prompt), "Do not introduce a frontend framework") || !strings.Contains(string(prompt), "subtraction pass") {
 		t.Fatalf("prompt = %q, want seeded codex prompt", prompt)
 	}
 	for _, unwanted := range []string{"App stack", "Rails", "index.php", "stack-expansion"} {

--- a/cli/internal/workflow/root_test.go
+++ b/cli/internal/workflow/root_test.go
@@ -398,8 +398,21 @@ func TestRootVibePreparesGoWebWorkspace(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(prompt), "/goal") || !strings.Contains(string(prompt), "A tiny CRM") || !strings.Contains(string(prompt), "Deployment intent") || !strings.Contains(string(prompt), "Agent autonomy") || !strings.Contains(string(prompt), "ask the user to confirm before changing app behavior") || !strings.Contains(string(prompt), "Before any production mutation") || !strings.Contains(string(prompt), "Go, net/http") || !strings.Contains(string(prompt), "vanilla HTML/CSS/JavaScript") || !strings.Contains(string(prompt), "Do not introduce a frontend framework") || !strings.Contains(string(prompt), "subtraction pass") {
-		t.Fatalf("prompt = %q, want seeded codex prompt", prompt)
+	for _, want := range []string{
+		"/goal",
+		"A tiny CRM",
+		"Deployment intent",
+		"Agent autonomy",
+		"ask the user to confirm before changing app behavior",
+		"Before any production mutation",
+		"Go, net/http",
+		"vanilla HTML/CSS/JavaScript",
+		"Do not introduce a frontend framework",
+		"subtraction pass",
+	} {
+		if !strings.Contains(string(prompt), want) {
+			t.Fatalf("prompt = %q, missing %q", prompt, want)
+		}
 	}
 	for _, unwanted := range []string{"App stack", "Rails", "index.php", "stack-expansion"} {
 		if strings.Contains(string(prompt), unwanted) {
@@ -410,8 +423,15 @@ func TestRootVibePreparesGoWebWorkspace(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(appSkill), "Go") || !strings.Contains(string(appSkill), "vanilla") || !strings.Contains(string(appSkill), "Do not add React") || !strings.Contains(string(appSkill), "Do not create a frontend build step") || strings.Contains(string(appSkill), "Rails") || strings.Contains(string(appSkill), "index.php") {
-		t.Fatalf("app skill = %q, want Go and vanilla web guidance", appSkill)
+	for _, want := range []string{"Go", "vanilla", "Do not add React", "Do not create a frontend build step", "subtraction pass"} {
+		if !strings.Contains(string(appSkill), want) {
+			t.Fatalf("app skill = %q, missing %q", appSkill, want)
+		}
+	}
+	for _, unwanted := range []string{"Rails", "index.php"} {
+		if strings.Contains(string(appSkill), unwanted) {
+			t.Fatalf("app skill = %q, should not contain %q", appSkill, unwanted)
+		}
 	}
 	nextCommands := jsonArrayFromMap(t, payload, "next_commands")
 	if !jsonArrayContains(nextCommands, "codex --sandbox 'workspace-write' --ask-for-approval 'on-request' -c 'model_reasoning_effort=\"high\"' 'Read .agents/prompts/devopsellence-vibe.md and follow it.'") {

--- a/cli/internal/workflow/vibe.go
+++ b/cli/internal/workflow/vibe.go
@@ -833,7 +833,7 @@ func vibePrompt(agent, autonomy string, idea string, intent vibeDeploymentIntent
 		"Use .agents/skills/devopsellence for deploy, secrets, logs, status, rollback, and node operations.",
 		vibePlanApprovalPromptLine(autonomy),
 		"Build with Go, net/http, html/template, SQLite, Docker, and vanilla HTML/CSS/JavaScript.",
-		"Keep the app usable without a frontend build step unless the user explicitly asks for one.",
+		"Do not introduce a frontend framework, npm, bundler, transpiler, Tailwind, or frontend build step unless the user explicitly asks for one.",
 		"",
 		"Deployment rules:",
 		"- Do not write provider tokens, API keys, passwords, or secret values into prompts, manifests, git, logs, or commits.",

--- a/cli/internal/workflow/vibe.go
+++ b/cli/internal/workflow/vibe.go
@@ -834,6 +834,7 @@ func vibePrompt(agent, autonomy string, idea string, intent vibeDeploymentIntent
 		vibePlanApprovalPromptLine(autonomy),
 		"Build with Go, net/http, html/template, SQLite, Docker, and vanilla HTML/CSS/JavaScript.",
 		"Do not introduce a frontend framework, npm, bundler, transpiler, Tailwind, or frontend build step unless the user explicitly asks for one.",
+		"After each feature slice, do a subtraction pass: remove unused scaffolding, duplicate code, stale styles, placeholder content, and speculative abstractions while preserving user-confirmed behavior.",
 		"",
 		"Deployment rules:",
 		"- Do not write provider tokens, API keys, passwords, or secret values into prompts, manifests, git, logs, or commits.",

--- a/docs-website/astro.config.mjs
+++ b/docs-website/astro.config.mjs
@@ -24,6 +24,7 @@ export default defineConfig({
           items: [
             { label: "Overview", link: "/getting-started/overview/" },
             { label: "Install", link: "/getting-started/install/" },
+            { label: "Build with vibe", link: "/getting-started/vibe/" },
             { label: "Solo quickstart", link: "/getting-started/solo-quickstart/" },
             { label: "Shared overview", link: "/getting-started/shared-overview/" },
           ],
@@ -35,6 +36,7 @@ export default defineConfig({
             { label: "Solo and shared", link: "/concepts/solo-and-shared/" },
             { label: "Node agent and desired state", link: "/concepts/agent-desired-state/" },
             { label: "AI operator model", link: "/concepts/agent-primary/" },
+            { label: "Vibe philosophy", link: "/concepts/vibe-philosophy/" },
           ],
         },
         {

--- a/docs-website/src/content/docs/concepts/vibe-philosophy.md
+++ b/docs-website/src/content/docs/concepts/vibe-philosophy.md
@@ -64,7 +64,7 @@ The generated `devopsellence-app` skill carries the harder product guidance:
 That split keeps the codebase small while still giving the agent enough taste
 and discipline to build a good app.
 
-## Replit-like, but inspectable
+## AI app-builder feel, inspectable output
 
 `vibe` can feel like an AI app builder because the user starts with an idea and
 an agent does the work. The difference is the ownership model.

--- a/docs-website/src/content/docs/concepts/vibe-philosophy.md
+++ b/docs-website/src/content/docs/concepts/vibe-philosophy.md
@@ -59,10 +59,23 @@ The generated `devopsellence-app` skill carries the harder product guidance:
 - build complete empty, success, validation, and error states;
 - use vanilla JavaScript only for progressive enhancement;
 - keep every slice deployable;
+- run regular subtraction passes so unused scaffolding, stale styles, duplicate
+  helpers, placeholder UI, and speculative abstractions do not accumulate;
 - checkpoint changes so iteration and revert stay natural.
 
 That split keeps the codebase small while still giving the agent enough taste
 and discipline to build a good app.
+
+## Subtraction as quality control
+
+Vibe-generated apps should get clearer as they mature. Every iteration should
+ask what can be removed, merged, or simplified before adding another route,
+helper, table, style block, or interaction.
+
+Subtraction is not permission to delete confirmed product behavior. It is the
+habit of removing leftovers: unused routes, duplicate code, stale tests,
+placeholder copy, speculative abstractions, and UI states that no longer serve
+the app.
 
 ## AI app-builder feel, inspectable output
 

--- a/docs-website/src/content/docs/concepts/vibe-philosophy.md
+++ b/docs-website/src/content/docs/concepts/vibe-philosophy.md
@@ -1,0 +1,93 @@
+---
+title: Vibe philosophy
+description: Why devopsellence vibe uses a tiny native-web template and stronger agent instructions instead of a full app framework.
+---
+
+`devopsellence vibe` is an AI app-building entrypoint, not a framework starter.
+Its job is to give an agent a clean workspace, a deployable baseline, and strong
+instructions for building a real web app with ordinary web technologies.
+
+The template stays intentionally small. The leverage lives in the skill.
+
+## Native web first
+
+The default stack is:
+
+- Go for the backend.
+- SQLite for durable local data.
+- Server-rendered HTML.
+- Handcrafted CSS.
+- Small vanilla JavaScript only when it improves an interaction.
+- Docker for the portable build and test path.
+- devopsellence for deployment to familiar VMs.
+
+Browsers keep getting more capable. HTML forms, CSS layout, native validation,
+`dialog`, `details`, URL APIs, fetch, and storage primitives cover a lot of app
+surface without a frontend framework or build chain.
+
+## What vibe avoids
+
+The generated app should not start with:
+
+- React, Vue, Svelte, Next, Astro, or another frontend framework.
+- npm, Vite, bundlers, transpilers, or frontend package managers.
+- Tailwind, component libraries, CDN UI kits, or generic design systems.
+- Client-side routing as the default app model.
+- A stack selector.
+
+Those tools can be useful elsewhere. `vibe` chooses not to make them the
+starting point because every new tool adds churn, hidden conventions, and more
+surface area for an agent to manage.
+
+## Skills over scaffolding
+
+The app template should be understandable in a few minutes. It exists to provide
+a safe shape:
+
+- routes;
+- templates;
+- static assets;
+- SQLite setup;
+- tests;
+- Docker;
+- `devopsellence.yml`.
+
+The generated `devopsellence-app` skill carries the harder product guidance:
+
+- derive the first real workflow from the user's idea;
+- keep the UI semantic, responsive, and accessible;
+- build complete empty, success, validation, and error states;
+- use vanilla JavaScript only for progressive enhancement;
+- keep every slice deployable;
+- checkpoint changes so iteration and revert stay natural.
+
+That split keeps the codebase small while still giving the agent enough taste
+and discipline to build a good app.
+
+## Replit-like, but inspectable
+
+`vibe` can feel like an AI app builder because the user starts with an idea and
+an agent does the work. The difference is the ownership model.
+
+The output is an ordinary repository with ordinary files. A human can inspect the
+handlers, templates, CSS, Dockerfile, SQLite schema, and deployment config. The
+agent can iterate with git. devopsellence can deploy the result to ordinary
+Linux VMs.
+
+The product promise is not magic. It is a narrow, repeatable path from idea to
+native-web app to VM deployment.
+
+## Quality bar
+
+A good vibe-generated app should:
+
+- solve one real workflow well;
+- load fast without a frontend build artifact;
+- work with normal forms before JavaScript enhancement;
+- look intentionally designed for its domain;
+- expose clear health and error states;
+- keep secrets out of prompts, commits, and logs;
+- pass `docker build --target test .`;
+- remain deployable with `devopsellence deploy --dry-run`.
+
+The goal is durable software, not a throwaway mockup.

--- a/docs-website/src/content/docs/getting-started/overview.md
+++ b/docs-website/src/content/docs/getting-started/overview.md
@@ -11,6 +11,12 @@ The immediate solo-mode value is an operator-safe deployment loop: dry-run,
 deploy, status, doctor, logs, exec, secrets, rollback, DNS checks, and HTTPS
 verification with structured output an AI assistant can act on.
 
+For new apps, `devopsellence vibe` creates a small native-web Go workspace and a
+project-local app-building skill so an AI agent can turn an idea into a
+deployable app without introducing a frontend framework or build system. See
+[Build with vibe](/getting-started/vibe/) and
+[Vibe philosophy](/concepts/vibe-philosophy/).
+
 The system has three product surfaces:
 
 - **Node agent**: runs on each node and reconciles containers, Envoy ingress,

--- a/docs-website/src/content/docs/getting-started/vibe.md
+++ b/docs-website/src/content/docs/getting-started/vibe.md
@@ -43,7 +43,9 @@ The intended loop is:
 3. The app stays native-web: Go, SQLite, HTML, CSS, and small vanilla JavaScript.
 4. The agent runs `docker build --target test .` while changing app behavior.
 5. The agent keeps Docker and `devopsellence.yml` deploy-ready as the app grows.
-6. Before a real deploy, the agent runs `devopsellence deploy --dry-run`.
+6. After each feature slice, the agent does a subtraction pass to remove unused
+   routes, styles, helpers, placeholder UI, and speculative abstractions.
+7. Before a real deploy, the agent runs `devopsellence deploy --dry-run`.
 
 `vibe` does not ask the agent to invent a stack. It gives the agent a narrow
 workspace and a high-quality set of product and implementation instructions.

--- a/docs-website/src/content/docs/getting-started/vibe.md
+++ b/docs-website/src/content/docs/getting-started/vibe.md
@@ -1,0 +1,99 @@
+---
+title: Build an app with vibe
+description: Use devopsellence vibe to create a native-web Go app that an AI agent can build, test, and deploy.
+---
+
+`devopsellence vibe` creates an agent-ready app workspace. It is for the moment
+when you have an app idea and want an AI coding agent to turn it into a
+deployable web app without choosing a frontend framework, package manager, or
+build system.
+
+```bash
+curl -fsSL https://www.devopsellence.com/lfg.sh | bash
+~/.local/bin/devopsellence vibe my-app --idea "A tiny CRM for solo consultants"
+cd ~/devopsellence-projects/my-app
+codex "Read .agents/prompts/devopsellence-vibe.md and follow it."
+```
+
+The command writes a small Go web app, a Dockerfile, `devopsellence.yml`, an
+initial git commit, and project-local agent skills. The generated prompt tells
+the agent what to build and where the boundaries are.
+
+## What it creates
+
+The generated app starts with:
+
+- Go `net/http` handlers and `html/template` pages.
+- SQLite storage.
+- Semantic HTML, one CSS file, and no frontend build step.
+- A Dockerfile with a `test` target.
+- `devopsellence.yml` with the default web service, health check, and `/data`
+  volume.
+- `.agents/skills/devopsellence-app`, the app-building skill used by the agent.
+- `.agents/skills/devopsellence`, the deploy and operations skill.
+- `.agents/prompts/devopsellence-vibe.md`, the prompt to hand to the agent.
+
+## Agent loop
+
+The intended loop is:
+
+1. The agent reads `.agents/prompts/devopsellence-vibe.md`.
+2. The agent uses `.agents/skills/devopsellence-app/SKILL.md` to shape and build
+   the product.
+3. The app stays native-web: Go, SQLite, HTML, CSS, and small vanilla JavaScript.
+4. The agent runs `docker build --target test .` while changing app behavior.
+5. The agent keeps Docker and `devopsellence.yml` deploy-ready as the app grows.
+6. Before a real deploy, the agent runs `devopsellence deploy --dry-run`.
+
+`vibe` does not ask the agent to invent a stack. It gives the agent a narrow
+workspace and a high-quality set of product and implementation instructions.
+
+## Local checks
+
+The generated app can be checked with Docker only:
+
+```bash
+./scripts/check
+docker build .
+```
+
+If Go is installed locally, the agent may also run:
+
+```bash
+go test ./...
+go run .
+```
+
+The Docker path is the portable contract. Local Go is just a convenience.
+
+## Deploy
+
+When the app is ready:
+
+```bash
+devopsellence deploy --dry-run
+devopsellence deploy
+devopsellence status
+```
+
+For solo mode, attach a node first if the workspace does not already have one:
+
+```bash
+devopsellence node create prod-1 --provider hetzner --install --attach
+```
+
+Use [Deploy with solo](/guides/solo-deploy/) for the full node setup and deploy
+flow.
+
+## When to use it
+
+Use `vibe` for new small-to-medium web apps where you want:
+
+- an AI agent to do the implementation work;
+- source code that remains easy to inspect and edit;
+- no frontend framework or JavaScript build pipeline;
+- a deploy path to ordinary VMs with devopsellence.
+
+Start from an existing app instead when you already have a working codebase.
+Install the deploy skill with `devopsellence skill install` and ask the agent to
+deploy that app.

--- a/docs-website/src/content/docs/index.md
+++ b/docs-website/src/content/docs/index.md
@@ -36,6 +36,9 @@ codex "deploy with devopsellence solo"
 `devopsellence skill install` installs the matching AI agent skill from the CLI
 itself.
 
+- [Build with vibe](/getting-started/vibe/) for starting from an app idea and
+  letting an AI agent build a native-web Go app with no frontend framework or
+  build system.
 - [Solo quickstart](/getting-started/solo-quickstart/) for the shortest path to
   one VM.
 - [Ingress and TLS](/guides/ingress-tls/) for hostnames, DNS checks, and HTTPS
@@ -47,6 +50,8 @@ itself.
 - [AI operator model](/concepts/agent-primary/) for the product thesis: a CLI
   that gives AI operators structured feedback, safe boundaries, and facts they
   can compose with the user's tools.
+- [Vibe philosophy](/concepts/vibe-philosophy/) for why vibe keeps the template
+  lean and puts the app-building discipline in a project-local skill.
 - [Runtime model](/concepts/runtime-model/) for desired state, releases,
   services, nodes, and status.
 - [CLI reference](/reference/cli/) for the AI-operator-safe command surface.

--- a/docs-website/src/content/docs/reference/cli.md
+++ b/docs-website/src/content/docs/reference/cli.md
@@ -9,6 +9,7 @@ operators and use explicit plan/apply boundaries.
 ## Workspace
 
 ```bash
+devopsellence vibe my-app --idea "A tiny CRM for solo consultants"
 devopsellence init --mode solo
 devopsellence init --mode shared
 devopsellence context show


### PR DESCRIPTION
## Summary
- strengthen the embedded devopsellence-app skill into the single app-building guide for vibe-generated apps
- make vibe prompts/tests enforce Go plus native HTML/CSS/vanilla JS with no frontend build step
- add docs for building with vibe and the lean native-web philosophy, with sidebar/index/CLI reference links

## Validation
- mise exec -- go test ./internal/agentskill
- mise exec -- go test ./internal/workflow -run 'TestRootVibe|TestVibe|TestRootSkill|TestBundledSkill|TestNormalizeVibe|TestTruncateVibe'
- npm run check (docs-website)
- npm run build (docs-website)
- git diff --check
- generated-app smoke: devopsellence vibe --no-agent, ./scripts/check, docker build
- TMPDIR=/home/elvin/Work/devopsellence-cli-test.* mise run test:cli