### PR TITLE
feat: add solo desktop app

### DIFF
--- a/cli/internal/desktop/index.go
+++ b/cli/internal/desktop/index.go
@@ -1,0 +1,71 @@
+package desktop
+
+const indexHTML = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>devopsellence solo desktop</title>
+  <style>
+    :root { color-scheme: dark; --bg:#070b12; --panel:#101827; --panel2:#0c1320; --text:#e5edf8; --muted:#8ea0b8; --accent:#7dd3fc; --ok:#86efac; --warn:#fde68a; --border:#253247; }
+    * { box-sizing: border-box; }
+    body { margin:0; font:14px/1.5 ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background:radial-gradient(circle at top left,#16233a 0,#070b12 36rem); color:var(--text); }
+    header { padding:32px; border-bottom:1px solid var(--border); }
+    h1 { margin:0; font-size:28px; letter-spacing:-.03em; }
+    h2 { margin:0 0 12px; font-size:15px; text-transform:uppercase; letter-spacing:.12em; color:var(--muted); }
+    code { color:var(--accent); }
+    .muted { color:var(--muted); }
+    .grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(260px,1fr)); gap:16px; padding:24px 32px 40px; }
+    .card { background:linear-gradient(180deg,var(--panel),var(--panel2)); border:1px solid var(--border); border-radius:18px; padding:18px; box-shadow:0 18px 60px rgb(0 0 0 / .24); }
+    .metric { font-size:30px; font-weight:700; letter-spacing:-.04em; }
+    .pill { display:inline-flex; align-items:center; gap:6px; border:1px solid var(--border); border-radius:999px; padding:4px 9px; color:var(--muted); margin:3px 4px 3px 0; }
+    .pill.ok { color:var(--ok); border-color:rgb(134 239 172 / .35); }
+    .pill.warn { color:var(--warn); border-color:rgb(253 230 138 / .35); }
+    table { width:100%; border-collapse:collapse; }
+    th, td { text-align:left; padding:8px 0; border-top:1px solid var(--border); vertical-align:top; }
+    th { color:var(--muted); font-weight:500; }
+    pre { white-space:pre-wrap; overflow:auto; background:#050812; border:1px solid var(--border); border-radius:12px; padding:12px; color:#c7d2fe; }
+    .wide { grid-column:1 / -1; }
+    .error { color:#fca5a5; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>devopsellence solo desktop</h1>
+    <div class="muted">Local-first control surface for the solo filesystem state. Secrets are shown by name only, never by value.</div>
+  </header>
+  <main id="app" class="grid"><div class="card wide">Loading…</div></main>
+  <script>
+    const esc = (value) => String(value ?? '').replace(/[&<>"]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+    const list = (items, render, empty='None') => items && items.length ? items.map(render).join('') : '<span class="muted">' + empty + '</span>';
+    function rowEmpty(cols, text) { return '<tr><td colspan="' + cols + '" class="muted">' + esc(text) + '</td></tr>'; }
+    function render(data) {
+      const project = data.project || {};
+      const envPill = project.default_environment ? '<div class="pill">env: ' + esc(project.default_environment) + '</div>' : '';
+      const nodePills = list(data.nodes, n => '<span class="pill ' + (n.attached ? 'ok' : 'warn') + '">' + esc(n.name) + (n.host ? ' · ' + esc(n.host) : '') + '</span>');
+      const attachmentRows = list(data.attachments, a => '<tr><td>' + esc(a.environment) + '</td><td>' + esc((a.node_names || []).join(', ')) + '</td></tr>', rowEmpty(2, 'No attachments for this workspace.'));
+      const releaseRows = list(data.releases.slice(0, 8), r => '<tr><td>' + (r.current ? '● ' : '') + esc(r.id) + '</td><td>' + esc(r.environment) + '</td><td><code>' + esc(r.revision) + '</code></td><td>' + esc((r.node_names || []).join(', ')) + '</td><td>' + esc(r.created_at) + '</td></tr>', rowEmpty(5, 'No releases yet.'));
+      const nextSteps = list(data.next_steps, s => '<p><strong>' + esc(s.label) + '</strong><br><span class="muted">' + esc(s.reason) + '</span><pre>' + esc(s.command) + '</pre></p>', 'No suggested next steps.');
+      document.getElementById('app').innerHTML =
+        '<section class="card">' +
+          '<h2>Workspace</h2>' +
+          '<div><strong>' + esc(project.project || 'Uninitialized') + '</strong></div>' +
+          '<div class="muted">' + esc(data.workspace.root) + '</div>' +
+          '<div class="pill ok">mode: ' + esc(data.workspace.mode) + '</div>' + envPill +
+        '</section>' +
+        '<section class="card"><h2>Nodes</h2><div class="metric">' + data.state.node_count + '</div><div>' + nodePills + '</div></section>' +
+        '<section class="card"><h2>Releases</h2><div class="metric">' + data.state.release_count + '</div><div class="muted">' + (data.state.current_revision ? 'current revision ' + esc(data.state.current_revision) : 'no current release') + '</div></section>' +
+        '<section class="card"><h2>Secrets</h2><div class="metric">' + data.state.secret_ref_count + '</div><div class="muted">Names and stores only; values stay redacted.</div></section>' +
+        '<section class="card wide"><h2>Attachments</h2><table><thead><tr><th>Environment</th><th>Nodes</th></tr></thead><tbody>' + attachmentRows + '</tbody></table></section>' +
+        '<section class="card wide"><h2>Recent releases</h2><table><thead><tr><th>Release</th><th>Environment</th><th>Revision</th><th>Nodes</th><th>Created</th></tr></thead><tbody>' + releaseRows + '</tbody></table></section>' +
+        '<section class="card wide"><h2>Next steps</h2>' + nextSteps + '</section>';
+    }
+    fetch('/api/summary').then(r => r.json()).then(data => {
+      if (data.ok === false) throw new Error(data.error && data.error.message || 'summary failed');
+      render(data);
+    }).catch(err => {
+      document.getElementById('app').innerHTML = '<div class="card wide error">' + esc(err.message) + '</div>';
+    });
+  </script>
+</body>
+</html>`

--- a/cli/internal/desktop/server.go
+++ b/cli/internal/desktop/server.go
@@ -1,0 +1,136 @@
+package desktop
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+)
+
+type Options struct {
+	Addr          string
+	WorkspaceRoot string
+	StatePath     string
+	OpenBrowser   bool
+	Out           io.Writer
+	Err           io.Writer
+}
+
+type ReadyEvent struct {
+	SchemaVersion int    `json:"schema_version"`
+	Event         string `json:"event"`
+	URL           string `json:"url"`
+	Address       string `json:"address"`
+	WorkspaceRoot string `json:"workspace_root"`
+}
+
+func Serve(ctx context.Context, opts Options) error {
+	addr := strings.TrimSpace(opts.Addr)
+	if addr == "" {
+		addr = "127.0.0.1:0"
+	}
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return err
+	}
+	defer listener.Close()
+
+	server := &http.Server{
+		Handler:           NewHandler(SummaryOptions{WorkspaceRoot: opts.WorkspaceRoot, StatePath: opts.StatePath}),
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	serverErr := make(chan error, 1)
+	go func() {
+		if err := server.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			serverErr <- err
+			return
+		}
+		serverErr <- nil
+	}()
+
+	url := "http://" + listener.Addr().String()
+	if opts.Out != nil {
+		_ = json.NewEncoder(opts.Out).Encode(ReadyEvent{
+			SchemaVersion: apiSchemaVersion,
+			Event:         "desktop_ready",
+			URL:           url,
+			Address:       listener.Addr().String(),
+			WorkspaceRoot: opts.WorkspaceRoot,
+		})
+	}
+	if opts.OpenBrowser {
+		if err := openURL(url); err != nil && opts.Err != nil {
+			fmt.Fprintf(opts.Err, "warning: could not open browser: %v\n", err)
+		}
+	}
+
+	select {
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			return err
+		}
+		if errors.Is(ctx.Err(), context.Canceled) {
+			return nil
+		}
+		return ctx.Err()
+	case err := <-serverErr:
+		return err
+	}
+}
+
+func NewHandler(summaryOpts SummaryOptions) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /", func(w http.ResponseWriter, r *http.Request) {
+		serveIndex(w)
+	})
+	mux.HandleFunc("GET /api/summary", func(w http.ResponseWriter, r *http.Request) {
+		summary, err := BuildSummary(summaryOpts)
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]any{
+				"schema_version": apiSchemaVersion,
+				"ok":             false,
+				"error": map[string]any{
+					"code":    "summary_failed",
+					"message": err.Error(),
+				},
+			})
+			return
+		}
+		writeJSON(w, http.StatusOK, summary)
+	})
+	return mux
+}
+
+func serveIndex(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_, _ = io.WriteString(w, indexHTML)
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(payload)
+}
+
+func openURL(url string) error {
+	switch runtime.GOOS {
+	case "darwin":
+		return exec.Command("open", url).Start()
+	case "linux":
+		return exec.Command("xdg-open", url).Start()
+	case "windows":
+		return exec.Command("rundll32", "url.dll,FileProtocolHandler", url).Start()
+	default:
+		return fmt.Errorf("unsupported platform %s", runtime.GOOS)
+	}
+}

--- a/cli/internal/desktop/summary.go
+++ b/cli/internal/desktop/summary.go
@@ -1,0 +1,287 @@
+package desktop
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/devopsellence/cli/internal/solo"
+	"github.com/devopsellence/devopsellence/deployment-core/pkg/deploycore/config"
+)
+
+const apiSchemaVersion = 1
+
+type SummaryOptions struct {
+	WorkspaceRoot string
+	StatePath     string
+}
+
+type Summary struct {
+	SchemaVersion int                 `json:"schema_version"`
+	Workspace     WorkspaceSummary    `json:"workspace"`
+	Project       *ProjectSummary     `json:"project,omitempty"`
+	State         SoloStateSummary    `json:"state"`
+	Nodes         []NodeSummary       `json:"nodes"`
+	Attachments   []AttachmentSummary `json:"attachments"`
+	Releases      []ReleaseSummary    `json:"releases"`
+	Secrets       []SecretSummary     `json:"secrets"`
+	NextSteps     []NextStep          `json:"next_steps,omitempty"`
+}
+
+type WorkspaceSummary struct {
+	Root string `json:"root"`
+	Key  string `json:"key"`
+	Mode string `json:"mode"`
+}
+
+type ProjectSummary struct {
+	Organization       string   `json:"organization"`
+	Project            string   `json:"project"`
+	DefaultEnvironment string   `json:"default_environment"`
+	Services           []string `json:"services"`
+	Environments       []string `json:"environments,omitempty"`
+}
+
+type SoloStateSummary struct {
+	Path              string `json:"path"`
+	NodeCount         int    `json:"node_count"`
+	AttachmentCount   int    `json:"attachment_count"`
+	ReleaseCount      int    `json:"release_count"`
+	SecretRefCount    int    `json:"secret_ref_count"`
+	CurrentReleaseID  string `json:"current_release_id,omitempty"`
+	CurrentRevision   string `json:"current_revision,omitempty"`
+	CurrentDeployment string `json:"current_deployment_id,omitempty"`
+}
+
+type NodeSummary struct {
+	Name     string   `json:"name"`
+	Host     string   `json:"host"`
+	User     string   `json:"user,omitempty"`
+	Port     int      `json:"port,omitempty"`
+	Provider string   `json:"provider,omitempty"`
+	Region   string   `json:"region,omitempty"`
+	Labels   []string `json:"labels,omitempty"`
+	Attached bool     `json:"attached"`
+}
+
+type AttachmentSummary struct {
+	Environment string   `json:"environment"`
+	NodeNames   []string `json:"node_names"`
+}
+
+type ReleaseSummary struct {
+	ID          string   `json:"id"`
+	Environment string   `json:"environment"`
+	Revision    string   `json:"revision"`
+	Image       string   `json:"image,omitempty"`
+	CreatedAt   string   `json:"created_at,omitempty"`
+	Current     bool     `json:"current"`
+	NodeNames   []string `json:"node_names,omitempty"`
+}
+
+type SecretSummary struct {
+	Environment string `json:"environment"`
+	ServiceName string `json:"service_name"`
+	Name        string `json:"name"`
+	Store       string `json:"store,omitempty"`
+	UpdatedAt   string `json:"updated_at,omitempty"`
+}
+
+type NextStep struct {
+	Label   string `json:"label"`
+	Command string `json:"command"`
+	Reason  string `json:"reason"`
+}
+
+func BuildSummary(opts SummaryOptions) (Summary, error) {
+	workspaceRoot := strings.TrimSpace(opts.WorkspaceRoot)
+	workspaceKey, err := solo.CanonicalWorkspaceKey(workspaceRoot)
+	if err != nil {
+		return Summary{}, err
+	}
+	statePath := strings.TrimSpace(opts.StatePath)
+	if statePath == "" {
+		statePath = solo.DefaultStatePath()
+	}
+	store := solo.NewStateStore(statePath)
+	current, err := store.Read()
+	if err != nil {
+		return Summary{}, err
+	}
+
+	cfg, err := config.LoadFromRoot(workspaceRoot)
+	if err != nil {
+		return Summary{}, err
+	}
+
+	summary := Summary{
+		SchemaVersion: apiSchemaVersion,
+		Workspace: WorkspaceSummary{
+			Root: workspaceRoot,
+			Key:  workspaceKey,
+			Mode: "solo",
+		},
+		State: SoloStateSummary{Path: statePath},
+	}
+	if cfg != nil {
+		summary.Project = projectSummary(*cfg)
+	}
+
+	attachmentNodeNames := map[string]bool{}
+	currentReleaseID := ""
+	currentDeploymentID := ""
+	for key, attachment := range current.Attachments {
+		if attachment.WorkspaceKey != workspaceKey {
+			continue
+		}
+		nodeNames := append([]string(nil), attachment.NodeNames...)
+		sort.Strings(nodeNames)
+		summary.Attachments = append(summary.Attachments, AttachmentSummary{
+			Environment: attachment.Environment,
+			NodeNames:   nodeNames,
+		})
+		for _, nodeName := range nodeNames {
+			attachmentNodeNames[nodeName] = true
+		}
+		if id := strings.TrimSpace(current.Current[key]); id != "" && currentReleaseID == "" {
+			currentReleaseID = id
+		}
+	}
+	sort.Slice(summary.Attachments, func(i, j int) bool {
+		return summary.Attachments[i].Environment < summary.Attachments[j].Environment
+	})
+
+	nodeNames := make([]string, 0, len(current.Nodes))
+	for name := range current.Nodes {
+		nodeNames = append(nodeNames, name)
+	}
+	sort.Strings(nodeNames)
+	for _, name := range nodeNames {
+		node := current.Nodes[name]
+		summary.Nodes = append(summary.Nodes, NodeSummary{
+			Name:     name,
+			Host:     node.Host,
+			User:     node.User,
+			Port:     node.Port,
+			Provider: node.Provider,
+			Region:   node.ProviderRegion,
+			Labels:   append([]string(nil), node.Labels...),
+			Attached: attachmentNodeNames[name],
+		})
+	}
+
+	releaseIDs := make([]string, 0, len(current.Releases))
+	for id, release := range current.Releases {
+		if release.Snapshot.WorkspaceKey != workspaceKey {
+			continue
+		}
+		releaseIDs = append(releaseIDs, id)
+	}
+	sort.Slice(releaseIDs, func(i, j int) bool {
+		return current.Releases[releaseIDs[i]].CreatedAt > current.Releases[releaseIDs[j]].CreatedAt
+	})
+	for _, id := range releaseIDs {
+		release := current.Releases[id]
+		image := release.Image.Reference
+		if image == "" {
+			image = release.Snapshot.Image
+		}
+		nodeNames := make([]string, 0, len(release.TargetNodeIDs))
+		for _, nodeName := range release.TargetNodeIDs {
+			nodeNames = append(nodeNames, nodeName)
+		}
+		sort.Strings(nodeNames)
+		summary.Releases = append(summary.Releases, ReleaseSummary{
+			ID:          id,
+			Environment: release.Snapshot.Environment,
+			Revision:    release.Revision,
+			Image:       image,
+			CreatedAt:   release.CreatedAt,
+			Current:     id == currentReleaseID,
+			NodeNames:   nodeNames,
+		})
+		if id == currentReleaseID {
+			summary.State.CurrentRevision = release.Revision
+		}
+	}
+
+	deploymentIDs := make([]string, 0, len(current.Deployments))
+	for id, deployment := range current.Deployments {
+		if deployment.ReleaseID == currentReleaseID {
+			deploymentIDs = append(deploymentIDs, id)
+		}
+	}
+	sort.Slice(deploymentIDs, func(i, j int) bool {
+		return current.Deployments[deploymentIDs[i]].CreatedAt > current.Deployments[deploymentIDs[j]].CreatedAt
+	})
+	if len(deploymentIDs) > 0 {
+		currentDeploymentID = deploymentIDs[0]
+	}
+
+	secretKeys := make([]string, 0, len(current.Secrets))
+	for key, secret := range current.Secrets {
+		if secret.WorkspaceKey != workspaceKey {
+			continue
+		}
+		secretKeys = append(secretKeys, key)
+	}
+	sort.Slice(secretKeys, func(i, j int) bool {
+		left := current.Secrets[secretKeys[i]]
+		right := current.Secrets[secretKeys[j]]
+		return strings.Join([]string{left.Environment, left.ServiceName, left.Name}, "\x00") < strings.Join([]string{right.Environment, right.ServiceName, right.Name}, "\x00")
+	})
+	for _, key := range secretKeys {
+		secret := current.Secrets[key]
+		summary.Secrets = append(summary.Secrets, SecretSummary{
+			Environment: secret.Environment,
+			ServiceName: secret.ServiceName,
+			Name:        secret.Name,
+			Store:       secret.Store,
+			UpdatedAt:   secret.UpdatedAt,
+		})
+	}
+
+	summary.State.NodeCount = len(summary.Nodes)
+	summary.State.AttachmentCount = len(summary.Attachments)
+	summary.State.ReleaseCount = len(summary.Releases)
+	summary.State.SecretRefCount = len(summary.Secrets)
+	summary.State.CurrentReleaseID = currentReleaseID
+	summary.State.CurrentDeployment = currentDeploymentID
+	summary.NextSteps = nextSteps(summary)
+	return summary, nil
+}
+
+func projectSummary(cfg config.ProjectConfig) *ProjectSummary {
+	services := cfg.ServiceNames()
+	environments := make([]string, 0, len(cfg.Environments))
+	for name := range cfg.Environments {
+		environments = append(environments, name)
+	}
+	sort.Strings(environments)
+	return &ProjectSummary{
+		Organization:       cfg.Organization,
+		Project:            cfg.Project,
+		DefaultEnvironment: cfg.DefaultEnvironment,
+		Services:           services,
+		Environments:       environments,
+	}
+}
+
+func nextSteps(summary Summary) []NextStep {
+	steps := []NextStep{}
+	if summary.Project == nil {
+		steps = append(steps, NextStep{Label: "Initialize solo workspace", Command: "devopsellence init --mode solo", Reason: "No devopsellence.yml was found in this workspace."})
+	}
+	if summary.State.NodeCount == 0 {
+		steps = append(steps, NextStep{Label: "Register a node", Command: "devopsellence node create prod-1 --host <ip> --user root --ssh-key ~/.ssh/id_ed25519", Reason: "Solo mode needs at least one SSH node."})
+	}
+	if summary.State.NodeCount > 0 && summary.State.AttachmentCount == 0 {
+		steps = append(steps, NextStep{Label: "Attach a node", Command: "devopsellence node attach <node>", Reason: "A node exists but this workspace has no environment attachment."})
+	}
+	if summary.Project != nil && summary.State.AttachmentCount > 0 && summary.State.ReleaseCount == 0 {
+		steps = append(steps, NextStep{Label: "Deploy", Command: "devopsellence deploy", Reason: "The workspace is configured and attached but has no release history yet."})
+	}
+	if summary.State.ReleaseCount > 0 {
+		steps = append(steps, NextStep{Label: "Check status", Command: "devopsellence status", Reason: "Verify the latest release has settled on attached nodes."})
+	}
+	return steps
+}

--- a/cli/internal/desktop/summary_test.go
+++ b/cli/internal/desktop/summary_test.go
@@ -1,0 +1,142 @@
+package desktop
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/devopsellence/cli/internal/solo"
+	"github.com/devopsellence/devopsellence/deployment-core/pkg/deploycore/config"
+	"github.com/devopsellence/devopsellence/deployment-core/pkg/deploycore/desiredstate"
+	corerelease "github.com/devopsellence/devopsellence/deployment-core/pkg/deploycore/release"
+)
+
+func TestBuildSummaryRedactsSecretsAndFiltersWorkspace(t *testing.T) {
+	workspace := t.TempDir()
+	otherWorkspace := t.TempDir()
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	workspaceKey, err := solo.CanonicalWorkspaceKey(workspace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherWorkspaceKey, err := solo.CanonicalWorkspaceKey(otherWorkspace)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := config.DefaultProjectConfig("solo", "demo", "production")
+	if _, err := config.Write(workspace, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	store := solo.NewStateStore(statePath)
+	state := solo.State{
+		SchemaVersion: 1,
+		Nodes: map[string]config.Node{
+			"prod-1": {Host: "203.0.113.10", User: "root", SSHKey: "/tmp/private", Labels: []string{"web"}},
+			"spare":  {Host: "203.0.113.11", User: "root"},
+		},
+		Attachments: map[string]solo.AttachmentRecord{
+			workspaceKey + "\nproduction":      {WorkspaceRoot: workspace, WorkspaceKey: workspaceKey, Environment: "production", NodeNames: []string{"prod-1"}},
+			otherWorkspaceKey + "\nproduction": {WorkspaceRoot: otherWorkspace, WorkspaceKey: otherWorkspaceKey, Environment: "production", NodeNames: []string{"spare"}},
+		},
+		Current: map[string]string{
+			workspaceKey + "\nproduction": "rel-1",
+		},
+		Releases: map[string]corerelease.Release{
+			"rel-1": {
+				ID:            "rel-1",
+				EnvironmentID: workspaceKey + "\nproduction",
+				Revision:      "abc123",
+				Snapshot:      desiredstate.DeploySnapshot{WorkspaceRoot: workspace, WorkspaceKey: workspaceKey, Environment: "production", Image: "demo:abc123"},
+				Image:         corerelease.ImageRef{Reference: "demo:abc123"},
+				TargetNodeIDs: []string{
+					"prod-1",
+				},
+				CreatedAt: "2026-05-26T10:00:00Z",
+			},
+			"other-rel": {
+				ID:            "other-rel",
+				EnvironmentID: otherWorkspaceKey + "\nproduction",
+				Revision:      "def456",
+				Snapshot:      desiredstate.DeploySnapshot{WorkspaceRoot: otherWorkspace, WorkspaceKey: otherWorkspaceKey, Environment: "production", Image: "other:def456"},
+				CreatedAt:     "2026-05-26T10:00:00Z",
+			},
+		},
+		Secrets: map[string]solo.SecretRecord{
+			workspaceKey + "\nproduction\nweb\nDATABASE_URL": {
+				WorkspaceRoot: workspace,
+				WorkspaceKey:  workspaceKey,
+				Environment:   "production",
+				ServiceName:   "web",
+				Name:          "DATABASE_URL",
+				Store:         solo.SecretStorePlaintext,
+				Value:         "postgres://super-secret",
+				UpdatedAt:     "2026-05-26T10:01:00Z",
+			},
+		},
+	}
+	if err := store.Write(state); err != nil {
+		t.Fatal(err)
+	}
+
+	summary, err := BuildSummary(SummaryOptions{WorkspaceRoot: workspace, StatePath: statePath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if summary.Project == nil || summary.Project.Project != "demo" {
+		t.Fatalf("project summary = %#v", summary.Project)
+	}
+	if summary.State.NodeCount != 2 {
+		t.Fatalf("node count = %d, want all registered nodes visible", summary.State.NodeCount)
+	}
+	if summary.State.AttachmentCount != 1 {
+		t.Fatalf("attachment count = %d, want current workspace only", summary.State.AttachmentCount)
+	}
+	if summary.State.ReleaseCount != 1 || summary.State.CurrentRevision != "abc123" {
+		t.Fatalf("release summary = %#v", summary.State)
+	}
+	if len(summary.Secrets) != 1 || summary.Secrets[0].Name != "DATABASE_URL" {
+		t.Fatalf("secrets = %#v", summary.Secrets)
+	}
+	payload, err := json.Marshal(summary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(payload), "super-secret") || strings.Contains(string(payload), "/tmp/private") {
+		t.Fatalf("summary leaked sensitive value: %s", payload)
+	}
+}
+
+func TestHandlerServesIndexAndSummary(t *testing.T) {
+	workspace := t.TempDir()
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	if err := solo.NewStateStore(statePath).Write(solo.State{SchemaVersion: 1}); err != nil {
+		t.Fatal(err)
+	}
+	handler := NewHandler(SummaryOptions{WorkspaceRoot: workspace, StatePath: statePath})
+
+	indexReq := httptest.NewRequest(http.MethodGet, "/", nil)
+	indexRec := httptest.NewRecorder()
+	handler.ServeHTTP(indexRec, indexReq)
+	if indexRec.Code != http.StatusOK || !strings.Contains(indexRec.Body.String(), "devopsellence solo desktop") {
+		t.Fatalf("index response = %d %q", indexRec.Code, indexRec.Body.String())
+	}
+
+	summaryReq := httptest.NewRequest(http.MethodGet, "/api/summary", nil)
+	summaryRec := httptest.NewRecorder()
+	handler.ServeHTTP(summaryRec, summaryReq)
+	if summaryRec.Code != http.StatusOK {
+		t.Fatalf("summary status = %d body=%s", summaryRec.Code, summaryRec.Body.String())
+	}
+	var summary Summary
+	if err := json.Unmarshal(summaryRec.Body.Bytes(), &summary); err != nil {
+		t.Fatal(err)
+	}
+	if summary.SchemaVersion != apiSchemaVersion || summary.Workspace.Mode != "solo" {
+		t.Fatalf("summary = %#v", summary)
+	}
+}

--- a/cli/internal/workflow/root.go
+++ b/cli/internal/workflow/root.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/devopsellence/cli/internal/agentskill"
+	"github.com/devopsellence/cli/internal/desktop"
 	"github.com/devopsellence/cli/internal/discovery"
 	"github.com/devopsellence/cli/internal/version"
 
@@ -126,6 +127,35 @@ func NewRootCommand(in io.Reader, out, err io.Writer, cwd string) *cobra.Command
 			return app.Printer.PrintJSON(versionPayload())
 		},
 	})
+
+	var desktopAddr string
+	var desktopNoOpen bool
+	desktopCommand := &cobra.Command{
+		Use:   "desktop",
+		Short: "Run the local solo desktop app",
+		Long: strings.Join([]string{
+			"Run a local loopback desktop-style control surface for solo mode.",
+			"The app reads local solo state and devopsellence.yml, redacts secret values,",
+			"and prints a structured desktop_ready event containing the local URL.",
+		}, "\n"),
+		Example: "  devopsellence desktop --no-open",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx := cmd.Context()
+			if ctx == nil {
+				ctx = context.Background()
+			}
+			return desktop.Serve(ctx, desktop.Options{
+				Addr:          desktopAddr,
+				WorkspaceRoot: cwd,
+				OpenBrowser:   !desktopNoOpen,
+				Out:           out,
+				Err:           err,
+			})
+		},
+	}
+	desktopCommand.Flags().StringVar(&desktopAddr, "addr", "127.0.0.1:0", "Loopback address to listen on")
+	desktopCommand.Flags().BoolVar(&desktopNoOpen, "no-open", false, "Print the URL without opening a browser")
+	root.AddCommand(desktopCommand)
 
 	modeCommand := &cobra.Command{
 		Use:   "mode",


### PR DESCRIPTION
## Summary
- adds `devopsellence desktop`, a local loopback solo desktop surface that serves a small app and prints a structured `desktop_ready` event with the URL
- adds a JSON `/api/summary` endpoint over local solo state plus `devopsellence.yml`, including nodes, attachments, releases, and redacted secret metadata
- adds tests covering workspace filtering, secret/SSH-key redaction, and handler responses

## Test Plan
- `cd cli && mise x -- go test ./...`
- `cd cli && mise run build`
- smoke: launch `./bin/devopsellence desktop --no-open --addr 127.0.0.1:0`, fetch `/`, fetch `/api/summary`

## Notes
This intentionally starts with a local-first webview-compatible backend instead of committing to heavyweight native packaging. It is ready to be embedded by Wails/Tauri later without changing the solo state summary API.
