### PR TITLE
[codex] Improve vibe neutral app readiness

### DIFF
--- a/cli/internal/agentskill/agentskill_test.go
+++ b/cli/internal/agentskill/agentskill_test.go
@@ -40,7 +40,7 @@ func TestInstallWritesAppSkillByID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadFile(%q) error = %v", path, err)
 	}
-	for _, want := range []string{"Go", "vanilla", "Do not add React", "Do not create a frontend build step", "subtraction pass", "docker build --target test ."} {
+	for _, want := range []string{"Go", "vanilla", "Do not add React", "Do not create a frontend build step", "subtraction pass", "./scripts/check", "Pattern snippets"} {
 		if !strings.Contains(string(data), want) {
 			t.Fatalf("%s missing %q", path, want)
 		}

--- a/cli/internal/agentskill/devopsellence-app/SKILL.md
+++ b/cli/internal/agentskill/devopsellence-app/SKILL.md
@@ -33,17 +33,21 @@ Hard constraints:
 
 Work loop:
 
-1. Preserve the generated baseline and understand the user's app idea.
+1. Understand the user's app idea and treat the generated app shell as a
+   deploy-ready starting point, not product behavior.
 2. Derive the smallest real product workflow that proves the app concept.
 3. Make a short implementation plan with data model, pages, actions, and states.
-4. Implement in small reversible slices; commit/checkpoint before risky changes
+4. After confirmation when the prompt requires it, delete or rewrite generated
+   shell code, routes, content, styles, and tests that do not serve the idea.
+5. Implement in small reversible slices; commit/checkpoint before risky changes
    when git is available.
-5. After each slice, run a subtraction pass: remove unused routes, handlers,
+6. After each slice, run a subtraction pass: remove unused routes, handlers,
    styles, helpers, placeholder content, stale tests, and speculative
    abstractions while preserving user-confirmed behavior.
-6. Run `docker build --target test .` after backend or data changes.
-7. Run `docker build .` after Dockerfile or deploy-surface changes.
-8. Keep the app deployable after every feature slice.
+7. Run `go test ./...` after backend or data changes.
+8. Run `./scripts/check` before treating the app as deploy-ready.
+9. Run `./scripts/smoke` against a running local server after UI or HTTP changes.
+10. Keep the app deployable after every feature slice.
 
 Product shaping:
 
@@ -69,6 +73,57 @@ Go implementation:
 - Do not add goroutines, background jobs, queues, caches, or service layers
   unless the product need is clear.
 
+Pattern snippets:
+
+Use these as shape examples, not as product scaffolding to preserve.
+
+Root route:
+
+```go
+func (a *app) home(w http.ResponseWriter, r *http.Request) {
+  if err := a.templates.ExecuteTemplate(w, "index.html", data); err != nil {
+    http.Error(w, "could not render page", http.StatusInternalServerError)
+  }
+}
+```
+
+SQLite-backed readiness:
+
+```go
+func (a *app) health(w http.ResponseWriter, r *http.Request) {
+  ctx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
+  defer cancel()
+  var ok int
+  if err := a.db.QueryRowContext(ctx, `SELECT 1`).Scan(&ok); err != nil {
+    http.Error(w, "database unavailable", http.StatusServiceUnavailable)
+    return
+  }
+  w.WriteHeader(http.StatusNoContent)
+}
+```
+
+Handler test shape:
+
+```go
+response := httptest.NewRecorder()
+request := httptest.NewRequest(http.MethodGet, "/", nil)
+application.routes().ServeHTTP(response, request)
+if response.Code != http.StatusOK {
+  t.Fatalf("expected 200, got %d", response.Code)
+}
+```
+
+Static traversal guard:
+
+```go
+response := httptest.NewRecorder()
+request := httptest.NewRequest(http.MethodGet, "/static/../templates/index.html", nil)
+application.routes().ServeHTTP(response, request)
+if response.Code == http.StatusOK {
+  t.Fatal("static traversal returned 200")
+}
+```
+
 Native UI craft:
 
 - Use semantic HTML first: forms, labels, buttons, headings, tables, lists,
@@ -90,6 +145,14 @@ Deploy readiness:
 - Keep runtime configuration in env vars and `devopsellence.yml`, not hardcoded
   secrets.
 - Keep persistent data under `/data` when deploying with the generated volume.
+- Keep `scripts/dev`, `scripts/smoke`, and `scripts/check` current as routes,
+  text, health behavior, ports, or deploy config change.
+- Before handoff, the machine-checkable baseline is `go test ./...`,
+  `./scripts/check`, local smoke when HTTP behavior changed, and
+  `devopsellence deploy --dry-run`.
+- If no server is selected yet, the acceptable dry-run blocker is the explicit
+  no-node/no-attachment message. Mode unset, invalid config, build failure, or
+  health mismatch is not acceptable.
 - Use `devopsellence deploy --dry-run` before a real deploy.
 - After deploy, report status, logs, health, and public URL evidence when
   ingress is configured.

--- a/cli/internal/agentskill/devopsellence-app/SKILL.md
+++ b/cli/internal/agentskill/devopsellence-app/SKILL.md
@@ -81,9 +81,13 @@ Root route:
 
 ```go
 func (a *app) home(w http.ResponseWriter, r *http.Request) {
-  if err := a.templates.ExecuteTemplate(w, "index.html", data); err != nil {
+  var body bytes.Buffer
+  if err := a.templates.ExecuteTemplate(&body, "index.html", data); err != nil {
     http.Error(w, "could not render page", http.StatusInternalServerError)
+    return
   }
+  w.Header().Set("Content-Type", "text/html; charset=utf-8")
+  _, _ = body.WriteTo(w)
 }
 ```
 

--- a/cli/internal/workflow/mode.go
+++ b/cli/internal/workflow/mode.go
@@ -33,17 +33,21 @@ func normalizeMode(value string) (Mode, error) {
 	}
 }
 
-func (a *App) modeWorkspaceKey() string {
-	if discovered, err := discovery.Discover(a.Cwd); err == nil && strings.TrimSpace(discovered.WorkspaceRoot) != "" {
+func modeWorkspaceKeyFor(cwd string) string {
+	if discovered, err := discovery.Discover(cwd); err == nil && strings.TrimSpace(discovered.WorkspaceRoot) != "" {
 		if path, absErr := filepath.Abs(discovered.WorkspaceRoot); absErr == nil {
 			return path
 		}
 		return discovered.WorkspaceRoot
 	}
-	if path, err := filepath.Abs(a.Cwd); err == nil {
+	if path, err := filepath.Abs(cwd); err == nil {
 		return path
 	}
-	return a.Cwd
+	return cwd
+}
+
+func (a *App) modeWorkspaceKey() string {
+	return modeWorkspaceKeyFor(a.Cwd)
 }
 
 func (a *App) savedMode() (Mode, bool, error) {
@@ -83,6 +87,14 @@ func (a *App) savedEnvironment() (string, bool, error) {
 }
 
 func (a *App) SetMode(mode Mode) error {
+	return a.setModeForKey(a.modeWorkspaceKey(), mode)
+}
+
+func (a *App) SetModeForPath(path string, mode Mode) error {
+	return a.setModeForKey(modeWorkspaceKeyFor(path), mode)
+}
+
+func (a *App) setModeForKey(key string, mode Mode) error {
 	if a.WorkspaceState == nil {
 		return nil
 	}
@@ -91,7 +103,7 @@ func (a *App) SetMode(mode Mode) error {
 		if modes == nil {
 			modes = map[string]any{}
 		}
-		modes[a.modeWorkspaceKey()] = string(mode)
+		modes[key] = string(mode)
 		current["modes"] = modes
 		return current, nil
 	})

--- a/cli/internal/workflow/root_test.go
+++ b/cli/internal/workflow/root_test.go
@@ -378,6 +378,8 @@ func TestRootVibePreparesGoWebWorkspace(t *testing.T) {
 		filepath.Join(appDir, "Dockerfile"),
 		filepath.Join(appDir, "devopsellence.yml"),
 		filepath.Join(appDir, "scripts", "check"),
+		filepath.Join(appDir, "scripts", "dev"),
+		filepath.Join(appDir, "scripts", "smoke"),
 		filepath.Join(appDir, ".agents", "skills", "devopsellence", "SKILL.md"),
 		filepath.Join(appDir, ".agents", "skills", "devopsellence-app", "SKILL.md"),
 		filepath.Join(appDir, ".agents", "devopsellence-vibe.json"),
@@ -386,12 +388,22 @@ func TestRootVibePreparesGoWebWorkspace(t *testing.T) {
 			t.Fatalf("expected %s: %v", path, err)
 		}
 	}
-	info, err := os.Stat(filepath.Join(appDir, "scripts", "check"))
-	if err != nil {
-		t.Fatal(err)
+	for _, script := range []string{"check", "dev", "smoke"} {
+		info, err := os.Stat(filepath.Join(appDir, "scripts", script))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Mode()&0o111 == 0 {
+			t.Fatalf("scripts/%s is not executable", script)
+		}
 	}
-	if info.Mode()&0o111 == 0 {
-		t.Fatalf("scripts/check is not executable")
+	modeApp := NewApp(bytes.NewBuffer(nil), &stdout, &stdout, appDir)
+	mode, ok, modeErr := modeApp.savedMode()
+	if modeErr != nil {
+		t.Fatalf("savedMode error = %v", modeErr)
+	}
+	if !ok || mode != ModeSolo {
+		t.Fatalf("saved mode = %q, %v; want solo, true", mode, ok)
 	}
 	promptPath := filepath.Join(appDir, ".agents", "prompts", "devopsellence-vibe.md")
 	prompt, err := os.ReadFile(promptPath)
@@ -408,6 +420,9 @@ func TestRootVibePreparesGoWebWorkspace(t *testing.T) {
 		"Go, net/http",
 		"vanilla HTML/CSS/JavaScript",
 		"Do not introduce a frontend framework",
+		"Deploy-readiness checklist",
+		"devopsellence deploy --dry-run must either succeed or report the expected no-node blocker",
+		"after confirmation, delete or rewrite generated shell code",
 		"subtraction pass",
 	} {
 		if !strings.Contains(string(prompt), want) {
@@ -423,7 +438,7 @@ func TestRootVibePreparesGoWebWorkspace(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, want := range []string{"Go", "vanilla", "Do not add React", "Do not create a frontend build step", "subtraction pass"} {
+	for _, want := range []string{"Go", "vanilla", "Do not add React", "Do not create a frontend build step", "subtraction pass", "Pattern snippets", "Static traversal guard"} {
 		if !strings.Contains(string(appSkill), want) {
 			t.Fatalf("app skill = %q, missing %q", appSkill, want)
 		}
@@ -448,6 +463,15 @@ func TestRootVibePreparesGoWebWorkspace(t *testing.T) {
 	if filepath.IsAbs(manifest.SkillDir) || filepath.IsAbs(manifest.PromptPath) || manifest.AgentEffort != "high" || manifest.AgentAutonomy != "builder" || manifest.DeploymentIntent.DeployGoal != "deploy-ready" {
 		t.Fatalf("manifest = %#v, want repo-relative paths", manifest)
 	}
+	mainSource, err := os.ReadFile(filepath.Join(appDir, "main.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, unwanted := range []string{"/notes", "CREATE TABLE IF NOT EXISTS notes", "type note struct"} {
+		if strings.Contains(string(mainSource), unwanted) {
+			t.Fatalf("main.go = %q, should not contain %q", mainSource, unwanted)
+		}
+	}
 	for _, path := range []string{".dockerignore", ".gitignore", "Dockerfile", "go.sum", "main.go", "main_test.go", "static/app.css"} {
 		source := path
 		switch path {
@@ -458,7 +482,7 @@ func TestRootVibePreparesGoWebWorkspace(t *testing.T) {
 		}
 		assertEmbeddedTemplateFile(t, source, filepath.Join(appDir, path), "{{APP_NAME}}", "my-app")
 	}
-	for _, path := range []string{"README.md", "devopsellence.yml", "go.mod", "scripts/check", "templates/index.html"} {
+	for _, path := range []string{"README.md", "devopsellence.yml", "go.mod", "scripts/check", "scripts/dev", "scripts/smoke", "templates/index.html"} {
 		source := path
 		if path == "go.mod" {
 			source = "go.mod.tmpl"

--- a/cli/internal/workflow/vibe.go
+++ b/cli/internal/workflow/vibe.go
@@ -181,6 +181,13 @@ func (a *App) Vibe(ctx context.Context, opts VibeOptions) error {
 	if err := ensureVibeGitignore(target); err != nil {
 		return err
 	}
+	workspaceModeSet := false
+	if intent.DevopsellenceMode == string(ModeSolo) {
+		if err := a.SetModeForPath(target, ModeSolo); err != nil {
+			return fmt.Errorf("set vibe workspace mode: %w", err)
+		}
+		workspaceModeSet = a.WorkspaceState != nil
+	}
 
 	prompt := vibePrompt(opts.AIAgent, opts.AgentAutonomy, opts.Idea, intent)
 	promptPath := filepath.Join(promptsDir, "devopsellence-vibe.md")
@@ -219,25 +226,26 @@ func (a *App) Vibe(ctx context.Context, opts VibeOptions) error {
 	}
 
 	payload := map[string]any{
-		"schema_version":    outputSchemaVersion,
-		"action":            "initialized",
-		"directory":         target,
-		"projects_dir":      projectsDir,
-		"ai_agent":          opts.AIAgent,
-		"agent_effort":      opts.AgentEffort,
-		"agent_autonomy":    opts.AgentAutonomy,
-		"detected_agents":   detectedAgents,
-		"skill_id":          agentskill.AppID,
-		"skill_name":        agentskill.AppName,
-		"skill":             agentskill.AppName,
-		"skill_dir":         skillsDir,
-		"prompt_path":       promptPath,
-		"manifest_path":     manifestPath,
-		"deployment_intent": intent,
-		"initial_commit":    initialCommit,
-		"launch_requested":  opts.Launch,
-		"launched":          false,
-		"next_commands":     nextCommands,
+		"schema_version":     outputSchemaVersion,
+		"action":             "initialized",
+		"directory":          target,
+		"projects_dir":       projectsDir,
+		"ai_agent":           opts.AIAgent,
+		"agent_effort":       opts.AgentEffort,
+		"agent_autonomy":     opts.AgentAutonomy,
+		"detected_agents":    detectedAgents,
+		"skill_id":           agentskill.AppID,
+		"skill_name":         agentskill.AppName,
+		"skill":              agentskill.AppName,
+		"skill_dir":          skillsDir,
+		"prompt_path":        promptPath,
+		"manifest_path":      manifestPath,
+		"deployment_intent":  intent,
+		"workspace_mode_set": workspaceModeSet,
+		"initial_commit":     initialCommit,
+		"launch_requested":   opts.Launch,
+		"launched":           false,
+		"next_commands":      nextCommands,
 	}
 	var launchErr error
 	if opts.Launch {
@@ -834,7 +842,14 @@ func vibePrompt(agent, autonomy string, idea string, intent vibeDeploymentIntent
 		vibePlanApprovalPromptLine(autonomy),
 		"Build with Go, net/http, html/template, SQLite, Docker, and vanilla HTML/CSS/JavaScript.",
 		"Do not introduce a frontend framework, npm, bundler, transpiler, Tailwind, or frontend build step unless the user explicitly asks for one.",
+		"If this prompt asks for plan confirmation, wait for it; after confirmation, delete or rewrite generated shell code, routes, content, styles, and tests that do not serve the user's idea.",
 		"After each feature slice, do a subtraction pass: remove unused scaffolding, duplicate code, stale styles, placeholder content, and speculative abstractions while preserving user-confirmed behavior.",
+		"",
+		"Deploy-readiness checklist:",
+		"- go test ./...",
+		"- ./scripts/check",
+		"- ./scripts/smoke against a running local server when UI or HTTP behavior changes.",
+		"- devopsellence deploy --dry-run must either succeed or report the expected no-node blocker when no server is selected.",
 		"",
 		"Deployment rules:",
 		"- Do not write provider tokens, API keys, passwords, or secret values into prompts, manifests, git, logs, or commits.",

--- a/cli/internal/workflow/vibe_template/root/README.md
+++ b/cli/internal/workflow/vibe_template/root/README.md
@@ -5,23 +5,33 @@ A devopsellence-ready web app: Go backend, vanilla HTML/CSS, SQLite storage, and
 ## Local development
 
 ```sh
-docker build --target test .
-docker build -t {{APP_NAME}}:local .
-docker run --rm -p 8080:8080 -v {{APP_NAME}}-data:/data {{APP_NAME}}:local
+./scripts/dev
 ```
 
-The app listens on `http://localhost:8080`.
+The app listens on `http://localhost:18080` and stores development data at
+`/tmp/{{APP_NAME}}.sqlite`.
 
-If Go is installed locally:
+To smoke-test a running local server:
 
 ```sh
-go run .
+./scripts/smoke
 ```
 
 ## Check
 
 ```sh
 ./scripts/check
+```
+
+The check runs Go tests, Docker test/build targets, and a devopsellence dry-run
+when the CLI is available. If no node is attached yet, the expected dry-run
+blocker is accepted.
+
+The app can also be run through Docker:
+
+```sh
+docker build -t {{APP_NAME}}:local .
+docker run --rm -p 8080:8080 -v {{APP_NAME}}-data:/data {{APP_NAME}}:local
 ```
 
 ## Deploy

--- a/cli/internal/workflow/vibe_template/root/README.md
+++ b/cli/internal/workflow/vibe_template/root/README.md
@@ -23,9 +23,10 @@ To smoke-test a running local server:
 ./scripts/check
 ```
 
-The check runs Go tests, Docker test/build targets, and a devopsellence dry-run
-when the CLI is available. If no node is attached yet, the expected dry-run
-blocker is accepted.
+The check requires Docker. It also runs `go test ./...` when Go is installed
+locally, then runs Docker test/build targets and a devopsellence dry-run when
+the CLI is available. If no node is attached yet, the expected dry-run blocker
+is accepted.
 
 The app can also be run through Docker:
 

--- a/cli/internal/workflow/vibe_template/root/main.go.tmpl
+++ b/cli/internal/workflow/vibe_template/root/main.go.tmpl
@@ -118,6 +118,7 @@ func (a *app) home(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "could not render page", http.StatusInternalServerError)
 		return
 	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	_, _ = body.WriteTo(w)
 }
 

--- a/cli/internal/workflow/vibe_template/root/main.go.tmpl
+++ b/cli/internal/workflow/vibe_template/root/main.go.tmpl
@@ -21,20 +21,11 @@ import (
 //go:embed templates/*.html static/*
 var assets embed.FS
 
-type note struct {
-	ID        int64
-	Title     string
-	Body      string
-	CreatedAt string
-}
-
 type app struct {
 	db        *sql.DB
 	templates *template.Template
 	static    http.Handler
 }
-
-const maxNotes = 50
 
 func main() {
 	addr := env("ADDR", ":8080")
@@ -91,13 +82,15 @@ func newApp(db *sql.DB) (*app, error) {
 
 func migrate(db *sql.DB) error {
 	_, err := db.Exec(`
-		CREATE TABLE IF NOT EXISTS notes (
-			id INTEGER PRIMARY KEY AUTOINCREMENT,
-			title TEXT NOT NULL,
-			body TEXT NOT NULL DEFAULT '',
-			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
-		)
-	`)
+		CREATE TABLE IF NOT EXISTS app_state (
+			key TEXT PRIMARY KEY,
+			value TEXT NOT NULL,
+			updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+		);
+		INSERT INTO app_state (key, value)
+		VALUES ('schema', 'ready')
+		ON CONFLICT(key) DO NOTHING;
+		`)
 	return err
 }
 
@@ -106,27 +99,21 @@ func (a *app) routes() http.Handler {
 	mux.Handle("GET /static/", a.static)
 	mux.HandleFunc("GET /healthz", a.health)
 	mux.HandleFunc("GET /", a.home)
-	mux.HandleFunc("POST /notes", a.createNote)
 	return mux
 }
 
 func (a *app) health(w http.ResponseWriter, r *http.Request) {
-	if err := a.db.PingContext(r.Context()); err != nil {
+	if err := a.databaseReady(r.Context()); err != nil {
 		http.Error(w, "database unavailable", http.StatusServiceUnavailable)
 		return
 	}
+	w.Header().Set("Cache-Control", "no-store")
 	w.WriteHeader(http.StatusNoContent)
 }
 
 func (a *app) home(w http.ResponseWriter, r *http.Request) {
-	notes, err := a.listNotes(r.Context())
-	if err != nil {
-		http.Error(w, "could not load notes", http.StatusInternalServerError)
-		return
-	}
-
 	var body bytes.Buffer
-	if err := a.templates.ExecuteTemplate(&body, "index.html", map[string]any{"Notes": notes}); err != nil {
+	if err := a.templates.ExecuteTemplate(&body, "index.html", nil); err != nil {
 		log.Printf("render home: %v", err)
 		http.Error(w, "could not render page", http.StatusInternalServerError)
 		return
@@ -134,48 +121,14 @@ func (a *app) home(w http.ResponseWriter, r *http.Request) {
 	_, _ = body.WriteTo(w)
 }
 
-func (a *app) createNote(w http.ResponseWriter, r *http.Request) {
-	if err := r.ParseForm(); err != nil {
-		http.Error(w, "invalid form", http.StatusBadRequest)
-		return
-	}
-
-	title := strings.TrimSpace(r.FormValue("title"))
-	body := strings.TrimSpace(r.FormValue("body"))
-	if title == "" {
-		http.Redirect(w, r, "/", http.StatusSeeOther)
-		return
-	}
-
-	ctx, cancel := context.WithTimeout(r.Context(), 3*time.Second)
+func (a *app) databaseReady(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
-	if _, err := a.db.ExecContext(ctx, `INSERT INTO notes (title, body) VALUES (?, ?)`, title, body); err != nil {
-		http.Error(w, "could not save note", http.StatusInternalServerError)
-		return
+	if err := a.db.PingContext(ctx); err != nil {
+		return err
 	}
-
-	http.Redirect(w, r, "/", http.StatusSeeOther)
-}
-
-func (a *app) listNotes(ctx context.Context) ([]note, error) {
-	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
-	defer cancel()
-
-	rows, err := a.db.QueryContext(ctx, `SELECT id, title, body, created_at FROM notes ORDER BY id DESC LIMIT ?`, maxNotes)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	var notes []note
-	for rows.Next() {
-		var item note
-		if err := rows.Scan(&item.ID, &item.Title, &item.Body, &item.CreatedAt); err != nil {
-			return nil, err
-		}
-		notes = append(notes, item)
-	}
-	return notes, rows.Err()
+	var value string
+	return a.db.QueryRowContext(ctx, `SELECT value FROM app_state WHERE key = ?`, "schema").Scan(&value)
 }
 
 func env(key, fallback string) string {

--- a/cli/internal/workflow/vibe_template/root/main_test.go.tmpl
+++ b/cli/internal/workflow/vibe_template/root/main_test.go.tmpl
@@ -4,14 +4,13 @@ import (
 	"database/sql"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"strings"
 	"testing"
 
 	_ "modernc.org/sqlite"
 )
 
-func TestHealth(t *testing.T) {
+func TestHealthChecksSQLiteReadiness(t *testing.T) {
 	db, err := sql.Open("sqlite", ":memory:")
 	if err != nil {
 		t.Fatal(err)
@@ -31,9 +30,19 @@ func TestHealth(t *testing.T) {
 	if response.Code != http.StatusNoContent {
 		t.Fatalf("expected 204, got %d", response.Code)
 	}
+
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	response = httptest.NewRecorder()
+	request = httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	application.routes().ServeHTTP(response, request)
+	if response.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 after closing database, got %d", response.Code)
+	}
 }
 
-func TestHomeListsCreatedNotes(t *testing.T) {
+func TestHomeRendersAppShell(t *testing.T) {
 	db, err := sql.Open("sqlite", ":memory:")
 	if err != nil {
 		t.Fatal(err)
@@ -45,23 +54,16 @@ func TestHomeListsCreatedNotes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	form := url.Values{"title": {"First note"}, "body": {"Hello from the app"}}
-	createResponse := httptest.NewRecorder()
-	createRequest := httptest.NewRequest(http.MethodPost, "/notes", strings.NewReader(form.Encode()))
-	createRequest.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	application.routes().ServeHTTP(createResponse, createRequest)
-	if createResponse.Code != http.StatusSeeOther {
-		t.Fatalf("expected 303, got %d", createResponse.Code)
-	}
-
 	homeResponse := httptest.NewRecorder()
 	homeRequest := httptest.NewRequest(http.MethodGet, "/", nil)
 	application.routes().ServeHTTP(homeResponse, homeRequest)
 	if homeResponse.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", homeResponse.Code, homeResponse.Body.String())
 	}
-	if !strings.Contains(homeResponse.Body.String(), "First note") {
-		t.Fatalf("home response missing saved note: %s", homeResponse.Body.String())
+	for _, want := range []string{"{{APP_NAME}}", "Deploy-ready app shell", "/healthz"} {
+		if !strings.Contains(homeResponse.Body.String(), want) {
+			t.Fatalf("home response missing %q: %s", want, homeResponse.Body.String())
+		}
 	}
 }
 

--- a/cli/internal/workflow/vibe_template/root/main_test.go.tmpl
+++ b/cli/internal/workflow/vibe_template/root/main_test.go.tmpl
@@ -60,6 +60,9 @@ func TestHomeRendersAppShell(t *testing.T) {
 	if homeResponse.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", homeResponse.Code, homeResponse.Body.String())
 	}
+	if got := homeResponse.Header().Get("Content-Type"); got != "text/html; charset=utf-8" {
+		t.Fatalf("Content-Type = %q, want text/html; charset=utf-8", got)
+	}
 	for _, want := range []string{"{{APP_NAME}}", "Deploy-ready app shell", "/healthz"} {
 		if !strings.Contains(homeResponse.Body.String(), want) {
 			t.Fatalf("home response missing %q: %s", want, homeResponse.Body.String())

--- a/cli/internal/workflow/vibe_template/root/scripts/check
+++ b/cli/internal/workflow/vibe_template/root/scripts/check
@@ -1,9 +1,39 @@
 #!/usr/bin/env sh
 set -eu
 
-if ! command -v docker >/dev/null 2>&1; then
-  echo "Docker is required to check this app" >&2
-  exit 1
-fi
+require() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "$1 is required to check this app" >&2
+    exit 1
+  fi
+}
 
-docker build --target test .
+run() {
+  printf '\n==> %s\n' "$*"
+  "$@"
+}
+
+require go
+require docker
+
+run go test ./...
+run docker build --target test .
+run docker build .
+
+if command -v devopsellence >/dev/null 2>&1; then
+  printf '\n==> devopsellence deploy --dry-run\n'
+  set +e
+  output="$(devopsellence deploy --dry-run 2>&1)"
+  status=$?
+  set -e
+  printf '%s\n' "$output"
+  if [ "$status" -ne 0 ]; then
+    if printf '%s\n' "$output" | grep -Eiq 'no nodes attached|no nodes selected|node attach'; then
+      echo "dry-run reached expected no-node blocker"
+    else
+      exit "$status"
+    fi
+  fi
+else
+  echo "devopsellence not found; skipping deploy dry-run"
+fi

--- a/cli/internal/workflow/vibe_template/root/scripts/check
+++ b/cli/internal/workflow/vibe_template/root/scripts/check
@@ -13,10 +13,13 @@ run() {
   "$@"
 }
 
-require go
 require docker
 
-run go test ./...
+if command -v go >/dev/null 2>&1; then
+  run go test ./...
+else
+  echo "go not found; Docker test target will run the test suite"
+fi
 run docker build --target test .
 run docker build .
 

--- a/cli/internal/workflow/vibe_template/root/scripts/dev
+++ b/cli/internal/workflow/vibe_template/root/scripts/dev
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+set -eu
+
+: "${ADDR:=:18080}"
+: "${DB_PATH:=/tmp/{{APP_NAME}}.sqlite}"
+export ADDR DB_PATH
+
+printf 'Starting dev server with ADDR=%s DB_PATH=%s\n' "$ADDR" "$DB_PATH"
+exec go run .

--- a/cli/internal/workflow/vibe_template/root/scripts/smoke
+++ b/cli/internal/workflow/vibe_template/root/scripts/smoke
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+set -eu
+
+: "${BASE_URL:=http://127.0.0.1:18080}"
+
+body="$(mktemp)"
+trap 'rm -f "$body"' EXIT
+
+curl -fsS "$BASE_URL/" -o "$body"
+grep -F "{{APP_NAME}}" "$body" >/dev/null
+grep -F "Deploy-ready app shell" "$body" >/dev/null
+curl -fsS -o /dev/null "$BASE_URL/healthz"
+
+echo "smoke checks passed for $BASE_URL"

--- a/cli/internal/workflow/vibe_template/root/scripts/smoke
+++ b/cli/internal/workflow/vibe_template/root/scripts/smoke
@@ -3,7 +3,7 @@ set -eu
 
 : "${BASE_URL:=http://127.0.0.1:18080}"
 
-body="$(mktemp)"
+body="$(mktemp "${TMPDIR:-/tmp}/{{APP_NAME}}-smoke.XXXXXX")"
 trap 'rm -f "$body"' EXIT
 
 curl -fsS "$BASE_URL/" -o "$body"

--- a/cli/internal/workflow/vibe_template/root/static/app.css
+++ b/cli/internal/workflow/vibe_template/root/static/app.css
@@ -15,17 +15,17 @@ body {
 }
 
 main {
-  width: min(960px, calc(100% - 32px));
+  width: min(880px, calc(100% - 32px));
   margin: 0 auto;
-  padding: 48px 0;
+  padding: 64px 0;
 }
 
-header {
-  margin-bottom: 28px;
+.hero {
+  margin-bottom: 32px;
 }
 
 h1 {
-  margin: 0;
+  margin: 8px 0 0;
   font-size: clamp(2rem, 5vw, 4rem);
   line-height: 1;
 }
@@ -35,77 +35,48 @@ p {
   line-height: 1.6;
 }
 
-.panel {
+.eyebrow {
+  margin: 0;
+  color: #1f6feb;
+  font-size: 0.78rem;
+  font-weight: 750;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.status-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.status-grid article {
   background: #ffffff;
   border: 1px solid #dde2ea;
   border-radius: 8px;
   box-shadow: 0 16px 40px rgb(30 41 59 / 8%);
-  padding: 24px;
+  min-height: 112px;
+  padding: 20px;
 }
 
-form {
-  display: grid;
-  gap: 14px;
-}
-
-label {
-  display: grid;
-  gap: 6px;
-  color: #384252;
-  font-weight: 650;
-}
-
-input,
-textarea,
-button {
-  font: inherit;
-}
-
-input,
-textarea {
-  width: 100%;
-  border: 1px solid #cbd3df;
-  border-radius: 6px;
-  padding: 12px 14px;
-}
-
-textarea {
-  min-height: 120px;
-  resize: vertical;
-}
-
-button {
-  justify-self: start;
-  border: 0;
-  border-radius: 6px;
-  background: #1f6feb;
-  color: white;
-  font-weight: 700;
-  padding: 11px 16px;
-}
-
-.notes {
-  display: grid;
-  gap: 14px;
-  margin-top: 24px;
-}
-
-.note {
-  background: #ffffff;
-  border: 1px solid #dde2ea;
-  border-radius: 8px;
-  padding: 18px;
-}
-
-.note h2 {
-  margin: 0 0 6px;
-  font-size: 1.125rem;
-}
-
-.empty {
-  border: 1px dashed #aeb8c7;
-  border-radius: 8px;
+.status-grid span {
   color: #586070;
-  padding: 24px;
-  text-align: center;
+  display: block;
+  font-size: 0.85rem;
+  margin-bottom: 10px;
+}
+
+.status-grid strong {
+  color: #161a20;
+  font-size: 1.25rem;
+}
+
+@media (max-width: 640px) {
+  main {
+    padding: 40px 0;
+  }
+
+  .status-grid {
+    grid-template-columns: 1fr;
+  }
 }

--- a/cli/internal/workflow/vibe_template/root/templates/index.html
+++ b/cli/internal/workflow/vibe_template/root/templates/index.html
@@ -8,36 +8,25 @@
   </head>
   <body>
     <main>
-      <header>
+      <header class="hero">
+        <p class="eyebrow">Deploy-ready app shell</p>
         <h1>{{APP_NAME}}</h1>
-        <p>A small Go app with durable storage and deployment defaults ready for devopsellence.</p>
+        <p>A neutral Go, SQLite, and vanilla web baseline ready for the first real product workflow.</p>
       </header>
 
-      <section class="panel" aria-label="New note">
-        <form method="post" action="/notes">
-          <label>
-            Title
-            <input name="title" autocomplete="off" required>
-          </label>
-          <label>
-            Body
-            <textarea name="body"></textarea>
-          </label>
-          <button type="submit">Save note</button>
-        </form>
-      </section>
-
-      <section class="notes" aria-label="Notes">
-        {{ if .Notes }}
-          {{ range .Notes }}
-            <article class="note">
-              <h2>{{ .Title }}</h2>
-              <p>{{ .Body }}</p>
-            </article>
-          {{ end }}
-        {{ else }}
-          <div class="empty">No notes yet.</div>
-        {{ end }}
+      <section class="status-grid" aria-label="Runtime readiness">
+        <article>
+          <span>HTTP</span>
+          <strong>online</strong>
+        </article>
+        <article>
+          <span>SQLite</span>
+          <strong>ready</strong>
+        </article>
+        <article>
+          <span>Health</span>
+          <strong>/healthz</strong>
+        </article>
       </section>
     </main>
   </body>

--- a/docs-website/src/content/docs/concepts/vibe-philosophy.md
+++ b/docs-website/src/content/docs/concepts/vibe-philosophy.md
@@ -44,12 +44,14 @@ surface area for an agent to manage.
 The app template should be understandable in a few minutes. It exists to provide
 a safe shape:
 
-- routes;
+- a neutral root route;
+- `/healthz`;
 - templates;
 - static assets;
 - SQLite setup;
 - tests;
 - Docker;
+- dev and smoke scripts;
 - `devopsellence.yml`.
 
 The generated `devopsellence-app` skill carries the harder product guidance:
@@ -61,6 +63,8 @@ The generated `devopsellence-app` skill carries the harder product guidance:
 - keep every slice deployable;
 - run regular subtraction passes so unused scaffolding, stale styles, duplicate
   helpers, placeholder UI, and speculative abstractions do not accumulate;
+- start product work by deleting or rewriting any generated shell code, routes,
+  content, styles, and tests that do not serve the user's idea;
 - checkpoint changes so iteration and revert stay natural.
 
 That split keeps the codebase small while still giving the agent enough taste
@@ -100,7 +104,9 @@ A good vibe-generated app should:
 - look intentionally designed for its domain;
 - expose clear health and error states;
 - keep secrets out of prompts, commits, and logs;
-- pass `docker build --target test .`;
-- remain deployable with `devopsellence deploy --dry-run`.
+- pass `go test ./...`, `./scripts/check`, and focused smoke checks when HTTP
+  behavior changes;
+- reach either a successful `devopsellence deploy --dry-run` or the expected
+  no-node blocker when no server is selected yet.
 
 The goal is durable software, not a throwaway mockup.

--- a/docs-website/src/content/docs/getting-started/vibe.md
+++ b/docs-website/src/content/docs/getting-started/vibe.md
@@ -25,8 +25,10 @@ The generated app starts with:
 
 - Go `net/http` handlers and `html/template` pages.
 - SQLite storage.
+- A neutral root page and `/healthz`; no idea-specific placeholder CRUD.
 - Semantic HTML, one CSS file, and no frontend build step.
 - A Dockerfile with a `test` target.
+- `scripts/dev`, `scripts/smoke`, and `scripts/check`.
 - `devopsellence.yml` with the default web service, health check, and `/data`
   volume.
 - `.agents/skills/devopsellence-app`, the app-building skill used by the agent.
@@ -43,30 +45,34 @@ The intended loop is:
 3. The app stays native-web: Go, SQLite, HTML, CSS, and small vanilla JavaScript.
 4. The agent runs `docker build --target test .` while changing app behavior.
 5. The agent keeps Docker and `devopsellence.yml` deploy-ready as the app grows.
-6. After each feature slice, the agent does a subtraction pass to remove unused
+6. Before adding product behavior, the agent deletes or rewrites generated shell
+   code, routes, content, styles, and tests that do not serve the idea.
+7. After each feature slice, the agent does a subtraction pass to remove unused
    routes, styles, helpers, placeholder UI, and speculative abstractions.
-7. Before a real deploy, the agent runs `devopsellence deploy --dry-run`.
+8. Before a real deploy, the agent runs `devopsellence deploy --dry-run`.
 
 `vibe` does not ask the agent to invent a stack. It gives the agent a narrow
 workspace and a high-quality set of product and implementation instructions.
 
 ## Local checks
 
-The generated app can be checked with Docker only:
+The generated app has a single readiness check:
 
 ```bash
 ./scripts/check
-docker build .
 ```
 
 If Go is installed locally, the agent may also run:
 
 ```bash
-go test ./...
-go run .
+./scripts/dev
+./scripts/smoke
 ```
 
-The Docker path is the portable contract. Local Go is just a convenience.
+`./scripts/check` runs Go tests, Docker test/build targets, and a
+`devopsellence deploy --dry-run` when the CLI is available. If no server is
+selected yet, the expected result is an explicit no-node/no-attachment blocker,
+not an unset mode or invalid config error.
 
 ## Deploy
 

--- a/docs-website/src/content/docs/getting-started/vibe.md
+++ b/docs-website/src/content/docs/getting-started/vibe.md
@@ -62,14 +62,15 @@ The generated app has a single readiness check:
 ./scripts/check
 ```
 
-If Go is installed locally, the agent may also run:
+If Go is installed locally, `./scripts/check` also runs `go test ./...`.
+The agent may use these during local iteration:
 
 ```bash
 ./scripts/dev
 ./scripts/smoke
 ```
 
-`./scripts/check` runs Go tests, Docker test/build targets, and a
+`./scripts/check` requires Docker, runs the Docker test/build targets, and runs a
 `devopsellence deploy --dry-run` when the CLI is available. If no server is
 selected yet, the expected result is an explicit no-node/no-attachment blocker,
 not an unset mode or invalid config error.


### PR DESCRIPTION
## Summary
- Replace the notes CRUD scaffold with a neutral Go app shell and SQLite-backed health readiness.
- Add scripts/dev, scripts/smoke, and a machine-checkable scripts/check deploy-readiness path.
- Set generated solo workspaces to solo mode and strengthen the prompt, app skill snippets, tests, and docs.

## Validation
- TMPDIR=/home/elvin/.cache/devopsellence-test-tmp mise run test:cli
- Generated vibe app: mise exec go@1.26.2 -- go test ./...
- Generated vibe app: PATH=/home/elvin/Work/devopsellence/devopsellence/cli/bin:$PATH DEVOPSELLENCE_STATE_HOME=/home/elvin/.cache/devopsellence-vibe-verify/state mise exec go@1.26.2 -- ./scripts/check
- Generated vibe app: ADDR=:18081 DB_PATH=/tmp/demo-shell-18081.sqlite mise exec go@1.26.2 -- ./scripts/dev + BASE_URL=http://127.0.0.1:18081 ./scripts/smoke
- cd docs-website && npm run check
- cd docs-website && npm run build
- git diff --check